### PR TITLE
Add SuUserContext

### DIFF
--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/ClientsBuilder.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/ClientsBuilder.kt
@@ -6,7 +6,7 @@ import no.nav.su.se.bakover.client.dokdistfordeling.DokDistFordeling
 import no.nav.su.se.bakover.client.inntekt.InntektOppslag
 import no.nav.su.se.bakover.client.kodeverk.Kodeverk
 import no.nav.su.se.bakover.client.pdf.PdfGenerator
-import no.nav.su.se.bakover.client.person.AdGraphApiOppslag
+import no.nav.su.se.bakover.client.person.MicrosoftGraphApiOppslag
 import no.nav.su.se.bakover.client.person.PersonOppslag
 import no.nav.su.se.bakover.client.sts.TokenOppslag
 import no.nav.su.se.bakover.domain.oppdrag.avstemming.AvstemmingPublisher
@@ -31,5 +31,5 @@ data class Clients(
     val utbetalingPublisher: UtbetalingPublisher,
     val dokDistFordeling: DokDistFordeling,
     val avstemmingPublisher: AvstemmingPublisher,
-    val adGraphApiClient: AdGraphApiOppslag,
+    val microsoftGraphApiClient: MicrosoftGraphApiOppslag,
 )

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/ClientsBuilder.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/ClientsBuilder.kt
@@ -6,7 +6,7 @@ import no.nav.su.se.bakover.client.dokdistfordeling.DokDistFordeling
 import no.nav.su.se.bakover.client.inntekt.InntektOppslag
 import no.nav.su.se.bakover.client.kodeverk.Kodeverk
 import no.nav.su.se.bakover.client.pdf.PdfGenerator
-import no.nav.su.se.bakover.client.person.AdGraphApiClient
+import no.nav.su.se.bakover.client.person.AdGraphApiOppslag
 import no.nav.su.se.bakover.client.person.PersonOppslag
 import no.nav.su.se.bakover.client.sts.TokenOppslag
 import no.nav.su.se.bakover.domain.oppdrag.avstemming.AvstemmingPublisher
@@ -31,5 +31,5 @@ data class Clients(
     val utbetalingPublisher: UtbetalingPublisher,
     val dokDistFordeling: DokDistFordeling,
     val avstemmingPublisher: AvstemmingPublisher,
-    val adGraphApiClient: AdGraphApiClient,
+    val adGraphApiClient: AdGraphApiOppslag,
 )

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/ProdClientsBuilder.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/ProdClientsBuilder.kt
@@ -13,7 +13,7 @@ import no.nav.su.se.bakover.client.oppdrag.simulering.SimuleringSoapClient
 import no.nav.su.se.bakover.client.oppdrag.utbetaling.UtbetalingMqPublisher
 import no.nav.su.se.bakover.client.oppgave.OppgaveHttpClient
 import no.nav.su.se.bakover.client.pdf.PdfClient
-import no.nav.su.se.bakover.client.person.AdGraphApiClient
+import no.nav.su.se.bakover.client.person.MicrosoftGraphApiClient
 import no.nav.su.se.bakover.client.person.PersonClient
 import no.nav.su.se.bakover.client.skjerming.SkjermingClient
 import no.nav.su.se.bakover.client.sts.StsClient
@@ -74,7 +74,7 @@ data class ProdClientsBuilder(internal val jmsContext: JMSContext) : ClientsBuil
                     )
                 }
             ),
-            adGraphApiClient = AdGraphApiClient(oAuth),
+            microsoftGraphApiClient = MicrosoftGraphApiClient(oAuth),
         )
     }
 }

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/StubClientsBuilder.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/StubClientsBuilder.kt
@@ -7,7 +7,7 @@ import no.nav.su.se.bakover.client.inntekt.InntektOppslag
 import no.nav.su.se.bakover.client.kodeverk.KodeverkHttpClient
 import no.nav.su.se.bakover.client.pdf.PdfClient
 import no.nav.su.se.bakover.client.pdf.PdfGenerator
-import no.nav.su.se.bakover.client.person.AdGraphApiClient
+import no.nav.su.se.bakover.client.person.MicrosoftGraphApiClient
 import no.nav.su.se.bakover.client.person.PersonOppslag
 import no.nav.su.se.bakover.client.sts.TokenOppslag
 import no.nav.su.se.bakover.client.stubs.dokarkiv.DokArkivStub
@@ -50,7 +50,7 @@ object StubClientsBuilder : ClientsBuilder {
             utbetalingPublisher = UtbetalingStub.also { log.warn("********** Using stub for ${UtbetalingPublisher::class.java} **********") },
             dokDistFordeling = DokDistFordelingStub.also { log.warn("********** Using stub for ${DokDistFordelingClient::class.java} **********") },
             avstemmingPublisher = AvstemmingStub.also { log.warn("********** Using stub for ${AvstemmingPublisher::class.java} **********") },
-            adGraphApiClient = AdGraphApiClient(azureClient),
+            microsoftGraphApiClient = MicrosoftGraphApiClient(azureClient),
         )
     }
 }

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/person/AdGraphApiClient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/person/AdGraphApiClient.kt
@@ -24,12 +24,16 @@ data class AdGraphResponse(
     val jobTitle: String
 )
 
+interface AdGraphApiOppslag {
+    fun hent(userToken: String): Either<String, AdGraphResponse>
+}
+
 class AdGraphApiClient(
     private val exchange: OAuth
-) {
+) : AdGraphApiOppslag {
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
 
-    fun hent(userToken: String): Either<String, AdGraphResponse> {
+    override fun hent(userToken: String): Either<String, AdGraphResponse> {
         val onBehalfOfToken = exchange.onBehalfOFToken(userToken, "https://graph.microsoft.com")
         val query =
             "onPremisesSamAccountName,displayName,givenName,mail,officeLocation,surname,userPrincipalName,id,jobTitle"

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/person/MicrosoftGraphApiClient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/person/MicrosoftGraphApiClient.kt
@@ -12,7 +12,7 @@ import no.nav.su.se.bakover.common.unsafeCatch
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-data class AdGraphResponse(
+data class MicrosoftGraphResponse(
     val onPremisesSamAccountName: String?,
     val displayName: String,
     val givenName: String,
@@ -24,16 +24,16 @@ data class AdGraphResponse(
     val jobTitle: String
 )
 
-interface AdGraphApiOppslag {
-    fun hent(userToken: String): Either<String, AdGraphResponse>
+interface MicrosoftGraphApiOppslag {
+    fun hent(userToken: String): Either<String, MicrosoftGraphResponse>
 }
 
-class AdGraphApiClient(
+class MicrosoftGraphApiClient(
     private val exchange: OAuth
-) : AdGraphApiOppslag {
+) : MicrosoftGraphApiOppslag {
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
 
-    override fun hent(userToken: String): Either<String, AdGraphResponse> {
+    override fun hent(userToken: String): Either<String, MicrosoftGraphResponse> {
         val onBehalfOfToken = exchange.onBehalfOFToken(userToken, "https://graph.microsoft.com")
         val query =
             "onPremisesSamAccountName,displayName,givenName,mail,officeLocation,surname,userPrincipalName,id,jobTitle"
@@ -58,7 +58,7 @@ class AdGraphApiClient(
             }
             .flatMap { res ->
                 Either.unsafeCatch {
-                    objectMapper.readValue<AdGraphResponse>(res)
+                    objectMapper.readValue<MicrosoftGraphResponse>(res)
                 }
                     .mapLeft {
                         log.info("Deserialisering av respons fra Microsoft Graph API feilet")

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/Application.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/Application.kt
@@ -45,6 +45,7 @@ import no.nav.su.se.bakover.database.DatabaseRepos
 import no.nav.su.se.bakover.domain.Behandling
 import no.nav.su.se.bakover.domain.UgyldigFnrException
 import no.nav.su.se.bakover.domain.behandlinger.stopp.StoppbehandlingService
+import no.nav.su.se.bakover.web.features.SuUserFeature
 import no.nav.su.se.bakover.web.routes.avstemming.avstemmingRoutes
 import no.nav.su.se.bakover.web.routes.behandling.behandlingRoutes
 import no.nav.su.se.bakover.web.routes.behandlinger.stopp.stoppbehandlingRoutes
@@ -186,6 +187,10 @@ internal fun Application.susebakover(
     }
 
     install(XForwardedHeaderSupport)
+
+    install(SuUserFeature) {
+        this.clients = clients
+    }
 
     routing {
         authenticate("jwt") {

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/features/SuUserFeature.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/features/SuUserFeature.kt
@@ -1,0 +1,70 @@
+package no.nav.su.se.bakover.web.features
+
+import arrow.core.Either
+import io.ktor.application.ApplicationCall
+import io.ktor.application.ApplicationCallPipeline
+import io.ktor.application.ApplicationFeature
+import io.ktor.application.call
+import io.ktor.http.HttpHeaders
+import io.ktor.request.header
+import io.ktor.util.AttributeKey
+import io.ktor.util.pipeline.PipelineContext
+import no.nav.su.se.bakover.client.Clients
+import no.nav.su.se.bakover.client.person.AdGraphResponse
+
+class SuUserFeature(configuration: Configuration) {
+    val clients = configuration.clients
+
+    class Configuration {
+        lateinit var clients: Clients
+    }
+
+    private fun intercept(context: PipelineContext<Unit, ApplicationCall>) {
+        val suUserContext = SuUserContext.from(context.call)
+
+        if (suUserContext.user != null) {
+            return
+        }
+
+        val authHeader = context.call.request.header(HttpHeaders.Authorization) ?: return
+
+        val u = clients.adGraphApiClient.hent(authHeader)
+        suUserContext.user = u
+    }
+
+    companion object Feature : ApplicationFeature<ApplicationCallPipeline, Configuration, SuUserFeature> {
+        override val key = AttributeKey<SuUserFeature>("SuUserFeature")
+
+        override fun install(pipeline: ApplicationCallPipeline, configure: Configuration.() -> Unit): SuUserFeature {
+            val config = Configuration().apply(configure)
+
+            val feature = SuUserFeature(config)
+
+            pipeline.intercept(ApplicationCallPipeline.Features) {
+                feature.intercept(this)
+            }
+
+            return feature
+        }
+    }
+}
+
+class SuUserContext(val call: ApplicationCall) {
+    var user: Either<String, AdGraphResponse>? = null
+
+    companion object {
+        private val AttributeKey = AttributeKey<SuUserContext>("SuUserContext")
+
+        internal fun from(call: ApplicationCall) =
+            call.attributes.computeIfAbsent(AttributeKey) { SuUserContext(call) }
+    }
+
+    fun getNAVIdent(): String? = user?.let { u ->
+        u
+            .map { it.onPremisesSamAccountName }
+            .orNull()
+    }
+}
+
+val ApplicationCall.suUserContext: SuUserContext
+    get() = SuUserContext.from(this)

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/features/SuUserFeature.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/features/SuUserFeature.kt
@@ -10,7 +10,7 @@ import io.ktor.request.header
 import io.ktor.util.AttributeKey
 import io.ktor.util.pipeline.PipelineContext
 import no.nav.su.se.bakover.client.Clients
-import no.nav.su.se.bakover.client.person.AdGraphResponse
+import no.nav.su.se.bakover.client.person.MicrosoftGraphResponse
 
 class SuUserFeature(configuration: Configuration) {
     val clients = configuration.clients
@@ -28,7 +28,7 @@ class SuUserFeature(configuration: Configuration) {
 
         val authHeader = context.call.request.header(HttpHeaders.Authorization) ?: return
 
-        val u = clients.adGraphApiClient.hent(authHeader)
+        val u = clients.microsoftGraphApiClient.hent(authHeader)
         suUserContext.user = u
     }
 
@@ -50,7 +50,7 @@ class SuUserFeature(configuration: Configuration) {
 }
 
 class SuUserContext(val call: ApplicationCall) {
-    var user: Either<String, AdGraphResponse>? = null
+    var user: Either<String, MicrosoftGraphResponse>? = null
 
     companion object {
         private val AttributeKey = AttributeKey<SuUserContext>("SuUserContext")

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/TestClientsBuilder.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/TestClientsBuilder.kt
@@ -4,7 +4,7 @@ import no.nav.su.se.bakover.client.Clients
 import no.nav.su.se.bakover.client.ClientsBuilder
 import no.nav.su.se.bakover.client.azure.OAuth
 import no.nav.su.se.bakover.client.kodeverk.KodeverkHttpClient
-import no.nav.su.se.bakover.client.person.AdGraphApiClient
+import no.nav.su.se.bakover.client.person.MicrosoftGraphApiClient
 import no.nav.su.se.bakover.client.stubs.dokarkiv.DokArkivStub
 import no.nav.su.se.bakover.client.stubs.dokdistfordeling.DokDistFordelingStub
 import no.nav.su.se.bakover.client.stubs.inntekt.InntektOppslagStub
@@ -33,7 +33,7 @@ object TestClientsBuilder : ClientsBuilder {
         utbetalingPublisher = UtbetalingStub,
         dokDistFordeling = DokDistFordelingStub,
         avstemmingPublisher = AvstemmingStub,
-        adGraphApiClient = AdGraphApiClient(OauthStub()),
+        microsoftGraphApiClient = MicrosoftGraphApiClient(OauthStub()),
     )
 
     override fun build(): Clients = testClients

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/features/SuUserFeatureTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/features/SuUserFeatureTest.kt
@@ -4,8 +4,8 @@ import arrow.core.Either
 import io.kotest.matchers.shouldBe
 import io.ktor.http.HttpMethod
 import io.ktor.server.testing.withTestApplication
-import no.nav.su.se.bakover.client.person.AdGraphApiOppslag
-import no.nav.su.se.bakover.client.person.AdGraphResponse
+import no.nav.su.se.bakover.client.person.MicrosoftGraphApiOppslag
+import no.nav.su.se.bakover.client.person.MicrosoftGraphResponse
 import no.nav.su.se.bakover.web.TestClientsBuilder.testClients
 import no.nav.su.se.bakover.web.defaultRequest
 import no.nav.su.se.bakover.web.testSusebakover
@@ -17,7 +17,7 @@ internal class SuUserFeatureTest {
     @Test
     fun `should`() {
         val response = Either.right(
-            AdGraphResponse(
+            MicrosoftGraphResponse(
                 onPremisesSamAccountName = "heisann",
                 displayName = "dp",
                 givenName = "gn",
@@ -33,8 +33,8 @@ internal class SuUserFeatureTest {
         withTestApplication({
             testSusebakover(
                 clients = testClients.copy(
-                    adGraphApiClient = object : AdGraphApiOppslag {
-                        override fun hent(userToken: String): Either<String, AdGraphResponse> = response
+                    microsoftGraphApiClient = object : MicrosoftGraphApiOppslag {
+                        override fun hent(userToken: String): Either<String, MicrosoftGraphResponse> = response
                     }
                 )
             )

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/features/SuUserFeatureTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/features/SuUserFeatureTest.kt
@@ -1,0 +1,48 @@
+package no.nav.su.se.bakover.web.features
+
+import arrow.core.Either
+import io.kotest.matchers.shouldBe
+import io.ktor.http.HttpMethod
+import io.ktor.server.testing.withTestApplication
+import no.nav.su.se.bakover.client.person.AdGraphApiOppslag
+import no.nav.su.se.bakover.client.person.AdGraphResponse
+import no.nav.su.se.bakover.web.TestClientsBuilder.testClients
+import no.nav.su.se.bakover.web.defaultRequest
+import no.nav.su.se.bakover.web.testSusebakover
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+internal class SuUserFeatureTest {
+
+    @Test
+    fun `should`() {
+        val response = Either.right(
+            AdGraphResponse(
+                onPremisesSamAccountName = "heisann",
+                displayName = "dp",
+                givenName = "gn",
+                mail = "mail",
+                officeLocation = "ol",
+                surname = "sn",
+                userPrincipalName = "upn",
+                id = "id",
+                jobTitle = "jt"
+            )
+        )
+
+        withTestApplication({
+            testSusebakover(
+                clients = testClients.copy(
+                    adGraphApiClient = object : AdGraphApiOppslag {
+                        override fun hent(userToken: String): Either<String, AdGraphResponse> = response
+                    }
+                )
+            )
+        }) {
+            defaultRequest(HttpMethod.Get, "/saker/${UUID.randomUUID()}").apply {
+                this.suUserContext.user shouldBe response
+                this.suUserContext.getNAVIdent() shouldBe "heisann"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is used for getting access to details of the logged-in user in a call
context. This can be used for example for getting the user's NAVIdent and for
handling authorization.