### PR TITLE
Avslagsgrunner

### DIFF
--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/DatabaseRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/DatabaseRepoTest.kt
@@ -125,7 +125,7 @@ internal class DatabaseRepoTest {
 
             behandling.status() shouldBe Behandling.BehandlingsStatus.VILKÅRSVURDERT_INNVILGET
 
-            val oppdatertStatus = repo.oppdaterBehandlingStatus(behandling.id, Behandling.BehandlingsStatus.BEREGNET)
+            val oppdatertStatus = repo.oppdaterBehandlingStatus(behandling.id, Behandling.BehandlingsStatus.BEREGNET_INVILGET)
             val hentet = repo.hentBehandling(behandling.id)
 
             hentet!!.status() shouldBe oppdatertStatus

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Behandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Behandling.kt
@@ -218,16 +218,16 @@ data class Behandling(
                     fradrag = fradrag,
                     forventetInntekt = forventetInntekt
                 )
-
-                if (beregning.erUnderMinstebeløp()) {
-                    nyTilstand(Vilkårsvurdert().Avslag())
-                    return
-                }
-
                 this@Behandling.beregning = persistenceObserver.opprettBeregning(
                     behandlingId = id,
                     beregning = beregning
                 )
+
+                if (beregning.beløpErNull() || beregning.beløpErOverNullMenUnderMinstebeløp()) {
+                    nyTilstand(Vilkårsvurdert().Avslag())
+                    return
+                }
+
                 nyTilstand(Beregnet())
             }
         }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Behandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Behandling.kt
@@ -295,6 +295,21 @@ data class Behandling(
             override fun simuler(simuleringClient: SimuleringClient): Either<SimuleringFeilet, Behandling> {
                 throw TilstandException(status, this::simuler.toString())
             }
+
+            override fun sendTilAttestering(
+                aktørId: AktørId,
+                oppgave: OppgaveClient,
+                saksbehandler: Saksbehandler,
+            ): Either<KunneIkkeOppretteOppgave, Behandling> = oppgave.opprettOppgave(
+                OppgaveConfig.Attestering(
+                    sakId = sakId.toString(),
+                    aktørId = aktørId
+                )
+            ).map {
+                this@Behandling.saksbehandler = persistenceObserver.settSaksbehandler(id, saksbehandler)
+                nyTilstand(TilAttestering().Avslag())
+                this@Behandling
+            }
         }
     }
 

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Behandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Behandling.kt
@@ -211,15 +211,22 @@ data class Behandling(
                         "Kan ikke opprette beregning. Forventet inntekt finnes ikke."
                     )
 
+                val beregning = Beregning(
+                    fraOgMed = fraOgMed,
+                    tilOgMed = tilOgMed,
+                    sats = sats,
+                    fradrag = fradrag,
+                    forventetInntekt = forventetInntekt
+                )
+
+                if (beregning.erUnderMinstebeløp()) {
+                    nyTilstand(Vilkårsvurdert().Avslag())
+                    return
+                }
+
                 this@Behandling.beregning = persistenceObserver.opprettBeregning(
                     behandlingId = id,
-                    beregning = Beregning(
-                        fraOgMed = fraOgMed,
-                        tilOgMed = tilOgMed,
-                        sats = sats,
-                        fradrag = fradrag,
-                        forventetInntekt = forventetInntekt
-                    )
+                    beregning = beregning
                 )
                 nyTilstand(Beregnet())
             }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Behandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Behandling.kt
@@ -70,7 +70,7 @@ data class Behandling(
 
     fun getUtledetSatsBeløp(): Int? {
         if (status == BehandlingsStatus.VILKÅRSVURDERT_INNVILGET ||
-            status == BehandlingsStatus.BEREGNET ||
+            status == BehandlingsStatus.BEREGNET_INVILGET ||
             status == BehandlingsStatus.SIMULERT
         ) {
             return behandlingsinformasjon().bosituasjon?.utledSats()?.fraDatoAsInt(LocalDate.now())
@@ -82,7 +82,7 @@ data class Behandling(
         BehandlingsStatus.OPPRETTET -> Opprettet()
         BehandlingsStatus.VILKÅRSVURDERT_INNVILGET -> Vilkårsvurdert().Innvilget()
         BehandlingsStatus.VILKÅRSVURDERT_AVSLAG -> Vilkårsvurdert().Avslag()
-        BehandlingsStatus.BEREGNET -> Beregnet()
+        BehandlingsStatus.BEREGNET_INVILGET -> Beregnet()
         BehandlingsStatus.BEREGNET_AVSLAG -> Beregnet().Avslag()
         BehandlingsStatus.SIMULERT -> Simulert()
         BehandlingsStatus.TIL_ATTESTERING_INNVILGET -> TilAttestering().Innvilget()
@@ -254,7 +254,7 @@ data class Behandling(
     }
 
     private open inner class Beregnet : Tilstand {
-        override val status: BehandlingsStatus = BehandlingsStatus.BEREGNET
+        override val status: BehandlingsStatus = BehandlingsStatus.BEREGNET_INVILGET
 
         override fun opprettBeregning(fraOgMed: LocalDate, tilOgMed: LocalDate, fradrag: List<Fradrag>) {
             nyTilstand(Vilkårsvurdert()).opprettBeregning(fraOgMed, tilOgMed, fradrag)
@@ -420,7 +420,7 @@ data class Behandling(
         OPPRETTET,
         VILKÅRSVURDERT_INNVILGET,
         VILKÅRSVURDERT_AVSLAG,
-        BEREGNET,
+        BEREGNET_INVILGET,
         BEREGNET_AVSLAG,
         SIMULERT,
         TIL_ATTESTERING_INNVILGET,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/VedtakInnhold.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/VedtakInnhold.kt
@@ -24,7 +24,7 @@ data class VedtakInnhold(
     val fradragSum: Int,
     val status: Behandling.BehandlingsStatus,
     val avslagsgrunn: Avslagsgrunn?,
-    val avslagsgrunnBeskrivelse: AvslagsgrunnBeskrivelseFlagg?,
+    val avslagsgrunnBeskrivelse: AvslagsgrunnBeskrivelse?,
     val halvGrunnbeløp: Int?,
 )
 
@@ -41,9 +41,10 @@ enum class Avslagsgrunn {
     INNLAGT_PÅ_INSTITUSJON
 }
 
-enum class AvslagsgrunnBeskrivelseFlagg {
+enum class AvslagsgrunnBeskrivelse {
     UFØRHET_FLYKTNING,
     FORMUE,
     HØY_INNTEKT,
     UTLAND_OG_OPPHOLD,
+    UNDER_MINSTEGRENSE
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/VedtakInnholdTestdataBuilder.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/VedtakInnholdTestdataBuilder.kt
@@ -28,7 +28,7 @@ object VedtakInnholdTestdataBuilder {
             fradragSum = 0,
             status = Behandling.BehandlingsStatus.TIL_ATTESTERING_INNVILGET,
             avslagsgrunn = Avslagsgrunn.FLYKTNING,
-            avslagsgrunnBeskrivelse = AvslagsgrunnBeskrivelseFlagg.FORMUE,
+            avslagsgrunnBeskrivelse = AvslagsgrunnBeskrivelse.FORMUE,
             halvGrunnbeløp = 50
         )
     }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Behandlingsinformasjon.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Behandlingsinformasjon.kt
@@ -4,7 +4,7 @@ import no.nav.su.se.bakover.domain.Boforhold
 import no.nav.su.se.bakover.domain.beregning.Sats
 
 data class Behandlingsinformasjon(
-    var uførhet: Uførhet? = null,
+    val uførhet: Uførhet? = null,
     val flyktning: Flyktning? = null,
     val lovligOpphold: LovligOpphold? = null,
     val fastOppholdINorge: FastOppholdINorge? = null,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Behandlingsinformasjon.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Behandlingsinformasjon.kt
@@ -4,7 +4,7 @@ import no.nav.su.se.bakover.domain.Boforhold
 import no.nav.su.se.bakover.domain.beregning.Sats
 
 data class Behandlingsinformasjon(
-    val uførhet: Uførhet? = null,
+    var uførhet: Uførhet? = null,
     val flyktning: Flyktning? = null,
     val lovligOpphold: LovligOpphold? = null,
     val fastOppholdINorge: FastOppholdINorge? = null,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Beregning.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Beregning.kt
@@ -55,7 +55,7 @@ data class Beregning(
     }
 
     fun beløpErOverNullMenUnderMinstebeløp(): Boolean {
-        val minstebeløp = (månedsberegninger.map { Sats.HØY.fraDato(it.fom) / 12 }.sum()) * TO_PROSENT
+        val minstebeløp = (månedsberegninger.map { Sats.HØY.fraDato(it.fraOgMed) / 12 }.sum()) * TO_PROSENT
         val gjennomsnittPerMåned = månedsberegninger.sumBy { it.beløp }
 
         return gjennomsnittPerMåned < minstebeløp

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Beregning.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Beregning.kt
@@ -8,6 +8,8 @@ import java.time.LocalDate
 import java.time.Period
 import java.util.UUID
 
+const val TO_PROSENT = 0.02 // https://lovdata.no/dokument/NL/lov/2005-04-29-21 - § 9
+
 data class Beregning(
     val id: UUID = UUID.randomUUID(),
     val opprettet: Tidspunkt = now(),
@@ -50,6 +52,13 @@ data class Beregning(
         override fun compare(o1: Beregning?, o2: Beregning?): Int {
             return o1!!.opprettet.toEpochMilli().compareTo(o2!!.opprettet.toEpochMilli())
         }
+    }
+
+    fun erUnderMinstebeløp(): Boolean {
+        val minstebeløp = (månedsberegninger.map { Sats.HØY.fraDato(it.fom) / 12 }.sum()) * TO_PROSENT
+        val gjennomsnittPerMåned = månedsberegninger.sumBy { it.beløp }
+
+        return gjennomsnittPerMåned < minstebeløp
     }
 }
 

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Beregning.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Beregning.kt
@@ -54,12 +54,15 @@ data class Beregning(
         }
     }
 
-    fun erUnderMinstebeløp(): Boolean {
+    fun beløpErOverNullMenUnderMinstebeløp(): Boolean {
         val minstebeløp = (månedsberegninger.map { Sats.HØY.fraDato(it.fom) / 12 }.sum()) * TO_PROSENT
         val gjennomsnittPerMåned = månedsberegninger.sumBy { it.beløp }
 
         return gjennomsnittPerMåned < minstebeløp
     }
+
+    fun beløpErNull() =
+        månedsberegninger.sumBy { it.beløp } == 0
 }
 
 private fun fradragWithForventetInntekt(fradrag: List<Fradrag>, forventetInntekt: Int): List<Fradrag> {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Beregning.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Beregning.kt
@@ -56,13 +56,13 @@ data class Beregning(
 
     fun beløpErOverNullMenUnderMinstebeløp(): Boolean {
         val minstebeløp = (månedsberegninger.map { Sats.HØY.fraDato(it.fraOgMed) / 12 }.sum()) * TO_PROSENT
-        val gjennomsnittPerMåned = månedsberegninger.sumBy { it.beløp }
+        val beregnetBeløp = månedsberegninger.sumBy { it.beløp }
 
-        return gjennomsnittPerMåned < minstebeløp
+        return beregnetBeløp > 0 && beregnetBeløp < minstebeløp
     }
 
     fun beløpErNull() =
-        månedsberegninger.sumBy { it.beløp } == 0
+        månedsberegninger.sumBy { it.beløp } <= 0
 }
 
 private fun fradragWithForventetInntekt(fradrag: List<Fradrag>, forventetInntekt: Int): List<Fradrag> {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Fradrag.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Fradrag.kt
@@ -2,6 +2,8 @@ package no.nav.su.se.bakover.domain.beregning
 
 import arrow.core.Either
 import kotlinx.coroutines.runBlocking
+import java.math.BigDecimal
+import java.math.RoundingMode
 import java.util.UUID
 
 enum class Fradragstype {
@@ -29,5 +31,5 @@ data class Fradrag(
     val beløp: Int,
     val beskrivelse: String? = null
 ) {
-    fun perMåned(): Int = beløp / 12
+    fun perMåned(): Int = BigDecimal(beløp).divide(BigDecimal(12), 0, RoundingMode.HALF_UP).toInt()
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Månedsberegning.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Månedsberegning.kt
@@ -26,9 +26,10 @@ data class Månedsberegning(
     }
 
     companion object {
+        // TODO AI: Se på möjligheterna för att ha fradrag som BigDecimal för att komma undan off-by-one fel.
         fun kalkulerBeløp(sats: Sats, fraOgMed: LocalDate, fradrag: Int) =
-            BigDecimal(sats.fraDato(fraOgMed)).divide(BigDecimal(12), 0, RoundingMode.HALF_UP)
-                .minus(BigDecimal(fradrag))
+            BigDecimal(sats.fraDato(fraOgMed)).divide(BigDecimal(12), 0, RoundingMode.HALF_UP) // 20637,32 --> 20637
+                .minus(BigDecimal(fradrag)) // Her runder vi av begge sider av regnestykket, kan potentiellt leda till fel.
                 .max(BigDecimal.ZERO)
                 .toInt()
     }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Månedsberegning.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Månedsberegning.kt
@@ -28,7 +28,7 @@ data class Månedsberegning(
     companion object {
         // TODO AI: Se på möjligheterna för att ha fradrag som BigDecimal för att komma undan off-by-one fel.
         fun kalkulerBeløp(sats: Sats, fraOgMed: LocalDate, fradrag: Int) =
-            BigDecimal(sats.fraDato(fraOgMed)).divide(BigDecimal(12), 0, RoundingMode.HALF_UP) // 20637,32 --> 20637
+            BigDecimal(sats.fraDato(fraOgMed)).divide(BigDecimal(12), 0, RoundingMode.HALF_UP)
                 .minus(BigDecimal(fradrag)) // Her runder vi av begge sider av regnestykket, kan potentiellt leda till fel.
                 .max(BigDecimal.ZERO)
                 .toInt()

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/BehandlingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/BehandlingTest.kt
@@ -466,9 +466,17 @@ internal class BehandlingTest {
             }
 
             @Test
+            fun `skal kunne sende til attestering`() {
+                val saksbehandler = Saksbehandler("S123456")
+                beregnet.sendTilAttestering(aktørId, OppgaveClientStub, saksbehandler)
+
+                beregnet.status() shouldBe TIL_ATTESTERING_AVSLAG
+                beregnet.saksbehandler() shouldBe saksbehandler
+            }
+
+            @Test
             fun `illegal operations`() {
                 assertThrows<Behandling.TilstandException> { beregnet.simuler(SimuleringClientStub) }
-                assertThrows<Behandling.TilstandException> { beregnet.sendTilAttestering(aktørId, OppgaveClientStub, Saksbehandler("S123456")) }
                 assertThrows<Behandling.TilstandException> {
                     beregnet.iverksett(
                         Attestant("A123456"),

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/BehandlingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/BehandlingTest.kt
@@ -14,8 +14,8 @@ import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.mai
 import no.nav.su.se.bakover.common.now
 import no.nav.su.se.bakover.domain.Behandling.BehandlingsStatus
-import no.nav.su.se.bakover.domain.Behandling.BehandlingsStatus.BEREGNET
 import no.nav.su.se.bakover.domain.Behandling.BehandlingsStatus.BEREGNET_AVSLAG
+import no.nav.su.se.bakover.domain.Behandling.BehandlingsStatus.BEREGNET_INVILGET
 import no.nav.su.se.bakover.domain.Behandling.BehandlingsStatus.IVERKSATT_AVSLAG
 import no.nav.su.se.bakover.domain.Behandling.BehandlingsStatus.IVERKSATT_INNVILGET
 import no.nav.su.se.bakover.domain.Behandling.BehandlingsStatus.OPPRETTET
@@ -225,7 +225,7 @@ internal class BehandlingTest {
         @Test
         fun `legal operations`() {
             vilkårsvurdert.opprettBeregning(1.januar(2020), 31.desember(2020))
-            vilkårsvurdert.status() shouldBe BEREGNET
+            vilkårsvurdert.status() shouldBe BEREGNET_INVILGET
         }
 
         @Test
@@ -303,7 +303,7 @@ internal class BehandlingTest {
                 fradrag = listOf(Fradrag(UUID.randomUUID(), Fradragstype.Arbeidsinntekt, inntektSomGerMinstebeløp))
             )
 
-            vilkårsvurdert.status() shouldBe BEREGNET
+            vilkårsvurdert.status() shouldBe BEREGNET_INVILGET
             vilkårsvurdert.beregning() shouldNotBe null
         }
 
@@ -377,7 +377,7 @@ internal class BehandlingTest {
                 extractBehandlingsinformasjon(beregnet).withAlleVilkårOppfylt()
             )
             beregnet.opprettBeregning(1.januar(2020), 31.desember(2020))
-            beregnet.status() shouldBe BEREGNET
+            beregnet.status() shouldBe BEREGNET_INVILGET
             observer.oppdatertStatus shouldBe beregnet.status()
         }
 
@@ -409,7 +409,7 @@ internal class BehandlingTest {
         @Test
         fun `skal kunne beregne på nytt`() {
             beregnet.opprettBeregning(1.januar(2020), 31.desember(2020))
-            beregnet.status() shouldBe BEREGNET
+            beregnet.status() shouldBe BEREGNET_INVILGET
         }
 
         @Test
@@ -453,7 +453,7 @@ internal class BehandlingTest {
             @Test
             fun `skal kunne beregne på nytt`() {
                 beregnet.opprettBeregning(1.januar(2020), 31.desember(2020))
-                beregnet.status() shouldBe BEREGNET
+                beregnet.status() shouldBe BEREGNET_INVILGET
             }
 
             @Test
@@ -516,7 +516,7 @@ internal class BehandlingTest {
         @Test
         fun `skal kunne beregne på nytt`() {
             simulert.opprettBeregning(1.januar(2020), 31.desember(2020))
-            simulert.status() shouldBe BEREGNET
+            simulert.status() shouldBe BEREGNET_INVILGET
         }
 
         @Test

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/BehandlingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/BehandlingTest.kt
@@ -260,7 +260,6 @@ internal class BehandlingTest {
             )
 
             vilkårsvurdert.status() shouldBe VILKÅRSVURDERT_AVSLAG
-            vilkårsvurdert.beregning() shouldBe null
         }
 
         @Test
@@ -275,7 +274,6 @@ internal class BehandlingTest {
             )
 
             vilkårsvurdert.status() shouldBe VILKÅRSVURDERT_AVSLAG
-            vilkårsvurdert.beregning() shouldBe null
         }
 
         @Test
@@ -289,7 +287,6 @@ internal class BehandlingTest {
             )
 
             vilkårsvurdert.status() shouldBe VILKÅRSVURDERT_AVSLAG
-            vilkårsvurdert.beregning() shouldBe null
         }
 
         @Test

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/BehandlingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/BehandlingTest.kt
@@ -295,13 +295,12 @@ internal class BehandlingTest {
 
         @Test
         fun `skal innvilge hvis utbetaling er nøyaktig minstebeløp`() {
-            // val maxUtbetaling2020 = 250116
-            val _maxUtbetaling2020 = 245114
+            val inntektSomGerMinstebeløp = 245114
 
             vilkårsvurdert.opprettBeregning(
                 fraOgMed = 1.januar(2020),
                 tilOgMed = 31.desember(2020),
-                fradrag = listOf(Fradrag(UUID.randomUUID(), Fradragstype.Arbeidsinntekt, _maxUtbetaling2020))
+                fradrag = listOf(Fradrag(UUID.randomUUID(), Fradragstype.Arbeidsinntekt, inntektSomGerMinstebeløp))
             )
 
             vilkårsvurdert.status() shouldBe BEREGNET

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/BehandlingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/BehandlingTest.kt
@@ -254,8 +254,8 @@ internal class BehandlingTest {
         @Test
         fun `skal avslå hvis utbetaling er 0 for arbeidsInntekt`() {
             vilkårsvurdert.opprettBeregning(
-                fom = 1.januar(2020),
-                tom = 31.desember(2020),
+                fraOgMed = 1.januar(2020),
+                tilOgMed = 31.desember(2020),
                 fradrag = listOf(Fradrag(UUID.randomUUID(), Fradragstype.Arbeidsinntekt, 600000))
             )
 
@@ -265,12 +265,15 @@ internal class BehandlingTest {
         @Test
         fun `skal avslå hvis utbetaling er 0 for forventetInntekt`() {
             var vilkårsvurdertInnvilget = extractBehandlingsinformasjon(vilkårsvurdert).withAlleVilkårOppfylt()
-            vilkårsvurdertInnvilget.uførhet = Behandlingsinformasjon.Uførhet(Behandlingsinformasjon.Uførhet.Status.VilkårOppfylt, 1, 600000)
-            vilkårsvurdert.oppdaterBehandlingsinformasjon(vilkårsvurdertInnvilget)
+            val behandlingsinformasjon = Behandlingsinformasjon(
+                uførhet = Behandlingsinformasjon.Uførhet(Behandlingsinformasjon.Uførhet.Status.VilkårOppfylt, 1, 600000)
+            )
+            val updatedUførhet = vilkårsvurdertInnvilget.patch(behandlingsinformasjon)
+            vilkårsvurdert.oppdaterBehandlingsinformasjon(updatedUførhet)
 
             vilkårsvurdert.opprettBeregning(
-                fom = 1.januar(2020),
-                tom = 31.desember(2020),
+                fraOgMed = 1.januar(2020),
+                tilOgMed = 31.desember(2020),
             )
 
             vilkårsvurdert.status() shouldBe VILKÅRSVURDERT_AVSLAG
@@ -281,8 +284,8 @@ internal class BehandlingTest {
             val maxUtbetaling2020 = 250116
 
             vilkårsvurdert.opprettBeregning(
-                fom = 1.januar(2020),
-                tom = 31.desember(2020),
+                fraOgMed = 1.januar(2020),
+                tilOgMed = 31.desember(2020),
                 fradrag = listOf(Fradrag(UUID.randomUUID(), Fradragstype.Arbeidsinntekt, (maxUtbetaling2020 * 0.99).toInt()))
             )
 
@@ -294,8 +297,8 @@ internal class BehandlingTest {
             val maxUtbetaling2020 = 250116
 
             vilkårsvurdert.opprettBeregning(
-                fom = 1.januar(2020),
-                tom = 31.desember(2020),
+                fraOgMed = 1.januar(2020),
+                tilOgMed = 31.desember(2020),
                 fradrag = listOf(Fradrag(UUID.randomUUID(), Fradragstype.Arbeidsinntekt, (maxUtbetaling2020 * 0.98).toInt()))
             )
 

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/BehandlingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/BehandlingTest.kt
@@ -265,7 +265,7 @@ internal class BehandlingTest {
 
         @Test
         fun `skal avslå hvis utbetaling er 0 for forventetInntekt`() {
-            var vilkårsvurdertInnvilget = extractBehandlingsinformasjon(vilkårsvurdert).withAlleVilkårOppfylt()
+            val vilkårsvurdertInnvilget = extractBehandlingsinformasjon(vilkårsvurdert).withAlleVilkårOppfylt()
             val behandlingsinformasjon = Behandlingsinformasjon(
                 uførhet = Behandlingsinformasjon.Uførhet(Behandlingsinformasjon.Uførhet.Status.VilkårOppfylt, 1, 600000)
             )
@@ -295,12 +295,13 @@ internal class BehandlingTest {
 
         @Test
         fun `skal innvilge hvis utbetaling er nøyaktig minstebeløp`() {
-            val maxUtbetaling2020 = 250116
+            // val maxUtbetaling2020 = 250116
+            val _maxUtbetaling2020 = 245114
 
             vilkårsvurdert.opprettBeregning(
                 fraOgMed = 1.januar(2020),
                 tilOgMed = 31.desember(2020),
-                fradrag = listOf(Fradrag(UUID.randomUUID(), Fradragstype.Arbeidsinntekt, (maxUtbetaling2020 * 0.98).toInt()))
+                fradrag = listOf(Fradrag(UUID.randomUUID(), Fradragstype.Arbeidsinntekt, _maxUtbetaling2020))
             )
 
             vilkårsvurdert.status() shouldBe BEREGNET

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/BeregningTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/BeregningTest.kt
@@ -187,27 +187,6 @@ internal class BeregningTest {
     }
 
     @Test
-    fun `beregnet beløp er akkurat på minstebeløp`() {
-        // 98% av full supplerende stønad (Høy sats) for
-        // 2019 - Jan, Feb, Mars, Apr
-        // 2020 - Maj, Juni, Juli, Aug, Sep, Okt, Nov, Dec
-        val høyInntekt = 245114
-
-        val b = Beregning(
-            fraOgMed = LocalDate.of(2020, Month.JANUARY, 1),
-            tilOgMed = LocalDate.of(2020, Month.DECEMBER, 31),
-            sats = Sats.HØY,
-            opprettet = LocalDateTime.of(2020, Month.JANUARY, 1, 12, 1, 1).toTidspunkt(),
-            fradrag = listOf(
-                Fradrag(type = Fradragstype.Arbeidsinntekt, beløp = høyInntekt),
-            ),
-            forventetInntekt = 0
-        )
-
-        b.beløpErOverNullMenUnderMinstebeløp() shouldBe false
-    }
-
-    @Test
     fun `beregnet beløp er rett under minstebeløp`() {
         // 98% av full supplerende stønad (Høy sats) for
         // 2019 - Jan, Feb, Mars, Apr
@@ -229,7 +208,7 @@ internal class BeregningTest {
     }
 
     @Test
-    fun `minstebeløp er to prosent av høy sats`() {
+    fun `beregnet beløp er akkurat på minstebeløp`() {
         // 98% av full supplerende stønad (Høy sats) for
         // 2019 - Jan, Feb, Mars, Apr
         // 2020 - Maj, Juni, Juli, Aug, Sep, Okt, Nov, Dec

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/BeregningTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/BeregningTest.kt
@@ -167,4 +167,85 @@ internal class BeregningTest {
             )
         }.also { it.message shouldContain "negativ" }
     }
+
+    @Test
+    fun `beregnet beløp er over null men under minstebeløp, for en måned`() {
+        val høyInntekt = 242695 // 98% av full supplerende stønad (Høy sats) for 2019
+
+        val b = Beregning(
+            fraOgMed = LocalDate.of(2020, Month.JANUARY, 1),
+            tilOgMed = LocalDate.of(2020, Month.JANUARY, 31),
+            sats = Sats.HØY,
+            opprettet = LocalDateTime.of(2020, Month.JANUARY, 1, 12, 1, 1).toTidspunkt(),
+            fradrag = listOf(
+                Fradrag(type = Fradragstype.Arbeidsinntekt, beløp = høyInntekt),
+            ),
+            forventetInntekt = 0
+        )
+
+        b.beløpErOverNullMenUnderMinstebeløp() shouldBe true
+    }
+
+    @Test
+    fun `beregnet beløp er akkurat på minstebeløp`() {
+        // 98% av full supplerende stønad (Høy sats) for
+        // 2019 - Jan, Feb, Mars, Apr
+        // 2020 - Maj, Juni, Juli, Aug, Sep, Okt, Nov, Dec
+        val høyInntekt = 245114
+
+        val b = Beregning(
+            fraOgMed = LocalDate.of(2020, Month.JANUARY, 1),
+            tilOgMed = LocalDate.of(2020, Month.DECEMBER, 31),
+            sats = Sats.HØY,
+            opprettet = LocalDateTime.of(2020, Month.JANUARY, 1, 12, 1, 1).toTidspunkt(),
+            fradrag = listOf(
+                Fradrag(type = Fradragstype.Arbeidsinntekt, beløp = høyInntekt),
+            ),
+            forventetInntekt = 0
+        )
+
+        b.beløpErOverNullMenUnderMinstebeløp() shouldBe false
+    }
+
+    @Test
+    fun `beregnet beløp er rett under minstebeløp`() {
+        // 98% av full supplerende stønad (Høy sats) for
+        // 2019 - Jan, Feb, Mars, Apr
+        // 2020 - Maj, Juni, Juli, Aug, Sep, Okt, Nov, Dec
+        val høyInntekt = 245114 + 8 // pågrundav avrundning så må vi legge på 8
+
+        val b = Beregning(
+            fraOgMed = LocalDate.of(2020, Month.JANUARY, 1),
+            tilOgMed = LocalDate.of(2020, Month.DECEMBER, 31),
+            sats = Sats.HØY,
+            opprettet = LocalDateTime.of(2020, Month.JANUARY, 1, 12, 1, 1).toTidspunkt(),
+            fradrag = listOf(
+                Fradrag(type = Fradragstype.Arbeidsinntekt, beløp = høyInntekt),
+            ),
+            forventetInntekt = 0
+        )
+
+        b.beløpErOverNullMenUnderMinstebeløp() shouldBe true
+    }
+
+    @Test
+    fun `minstebeløp er to prosent av høy sats`() {
+        // 98% av full supplerende stønad (Høy sats) for
+        // 2019 - Jan, Feb, Mars, Apr
+        // 2020 - Maj, Juni, Juli, Aug, Sep, Okt, Nov, Dec
+        val høyInntekt = 245114
+
+        val b = Beregning(
+            fraOgMed = LocalDate.of(2020, Month.JANUARY, 1),
+            tilOgMed = LocalDate.of(2020, Month.DECEMBER, 31),
+            sats = Sats.HØY,
+            opprettet = LocalDateTime.of(2020, Month.JANUARY, 1, 12, 1, 1).toTidspunkt(),
+            fradrag = listOf(
+                Fradrag(type = Fradragstype.Arbeidsinntekt, beløp = høyInntekt),
+            ),
+            forventetInntekt = 0
+        )
+
+        b.beløpErOverNullMenUnderMinstebeløp() shouldBe false
+    }
 }


### PR DESCRIPTION
- Nya avslagsgrunner
- Avslår behandling nå hvis beregnet beløp er under minstebeløp (2% av full supplerende stønad)

Notes:
* Har lagt till ett nytt `Tilstand` nå som heter `BEREGNET_AVSLAG`, eftersom vi nå kan avslå en behandling p.g.a beregnet beløp er under minstebeløp. Provade att sette statusen tidigare till `VILKÅRSVURDERT_AVSLAG` men det introducerade många bugs.