### PR TITLE
Fix typo - BEREGNET_INNVILGET

### DIFF
--- a/database/src/main/resources/db/migration/V25__rename_beregnet_status.sql
+++ b/database/src/main/resources/db/migration/V25__rename_beregnet_status.sql
@@ -1,0 +1,2 @@
+update behandling set status = REPLACE(status, 'BEREGNET', 'BEREGNET_INNVILGET');
+update behandling set status = REPLACE(status, 'BEREGNET_INVILGET', 'BEREGNET_INNVILGET');

--- a/database/src/main/resources/db/migration/V25__rename_beregnet_status.sql
+++ b/database/src/main/resources/db/migration/V25__rename_beregnet_status.sql
@@ -1,2 +1,2 @@
-update behandling set status = REPLACE(status, 'BEREGNET', 'BEREGNET_INNVILGET');
-update behandling set status = REPLACE(status, 'BEREGNET_INVILGET', 'BEREGNET_INNVILGET');
+update behandling set status = REPLACE(status, 'BEREGNET', 'BEREGNET_INNVILGET') where behandling.status = 'BEREGNET';
+update behandling set status = REPLACE(status, 'BEREGNET_INVILGET', 'BEREGNET_INNVILGET') where behandling.status = 'BEREGNET_INVILGET';

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/DatabaseRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/DatabaseRepoTest.kt
@@ -125,7 +125,7 @@ internal class DatabaseRepoTest {
 
             behandling.status() shouldBe Behandling.BehandlingsStatus.VILKÅRSVURDERT_INNVILGET
 
-            val oppdatertStatus = repo.oppdaterBehandlingStatus(behandling.id, Behandling.BehandlingsStatus.BEREGNET_INVILGET)
+            val oppdatertStatus = repo.oppdaterBehandlingStatus(behandling.id, Behandling.BehandlingsStatus.BEREGNET_INNVILGET)
             val hentet = repo.hentBehandling(behandling.id)
 
             hentet!!.status() shouldBe oppdatertStatus

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Behandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Behandling.kt
@@ -69,7 +69,7 @@ data class Behandling(
 
     fun getUtledetSatsBeløp(): Int? {
         if (status == BehandlingsStatus.VILKÅRSVURDERT_INNVILGET ||
-            status == BehandlingsStatus.BEREGNET_INVILGET ||
+            status == BehandlingsStatus.BEREGNET_INNVILGET ||
             status == BehandlingsStatus.SIMULERT
         ) {
             return behandlingsinformasjon().bosituasjon?.utledSats()?.fraDatoAsInt(LocalDate.now())
@@ -81,7 +81,7 @@ data class Behandling(
         BehandlingsStatus.OPPRETTET -> Opprettet()
         BehandlingsStatus.VILKÅRSVURDERT_INNVILGET -> Vilkårsvurdert().Innvilget()
         BehandlingsStatus.VILKÅRSVURDERT_AVSLAG -> Vilkårsvurdert().Avslag()
-        BehandlingsStatus.BEREGNET_INVILGET -> Beregnet()
+        BehandlingsStatus.BEREGNET_INNVILGET -> Beregnet()
         BehandlingsStatus.BEREGNET_AVSLAG -> Beregnet().Avslag()
         BehandlingsStatus.SIMULERT -> Simulert()
         BehandlingsStatus.TIL_ATTESTERING_INNVILGET -> TilAttestering().Innvilget()
@@ -253,7 +253,7 @@ data class Behandling(
     }
 
     private open inner class Beregnet : Tilstand {
-        override val status: BehandlingsStatus = BehandlingsStatus.BEREGNET_INVILGET
+        override val status: BehandlingsStatus = BehandlingsStatus.BEREGNET_INNVILGET
 
         override fun opprettBeregning(fraOgMed: LocalDate, tilOgMed: LocalDate, fradrag: List<Fradrag>) {
             nyTilstand(Vilkårsvurdert()).opprettBeregning(fraOgMed, tilOgMed, fradrag)
@@ -413,7 +413,7 @@ data class Behandling(
         OPPRETTET,
         VILKÅRSVURDERT_INNVILGET,
         VILKÅRSVURDERT_AVSLAG,
-        BEREGNET_INVILGET,
+        BEREGNET_INNVILGET,
         BEREGNET_AVSLAG,
         SIMULERT,
         TIL_ATTESTERING_INNVILGET,

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/BehandlingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/BehandlingTest.kt
@@ -15,7 +15,7 @@ import no.nav.su.se.bakover.common.mai
 import no.nav.su.se.bakover.common.now
 import no.nav.su.se.bakover.domain.Behandling.BehandlingsStatus
 import no.nav.su.se.bakover.domain.Behandling.BehandlingsStatus.BEREGNET_AVSLAG
-import no.nav.su.se.bakover.domain.Behandling.BehandlingsStatus.BEREGNET_INVILGET
+import no.nav.su.se.bakover.domain.Behandling.BehandlingsStatus.BEREGNET_INNVILGET
 import no.nav.su.se.bakover.domain.Behandling.BehandlingsStatus.IVERKSATT_AVSLAG
 import no.nav.su.se.bakover.domain.Behandling.BehandlingsStatus.IVERKSATT_INNVILGET
 import no.nav.su.se.bakover.domain.Behandling.BehandlingsStatus.OPPRETTET
@@ -227,7 +227,7 @@ internal class BehandlingTest {
         @Test
         fun `legal operations`() {
             vilkårsvurdert.opprettBeregning(1.januar(2020), 31.desember(2020))
-            vilkårsvurdert.status() shouldBe BEREGNET_INVILGET
+            vilkårsvurdert.status() shouldBe BEREGNET_INNVILGET
         }
 
         @Test
@@ -305,7 +305,7 @@ internal class BehandlingTest {
                 fradrag = listOf(Fradrag(UUID.randomUUID(), Fradragstype.Arbeidsinntekt, inntektSomGerMinstebeløp))
             )
 
-            vilkårsvurdert.status() shouldBe BEREGNET_INVILGET
+            vilkårsvurdert.status() shouldBe BEREGNET_INNVILGET
             vilkårsvurdert.beregning() shouldNotBe null
         }
 
@@ -379,7 +379,7 @@ internal class BehandlingTest {
                 extractBehandlingsinformasjon(beregnet).withAlleVilkårOppfylt()
             )
             beregnet.opprettBeregning(1.januar(2020), 31.desember(2020))
-            beregnet.status() shouldBe BEREGNET_INVILGET
+            beregnet.status() shouldBe BEREGNET_INNVILGET
             observer.oppdatertStatus shouldBe beregnet.status()
         }
 
@@ -411,7 +411,7 @@ internal class BehandlingTest {
         @Test
         fun `skal kunne beregne på nytt`() {
             beregnet.opprettBeregning(1.januar(2020), 31.desember(2020))
-            beregnet.status() shouldBe BEREGNET_INVILGET
+            beregnet.status() shouldBe BEREGNET_INNVILGET
         }
 
         @Test
@@ -455,7 +455,7 @@ internal class BehandlingTest {
             @Test
             fun `skal kunne beregne på nytt`() {
                 beregnet.opprettBeregning(1.januar(2020), 31.desember(2020))
-                beregnet.status() shouldBe BEREGNET_INVILGET
+                beregnet.status() shouldBe BEREGNET_INNVILGET
             }
 
             @Test
@@ -518,7 +518,7 @@ internal class BehandlingTest {
         @Test
         fun `skal kunne beregne på nytt`() {
             simulert.opprettBeregning(1.januar(2020), 31.desember(2020))
-            simulert.status() shouldBe BEREGNET_INVILGET
+            simulert.status() shouldBe BEREGNET_INNVILGET
         }
 
         @Test


### PR DESCRIPTION
Also add migration script to convert values in db to correct ones:

`BEREGNET` / `BEREGNET_INVILGET` -> `BEREGNET_INNVILGET`