### PR TITLE
Use specific role-based groups for authentication

### DIFF
--- a/common/src/main/kotlin/no/nav/su/se/bakover/common/Config.kt
+++ b/common/src/main/kotlin/no/nav/su/se/bakover/common/Config.kt
@@ -18,7 +18,6 @@ object Config {
     val azureWellKnownUrl = env["AZURE_WELLKNOWN_URL"] ?: "https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/v2.0/.well-known/openid-configuration"
     val azureClientId = env["AZURE_CLIENT_ID"] ?: "24ea4acb-547e-45de-a6d3-474bd8bed46e"
     val azureBackendCallbackUrl = env["BACKEND_CALLBACK_URL"] ?: "http://localhost:8080/callback"
-    val azureRequiredGroup = env["AZURE_REQUIRED_GROUP"] ?: "requiredgroup"
     val azureGroupAttestant = env["AZURE_GROUP_ATTESTANT"] ?: "d75164fa-39e6-4149-956e-8404bc9080b6"
     val azureGroupSaksbehandler = env["AZURE_GROUP_SAKSBEHANDLER"] ?: "0ba009c4-d148-4a51-b501-4b1cf906889d"
     val azureGroupVeileder = env["AZURE_GROUP_VEILEDER"] ?: "062d4814-8538-4f3a-bcb9-32821af7909a"

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Brukerrolle.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Brukerrolle.kt
@@ -15,5 +15,12 @@ enum class Brukerrolle(val type: String) {
                 Config.azureGroupVeileder -> Brukerrolle.Veileder
                 else -> null
             }
+
+        fun toAzureGroup(rolle: Brukerrolle) =
+            when (rolle) {
+                Brukerrolle.Attestant -> Config.azureGroupAttestant
+                Brukerrolle.Saksbehandler -> Config.azureGroupSaksbehandler
+                Brukerrolle.Veileder -> Config.azureGroupVeileder
+            }
     }
 }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/AuthenticationTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/AuthenticationTest.kt
@@ -14,6 +14,7 @@ import io.ktor.http.HttpStatusCode.Companion.Unauthorized
 import io.ktor.server.testing.handleRequest
 import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.common.Config
+import no.nav.su.se.bakover.domain.Brukerrolle
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -40,7 +41,7 @@ internal class AuthenticationTest {
         withTestApplication({
             testSusebakover()
         }) {
-            defaultRequest(Get, secureEndpoint)
+            defaultRequest(Get, secureEndpoint, listOf(Brukerrolle.Veileder))
         }.apply {
             assertEquals(OK, response.status())
         }
@@ -65,7 +66,7 @@ internal class AuthenticationTest {
             testSusebakover()
         }) {
             handleRequest(Get, secureEndpoint) {
-                addHeader(Authorization, Jwt.create(groups = listOf("WRONG_GROUP_UUID")))
+                addHeader(Authorization, Jwt.create(roller = emptyList()))
             }
         }.apply {
             assertEquals(Forbidden, response.status())
@@ -94,7 +95,11 @@ internal class AuthenticationTest {
             applog = environment.log as Logger
         }) {
             applog.apply { addAppender(appender) }
-            defaultRequest(Get, "/callback?code=code&state=state&session_state=session_state") {
+            defaultRequest(
+                Get,
+                "/callback?code=code&state=state&session_state=session_state",
+                listOf(Brukerrolle.Veileder)
+            ) {
             }
         }.apply {
             appender.list.forEach {
@@ -111,7 +116,7 @@ internal class AuthenticationTest {
         withTestApplication({
             testSusebakover()
         }) {
-            defaultRequest(Get, "auth/refresh") {
+            defaultRequest(Get, "auth/refresh", listOf(Brukerrolle.Veileder)) {
                 addHeader("refresh_token", "my.refresh.token")
             }
         }.apply {

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/Jwt.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/Jwt.kt
@@ -3,6 +3,7 @@ package no.nav.su.se.bakover.web
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import no.nav.su.se.bakover.common.Config
+import no.nav.su.se.bakover.domain.Brukerrolle
 import java.security.KeyPairGenerator
 import java.security.interfaces.RSAPrivateKey
 import java.security.interfaces.RSAPublicKey
@@ -13,7 +14,7 @@ object Jwt {
     val keys = generate()
     fun create(
         subject: String = "enSaksbehandler",
-        groups: List<String> = listOf(Config.azureRequiredGroup),
+        roller: List<Brukerrolle> = emptyList(),
         audience: String = Config.azureClientId,
         expiresAt: Date = Date.from(Instant.now().plusSeconds(3600)),
         algorithm: Algorithm = Algorithm.RSA256(keys.first, keys.second)
@@ -23,7 +24,7 @@ object Jwt {
             .withAudience(audience)
             .withKeyId("key-1234")
             .withSubject(subject)
-            .withArrayClaim("groups", groups.toTypedArray())
+            .withArrayClaim("groups", roller.map(Brukerrolle::toAzureGroup).toTypedArray())
             .withClaim("oid", subject + "oid")
             .withExpiresAt(expiresAt)
             .sign(algorithm)}"

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/RoutesTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/RoutesTest.kt
@@ -16,6 +16,7 @@ import io.ktor.server.testing.handleRequest
 import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.client.person.PdlFeil
 import no.nav.su.se.bakover.client.person.PersonOppslag
+import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.Person
 import no.nav.su.se.bakover.web.TestClientsBuilder.testClients
@@ -36,7 +37,7 @@ class RoutesTest {
         withTestApplication({
             testSusebakover()
         }) {
-            defaultRequest(Get, secureEndpoint)
+            defaultRequest(Get, secureEndpoint, listOf(Brukerrolle.Veileder))
         }.apply {
             assertEquals(OK, response.status())
             assertEquals(DEFAULT_CALL_ID, response.headers[XCorrelationId])
@@ -49,7 +50,7 @@ class RoutesTest {
             testSusebakover()
         }) {
             handleRequest(Get, secureEndpoint) {
-                addHeader(HttpHeaders.Authorization, Jwt.create())
+                addHeader(HttpHeaders.Authorization, Jwt.create(roller = listOf(Brukerrolle.Veileder)))
             }
         }.apply {
             assertEquals(OK, response.status())
@@ -69,7 +70,7 @@ class RoutesTest {
         }) {
             applog.apply { addAppender(appender) }
             handleRequest(Get, secureEndpoint) {
-                addHeader(HttpHeaders.Authorization, Jwt.create())
+                addHeader(HttpHeaders.Authorization, Jwt.create(roller = listOf(Brukerrolle.Veileder)))
             }
         }
         val logStatement = appender.list.first { it.message.contains("200 OK") }
@@ -93,7 +94,7 @@ class RoutesTest {
                 )
             )
         }) {
-            defaultRequest(Get, "$personPath/${FnrGenerator.random()}")
+            defaultRequest(Get, "$personPath/${FnrGenerator.random()}", listOf(Brukerrolle.Veileder))
         }.apply {
             assertEquals(InternalServerError, response.status())
             JSONAssert.assertEquals("""{"message":"Ukjent feil"}""", response.content, true)
@@ -105,7 +106,7 @@ class RoutesTest {
         withTestApplication({
             testSusebakover()
         }) {
-            defaultRequest(Get, "$personPath/${FnrGenerator.random()}")
+            defaultRequest(Get, "$personPath/${FnrGenerator.random()}", listOf(Brukerrolle.Veileder))
         }.apply {
             assertEquals(
                 "${ContentType.Application.Json}; charset=${Charsets.UTF_8}",

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/TestEnvironment.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/TestEnvironment.kt
@@ -15,10 +15,10 @@ import io.ktor.server.testing.TestApplicationEngine
 import io.ktor.server.testing.TestApplicationRequest
 import io.ktor.server.testing.handleRequest
 import no.nav.su.se.bakover.client.Clients
-import no.nav.su.se.bakover.common.Config
 import no.nav.su.se.bakover.database.DatabaseBuilder
 import no.nav.su.se.bakover.database.DatabaseRepos
 import no.nav.su.se.bakover.database.EmbeddedDatabase
+import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.service.ServiceBuilder
 import no.nav.su.se.bakover.service.Services
 import java.util.Base64
@@ -83,11 +83,12 @@ internal object JwkProviderStub : JwkProvider {
 fun TestApplicationEngine.defaultRequest(
     method: HttpMethod,
     uri: String,
+    roller: List<Brukerrolle>,
     setup: TestApplicationRequest.() -> Unit = {}
 ): TestApplicationCall {
     return handleRequest(method, uri) {
         addHeader(HttpHeaders.XCorrelationId, DEFAULT_CALL_ID)
-        addHeader(HttpHeaders.Authorization, Jwt.create())
+        addHeader(HttpHeaders.Authorization, Jwt.create(roller = roller))
         setup()
     }
 }
@@ -101,7 +102,7 @@ fun TestApplicationEngine.requestSomAttestant(
         addHeader(HttpHeaders.XCorrelationId, DEFAULT_CALL_ID)
         addHeader(
             HttpHeaders.Authorization,
-            Jwt.create(groups = listOf(Config.azureRequiredGroup, Config.azureGroupAttestant))
+            Jwt.create(roller = listOf(Brukerrolle.Attestant))
         )
         setup()
     }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/features/SuUserFeatureTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/features/SuUserFeatureTest.kt
@@ -8,6 +8,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.client.person.MicrosoftGraphApiOppslag
 import no.nav.su.se.bakover.client.person.MicrosoftGraphResponse
+import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.web.TestClientsBuilder.testClients
 import no.nav.su.se.bakover.web.defaultRequest
 import no.nav.su.se.bakover.web.testSusebakover
@@ -40,7 +41,7 @@ internal class SuUserFeatureTest {
                 )
             )
         }) {
-            defaultRequest(HttpMethod.Get, "/saker/${UUID.randomUUID()}").apply {
+            defaultRequest(HttpMethod.Get, "/saker/${UUID.randomUUID()}", listOf(Brukerrolle.Veileder)).apply {
                 this.suUserContext.user shouldBe response
                 this.suUserContext.getNAVIdent() shouldBe "heisann"
             }
@@ -62,7 +63,7 @@ internal class SuUserFeatureTest {
                 )
             )
         }) {
-            defaultRequest(HttpMethod.Get, "/saker/${UUID.randomUUID()}").apply {
+            defaultRequest(HttpMethod.Get, "/saker/${UUID.randomUUID()}", listOf(Brukerrolle.Veileder)).apply {
                 this.response.status() shouldBe HttpStatusCode.NotFound
             }
         }
@@ -83,7 +84,7 @@ internal class SuUserFeatureTest {
                 )
             )
         }) {
-            defaultRequest(HttpMethod.Get, "/me").apply {
+            defaultRequest(HttpMethod.Get, "/me", listOf(Brukerrolle.Veileder)).apply {
                 this.response.status() shouldBe HttpStatusCode.InternalServerError
                 shouldThrow<KallMotMicrosoftGraphApiFeilet> { suUserContext.user }
                 shouldThrow<KallMotMicrosoftGraphApiFeilet> { suUserContext.getNAVIdent() }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/InntektRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/InntektRoutesKtTest.kt
@@ -8,6 +8,7 @@ import io.ktor.server.testing.handleRequest
 import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.client.ClientResponse
 import no.nav.su.se.bakover.client.inntekt.InntektOppslag
+import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.web.TestClientsBuilder.testClients
 import no.nav.su.se.bakover.web.defaultRequest
@@ -39,7 +40,7 @@ internal class InntektRoutesKtTest {
         withTestApplication({
             testSusebakover()
         }) {
-            defaultRequest(Get, path)
+            defaultRequest(Get, path, listOf(Brukerrolle.Saksbehandler))
         }.apply {
             assertEquals(OK, response.status())
             assertEquals(ident, JSONObject(response.content!!).getJSONObject("ident").getString("identifikator"))
@@ -65,7 +66,7 @@ internal class InntektRoutesKtTest {
                 )
             )
         }) {
-            defaultRequest(Get, path)
+            defaultRequest(Get, path, listOf(Brukerrolle.Veileder))
         }.apply {
             assertEquals(InternalServerError, response.status())
             assertEquals(errorMessage, response.content!!)

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/PersonRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/PersonRoutesKtTest.kt
@@ -13,6 +13,7 @@ import no.nav.su.se.bakover.client.person.PdlFeil
 import no.nav.su.se.bakover.client.person.PersonOppslag
 import no.nav.su.se.bakover.client.stubs.person.PersonOppslagStub
 import no.nav.su.se.bakover.domain.AktørId
+import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.Person
 import no.nav.su.se.bakover.web.TestClientsBuilder.testClients
@@ -39,7 +40,7 @@ internal class PersonRoutesKtTest {
         withTestApplication({
             testSusebakover()
         }) {
-            defaultRequest(Get, "$personPath/qwertyuiopå")
+            defaultRequest(Get, "$personPath/qwertyuiopå", listOf(Brukerrolle.Veileder))
         }.apply {
             assertEquals(HttpStatusCode.BadRequest, response.status())
         }
@@ -87,7 +88,7 @@ internal class PersonRoutesKtTest {
         withTestApplication({
             testSusebakover(clients = testClients.copy(personOppslag = personoppslag(testIdent = testIdent)))
         }) {
-            defaultRequest(Get, "$personPath/$testIdent")
+            defaultRequest(Get, "$personPath/$testIdent", listOf(Brukerrolle.Veileder))
         }.apply {
             assertEquals(OK, response.status())
             JSONAssert.assertEquals(excpectedResponseJson, response.content!!, true)
@@ -101,7 +102,7 @@ internal class PersonRoutesKtTest {
         withTestApplication({
             testSusebakover(clients = testClients.copy(personOppslag = personoppslag(PdlFeil.Ukjent, null)))
         }) {
-            defaultRequest(Get, "$personPath/$testIdent")
+            defaultRequest(Get, "$personPath/$testIdent", listOf(Brukerrolle.Veileder))
         }.apply {
             response.status() shouldBe HttpStatusCode.InternalServerError
         }
@@ -114,7 +115,7 @@ internal class PersonRoutesKtTest {
         withTestApplication({
             testSusebakover(clients = testClients.copy(personOppslag = personoppslag(PdlFeil.FantIkkePerson, null)))
         }) {
-            defaultRequest(Get, "$personPath/$testIdent")
+            defaultRequest(Get, "$personPath/$testIdent", listOf(Brukerrolle.Veileder))
         }.apply {
             response.status() shouldBe NotFound
         }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/behandling/BehandlingRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/behandling/BehandlingRoutesKtTest.kt
@@ -17,7 +17,6 @@ import io.ktor.server.testing.setBody
 import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.client.person.MicrosoftGraphApiOppslag
 import no.nav.su.se.bakover.client.person.MicrosoftGraphResponse
-import no.nav.su.se.bakover.common.Config
 import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.deserialize
 import no.nav.su.se.bakover.common.januar
@@ -26,6 +25,7 @@ import no.nav.su.se.bakover.database.DatabaseBuilder
 import no.nav.su.se.bakover.database.EmbeddedDatabase
 import no.nav.su.se.bakover.domain.AktørId
 import no.nav.su.se.bakover.domain.Behandling
+import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.Saksbehandler
 import no.nav.su.se.bakover.domain.Søknad
@@ -74,7 +74,11 @@ internal class BehandlingRoutesKtTest {
             testSusebakover(services = services)
         }) {
             val objects = setup()
-            defaultRequest(HttpMethod.Get, "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}").apply {
+            defaultRequest(
+                HttpMethod.Get,
+                "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}",
+                listOf(Brukerrolle.Attestant)
+            ).apply {
                 objectMapper.readValue<BehandlingJson>(response.content!!).let {
                     it.id shouldBe objects.behandling.id.toString()
                     it.behandlingsinformasjon shouldNotBe null
@@ -103,7 +107,8 @@ internal class BehandlingRoutesKtTest {
             services.behandling.simuler(objects.behandling.id)
             defaultRequest(
                 HttpMethod.Post,
-                "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}/tilAttestering"
+                "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}/tilAttestering",
+                listOf(Brukerrolle.Saksbehandler)
             ) {
             }.apply {
                 response.status() shouldBe HttpStatusCode.OK
@@ -144,7 +149,8 @@ internal class BehandlingRoutesKtTest {
             services.behandling.simuler(objects.behandling.id)
             defaultRequest(
                 HttpMethod.Post,
-                "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}/tilAttestering"
+                "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}/tilAttestering",
+                listOf(Brukerrolle.Saksbehandler)
             ) {
             }.apply {
                 response.status() shouldBe HttpStatusCode.InternalServerError
@@ -168,7 +174,11 @@ internal class BehandlingRoutesKtTest {
                 extractBehandlingsinformasjon(objects.behandling).withAlleVilkårOppfylt()
             )
 
-            defaultRequest(HttpMethod.Post, "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}/beregn") {
+            defaultRequest(
+                HttpMethod.Post,
+                "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}/beregn",
+                listOf(Brukerrolle.Saksbehandler)
+            ) {
                 setBody(
                     """
                     {
@@ -205,7 +215,11 @@ internal class BehandlingRoutesKtTest {
                 extractBehandlingsinformasjon(objects.behandling).withAlleVilkårOppfylt()
             )
 
-            defaultRequest(HttpMethod.Post, "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}/beregn") {
+            defaultRequest(
+                HttpMethod.Post,
+                "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}/beregn",
+                listOf(Brukerrolle.Saksbehandler)
+            ) {
                 setBody(
                     """
                     {
@@ -262,7 +276,11 @@ internal class BehandlingRoutesKtTest {
                 extractBehandlingsinformasjon(objects.behandling).withAlleVilkårOppfylt()
             )
 
-            defaultRequest(HttpMethod.Post, "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}/beregn") {
+            defaultRequest(
+                HttpMethod.Post,
+                "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}/beregn",
+                listOf(Brukerrolle.Saksbehandler)
+            ) {
                 setBody(
                     """
                     {
@@ -301,25 +319,35 @@ internal class BehandlingRoutesKtTest {
             testSusebakover()
         }) {
             val objects = setup()
-            defaultRequest(HttpMethod.Post, "$sakPath/${objects.sak.id}/behandlinger/blabla/beregn") {}.apply {
+            defaultRequest(
+                HttpMethod.Post,
+                "$sakPath/${objects.sak.id}/behandlinger/blabla/beregn",
+                listOf(Brukerrolle.Saksbehandler)
+            ) {}.apply {
                 response.status() shouldBe HttpStatusCode.BadRequest
                 response.content shouldContain "ikke en gyldig UUID"
             }
             defaultRequest(
                 HttpMethod.Post,
-                "$sakPath/${objects.sak.id}/behandlinger/${UUID.randomUUID()}/beregn"
+                "$sakPath/${objects.sak.id}/behandlinger/${UUID.randomUUID()}/beregn",
+                listOf(Brukerrolle.Saksbehandler)
             ).apply {
                 response.status() shouldBe HttpStatusCode.NotFound
                 response.content shouldContain "Fant ikke behandling med behandlingId"
             }
             defaultRequest(
                 HttpMethod.Post,
-                "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}/beregn"
+                "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}/beregn",
+                listOf(Brukerrolle.Saksbehandler)
             ).apply {
                 response.status() shouldBe HttpStatusCode.BadRequest
                 response.content shouldContain "Ugyldig body"
             }
-            defaultRequest(HttpMethod.Post, "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}/beregn") {
+            defaultRequest(
+                HttpMethod.Post,
+                "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}/beregn",
+                listOf(Brukerrolle.Saksbehandler)
+            ) {
                 setBody(
                     """
                     {
@@ -342,7 +370,11 @@ internal class BehandlingRoutesKtTest {
 
             objects.behandling.oppdaterBehandlingsinformasjon(extractBehandlingsinformasjon(objects.behandling).withAlleVilkårOppfylt())
 
-            defaultRequest(HttpMethod.Post, "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}/beregn") {
+            defaultRequest(
+                HttpMethod.Post,
+                "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}/beregn",
+                listOf(Brukerrolle.Saksbehandler)
+            ) {
                 setBody(
                     """{
                            "fraOgMed":"$fom",
@@ -375,24 +407,34 @@ internal class BehandlingRoutesKtTest {
             testSusebakover()
         }) {
             val objects = setup()
-            defaultRequest(HttpMethod.Post, "$sakPath/missing/behandlinger/${objects.behandling.id}/simuler") {}.apply {
+            defaultRequest(
+                HttpMethod.Post,
+                "$sakPath/missing/behandlinger/${objects.behandling.id}/simuler",
+                listOf(Brukerrolle.Saksbehandler)
+            ) {}.apply {
                 response.status() shouldBe HttpStatusCode.BadRequest
                 response.content shouldContain "ikke en gyldig UUID"
             }
             defaultRequest(
                 HttpMethod.Post,
-                "$sakPath/${UUID.randomUUID()}/behandlinger/${objects.behandling.id}/simuler"
+                "$sakPath/${UUID.randomUUID()}/behandlinger/${objects.behandling.id}/simuler",
+                listOf(Brukerrolle.Saksbehandler)
             ).apply {
                 response.status() shouldBe HttpStatusCode.NotFound
                 response.content shouldContain "Ugyldig kombinasjon av sak og behandling"
             }
-            defaultRequest(HttpMethod.Post, "$sakPath/${objects.sak.id}/behandlinger/blabla/simuler") {}.apply {
+            defaultRequest(
+                HttpMethod.Post,
+                "$sakPath/${objects.sak.id}/behandlinger/blabla/simuler",
+                listOf(Brukerrolle.Saksbehandler)
+            ) {}.apply {
                 response.status() shouldBe HttpStatusCode.BadRequest
                 response.content shouldContain "ikke en gyldig UUID"
             }
             defaultRequest(
                 HttpMethod.Post,
-                "$sakPath/${objects.sak.id}/behandlinger/${UUID.randomUUID()}/simuler"
+                "$sakPath/${objects.sak.id}/behandlinger/${UUID.randomUUID()}/simuler",
+                listOf(Brukerrolle.Saksbehandler)
             ).apply {
                 response.status() shouldBe HttpStatusCode.NotFound
                 response.content shouldContain "Fant ikke behandling med behandlingId"
@@ -411,7 +453,8 @@ internal class BehandlingRoutesKtTest {
 
             defaultRequest(
                 HttpMethod.Post,
-                "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}/simuler"
+                "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}/simuler",
+                listOf(Brukerrolle.Saksbehandler)
             ) {}.apply {
                 response.status() shouldBe HttpStatusCode.OK
                 response.content shouldContain "utbetaling"
@@ -427,7 +470,11 @@ internal class BehandlingRoutesKtTest {
             val objects = setup()
             objects.behandling.status() shouldBe Behandling.BehandlingsStatus.OPPRETTET
 
-            defaultRequest(HttpMethod.Post, "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}/beregn") {
+            defaultRequest(
+                HttpMethod.Post,
+                "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}/beregn",
+                listOf(Brukerrolle.Saksbehandler)
+            ) {
                 setBody(
                     """
                     {
@@ -484,14 +531,16 @@ internal class BehandlingRoutesKtTest {
             withFerdigbehandletSakForBruker(navIdentSaksbehandler) {
                 defaultRequest(
                     HttpMethod.Patch,
-                    "$sakPath/rubbish/behandlinger/${it.behandling.id}/iverksett"
+                    "$sakPath/rubbish/behandlinger/${it.behandling.id}/iverksett",
+                    listOf(Brukerrolle.Saksbehandler)
                 ).apply {
                     response.status() shouldBe HttpStatusCode.Forbidden
                 }
 
                 defaultRequest(
                     HttpMethod.Patch,
-                    "$sakPath/${it.sak.id}/behandlinger/${UUID.randomUUID()}/iverksett"
+                    "$sakPath/${it.sak.id}/behandlinger/${UUID.randomUUID()}/iverksett",
+                    listOf(Brukerrolle.Saksbehandler)
                 ).apply {
                     response.status() shouldBe HttpStatusCode.Forbidden
                 }
@@ -537,7 +586,7 @@ internal class BehandlingRoutesKtTest {
                         HttpHeaders.Authorization,
                         Jwt.create(
                             subject = "random",
-                            groups = listOf(Config.azureRequiredGroup, Config.azureGroupAttestant)
+                            roller = listOf(Brukerrolle.Attestant)
                         )
                     )
                 }.apply {
@@ -600,7 +649,8 @@ internal class BehandlingRoutesKtTest {
             withFerdigbehandletSakForBruker(navIdentSaksbehandler) { objects ->
                 defaultRequest(
                     HttpMethod.Patch,
-                    "$sakPath/rubbish/behandlinger/${objects.behandling.id}/underkjenn"
+                    "$sakPath/rubbish/behandlinger/${objects.behandling.id}/underkjenn",
+                    listOf(Brukerrolle.Saksbehandler)
                 ).apply {
                     response.status() shouldBe HttpStatusCode.Forbidden
                 }
@@ -608,6 +658,7 @@ internal class BehandlingRoutesKtTest {
                 defaultRequest(
                     HttpMethod.Patch,
                     "$sakPath/${objects.sak.id}/behandlinger/rubbish/underkjenn",
+                    listOf(Brukerrolle.Saksbehandler)
                 ).apply {
                     response.status() shouldBe HttpStatusCode.Forbidden
                 }
@@ -615,6 +666,7 @@ internal class BehandlingRoutesKtTest {
                 defaultRequest(
                     HttpMethod.Patch,
                     "$sakPath/${objects.sak.id}/behandlinger/${objects.behandling.id}/underkjenn",
+                    listOf(Brukerrolle.Saksbehandler)
                 ).apply {
                     response.status() shouldBe HttpStatusCode.Forbidden
                 }
@@ -684,7 +736,7 @@ internal class BehandlingRoutesKtTest {
                         HttpHeaders.Authorization,
                         Jwt.create(
                             subject = "S123456",
-                            groups = listOf(Config.azureRequiredGroup, Config.azureGroupAttestant)
+                            roller = listOf(Brukerrolle.Attestant)
                         )
                     )
                     setBody(

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/me/MeRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/me/MeRoutesKtTest.kt
@@ -10,7 +10,6 @@ import io.ktor.server.testing.handleRequest
 import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.client.person.MicrosoftGraphApiOppslag
 import no.nav.su.se.bakover.client.person.MicrosoftGraphResponse
-import no.nav.su.se.bakover.common.Config
 import no.nav.su.se.bakover.common.deserialize
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.web.Jwt
@@ -52,7 +51,7 @@ internal class MeRoutesKtTest {
                     HttpHeaders.Authorization,
                     Jwt.create(
                         subject = "random",
-                        groups = listOf(Config.azureRequiredGroup, Config.azureGroupAttestant)
+                        roller = listOf(Brukerrolle.Attestant)
                     )
                 )
             }.apply {

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/sak/SakRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/sak/SakRoutesKtTest.kt
@@ -13,6 +13,7 @@ import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.database.DatabaseBuilder
 import no.nav.su.se.bakover.database.EmbeddedDatabase
+import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
@@ -42,7 +43,11 @@ internal class SakRoutesKtTest {
         ) {
             val opprettetSakId = repos.sak.opprettSak(Fnr(sakFnr01)).id
 
-            defaultRequest(Get, "$sakPath/$opprettetSakId").apply {
+            defaultRequest(
+                Get,
+                "$sakPath/$opprettetSakId",
+                listOf(Brukerrolle.Saksbehandler)
+            ).apply {
                 assertEquals(OK, response.status())
                 assertEquals(sakFnr01, JSONObject(response.content).getString("fnr"))
             }
@@ -60,7 +65,11 @@ internal class SakRoutesKtTest {
         ) {
             repos.sak.opprettSak(Fnr(sakFnr01))
 
-            defaultRequest(Get, "$sakPath/?fnr=$sakFnr01").apply {
+            defaultRequest(
+                Get,
+                "$sakPath/?fnr=$sakFnr01",
+                listOf(Brukerrolle.Saksbehandler)
+            ).apply {
                 assertEquals(OK, response.status())
                 assertEquals(sakFnr01, JSONObject(response.content).getString("fnr"))
             }
@@ -76,19 +85,35 @@ internal class SakRoutesKtTest {
                 }
                 )
         ) {
-            defaultRequest(Get, sakPath).apply {
+            defaultRequest(
+                Get,
+                sakPath,
+                listOf(Brukerrolle.Saksbehandler)
+            ).apply {
                 assertEquals(BadRequest, response.status(), "$sakPath gir 400 ved manglende fnr")
             }
 
-            defaultRequest(Get, "$sakPath?fnr=12341234123").apply {
+            defaultRequest(
+                Get,
+                "$sakPath?fnr=12341234123",
+                listOf(Brukerrolle.Saksbehandler)
+            ).apply {
                 assertEquals(NotFound, response.status(), "$sakPath?fnr= gir 404 ved ukjent fnr")
             }
 
-            defaultRequest(Get, "$sakPath/${UUID.randomUUID()}").apply {
+            defaultRequest(
+                Get,
+                "$sakPath/${UUID.randomUUID()}",
+                listOf(Brukerrolle.Saksbehandler)
+            ).apply {
                 assertEquals(NotFound, response.status(), "$sakPath/UUID gir 404 ved ikke-eksisterende sak-ID")
             }
 
-            defaultRequest(Get, "$sakPath/adad").apply {
+            defaultRequest(
+                Get,
+                "$sakPath/adad",
+                listOf(Brukerrolle.Saksbehandler)
+            ).apply {
                 assertEquals(BadRequest, response.status(), "$sakPath/UUID gir 400 ved ugyldig UUID")
             }
         }
@@ -103,7 +128,11 @@ internal class SakRoutesKtTest {
         withTestApplication({
             testSusebakover()
         }) {
-            defaultRequest(HttpMethod.Post, "$sakPath/${nySak.id}/behandlinger") {
+            defaultRequest(
+                HttpMethod.Post,
+                "$sakPath/${nySak.id}/behandlinger",
+                listOf(Brukerrolle.Saksbehandler)
+            ) {
                 setBody("""{ "soknadId": "${nySøknad.id}" }""")
             }.apply {
                 response.status() shouldBe HttpStatusCode.Created

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutesKtTest.kt
@@ -30,6 +30,7 @@ import no.nav.su.se.bakover.client.stubs.person.PersonOppslagStub
 import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.database.DatabaseBuilder
 import no.nav.su.se.bakover.database.EmbeddedDatabase
+import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.SøknadInnhold
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
@@ -69,7 +70,8 @@ internal class SøknadRoutesKtTest {
         }) {
             val createResponse = defaultRequest(
                 Post,
-                søknadPath
+                søknadPath,
+                listOf(Brukerrolle.Veileder)
             ) {
                 addHeader(ContentType, Json.toString())
                 setBody(soknadJson)
@@ -91,7 +93,7 @@ internal class SøknadRoutesKtTest {
         withTestApplication({
             testSusebakover()
         }) {
-            defaultRequest(Post, søknadPath) {
+            defaultRequest(Post, søknadPath, listOf(Brukerrolle.Veileder)) {
                 addHeader(ContentType, Json.toString())
                 setBody(soknadJson)
             }.apply {
@@ -99,7 +101,7 @@ internal class SøknadRoutesKtTest {
                 sakNr = objectMapper.readValue<SakJson>(response.content!!).id
             }
 
-            defaultRequest(Get, "$sakPath/$sakNr").apply {
+            defaultRequest(Get, "$sakPath/$sakNr", listOf(Brukerrolle.Veileder)).apply {
                 assertEquals(OK, response.status())
                 val sakJson = objectMapper.readValue<SakJson>(response.content!!)
                 sakJson.søknader.first().søknadInnhold.personopplysninger.fnr shouldMatch fnr.toString()
@@ -151,12 +153,13 @@ internal class SøknadRoutesKtTest {
         withTestApplication({
             testSusebakover(
                 clients = clients,
-                services = services
+                services = services,
             )
         }) {
             defaultRequest(
                 Post,
-                søknadPath
+                søknadPath,
+                listOf(Brukerrolle.Veileder)
             ) {
                 addHeader(ContentType, Json.toString())
                 setBody(soknadJson)

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/utbetaling/stans/StansUtbetalingRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/utbetaling/stans/StansUtbetalingRoutesKtTest.kt
@@ -16,6 +16,7 @@ import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.database.DatabaseRepos
 import no.nav.su.se.bakover.database.sak.SakRepo
+import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.oppdrag.Oppdrag
@@ -73,7 +74,11 @@ internal class StansUtbetalingRoutesKtTest {
                 )
             )
         }) {
-            defaultRequest(HttpMethod.Post, "$sakPath/$sakId/utbetalinger/stans") {
+            defaultRequest(
+                HttpMethod.Post,
+                "$sakPath/$sakId/utbetalinger/stans",
+                listOf(Brukerrolle.Saksbehandler)
+            ) {
             }.apply {
                 response.status() shouldBe HttpStatusCode.InternalServerError
                 response.content shouldContain "Kunne ikke stanse utbetalinger for sak med id $sakId"
@@ -111,7 +116,11 @@ internal class StansUtbetalingRoutesKtTest {
                 )
             )
         }) {
-            defaultRequest(HttpMethod.Post, "$sakPath/$sakId/utbetalinger/stans") {
+            defaultRequest(
+                HttpMethod.Post,
+                "$sakPath/$sakId/utbetalinger/stans",
+                listOf(Brukerrolle.Saksbehandler)
+            ) {
             }.apply {
                 response.status() shouldBe HttpStatusCode.OK
                 objectMapper.readValue<SakJson>(response.content!!) shouldBe sak.toJson()

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/utbetaling/start/StartUtbetalingRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/utbetaling/start/StartUtbetalingRoutesKtTest.kt
@@ -13,6 +13,7 @@ import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.objectMapper
+import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.oppdrag.Oppdrag
@@ -55,7 +56,11 @@ internal class StartUtbetalingRoutesKtTest {
                 )
             )
         }) {
-            defaultRequest(HttpMethod.Post, "$sakPath/$sakId/utbetalinger/gjenoppta") {
+            defaultRequest(
+                HttpMethod.Post,
+                "$sakPath/$sakId/utbetalinger/gjenoppta",
+                listOf(Brukerrolle.Saksbehandler)
+            ) {
             }.apply {
                 response.status() shouldBe HttpStatusCode.NotFound
                 response.content shouldContain "Fant ikke sak"
@@ -75,7 +80,11 @@ internal class StartUtbetalingRoutesKtTest {
                 )
             )
         }) {
-            defaultRequest(HttpMethod.Post, "$sakPath/$sakId/utbetalinger/gjenoppta") {
+            defaultRequest(
+                HttpMethod.Post,
+                "$sakPath/$sakId/utbetalinger/gjenoppta",
+                listOf(Brukerrolle.Saksbehandler)
+            ) {
             }.apply {
                 response.status() shouldBe HttpStatusCode.BadRequest
                 response.content shouldContain "Ingen utbetalinger"
@@ -95,7 +104,11 @@ internal class StartUtbetalingRoutesKtTest {
                 )
             )
         }) {
-            defaultRequest(HttpMethod.Post, "$sakPath/$sakId/utbetalinger/gjenoppta") {
+            defaultRequest(
+                HttpMethod.Post,
+                "$sakPath/$sakId/utbetalinger/gjenoppta",
+                listOf(Brukerrolle.Saksbehandler)
+            ) {
             }.apply {
                 response.status() shouldBe HttpStatusCode.BadRequest
                 response.content shouldContain "Siste utbetaling er ikke en stans"
@@ -115,7 +128,11 @@ internal class StartUtbetalingRoutesKtTest {
                 )
             )
         }) {
-            defaultRequest(HttpMethod.Post, "$sakPath/$sakId/utbetalinger/gjenoppta") {
+            defaultRequest(
+                HttpMethod.Post,
+                "$sakPath/$sakId/utbetalinger/gjenoppta",
+                listOf(Brukerrolle.Saksbehandler)
+            ) {
             }.apply {
                 response.status() shouldBe HttpStatusCode.InternalServerError
                 response.content shouldContain "Simulering feilet"
@@ -135,7 +152,11 @@ internal class StartUtbetalingRoutesKtTest {
                 )
             )
         }) {
-            defaultRequest(HttpMethod.Post, "$sakPath/$sakId/utbetalinger/gjenoppta") {
+            defaultRequest(
+                HttpMethod.Post,
+                "$sakPath/$sakId/utbetalinger/gjenoppta",
+                listOf(Brukerrolle.Saksbehandler)
+            ) {
             }.apply {
                 response.status() shouldBe HttpStatusCode.InternalServerError
                 response.content shouldContain "Oversendelse til oppdrag feilet"
@@ -175,7 +196,11 @@ internal class StartUtbetalingRoutesKtTest {
                 )
             )
         }) {
-            defaultRequest(HttpMethod.Post, "$sakPath/$sakId/utbetalinger/gjenoppta") {
+            defaultRequest(
+                HttpMethod.Post,
+                "$sakPath/$sakId/utbetalinger/gjenoppta",
+                listOf(Brukerrolle.Saksbehandler)
+            ) {
             }.apply {
                 response.status() shouldBe HttpStatusCode.OK
                 objectMapper.readValue<SakJson>(response.content!!) shouldBe sak.toJson()


### PR DESCRIPTION
This removes the need for the general "SU role", since we use the specific
roles (veileder, saksbehandler, attestant) more actively. We could probably now
remove the general role from Vault.

Do note that we don't have proper authorization on routes in place yet at this
point. Implementing this should be the next step.