### PR TITLE
Henter kontaktinfo fra KRR via Dkif

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -40,7 +40,7 @@ jobs:
             ORG_GRADLE_PROJECT_githubUser: x-access-token
             ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
         - name: Build and publish Docker image
-          if: github.ref == 'refs/heads/branch_name'
+          if: github.ref == 'refs/heads/BRANCH_NAME'
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           run: |
@@ -52,7 +52,7 @@ jobs:
       name: Deploy specific branch-name to dev
       needs: build
       runs-on: ubuntu-latest
-      if: github.ref == 'refs/heads/branch_name'
+      if: github.ref == 'refs/heads/BRANCH_NAME'
       steps:
         - uses: actions/checkout@v2
         - uses: nais/deploy/actions/deploy@v1

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/ClientsBuilder.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/ClientsBuilder.kt
@@ -2,7 +2,7 @@ package no.nav.su.se.bakover.client
 
 import com.github.kittinunf.fuel.core.FuelManager
 import no.nav.su.se.bakover.client.azure.OAuth
-import no.nav.su.se.bakover.client.dkif.Dkif
+import no.nav.su.se.bakover.client.dkif.DigitalKontaktinformasjon
 import no.nav.su.se.bakover.client.dokarkiv.DokArkiv
 import no.nav.su.se.bakover.client.dokdistfordeling.DokDistFordeling
 import no.nav.su.se.bakover.client.inntekt.InntektOppslag
@@ -34,7 +34,7 @@ data class Clients(
     val dokDistFordeling: DokDistFordeling,
     val avstemmingPublisher: AvstemmingPublisher,
     val microsoftGraphApiClient: MicrosoftGraphApiOppslag,
-    val dkif: Dkif,
+    val digitalKontaktinformasjon: DigitalKontaktinformasjon,
 ) {
     init {
         // https://fuel.gitbook.io/documentation/core/fuel

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/ClientsBuilder.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/ClientsBuilder.kt
@@ -2,6 +2,7 @@ package no.nav.su.se.bakover.client
 
 import com.github.kittinunf.fuel.core.FuelManager
 import no.nav.su.se.bakover.client.azure.OAuth
+import no.nav.su.se.bakover.client.dkif.Dkif
 import no.nav.su.se.bakover.client.dokarkiv.DokArkiv
 import no.nav.su.se.bakover.client.dokdistfordeling.DokDistFordeling
 import no.nav.su.se.bakover.client.inntekt.InntektOppslag
@@ -33,6 +34,7 @@ data class Clients(
     val dokDistFordeling: DokDistFordeling,
     val avstemmingPublisher: AvstemmingPublisher,
     val microsoftGraphApiClient: MicrosoftGraphApiOppslag,
+    val dkif: Dkif,
 ) {
     init {
         // https://fuel.gitbook.io/documentation/core/fuel

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/ProdClientsBuilder.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/ProdClientsBuilder.kt
@@ -77,7 +77,7 @@ data class ProdClientsBuilder(internal val jmsContext: JMSContext) : ClientsBuil
                 }
             ),
             microsoftGraphApiClient = MicrosoftGraphApiClient(oAuth),
-            dkif = dkif,
+            digitalKontaktinformasjon = dkif,
         )
     }
 }

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/ProdClientsBuilder.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/ProdClientsBuilder.kt
@@ -1,6 +1,7 @@
 package no.nav.su.se.bakover.client
 
 import no.nav.su.se.bakover.client.azure.AzureClient
+import no.nav.su.se.bakover.client.dkif.DkifClient
 import no.nav.su.se.bakover.client.dokarkiv.DokArkivClient
 import no.nav.su.se.bakover.client.dokdistfordeling.DokDistFordelingClient
 import no.nav.su.se.bakover.client.inntekt.SuInntektClient
@@ -28,7 +29,8 @@ data class ProdClientsBuilder(internal val jmsContext: JMSContext) : ClientsBuil
         val oAuth = AzureClient(Config.azureClientId, Config.azureClientSecret, Config.azureWellKnownUrl)
         val kodeverk = KodeverkHttpClient(Config.kodeverkUrl, consumerId)
         val tokenOppslag = StsClient(Config.stsUrl, Config.serviceUser.username, Config.serviceUser.password)
-        val personOppslag = PersonClient(kodeverk, SkjermingClient(Config.skjermingUrl), Config.pdlUrl, tokenOppslag)
+        val dkif = DkifClient(Config.dkifUrl, tokenOppslag, consumerId)
+        val personOppslag = PersonClient(Config.pdlUrl, kodeverk, SkjermingClient(Config.skjermingUrl), dkif, tokenOppslag)
 
         return Clients(
             oauth = oAuth,
@@ -75,6 +77,7 @@ data class ProdClientsBuilder(internal val jmsContext: JMSContext) : ClientsBuil
                 }
             ),
             microsoftGraphApiClient = MicrosoftGraphApiClient(oAuth),
+            dkif = dkif,
         )
     }
 }

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/StubClientsBuilder.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/StubClientsBuilder.kt
@@ -1,6 +1,7 @@
 package no.nav.su.se.bakover.client
 
 import no.nav.su.se.bakover.client.azure.AzureClient
+import no.nav.su.se.bakover.client.dkif.Dkif
 import no.nav.su.se.bakover.client.dokarkiv.DokArkiv
 import no.nav.su.se.bakover.client.dokdistfordeling.DokDistFordelingClient
 import no.nav.su.se.bakover.client.inntekt.InntektOppslag
@@ -10,6 +11,7 @@ import no.nav.su.se.bakover.client.pdf.PdfGenerator
 import no.nav.su.se.bakover.client.person.MicrosoftGraphApiClient
 import no.nav.su.se.bakover.client.person.PersonOppslag
 import no.nav.su.se.bakover.client.sts.TokenOppslag
+import no.nav.su.se.bakover.client.stubs.dkif.DkifClientStub
 import no.nav.su.se.bakover.client.stubs.dokarkiv.DokArkivStub
 import no.nav.su.se.bakover.client.stubs.dokdistfordeling.DokDistFordelingStub
 import no.nav.su.se.bakover.client.stubs.inntekt.InntektOppslagStub
@@ -51,6 +53,7 @@ object StubClientsBuilder : ClientsBuilder {
             dokDistFordeling = DokDistFordelingStub.also { log.warn("********** Using stub for ${DokDistFordelingClient::class.java} **********") },
             avstemmingPublisher = AvstemmingStub.also { log.warn("********** Using stub for ${AvstemmingPublisher::class.java} **********") },
             microsoftGraphApiClient = MicrosoftGraphApiClient(azureClient),
+            dkif = DkifClientStub.also { log.warn("********** Using stub for ${Dkif::class.java} **********") }
         )
     }
 }

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/StubClientsBuilder.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/StubClientsBuilder.kt
@@ -1,7 +1,7 @@
 package no.nav.su.se.bakover.client
 
 import no.nav.su.se.bakover.client.azure.AzureClient
-import no.nav.su.se.bakover.client.dkif.Dkif
+import no.nav.su.se.bakover.client.dkif.DigitalKontaktinformasjon
 import no.nav.su.se.bakover.client.dokarkiv.DokArkiv
 import no.nav.su.se.bakover.client.dokdistfordeling.DokDistFordelingClient
 import no.nav.su.se.bakover.client.inntekt.InntektOppslag
@@ -53,7 +53,7 @@ object StubClientsBuilder : ClientsBuilder {
             dokDistFordeling = DokDistFordelingStub.also { log.warn("********** Using stub for ${DokDistFordelingClient::class.java} **********") },
             avstemmingPublisher = AvstemmingStub.also { log.warn("********** Using stub for ${AvstemmingPublisher::class.java} **********") },
             microsoftGraphApiClient = MicrosoftGraphApiClient(azureClient),
-            dkif = DkifClientStub.also { log.warn("********** Using stub for ${Dkif::class.java} **********") }
+            digitalKontaktinformasjon = DkifClientStub.also { log.warn("********** Using stub for ${DigitalKontaktinformasjon::class.java} **********") }
         )
     }
 }

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/dkif/DigitalKontaktinformasjon.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/dkif/DigitalKontaktinformasjon.kt
@@ -1,0 +1,10 @@
+package no.nav.su.se.bakover.client.dkif
+
+import arrow.core.Either
+import no.nav.su.se.bakover.domain.Fnr
+
+interface DigitalKontaktinformasjon {
+    fun hentKontaktinformasjon(fnr: Fnr): Either<KunneIkkeHenteKontaktinformasjon, Kontaktinformasjon>
+
+    object KunneIkkeHenteKontaktinformasjon
+}

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/dkif/Dkif.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/dkif/Dkif.kt
@@ -1,0 +1,9 @@
+package no.nav.su.se.bakover.client.dkif
+
+import arrow.core.Either
+import no.nav.su.se.bakover.client.ClientError
+import no.nav.su.se.bakover.domain.Fnr
+
+interface Dkif {
+    fun hentKontaktinformasjon(fnr: Fnr) : Either<ClientError, Kontaktinformasjon>
+}

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/dkif/Dkif.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/dkif/Dkif.kt
@@ -5,5 +5,5 @@ import no.nav.su.se.bakover.client.ClientError
 import no.nav.su.se.bakover.domain.Fnr
 
 interface Dkif {
-    fun hentKontaktinformasjon(fnr: Fnr) : Either<ClientError, Kontaktinformasjon>
+    fun hentKontaktinformasjon(fnr: Fnr): Either<ClientError, Kontaktinformasjon>
 }

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/dkif/Dkif.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/dkif/Dkif.kt
@@ -1,9 +1,0 @@
-package no.nav.su.se.bakover.client.dkif
-
-import arrow.core.Either
-import no.nav.su.se.bakover.client.ClientError
-import no.nav.su.se.bakover.domain.Fnr
-
-interface Dkif {
-    fun hentKontaktinformasjon(fnr: Fnr): Either<ClientError, Kontaktinformasjon>
-}

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/dkif/DkifClient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/dkif/DkifClient.kt
@@ -3,45 +3,70 @@ package no.nav.su.se.bakover.client.dkif
 import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.github.kittinunf.fuel.core.extensions.authentication
 import com.github.kittinunf.fuel.httpGet
 import no.nav.su.se.bakover.client.ClientError
 import no.nav.su.se.bakover.client.sts.TokenOppslag
+import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.domain.Fnr
-import org.json.JSONObject
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 
 internal const val dkifPath = "/api/v1/personer/kontaktinformasjon"
 
-class DkifClient(val baseUrl: String, val tokenOppslag: TokenOppslag) : Dkif {
+class DkifClient(val baseUrl: String, val tokenOppslag: TokenOppslag, val consumerId: String) : Dkif {
     private val log = LoggerFactory.getLogger(this::class.java)
 
     override fun hentKontaktinformasjon(fnr: Fnr): Either<ClientError, Kontaktinformasjon> {
         val (_, response, result) = "$baseUrl$dkifPath".httpGet()
             .authentication().bearer(tokenOppslag.token())
-            .header("Content-Type", "application/json")
             .header("Accept", "application/json")
-            .header("X-Correlation-ID", MDC.get("X-Correlation-ID"))
+            .header("Nav-Consumer-Id", consumerId)
+            .header("Nav-Call-Id", MDC.get("X-Correlation-ID"))
             .header("Nav-Personidenter", listOf(fnr.toString())).responseString()
 
         return result.fold(
             { json ->
-                JSONObject(json)?.let {
+                val resultat: DkifResultat = objectMapper.readValue(json)
+                val kontaktinfo: DkifKontaktinfo? = resultat.kontaktinfo?.get(fnr.fnr)
+
+                if (kontaktinfo != null) {
                     Kontaktinformasjon(
-                        epostadresse = it.optString("epostadresse"),
-                        mobiltelefonnummer = it.optString("mobiltelefonnummer"),
-                        reservert = it.optBoolean("reservert"),
-                        kanVarsles = it.optBoolean("kanVarsles"),
-                        spraak = it.optString("spraak")
+                        epostadresse = kontaktinfo.epostadresse,
+                        mobiltelefonnummer = kontaktinfo.mobiltelefonnummer,
+                        reservert = kontaktinfo.reservert,
+                        kanVarsles = kontaktinfo.kanVarsles,
+                        språk = kontaktinfo.spraak
                     ).right()
+                } else {
+                    val errorMessage = "Feil i kontaktinfo: ${resultat.feil?.get(fnr.fnr)?.melding ?: "Ukjent"}"
+                    log.error(errorMessage)
+                    return ClientError(500, errorMessage).left()
                 }
             },
             {
                 val errorMessage = "Feil ved henting av digital kontaktinformasjon"
-                log.error(errorMessage)
+                log.error("$errorMessage. Status=${response.statusCode} Body=${String(response.data)}", it)
                 ClientError(response.statusCode, errorMessage).left()
             }
         )
     }
 }
+
+private data class DkifResultat(
+    val feil: Map<String, DkifFeil>?,
+    val kontaktinfo: Map<String, DkifKontaktinfo>?
+)
+
+private data class DkifFeil(
+    val melding: String
+)
+
+class DkifKontaktinfo(
+    val reservert: Boolean,
+    val kanVarsles: Boolean,
+    val epostadresse: String?,
+    val mobiltelefonnummer: String?,
+    val spraak: String?
+)

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/dkif/DkifClient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/dkif/DkifClient.kt
@@ -1,0 +1,47 @@
+package no.nav.su.se.bakover.client.dkif
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import com.github.kittinunf.fuel.core.extensions.authentication
+import com.github.kittinunf.fuel.httpGet
+import no.nav.su.se.bakover.client.ClientError
+import no.nav.su.se.bakover.client.sts.TokenOppslag
+import no.nav.su.se.bakover.domain.Fnr
+import org.json.JSONObject
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+
+internal const val dkifPath = "/api/v1/personer/kontaktinformasjon"
+
+class DkifClient(val baseUrl: String, val tokenOppslag: TokenOppslag) : Dkif {
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    override fun hentKontaktinformasjon(fnr: Fnr): Either<ClientError, Kontaktinformasjon> {
+        val (_, response, result) = "$baseUrl$dkifPath".httpGet()
+            .authentication().bearer(tokenOppslag.token())
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .header("X-Correlation-ID", MDC.get("X-Correlation-ID"))
+            .header("Nav-Personidenter", listOf(fnr.toString())).responseString()
+
+        return result.fold(
+            { json ->
+                JSONObject(json)?.let {
+                    Kontaktinformasjon(
+                        epostadresse = it.optString("epostadresse"),
+                        mobiltelefonnummer = it.optString("mobiltelefonnummer"),
+                        reservert = it.optBoolean("reservert"),
+                        kanVarsles = it.optBoolean("kanVarsles"),
+                        spraak = it.optString("spraak")
+                    ).right()
+                }
+            },
+            {
+                val errorMessage = "Feil ved henting av digital kontaktinformasjon"
+                log.error(errorMessage)
+                ClientError(response.statusCode, errorMessage).left()
+            }
+        )
+    }
+}

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/dkif/Kontaktinformasjon.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/dkif/Kontaktinformasjon.kt
@@ -1,0 +1,11 @@
+package no.nav.su.se.bakover.client.dkif
+
+
+
+data class Kontaktinformasjon(
+    val epostadresse: String?,
+    val mobiltelefonnummer: String?,
+    val reservert: Boolean,
+    val kanVarsles: Boolean,
+    val spraak: String?, // "nb"
+)

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/dkif/Kontaktinformasjon.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/dkif/Kontaktinformasjon.kt
@@ -1,11 +1,9 @@
 package no.nav.su.se.bakover.client.dkif
 
-
-
 data class Kontaktinformasjon(
     val epostadresse: String?,
     val mobiltelefonnummer: String?,
     val reservert: Boolean,
     val kanVarsles: Boolean,
-    val spraak: String?, // "nb"
+    val språk: String?, // "nb"
 )

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/person/PersonClient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/person/PersonClient.kt
@@ -1,8 +1,7 @@
 package no.nav.su.se.bakover.client.person
 
 import arrow.core.Either
-import arrow.core.orNull
-import no.nav.su.se.bakover.client.dkif.Dkif
+import no.nav.su.se.bakover.client.dkif.DigitalKontaktinformasjon
 import no.nav.su.se.bakover.client.dkif.Kontaktinformasjon
 import no.nav.su.se.bakover.client.kodeverk.Kodeverk
 import no.nav.su.se.bakover.client.skjerming.Skjerming
@@ -16,7 +15,7 @@ class PersonClient(
     pdlUrl: String,
     private val kodeverk: Kodeverk,
     private val skjerming: Skjerming,
-    private val dkif: Dkif,
+    private val digitalKontaktinformasjon: DigitalKontaktinformasjon,
     tokenOppslag: TokenOppslag
 ) : PersonOppslag {
     private val pdlClient = PdlClient(pdlUrl, tokenOppslag)
@@ -67,13 +66,15 @@ class PersonClient(
     )
 
     private fun kontaktinfo(fnr: Fnr): Person.Kontaktinfo? {
-        val dkifInfo: Kontaktinformasjon? = dkif.hentKontaktinformasjon(fnr).orNull()
-        return if (dkifInfo == null) null else Person.Kontaktinfo(
-            dkifInfo.epostadresse,
-            dkifInfo.mobiltelefonnummer,
-            dkifInfo.reservert,
-            dkifInfo.kanVarsles,
-            dkifInfo.språk
-        )
+        val dkifInfo: Kontaktinformasjon? = digitalKontaktinformasjon.hentKontaktinformasjon(fnr).orNull()
+        return dkifInfo?.let {
+            Person.Kontaktinfo(
+                it.epostadresse,
+                it.mobiltelefonnummer,
+                it.reservert,
+                it.kanVarsles,
+                it.språk
+            )
+        }
     }
 }

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/dkif/DkifClientStub.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/dkif/DkifClientStub.kt
@@ -1,0 +1,20 @@
+package no.nav.su.se.bakover.client.stubs.dkif
+
+import arrow.core.Either
+import arrow.core.right
+import no.nav.su.se.bakover.client.ClientError
+import no.nav.su.se.bakover.client.dkif.Dkif
+import no.nav.su.se.bakover.client.dkif.Kontaktinformasjon
+import no.nav.su.se.bakover.domain.Fnr
+
+object DkifClientStub : Dkif {
+    override fun hentKontaktinformasjon(fnr: Fnr): Either<ClientError, Kontaktinformasjon> {
+        return Kontaktinformasjon(
+            epostadresse = "mail@epost.com",
+            mobiltelefonnummer = "90909090",
+            reservert = false,
+            kanVarsles = true,
+            språk = "nb"
+        ).right()
+    }
+}

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/dkif/DkifClientStub.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/dkif/DkifClientStub.kt
@@ -2,13 +2,12 @@ package no.nav.su.se.bakover.client.stubs.dkif
 
 import arrow.core.Either
 import arrow.core.right
-import no.nav.su.se.bakover.client.ClientError
-import no.nav.su.se.bakover.client.dkif.Dkif
+import no.nav.su.se.bakover.client.dkif.DigitalKontaktinformasjon
 import no.nav.su.se.bakover.client.dkif.Kontaktinformasjon
 import no.nav.su.se.bakover.domain.Fnr
 
-object DkifClientStub : Dkif {
-    override fun hentKontaktinformasjon(fnr: Fnr): Either<ClientError, Kontaktinformasjon> {
+object DkifClientStub : DigitalKontaktinformasjon {
+    override fun hentKontaktinformasjon(fnr: Fnr): Either<DigitalKontaktinformasjon.KunneIkkeHenteKontaktinformasjon, Kontaktinformasjon> {
         return Kontaktinformasjon(
             epostadresse = "mail@epost.com",
             mobiltelefonnummer = "90909090",

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/person/PersonOppslagStub.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/person/PersonOppslagStub.kt
@@ -31,7 +31,14 @@ object PersonOppslagStub :
         statsborgerskap = "NOR",
         kjønn = "MANN",
         adressebeskyttelse = null,
-        skjermet = false
+        skjermet = false,
+        kontaktinfo = Person.Kontaktinfo(
+            epostadresse = "mail@epost.com",
+            mobiltelefonnummer = "90909090",
+            reservert = false,
+            kanVarsles = true,
+            språk = "nb"
+        )
     ).right()
 
     override fun aktørId(fnr: Fnr) = AktørId("2437280977705").right()

--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/dkif/DkifClientTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/dkif/DkifClientTest.kt
@@ -1,0 +1,85 @@
+package no.nav.su.se.bakover.client.dkif
+
+import arrow.core.left
+import arrow.core.right
+import com.github.tomakehurst.wiremock.client.MappingBuilder
+import com.github.tomakehurst.wiremock.client.WireMock
+import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.client.ClientError
+import no.nav.su.se.bakover.client.WiremockBase
+import no.nav.su.se.bakover.client.stubs.sts.TokenOppslagStub
+import no.nav.su.se.bakover.domain.Fnr
+import org.junit.jupiter.api.Test
+
+class DkifClientTest : WiremockBase {
+    private val fødselsnummer = "10109900100"
+    private val consumerId = "consumerId"
+
+    private val client = DkifClient(WiremockBase.wireMockServer.baseUrl(), TokenOppslagStub, consumerId)
+    private val fnr: Fnr = Fnr(fødselsnummer)
+
+    @Test
+    fun `should parse kontaktinfo correctly`() {
+        WiremockBase.wireMockServer.stubFor(
+            wiremockBuilder
+                .willReturn(
+                    WireMock.okJson(
+                        """
+                        {
+                          "kontaktinfo": {
+                            "$fødselsnummer": {
+                              "personident": "$fødselsnummer",
+                              "kanVarsles": false,
+                              "reservert": false,
+                              "epostadresse": "noreply@nav.no",
+                              "mobiltelefonnummer": "11111111",
+                              "spraak": "nb"
+                            }
+                          },
+                          "feil": {}
+                        }
+                        """.trimIndent()
+                    )
+                )
+        )
+        client.hentKontaktinformasjon(fnr) shouldBe Kontaktinformasjon(
+            epostadresse = "noreply@nav.no",
+            mobiltelefonnummer = "11111111",
+            reservert = false,
+            kanVarsles = false,
+            språk = "nb"
+        ).right()
+    }
+
+    @Test
+    fun `should return error if response contains feil`() {
+        WiremockBase.wireMockServer.stubFor(
+            wiremockBuilder
+                .willReturn(
+                    WireMock.okJson(
+                        """
+                        {
+                          "feil": {
+                            "$fødselsnummer": {
+                              "melding": "Et eller annet gikk galt"
+                            }
+                          },
+                          "kontaktinfo": {}
+                        }
+                        """.trimIndent()
+                    )
+                )
+        )
+        client.hentKontaktinformasjon(fnr) shouldBe ClientError(
+            500,
+            "Feil i kontaktinfo: Et eller annet gikk galt"
+        ).left()
+    }
+
+    private val wiremockBuilder: MappingBuilder = WireMock.get(WireMock.urlPathEqualTo(dkifPath))
+        .withHeader("Authorization", WireMock.equalTo("Bearer token"))
+        .withHeader("Accept", WireMock.equalTo("application/json"))
+        .withHeader("Nav-Consumer-Id", WireMock.equalTo(consumerId))
+        .withHeader("Nav-Call-Id", WireMock.equalTo("correlationId"))
+        .withHeader("Nav-Personidenter", WireMock.equalTo(fødselsnummer))
+}

--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/dkif/DkifClientTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/dkif/DkifClientTest.kt
@@ -5,7 +5,6 @@ import arrow.core.right
 import com.github.tomakehurst.wiremock.client.MappingBuilder
 import com.github.tomakehurst.wiremock.client.WireMock
 import io.kotest.matchers.shouldBe
-import no.nav.su.se.bakover.client.ClientError
 import no.nav.su.se.bakover.client.WiremockBase
 import no.nav.su.se.bakover.client.stubs.sts.TokenOppslagStub
 import no.nav.su.se.bakover.domain.Fnr
@@ -70,10 +69,7 @@ class DkifClientTest : WiremockBase {
                     )
                 )
         )
-        client.hentKontaktinformasjon(fnr) shouldBe ClientError(
-            500,
-            "Feil i kontaktinfo: Et eller annet gikk galt"
-        ).left()
+        client.hentKontaktinformasjon(fnr) shouldBe DigitalKontaktinformasjon.KunneIkkeHenteKontaktinformasjon.left()
     }
 
     private val wiremockBuilder: MappingBuilder = WireMock.get(WireMock.urlPathEqualTo(dkifPath))

--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/inntekt/InntektClientTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/inntekt/InntektClientTest.kt
@@ -67,8 +67,8 @@ internal class InntektClientTest : WiremockBase {
             statsborgerskap = "NOR",
             kjønn = "MANN",
             adressebeskyttelse = null,
-            skjermet = false
-
+            skjermet = false,
+            kontaktinfo = null
         ).right()
 
         override fun aktørId(fnr: Fnr) = AktørId("aktoerId").right()

--- a/common/src/main/kotlin/no/nav/su/se/bakover/common/Config.kt
+++ b/common/src/main/kotlin/no/nav/su/se/bakover/common/Config.kt
@@ -32,6 +32,7 @@ object Config {
     val kodeverkUrl = env["KODEVERK_URL"] ?: "http://kodeverk.default.svc.nais.local"
     val stsUrl = env["STS_URL"] ?: "http://security-token-service.default.svc.nais.local"
     val skjermingUrl = env["SKJERMING_URL"] ?: "https://skjermede-personer-pip.nais.adeo.no"
+    val dkifUrl = env["DKIF_URL"] ?: "http://dkif.default.svc.nais.local"
 
     val serviceUser = ServiceUser()
     data class ServiceUser(

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Person.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Person.kt
@@ -8,7 +8,8 @@ data class Person(
     val statsborgerskap: String?,
     val kjønn: String?,
     val adressebeskyttelse: String?,
-    val skjermet: Boolean?
+    val skjermet: Boolean?,
+    val kontaktinfo: Kontaktinfo?
 ) {
     data class Navn(
         val fornavn: String,
@@ -33,5 +34,13 @@ data class Person(
     data class Poststed(
         val postnummer: String,
         val poststed: String?
+    )
+
+    data class Kontaktinfo(
+        val epostadresse: String?,
+        val mobiltelefonnummer: String?,
+        val reservert: Boolean,
+        val kanVarsles: Boolean,
+        val språk: String?,
     )
 }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/brev/BrevServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/brev/BrevServiceImplTest.kt
@@ -39,7 +39,8 @@ internal class BrevServiceImplTest {
         statsborgerskap = null,
         kjønn = null,
         adressebeskyttelse = null,
-        skjermet = null
+        skjermet = null,
+        kontaktinfo = null
     )
 
     @Test

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/PersonRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/PersonRoutes.kt
@@ -48,7 +48,8 @@ data class PersonResponseJson(
     val statsborgerskap: String?,
     val kjønn: String?,
     val adressebeskyttelse: String?,
-    val skjermet: Boolean?
+    val skjermet: Boolean?,
+    val kontaktinfo: KontaktinfoJson?
 ) {
     data class NavnJson(
         val fornavn: String,
@@ -70,6 +71,14 @@ data class PersonResponseJson(
         val bruksenhet: String?,
         val kommunenummer: String?,
         val kommunenavn: String?
+    )
+
+    data class KontaktinfoJson(
+        val epostadresse: String?,
+        val mobiltelefonnummer: String?,
+        val reservert: Boolean,
+        val kanVarsles: Boolean,
+        val språk: String?
     )
 
     companion object {
@@ -105,7 +114,16 @@ data class PersonResponseJson(
             statsborgerskap = this.statsborgerskap,
             kjønn = this.kjønn,
             adressebeskyttelse = this.adressebeskyttelse,
-            skjermet = this.skjermet
+            skjermet = this.skjermet,
+            kontaktinfo = this.kontaktinfo?.let {
+                KontaktinfoJson(
+                    epostadresse = it.epostadresse,
+                    mobiltelefonnummer = it.mobiltelefonnummer,
+                    reservert = it.reservert,
+                    kanVarsles = it.kanVarsles,
+                    språk = it.språk
+                )
+            }
         )
     }
 }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/TestClientsBuilder.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/TestClientsBuilder.kt
@@ -35,7 +35,7 @@ object TestClientsBuilder : ClientsBuilder {
         dokDistFordeling = DokDistFordelingStub,
         avstemmingPublisher = AvstemmingStub,
         microsoftGraphApiClient = MicrosoftGraphApiClientStub(),
-        dkif = DkifClientStub
+        digitalKontaktinformasjon = DkifClientStub
     )
 
     override fun build(): Clients = testClients

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/TestClientsBuilder.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/TestClientsBuilder.kt
@@ -4,6 +4,7 @@ import no.nav.su.se.bakover.client.Clients
 import no.nav.su.se.bakover.client.ClientsBuilder
 import no.nav.su.se.bakover.client.azure.OAuth
 import no.nav.su.se.bakover.client.kodeverk.KodeverkHttpClient
+import no.nav.su.se.bakover.client.stubs.dkif.DkifClientStub
 import no.nav.su.se.bakover.client.stubs.dokarkiv.DokArkivStub
 import no.nav.su.se.bakover.client.stubs.dokdistfordeling.DokDistFordelingStub
 import no.nav.su.se.bakover.client.stubs.inntekt.InntektOppslagStub
@@ -34,6 +35,7 @@ object TestClientsBuilder : ClientsBuilder {
         dokDistFordeling = DokDistFordelingStub,
         avstemmingPublisher = AvstemmingStub,
         microsoftGraphApiClient = MicrosoftGraphApiClientStub(),
+        dkif = DkifClientStub
     )
 
     override fun build(): Clients = testClients

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/PersonRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/PersonRoutesKtTest.kt
@@ -81,7 +81,14 @@ internal class PersonRoutesKtTest {
                     "statsborgerskap": "NOR",
                     "kjønn": "MANN",
                     "adressebeskyttelse": null,
-                    "skjermet": false
+                    "skjermet": false,
+                    "kontaktinfo": {
+                        "epostadresse": "mail@epost.com",
+                        "mobiltelefonnummer": "90909090",
+                        "reservert": false,
+                        "kanVarsles": true,
+                        "språk": "nb"
+                    }
                 }
             """.trimIndent()
 


### PR DESCRIPTION
Vi trenger å vise noe informasjon om hvordan søkeren ønsker å få tilsendt kommunikasjon fra det offentlige, og det ligger i et register som heter KRR (Kontakt- og reservasjonsregisteret). I NAV kalles tjenesten som tilbyr dette DKIF (Digital kontaktinformasjon, tror jeg). 

Vi trenger i utgangspunktet mobil og epost, og hvorvidt de har reservert seg mot elektronisk kommunikasjon. Men vi får også ut målform/språk, som vi muligens senere trenger for å sende brev på riktig målform.