### PR TITLE
Saksnummer

### DIFF
--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
@@ -10,6 +10,7 @@ import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.NySak
 import no.nav.su.se.bakover.domain.Sak
+import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnhold
 import no.nav.su.se.bakover.domain.behandling.Behandling
@@ -239,7 +240,7 @@ class AccessCheckProxy(
                 }
             },
             søknad = object : SøknadService {
-                override fun nySøknad(søknadInnhold: SøknadInnhold): Either<KunneIkkeOppretteSøknad, Søknad> {
+                override fun nySøknad(søknadInnhold: SøknadInnhold): Either<KunneIkkeOppretteSøknad, Pair<Saksnummer, Søknad>> {
                     assertHarTilgangTilPerson(søknadInnhold.personopplysninger.fnr)
 
                     return services.søknad.nySøknad(søknadInnhold)

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/SøknadService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/SøknadService.kt
@@ -1,12 +1,13 @@
 package no.nav.su.se.bakover.service.søknad
 
 import arrow.core.Either
+import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnhold
 import java.util.UUID
 
 interface SøknadService {
-    fun nySøknad(søknadInnhold: SøknadInnhold): Either<KunneIkkeOppretteSøknad, Søknad>
+    fun nySøknad(søknadInnhold: SøknadInnhold): Either<KunneIkkeOppretteSøknad, Pair<Saksnummer, Søknad>>
     fun hentSøknad(søknadId: UUID): Either<FantIkkeSøknad, Søknad>
     fun hentSøknadPdf(søknadId: UUID): Either<KunneIkkeLageSøknadPdf, ByteArray>
 }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/SøknadServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/SøknadServiceImpl.kt
@@ -15,6 +15,7 @@ import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.Person
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.SakFactory
+import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnhold
 import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
@@ -38,7 +39,7 @@ internal class SøknadServiceImpl(
 
     private val log = LoggerFactory.getLogger(this::class.java)
 
-    override fun nySøknad(søknadInnhold: SøknadInnhold): Either<KunneIkkeOppretteSøknad, Søknad> {
+    override fun nySøknad(søknadInnhold: SøknadInnhold): Either<KunneIkkeOppretteSøknad, Pair<Saksnummer, Søknad>> {
         val innsendtFødselsnummer: Fnr = søknadInnhold.personopplysninger.fnr
 
         val person = personOppslag.person(innsendtFødselsnummer).getOrHandle {
@@ -83,7 +84,7 @@ internal class SøknadServiceImpl(
         // Ved å gjøre increment først, kan vi lage en alert dersom vi får mismatch på dette.
         søknadMetrics.incrementNyCounter(SøknadMetrics.NyHandlinger.PERSISTERT)
         opprettJournalpostOgOppgave(sak.id, person, søknad)
-        return søknad.right()
+        return Pair(sak.saksnummer, søknad).right()
     }
 
     private fun opprettJournalpostOgOppgave(sakId: UUID, person: Person, søknad: Søknad) {

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/NySøknadTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/NySøknadTest.kt
@@ -169,7 +169,7 @@ class NySøknadTest {
             dokArkivMock,
             oppgaveServiceMock
         )
-        actual shouldBe expected.right()
+        actual shouldBe Pair(sak.saksnummer, expected).right()
     }
 
     @Test
@@ -251,8 +251,8 @@ class NySøknadTest {
             )
         }
 
-        nySøknad.map {
-            it.opprettet shouldNotBe sak.søknader().first().opprettet
+        nySøknad.map { (_, søknad) ->
+            søknad.opprettet shouldNotBe sak.søknader().first().opprettet
         }
     }
 
@@ -331,7 +331,7 @@ class NySøknadTest {
             oppgaveServiceMock
         )
 
-        actual shouldBe expectedSøknad.right()
+        actual shouldBe Pair(sak.saksnummer, expectedSøknad).right()
     }
 
     @Test
@@ -426,7 +426,7 @@ class NySøknadTest {
             oppgaveServiceMock
         )
 
-        actual shouldBe expectedSøknad.right()
+        actual shouldBe Pair(sak.saksnummer, expectedSøknad).right()
     }
 
     @Test
@@ -526,6 +526,6 @@ class NySøknadTest {
             oppgaveServiceMock
         )
 
-        actual shouldBe expectedSøknad.right()
+        actual shouldBe Pair(sak.saksnummer, expectedSøknad).right()
     }
 }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadInnholdJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadInnholdJson.kt
@@ -351,11 +351,11 @@ data class SøknadInnholdJson(
             pensjon = pensjon.toPensjonList()
         )
 
-        fun List<PensjonsOrdningBeløpJson>?.toPensjonList() = this?.map {
+        private fun List<PensjonsOrdningBeløpJson>?.toPensjonList() = this?.map {
             it.toPensjonsOrdningBeløp()
         }
 
-        fun List<TrygdeytelserIUtlandetJson>?.toTrygdeytelseList() = this?.map {
+        private fun List<TrygdeytelserIUtlandetJson>?.toTrygdeytelseList() = this?.map {
             it.toTrygdeytelseIUtlandet()
         }
 
@@ -371,11 +371,11 @@ data class SøknadInnholdJson(
                     pensjon = pensjon.toPensjonsOrdningBeløpListJson()
                 )
 
-            fun List<PensjonsOrdningBeløp>?.toPensjonsOrdningBeløpListJson() = this?.map {
+            private fun List<PensjonsOrdningBeløp>?.toPensjonsOrdningBeløpListJson() = this?.map {
                 it.toPensjonsOrdningBeløpJson()
             }
 
-            fun List<TrygdeytelseIUtlandet>?.toTrygdeytelseIUtlandetJson() = this?.map {
+            private fun List<TrygdeytelseIUtlandet>?.toTrygdeytelseIUtlandetJson() = this?.map {
                 it.toTrygdeytelseIUtlandetJson()
             }
         }
@@ -410,7 +410,7 @@ data class SøknadInnholdJson(
             kontanterBeløp = kontanterBeløp
         )
 
-        fun List<KjøretøyJson>?.toKjøretøyList() = this?.map {
+        private fun List<KjøretøyJson>?.toKjøretøyList() = this?.map {
             it.toKjøretøy()
         }
 
@@ -516,7 +516,7 @@ data class SøknadInnholdJson(
                 inntektOgPensjon = inntektOgPensjon.toInntektOgPensjonJson(),
                 formue = formue.toFormueJson(),
                 forNav = forNav.toForNavJson(),
-                ektefelle = ektefelle?.let { it.toJson() }
+                ektefelle = ektefelle?.toJson()
             )
     }
 }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadJson.kt
@@ -4,6 +4,10 @@ import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.web.routes.søknad.SøknadInnholdJson.Companion.toSøknadInnholdJson
 import java.time.format.DateTimeFormatter
 
+internal data class OpprettetSøknadJson(
+    val saksnummer: Long,
+    val søknad: SøknadJson
+)
 internal data class SøknadJson(
     val id: String,
     val sakId: String,

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutes.kt
@@ -56,10 +56,16 @@ internal fun Route.søknadRoutes(
                                 }
                             )
                         },
-                        { søknad ->
-                            call.audit("Lagrer søknad for person: $søknad")
+                        { (saksnummer, søknad) ->
+                            call.audit("Lagrer søknad for person: ${søknad.id}")
                             call.svar(
-                                Resultat.json(Created, serialize(søknad.toJson()))
+                                Resultat.json(
+                                    Created,
+                                    serialize(hashMapOf(
+                                        "saksnummer" to saksnummer,
+                                        "søknad" to søknad.toJson())
+                                    )
+                                )
                             )
                         }
                     )
@@ -125,10 +131,10 @@ internal fun Route.søknadRoutes(
                             when (it) {
                                 KunneIkkeLageBrevutkast.FantIkkeSøknad ->
                                     call.svar(NotFound.message("Fant Ikke Søknad"))
-                                KunneIkkeLageBrevutkast.KunneIkkeLageBrev ->
-                                    call.svar(InternalServerError.message("Kunne ikke lage brevutkast"))
                                 KunneIkkeLageBrevutkast.UkjentBrevtype ->
                                     call.svar(BadRequest.message("Kunne ikke lage brev for ukjent brevtype"))
+                                else ->
+                                    call.svar(InternalServerError.message("Kunne ikke lage brevutkast"))
                             }
                         },
                         { call.respondBytes(it, ContentType.Application.Pdf) }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutes.kt
@@ -61,9 +61,11 @@ internal fun Route.søknadRoutes(
                             call.svar(
                                 Resultat.json(
                                     Created,
-                                    serialize(hashMapOf(
-                                        "saksnummer" to saksnummer,
-                                        "søknad" to søknad.toJson())
+                                    serialize(
+                                        OpprettetSøknadJson(
+                                            saksnummer = saksnummer.nummer,
+                                            søknad = søknad.toJson()
+                                        )
                                     )
                                 )
                             )


### PR DESCRIPTION
Lade till ny json response før når man oppretter en ny søknad som innehåller saksnummer. Detta är så att vi i `Kvitteringen` kan visa saksnummer istället för en kryptisk uuid.