### PR TITLE
Rename ektefellesVerdier -> epsVerdier & add migration script

### DIFF
--- a/database/src/main/resources/db/migration/V52__ektefellesVerdier_rename.sql
+++ b/database/src/main/resources/db/migration/V52__ektefellesVerdier_rename.sql
@@ -1,0 +1,5 @@
+update behandling
+set behandlingsinformasjon = jsonb_set(behandlingsinformasjon #- '{formue,ektefellesVerdier}',
+                 '{formue, epsVerdier}',
+                 behandlingsinformasjon #> '{formue, ektefellesVerdier}')
+WHERE behandlingsinformasjon #> '{formue, ektefellesVerdier}' is not null;

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Behandlingsinformasjon.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Behandlingsinformasjon.kt
@@ -182,7 +182,7 @@ data class Behandlingsinformasjon(
         val status: Status,
         val verdier: Verdier?,
         val borSøkerMedEPS: Boolean,
-        val ektefellesVerdier: Verdier?,
+        val epsVerdier: Verdier?,
         val begrunnelse: String?
     ) : Base() {
         data class Verdier(

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/BehandlingsinformasjonTestdataBuilder.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/BehandlingsinformasjonTestdataBuilder.kt
@@ -42,14 +42,14 @@ fun Behandlingsinformasjon.withAlleVilkårOppfylt() =
                 kontanter = formue?.verdier?.kontanter ?: 0,
                 depositumskonto = formue?.verdier?.depositumskonto ?: 0,
             ),
-            ektefellesVerdier = Behandlingsinformasjon.Formue.Verdier(
-                verdiIkkePrimærbolig = formue?.ektefellesVerdier?.verdiIkkePrimærbolig ?: 0,
-                verdiKjøretøy = formue?.ektefellesVerdier?.verdiKjøretøy ?: 0,
-                innskudd = formue?.ektefellesVerdier?.innskudd ?: 0,
-                verdipapir = formue?.ektefellesVerdier?.verdipapir ?: 0,
-                pengerSkyldt = formue?.ektefellesVerdier?.pengerSkyldt ?: 0,
-                kontanter = formue?.ektefellesVerdier?.kontanter ?: 0,
-                depositumskonto = formue?.ektefellesVerdier?.depositumskonto ?: 0,
+            epsVerdier = Behandlingsinformasjon.Formue.Verdier(
+                verdiIkkePrimærbolig = formue?.epsVerdier?.verdiIkkePrimærbolig ?: 0,
+                verdiKjøretøy = formue?.epsVerdier?.verdiKjøretøy ?: 0,
+                innskudd = formue?.epsVerdier?.innskudd ?: 0,
+                verdipapir = formue?.epsVerdier?.verdipapir ?: 0,
+                pengerSkyldt = formue?.epsVerdier?.pengerSkyldt ?: 0,
+                kontanter = formue?.epsVerdier?.kontanter ?: 0,
+                depositumskonto = formue?.epsVerdier?.depositumskonto ?: 0,
             ),
             begrunnelse = formue?.begrunnelse
         ),

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/BehandlingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/BehandlingTest.kt
@@ -114,7 +114,7 @@ internal class BehandlingTest {
                             kontanter = 49,
                             depositumskonto = 315177
                         ),
-                        ektefellesVerdier = null,
+                        epsVerdier = null,
                         begrunnelse = null
                     )
                 )

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/behandling/BehandlingsinformasjonTestData.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/behandling/BehandlingsinformasjonTestData.kt
@@ -105,7 +105,7 @@ object BehandlingsinformasjonTestData {
                 kontanter = 1500,
                 depositumskonto = 0
             ),
-            ektefellesVerdier = Behandlingsinformasjon.Formue.Verdier(
+            epsVerdier = Behandlingsinformasjon.Formue.Verdier(
                 verdiIkkePrimærbolig = 74500,
                 verdiKjøretøy = 0,
                 innskudd = 13000,
@@ -128,7 +128,7 @@ object BehandlingsinformasjonTestData {
                 kontanter = 1500,
                 depositumskonto = 0
             ),
-            ektefellesVerdier = Behandlingsinformasjon.Formue.Verdier(
+            epsVerdier = Behandlingsinformasjon.Formue.Verdier(
                 verdiIkkePrimærbolig = 74500,
                 verdiKjøretøy = 0,
                 innskudd = 13000,
@@ -143,7 +143,7 @@ object BehandlingsinformasjonTestData {
             status = Behandlingsinformasjon.Formue.Status.MåInnhenteMerInformasjon,
             verdier = null,
             borSøkerMedEPS = false,
-            ektefellesVerdier = null,
+            epsVerdier = null,
             begrunnelse = null
         )
     }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/behandling/FormueTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/behandling/FormueTest.kt
@@ -11,7 +11,7 @@ internal class FormueTest {
             status = Behandlingsinformasjon.Formue.Status.MåInnhenteMerInformasjon,
             verdier = null,
             borSøkerMedEPS = false,
-            ektefellesVerdier = null,
+            epsVerdier = null,
             begrunnelse = null
         ).erGyldig() shouldBe true
     }
@@ -22,7 +22,7 @@ internal class FormueTest {
             status = Behandlingsinformasjon.Formue.Status.VilkårOppfylt,
             verdier = null,
             borSøkerMedEPS = false,
-            ektefellesVerdier = null,
+            epsVerdier = null,
             begrunnelse = "null"
         ).erGyldig() shouldBe false
     }
@@ -41,7 +41,7 @@ internal class FormueTest {
                 kontanter = 100,
                 depositumskonto = 100
             ),
-            ektefellesVerdier = null,
+            epsVerdier = null,
             begrunnelse = "null"
         ).erGyldig() shouldBe false
     }
@@ -60,7 +60,7 @@ internal class FormueTest {
                 kontanter = 100,
                 depositumskonto = null
             ),
-            ektefellesVerdier = null,
+            epsVerdier = null,
             begrunnelse = "null"
         ).erGyldig() shouldBe false
     }
@@ -79,7 +79,7 @@ internal class FormueTest {
                 kontanter = 100,
                 depositumskonto = 100
             ),
-            ektefellesVerdier = null,
+            epsVerdier = null,
             begrunnelse = "null"
         ).erGyldig() shouldBe true
     }
@@ -98,7 +98,7 @@ internal class FormueTest {
                 kontanter = 100,
                 depositumskonto = 100
             ),
-            ektefellesVerdier = Behandlingsinformasjon.Formue.Verdier(
+            epsVerdier = Behandlingsinformasjon.Formue.Verdier(
                 verdiIkkePrimærbolig = 100,
                 verdiKjøretøy = 100,
                 innskudd = 100,
@@ -117,7 +117,7 @@ internal class FormueTest {
             status = Behandlingsinformasjon.Formue.Status.MåInnhenteMerInformasjon,
             verdier = null,
             borSøkerMedEPS = false,
-            ektefellesVerdier = null,
+            epsVerdier = null,
             begrunnelse = "null"
         ).let {
             it.erVilkårOppfylt() shouldBe false
@@ -131,7 +131,7 @@ internal class FormueTest {
             status = Behandlingsinformasjon.Formue.Status.VilkårOppfylt,
             verdier = null,
             borSøkerMedEPS = false,
-            ektefellesVerdier = null,
+            epsVerdier = null,
             begrunnelse = "null"
         ).erVilkårOppfylt() shouldBe true
     }
@@ -142,7 +142,7 @@ internal class FormueTest {
             status = Behandlingsinformasjon.Formue.Status.VilkårIkkeOppfylt,
             verdier = null,
             borSøkerMedEPS = false,
-            ektefellesVerdier = null,
+            epsVerdier = null,
             begrunnelse = "null"
         ).erVilkårOppfylt() shouldBe false
 
@@ -150,7 +150,7 @@ internal class FormueTest {
             status = Behandlingsinformasjon.Formue.Status.MåInnhenteMerInformasjon,
             verdier = null,
             borSøkerMedEPS = false,
-            ektefellesVerdier = null,
+            epsVerdier = null,
             begrunnelse = "null"
         ).erVilkårOppfylt() shouldBe false
     }
@@ -161,7 +161,7 @@ internal class FormueTest {
             status = Behandlingsinformasjon.Formue.Status.VilkårIkkeOppfylt,
             verdier = null,
             borSøkerMedEPS = false,
-            ektefellesVerdier = null,
+            epsVerdier = null,
             begrunnelse = "null"
         ).avslagsgrunn() shouldBe Avslagsgrunn.FORMUE
     }
@@ -172,7 +172,7 @@ internal class FormueTest {
             status = Behandlingsinformasjon.Formue.Status.VilkårOppfylt,
             verdier = null,
             borSøkerMedEPS = false,
-            ektefellesVerdier = null,
+            epsVerdier = null,
             begrunnelse = "null"
         ).avslagsgrunn() shouldBe null
     }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/behandling/BehandlingTestUtils.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/behandling/BehandlingTestUtils.kt
@@ -95,7 +95,7 @@ object BehandlingTestUtils {
                 kontanter = 0,
                 depositumskonto = 0
             ),
-            ektefellesVerdier = Verdier(
+            epsVerdier = Verdier(
                 verdiIkkePrimærbolig = 0,
                 verdiKjøretøy = 0,
                 innskudd = 0,

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/behandling/BehandlingsinformasjonJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/behandling/BehandlingsinformasjonJson.kt
@@ -91,15 +91,15 @@ internal fun behandlingsinformasjonFromJson(b: BehandlingsinformasjonJson) =
                     kontanter = f.verdier?.kontanter,
                     depositumskonto = f.verdier?.depositumskonto
                 ),
-                ektefellesVerdier = b.ektefelle?.fnr?.let {
+                epsVerdier = b.ektefelle?.fnr?.let {
                     Behandlingsinformasjon.Formue.Verdier(
-                        verdiIkkePrimærbolig = f.ektefellesVerdier?.verdiIkkePrimærbolig,
-                        verdiKjøretøy = f.ektefellesVerdier?.verdiKjøretøy,
-                        innskudd = f.ektefellesVerdier?.innskudd,
-                        verdipapir = f.ektefellesVerdier?.verdipapir,
-                        pengerSkyldt = f.ektefellesVerdier?.pengerSkyldt,
-                        kontanter = f.ektefellesVerdier?.kontanter,
-                        depositumskonto = f.ektefellesVerdier?.depositumskonto
+                        verdiIkkePrimærbolig = f.epsVerdier?.verdiIkkePrimærbolig,
+                        verdiKjøretøy = f.epsVerdier?.verdiKjøretøy,
+                        innskudd = f.epsVerdier?.innskudd,
+                        verdipapir = f.epsVerdier?.verdipapir,
+                        pengerSkyldt = f.epsVerdier?.pengerSkyldt,
+                        kontanter = f.epsVerdier?.kontanter,
+                        depositumskonto = f.epsVerdier?.depositumskonto
                     )
                 },
                 begrunnelse = f.begrunnelse
@@ -166,7 +166,7 @@ internal fun Behandlingsinformasjon.Formue.toJson() =
         status = status.name,
         verdier = this.verdier?.toJson(),
         borSøkerMedEPS = this.borSøkerMedEPS,
-        ektefellesVerdier = this.ektefellesVerdier?.toJson(),
+        epsVerdier = this.epsVerdier?.toJson(),
         begrunnelse = begrunnelse
     )
 
@@ -264,7 +264,7 @@ data class FormueJson(
     val status: String,
     val verdier: VerdierJson?,
     val borSøkerMedEPS: Boolean,
-    val ektefellesVerdier: VerdierJson?,
+    val epsVerdier: VerdierJson?,
     val begrunnelse: String?
 )
 

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/behandling/BehandlingJsonTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/behandling/BehandlingJsonTest.kt
@@ -63,7 +63,7 @@ internal class BehandlingJsonTest {
                         "kontanter": 0,
                         "depositumskonto": 0
                     },
-                    "ektefellesVerdier": {
+                    "epsVerdier": {
                         "verdiIkkePrimærbolig": 0,
                         "verdiKjøretøy": 0,
                         "innskudd": 0,

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/behandling/BehandlingTestUtils.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/behandling/BehandlingTestUtils.kt
@@ -71,7 +71,7 @@ object BehandlingTestUtils {
                     kontanter = 0,
                     depositumskonto = 0
                 ),
-                ektefellesVerdier = Behandlingsinformasjon.Formue.Verdier(
+                epsVerdier = Behandlingsinformasjon.Formue.Verdier(
                     verdiIkkePrimærbolig = 0,
                     verdiKjøretøy = 0,
                     innskudd = 0,


### PR DESCRIPTION
Bug fix: Frontend och backend refererar till forskjellige navn i json-objektet for ektefelles inntekt. Så just nu är det ikke muligt att ändra ektefelles inntekt i saksbehandlingen i Formue-steget.

* Har nå refaktorerat backenden så att det blir samma verdi (syns epsVerdier är mer korrekt än ektefellesVerdier).
* Har lagt till migreringsscript så att det som ligger i databasen endres också.
