### PR TITLE
Allow saving EPS without name

### DIFF
--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/person/PersonOppslagStub.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/person/PersonOppslagStub.kt
@@ -2,6 +2,7 @@ package no.nav.su.se.bakover.client.stubs.person
 
 import arrow.core.Either
 import arrow.core.right
+import no.nav.su.se.bakover.common.Config
 import no.nav.su.se.bakover.domain.AktørId
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.Ident
@@ -12,38 +13,43 @@ import no.nav.su.se.bakover.domain.person.PersonOppslag.KunneIkkeHentePerson
 
 object PersonOppslagStub :
     PersonOppslag {
-    override fun person(fnr: Fnr): Either<KunneIkkeHentePerson, Person> = Person(
-        ident = Ident(fnr, AktørId("2437280977705")),
-        navn = Person.Navn(
-            fornavn = "Tore",
-            mellomnavn = "Johnas",
-            etternavn = "Strømøy"
-        ),
-        telefonnummer = Telefonnummer(landskode = "+47", nummer = "12345678"),
-        adresse = listOf(
-            Person.Adresse(
-                adresselinje = "Oslogata 12",
-                bruksenhet = "U1H20",
-                poststed = Person.Poststed(postnummer = "0050", poststed = "OSLO"),
-                kommune = Person.Kommune(kommunenummer = "0301", kommunenavn = "OSLO"),
-                adressetype = "Bostedsadresse",
-                adresseformat = "Vegadresse"
-            )
-        ),
-        statsborgerskap = "NOR",
-        kjønn = "MANN",
-        adressebeskyttelse = null,
-        skjermet = false,
-        kontaktinfo = Person.Kontaktinfo(
-            epostadresse = "mail@epost.com",
-            mobiltelefonnummer = "90909090",
-            reservert = false,
-            kanVarsles = true,
-            språk = "nb"
-        ),
-        vergemål = null,
-        fullmakt = null
-    ).right()
+    override fun person(fnr: Fnr): Either<KunneIkkeHentePerson, Person> =
+        if (fnr.toString() == Config.fnrForPersonMedSkjerming) {
+            Either.left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
+        } else {
+            Person(
+                ident = Ident(fnr, AktørId("2437280977705")),
+                navn = Person.Navn(
+                    fornavn = "Tore",
+                    mellomnavn = "Johnas",
+                    etternavn = "Strømøy"
+                ),
+                telefonnummer = Telefonnummer(landskode = "+47", nummer = "12345678"),
+                adresse = listOf(
+                    Person.Adresse(
+                        adresselinje = "Oslogata 12",
+                        bruksenhet = "U1H20",
+                        poststed = Person.Poststed(postnummer = "0050", poststed = "OSLO"),
+                        kommune = Person.Kommune(kommunenummer = "0301", kommunenavn = "OSLO"),
+                        adressetype = "Bostedsadresse",
+                        adresseformat = "Vegadresse"
+                    )
+                ),
+                statsborgerskap = "NOR",
+                kjønn = "MANN",
+                adressebeskyttelse = null,
+                skjermet = false,
+                kontaktinfo = Person.Kontaktinfo(
+                    epostadresse = "mail@epost.com",
+                    mobiltelefonnummer = "90909090",
+                    reservert = false,
+                    kanVarsles = true,
+                    språk = "nb"
+                ),
+                vergemål = null,
+                fullmakt = null
+            ).right()
+        }
 
     override fun aktørId(fnr: Fnr) = AktørId("2437280977705").right()
 }

--- a/common/src/main/kotlin/no/nav/su/se/bakover/common/Config.kt
+++ b/common/src/main/kotlin/no/nav/su/se/bakover/common/Config.kt
@@ -47,6 +47,7 @@ object Config {
     }
 
     val pdfgenLocal = env["PDFGEN_LOCAL"]?.toBoolean() ?: false
+    val fnrForPersonMedSkjerming = env["DEV_FNR_WITH_SKJERMING"]
 
     val corsAllowOrigin = env["ALLOW_CORS_ORIGIN"] ?: "localhost:1234"
     val frontendBaseUrl = env["FRONTEND_BASE_URL"] ?: "http://localhost:1234"

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Behandlingsinformasjon.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Behandlingsinformasjon.kt
@@ -314,7 +314,7 @@ data class Behandlingsinformasjon(
     sealed class EktefellePartnerSamboer : Base() {
         data class Ektefelle(
             val fnr: Fnr,
-            val navn: Person.Navn,
+            val navn: Person.Navn?,
             val kjønn: String?,
             val adressebeskyttelse: String?,
             val skjermet: Boolean?

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/behandling/BehandlingsinformasjonJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/behandling/BehandlingsinformasjonJson.kt
@@ -129,13 +129,15 @@ internal fun behandlingsinformasjonFromJson(b: BehandlingsinformasjonJson) =
             )
         },
         ektefelle = b.ektefelle?.let { e ->
-            if (e.fnr != null && e.navn != null) Behandlingsinformasjon.EktefellePartnerSamboer.Ektefelle(
-                fnr = e.fnr,
-                navn = e.navn,
-                kjønn = e.kjønn,
-                adressebeskyttelse = e.adressebeskyttelse,
-                skjermet = e.skjermet,
-            ) else Behandlingsinformasjon.EktefellePartnerSamboer.IngenEktefelle
+            if (e.fnr != null) {
+                Behandlingsinformasjon.EktefellePartnerSamboer.Ektefelle(
+                    fnr = e.fnr,
+                    navn = e.navn,
+                    kjønn = e.kjønn,
+                    adressebeskyttelse = e.adressebeskyttelse,
+                    skjermet = e.skjermet,
+                )
+            } else Behandlingsinformasjon.EktefellePartnerSamboer.IngenEktefelle
         }
     )
 


### PR DESCRIPTION
If the person has some form of skjerming we won't know their name,
but we still need to save their fnr.