### PR TITLE
Håndtering av feil ved publisering av kafka-meldinger.

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -40,7 +40,7 @@ jobs:
             ORG_GRADLE_PROJECT_githubUser: x-access-token
             ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
         - name: Build and publish Docker image
-          if: github.ref == 'refs/heads/statistikk-events'
+          if: github.ref == 'refs/heads/kafka_rotating_credentials'
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           run: |
@@ -52,7 +52,7 @@ jobs:
       name: Deploy specific branch-name to dev
       needs: build
       runs-on: ubuntu-latest
-      if: github.ref == 'refs/heads/statistikk-events'
+      if: github.ref == 'refs/heads/kafka_rotating_credentials'
       steps:
         - uses: actions/checkout@v2
         - uses: nais/deploy/actions/deploy@v1

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/ProdClientsBuilder.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/ProdClientsBuilder.kt
@@ -84,7 +84,7 @@ data class ProdClientsBuilder(
             microsoftGraphApiClient = MicrosoftGraphApiClient(oAuth),
             digitalKontaktinformasjon = dkif,
             leaderPodLookup = LeaderPodLookupClient(applicationConfig.leaderPodLookupPath),
-            kafkaPublisher = KafkaPublisherClient(applicationConfig.kafkaConfig)
+            kafkaPublisher = KafkaPublisherClient(applicationConfig.kafkaConfig.producerCfg)
         )
     }
 }

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/ProdClientsBuilder.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/ProdClientsBuilder.kt
@@ -21,7 +21,6 @@ import no.nav.su.se.bakover.client.skjerming.SkjermingClient
 import no.nav.su.se.bakover.client.sts.StsClient
 import no.nav.su.se.bakover.common.ApplicationConfig
 import no.nav.su.se.bakover.common.JmsConfig
-import org.apache.kafka.clients.producer.KafkaProducer
 import java.time.Clock
 
 data class ProdClientsBuilder(
@@ -84,7 +83,7 @@ data class ProdClientsBuilder(
             microsoftGraphApiClient = MicrosoftGraphApiClient(oAuth),
             digitalKontaktinformasjon = dkif,
             leaderPodLookup = LeaderPodLookupClient(applicationConfig.leaderPodLookupPath),
-            kafkaPublisher = KafkaPublisherClient(KafkaProducer(applicationConfig.kafkaConfig.producerConfig))
+            kafkaPublisher = KafkaPublisherClient(applicationConfig.kafkaConfig)
         )
     }
 }

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/kafka/KafkaPublisherClient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/kafka/KafkaPublisherClient.kt
@@ -1,20 +1,41 @@
 package no.nav.su.se.bakover.client.kafka
 
+import no.nav.su.se.bakover.common.ApplicationConfig
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.errors.AuthorizationException
 import org.slf4j.LoggerFactory
 
 internal class KafkaPublisherClient(
-    private val producer: KafkaProducer<String, String>
+    private val kafkaConfig: ApplicationConfig.KafkaConfig
 ) : KafkaPublisher {
     private val log = LoggerFactory.getLogger(this::class.java)
+    private var producer = KafkaProducer<String, String>(kafkaConfig.producerConfig)
 
     override fun publiser(topic: String, melding: String) {
+        publiser(topic, melding, 0)
+    }
+
+    private fun publiser(topic: String, melding: String, retries: Int) {
         try {
             producer.send(ProducerRecord(topic, melding)) { recordMetadata, exception ->
-                if (exception != null)
-                    log.error("Feil ved publisering av melding til topic:$topic", exception)
-                else log.info("Publiserte meldig til $topic med offset: ${recordMetadata.offset()}")
+                when (exception) {
+                    null -> log.info("Publiserte meldig til $topic med offset: ${recordMetadata.offset()}")
+                    is AuthorizationException -> {
+                        log.warn("Autorisasjonsfeil ved publisering av melding til $topic, rekonfigurerer producer før retry.")
+                        producer.close()
+                        producer = KafkaProducer<String, String>(kafkaConfig.producerConfig).also {
+                            if (retries < 3) {
+                                log.info("Resender melding til $topic med ny producer, retry antall: $retries")
+                                Thread.sleep(500)
+                                publiser(topic, melding, retries + 1)
+                            } else {
+                                log.info("Antall retry overskredet, stopper.")
+                            }
+                        }
+                    }
+                    else -> log.error("Ukejent feil ved publisering av melding til topic:$topic", exception)
+                }
             }
         } catch (exception: Throwable) {
             log.error("Fanget exception ved publisering av melding til topic:$topic", exception)

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/kafka/KafkaPublisherClient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/kafka/KafkaPublisherClient.kt
@@ -13,15 +13,15 @@ import java.util.Timer
 import kotlin.concurrent.timer
 
 internal class KafkaPublisherClient(
-    private val kafkaConfig: ApplicationConfig.KafkaConfig,
-    private val initProducer: () -> Producer<String, String> = { KafkaProducer(kafkaConfig.producerConfig) }
+    private val producerConfig: ApplicationConfig.KafkaConfig.ProducerCfg,
+    private val initProducer: () -> Producer<String, String> = { KafkaProducer(producerConfig.kafkaConfig) }
 ) : KafkaPublisher {
     private val log = LoggerFactory.getLogger(this::class.java)
     private var producer: Producer<String, String> = initProducer()
     private val failed: Queue<ProducerRecord<String, String>> = LinkedList()
 
     init {
-        retryTask(kafkaConfig)
+        retryTask(producerConfig)
     }
 
     override fun publiser(topic: String, melding: String) {
@@ -48,8 +48,8 @@ internal class KafkaPublisherClient(
         }
     }
 
-    private fun retryTask(kafkaConfig: ApplicationConfig.KafkaConfig): Timer {
-        val period = kafkaConfig.producerConfig["RETRY_INTERVAL"]?.let { it as Long } ?: 15_000L
+    private fun retryTask(kafkaConfig: ApplicationConfig.KafkaConfig.ProducerCfg): Timer {
+        val period = kafkaConfig.retryTaskInterval
         log.info("Konfigurerer retry task med intervall $period ms for KafkaPublisherClient")
         return timer(
             name = "KafkaPublisherClient retry task",

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/kafka/KafkaPublisherClient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/kafka/KafkaPublisherClient.kt
@@ -5,6 +5,7 @@ import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.errors.AuthorizationException
 import org.slf4j.LoggerFactory
+import java.time.Duration
 
 internal class KafkaPublisherClient(
     private val kafkaConfig: ApplicationConfig.KafkaConfig
@@ -23,7 +24,7 @@ internal class KafkaPublisherClient(
                     null -> log.info("Publiserte meldig til $topic med offset: ${recordMetadata.offset()}")
                     is AuthorizationException -> {
                         log.warn("Autorisasjonsfeil ved publisering av melding til $topic, rekonfigurerer producer før retry.")
-                        producer.close()
+                        producer.close(Duration.ZERO)
                         producer = KafkaProducer<String, String>(kafkaConfig.producerConfig).also {
                             if (retries < 3) {
                                 log.info("Resender melding til $topic med ny producer, retry antall: $retries")

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/kafka/KafkaPublisherClient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/kafka/KafkaPublisherClient.kt
@@ -2,38 +2,36 @@ package no.nav.su.se.bakover.client.kafka
 
 import no.nav.su.se.bakover.common.ApplicationConfig
 import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.Producer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.errors.AuthorizationException
 import org.slf4j.LoggerFactory
 import java.time.Duration
 
 internal class KafkaPublisherClient(
-    private val kafkaConfig: ApplicationConfig.KafkaConfig
+    private val kafkaConfig: ApplicationConfig.KafkaConfig,
+    private val initProducer: () -> Producer<String, String> = { KafkaProducer(kafkaConfig.producerConfig) }
 ) : KafkaPublisher {
     private val log = LoggerFactory.getLogger(this::class.java)
-    private var producer = KafkaProducer<String, String>(kafkaConfig.producerConfig)
+    private var producer: Producer<String, String> = initProducer()
+    private val failed: MutableSet<ProducerRecord<String, String>> = mutableSetOf()
 
     override fun publiser(topic: String, melding: String) {
-        publiser(topic, melding, 0)
+        return publiser(topic, melding, 0)
     }
 
     private fun publiser(topic: String, melding: String, retries: Int) {
         try {
-            producer.send(ProducerRecord(topic, melding)) { recordMetadata, exception ->
+            val record = ProducerRecord<String, String>(topic, melding)
+            producer.send(record) { recordMetadata, exception ->
                 when (exception) {
                     null -> log.info("Publiserte meldig til $topic med offset: ${recordMetadata.offset()}")
                     is AuthorizationException -> {
                         log.warn("Autorisasjonsfeil ved publisering av melding til $topic, rekonfigurerer producer før retry.")
                         producer.close(Duration.ZERO)
-                        producer = KafkaProducer<String, String>(kafkaConfig.producerConfig).also {
-                            if (retries < 3) {
-                                log.info("Resender melding til $topic med ny producer, retry antall: $retries")
-                                Thread.sleep(500)
-                                publiser(topic, melding, retries + 1)
-                            } else {
-                                log.info("Antall retry overskredet, stopper.")
-                            }
-                        }
+                        producer = initProducer()
+                        // TODO solution for the record that failed
+                        failed.add(record)
                     }
                     else -> log.error("Ukejent feil ved publisering av melding til topic:$topic", exception)
                 }

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/kafka/KafkaPublisherClient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/kafka/KafkaPublisherClient.kt
@@ -7,6 +7,10 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.errors.AuthorizationException
 import org.slf4j.LoggerFactory
 import java.time.Duration
+import java.util.LinkedList
+import java.util.Queue
+import java.util.Timer
+import kotlin.concurrent.timer
 
 internal class KafkaPublisherClient(
     private val kafkaConfig: ApplicationConfig.KafkaConfig,
@@ -14,15 +18,15 @@ internal class KafkaPublisherClient(
 ) : KafkaPublisher {
     private val log = LoggerFactory.getLogger(this::class.java)
     private var producer: Producer<String, String> = initProducer()
-    private val failed: MutableSet<ProducerRecord<String, String>> = mutableSetOf()
+    private val failed: Queue<ProducerRecord<String, String>> = LinkedList()
 
-    override fun publiser(topic: String, melding: String) {
-        return publiser(topic, melding, 0)
+    init {
+        retryTask(kafkaConfig)
     }
 
-    private fun publiser(topic: String, melding: String, retries: Int) {
+    override fun publiser(topic: String, melding: String) {
+        val record = ProducerRecord<String, String>(topic, melding)
         try {
-            val record = ProducerRecord<String, String>(topic, melding)
             producer.send(record) { recordMetadata, exception ->
                 when (exception) {
                     null -> log.info("Publiserte meldig til $topic med offset: ${recordMetadata.offset()}")
@@ -30,14 +34,32 @@ internal class KafkaPublisherClient(
                         log.warn("Autorisasjonsfeil ved publisering av melding til $topic, rekonfigurerer producer før retry.")
                         producer.close(Duration.ZERO)
                         producer = initProducer()
-                        // TODO solution for the record that failed
                         failed.add(record)
                     }
-                    else -> log.error("Ukejent feil ved publisering av melding til topic:$topic", exception)
+                    else -> {
+                        log.error("Ukjent feil ved publisering av melding til topic:$topic", exception)
+                        failed.add(record)
+                    }
                 }
             }
         } catch (exception: Throwable) {
             log.error("Fanget exception ved publisering av melding til topic:$topic", exception)
+            failed.add(record)
+        }
+    }
+
+    private fun retryTask(kafkaConfig: ApplicationConfig.KafkaConfig): Timer {
+        val period = kafkaConfig.producerConfig["RETRY_INTERVAL"]?.let { it as Long } ?: 15_000L
+        log.info("Konfigurerer retry task med intervall $period ms for KafkaPublisherClient")
+        return timer(
+            name = "KafkaPublisherClient retry task",
+            daemon = true,
+            period = Duration.ofMillis(period).toMillis()
+        ) {
+            failed.poll()?.let {
+                log.info("Fant ${failed.size + 1} kafkameldinger som har feilet. Forsøker å sende første melding i køen på nytt.")
+                publiser(it.topic(), it.value())
+            }
         }
     }
 }

--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/kafka/KafkaPublisherClientTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/kafka/KafkaPublisherClientTest.kt
@@ -12,8 +12,9 @@ import org.junit.jupiter.api.assertDoesNotThrow
 
 internal class KafkaPublisherClientTest {
 
-    private val config = ApplicationConfig.KafkaConfig.createLocalConfig().copy(
-        producerConfig = mapOf("RETRY_INTERVAL" to 1L)
+    private val config = ApplicationConfig.KafkaConfig.ProducerCfg(
+        kafkaConfig = mapOf(),
+        retryTaskInterval = 1L
     )
 
     @Test

--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/kafka/KafkaPublisherClientTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/kafka/KafkaPublisherClientTest.kt
@@ -1,0 +1,93 @@
+package no.nav.su.se.bakover.client.kafka
+
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.common.ApplicationConfig
+import org.apache.kafka.clients.producer.MockProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.errors.TopicAuthorizationException
+import org.apache.kafka.common.serialization.StringSerializer
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+
+internal class KafkaPublisherClientTest {
+
+    @Test
+    fun `publiserer meldinger til kafka`() {
+        val producers: MutableList<MockProducer<String, String>> = mutableListOf()
+        KafkaPublisherClient(ApplicationConfig.KafkaConfig.createLocalConfig()) { autoProducer(producers) }.publiser(
+            topic = "happy",
+            melding = "path"
+        )
+        producers shouldHaveSize 1
+        producers.first().let {
+            it.history() shouldBe listOf(ProducerRecord("happy", "path"))
+        }
+    }
+
+    @Test
+    fun `fanger exception hvis kall til send() feiler`() {
+        val producers: MutableList<MockProducer<String, String>> = mutableListOf()
+        assertDoesNotThrow {
+            KafkaPublisherClient(ApplicationConfig.KafkaConfig.createLocalConfig()) {
+                autoProducer(producers).apply {
+                    sendException = IllegalStateException()
+                }
+            }.publiser(
+                topic = "not so happy",
+                melding = "path"
+            )
+            producers shouldHaveSize 1
+            producers.first().history() shouldBe emptyList()
+        }
+    }
+
+    @Test
+    fun `overlever ukjente feil i callback`() {
+        val producers: MutableList<MockProducer<String, String>> = mutableListOf()
+        assertDoesNotThrow {
+            KafkaPublisherClient(ApplicationConfig.KafkaConfig.createLocalConfig()) { manualProducer(producers) }.publiser(
+                topic = "not so happy",
+                melding = "path"
+            )
+
+            val producer = producers.first()
+            producer.errorNext(RuntimeException())
+
+            producers shouldHaveSize 1
+        }
+    }
+
+    @Test
+    fun `stenger eksisterende producer og oppretter ny dersom callback responderer med authorization-exception`() {
+        val producers: MutableList<MockProducer<String, String>> = mutableListOf()
+        assertDoesNotThrow {
+            KafkaPublisherClient(ApplicationConfig.KafkaConfig.createLocalConfig()) { manualProducer(producers) }.publiser(
+                topic = "not so happy",
+                melding = "path"
+            )
+
+            val producer = producers.first()
+            // fail with auth-exception to invoke instantiation of new producer
+            producer.errorNext(TopicAuthorizationException("forbidden"))
+
+            producers shouldHaveSize 2
+            producers.let {
+                it[0].closed() shouldBe true // first instance should be closed
+                it[1].closed() shouldBe false // second instance should be alive
+            }
+        }
+    }
+
+    /**
+     * autoCompleteFuture = true -> complete future immediately and invoke callback
+     */
+    private fun autoProducer(producers: MutableList<MockProducer<String, String>> = mutableListOf()): MockProducer<String, String> =
+        MockProducer(true, StringSerializer(), StringSerializer()).also { producers.add(it) }
+
+    /**
+     * autoCompleteFuture = false -> completion of future is controlled manully through completeNext()/errorNext() before callback is invoked.
+     */
+    private fun manualProducer(producers: MutableList<MockProducer<String, String>> = mutableListOf()): MockProducer<String, String> =
+        MockProducer(false, StringSerializer(), StringSerializer()).also { producers.add(it) }
+}

--- a/common/src/main/kotlin/no/nav/su/se/bakover/common/Config.kt
+++ b/common/src/main/kotlin/no/nav/su/se/bakover/common/Config.kt
@@ -318,24 +318,30 @@ data class ApplicationConfig(
 
     data class KafkaConfig(
         private val common: Map<String, String>,
-        val producerConfig: Map<String, Any>,
+        val producerCfg: ProducerCfg,
     ) {
         companion object {
             fun createFromEnvironmentVariables() = KafkaConfig(
                 common = Common().configure(),
-                producerConfig = Common().configure() + mapOf(
-                    ProducerConfig.ACKS_CONFIG to "all",
-                    ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java,
-                    ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java,
-                    "RETRY_INTERVAL" to 15_000L
+                producerCfg = ProducerCfg(
+                    kafkaConfig = Common().configure() + mapOf(
+                        ProducerConfig.ACKS_CONFIG to "all",
+                        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java,
+                        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java,
+                    )
                 )
             )
 
             fun createLocalConfig() = KafkaConfig(
                 common = emptyMap(),
-                producerConfig = emptyMap()
+                producerCfg = ProducerCfg(emptyMap())
             )
         }
+
+        data class ProducerCfg(
+            val kafkaConfig: Map<String, Any>,
+            val retryTaskInterval: Long = 15_000L
+        )
 
         private data class Common(
             val brokers: String = getEnvironmentVariableOrDefault("KAFKA_BROKERS", "brokers"),

--- a/common/src/main/kotlin/no/nav/su/se/bakover/common/Config.kt
+++ b/common/src/main/kotlin/no/nav/su/se/bakover/common/Config.kt
@@ -260,7 +260,10 @@ data class ApplicationConfig(
                 pdfgenUrl = getEnvironmentVariableOrDefault("PDFGEN_URL", "http://su-pdfgen.supstonad.svc.nais.local"),
                 dokarkivUrl = getEnvironmentVariableOrThrow("DOKARKIV_URL"),
                 kodeverkUrl = getEnvironmentVariableOrDefault("KODEVERK_URL", "http://kodeverk.default.svc.nais.local"),
-                stsUrl = getEnvironmentVariableOrDefault("STS_URL", "http://security-token-service.default.svc.nais.local"),
+                stsUrl = getEnvironmentVariableOrDefault(
+                    "STS_URL",
+                    "http://security-token-service.default.svc.nais.local"
+                ),
                 skjermingUrl = getEnvironmentVariableOrThrow("SKJERMING_URL"),
                 dkifUrl = getEnvironmentVariableOrDefault("DKIF_URL", "http://dkif.default.svc.nais.local"),
             )
@@ -323,7 +326,8 @@ data class ApplicationConfig(
                 producerConfig = Common().configure() + mapOf(
                     ProducerConfig.ACKS_CONFIG to "all",
                     ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java,
-                    ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java
+                    ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java,
+                    "RETRY_INTERVAL" to 15_000L
                 )
             )
 

--- a/common/src/test/kotlin/no/nav/su/se/bakover/common/ApplicationConfigTest.kt
+++ b/common/src/test/kotlin/no/nav/su/se/bakover/common/ApplicationConfigTest.kt
@@ -90,6 +90,7 @@ internal class ApplicationConfigTest {
                 "acks" to "all",
                 "key.serializer" to StringSerializer::class.java,
                 "value.serializer" to StringSerializer::class.java,
+                "RETRY_INTERVAL" to 15_000L
             )
         ),
     )

--- a/common/src/test/kotlin/no/nav/su/se/bakover/common/ApplicationConfigTest.kt
+++ b/common/src/test/kotlin/no/nav/su/se/bakover/common/ApplicationConfigTest.kt
@@ -76,21 +76,23 @@ internal class ApplicationConfigTest {
                 "ssl.keystore.password" to "credstorePwd",
                 "ssl.key.password" to "credstorePwd",
             ),
-            producerConfig = mapOf(
-                "bootstrap.servers" to "brokers",
-                "security.protocol" to "SSL",
-                "ssl.endpoint.identification.algorithm" to "",
-                "ssl.truststore.type" to "jks",
-                "ssl.keystore.type" to "PKCS12",
-                "ssl.truststore.location" to "truststorePath",
-                "ssl.truststore.password" to "credstorePwd",
-                "ssl.keystore.location" to "keystorePath",
-                "ssl.keystore.password" to "credstorePwd",
-                "ssl.key.password" to "credstorePwd",
-                "acks" to "all",
-                "key.serializer" to StringSerializer::class.java,
-                "value.serializer" to StringSerializer::class.java,
-                "RETRY_INTERVAL" to 15_000L
+            producerCfg = ApplicationConfig.KafkaConfig.ProducerCfg(
+                mapOf(
+                    "bootstrap.servers" to "brokers",
+                    "security.protocol" to "SSL",
+                    "ssl.endpoint.identification.algorithm" to "",
+                    "ssl.truststore.type" to "jks",
+                    "ssl.keystore.type" to "PKCS12",
+                    "ssl.truststore.location" to "truststorePath",
+                    "ssl.truststore.password" to "credstorePwd",
+                    "ssl.keystore.location" to "keystorePath",
+                    "ssl.keystore.password" to "credstorePwd",
+                    "ssl.key.password" to "credstorePwd",
+                    "acks" to "all",
+                    "key.serializer" to StringSerializer::class.java,
+                    "value.serializer" to StringSerializer::class.java
+                ),
+                retryTaskInterval = 15_000L
             )
         ),
     )
@@ -192,7 +194,9 @@ internal class ApplicationConfigTest {
                     dkifUrl = "mocked",
                 ),
                 frontendCallbackUrls = ApplicationConfig.FrontendCallbackUrls("http://localhost:1234"),
-                kafkaConfig = ApplicationConfig.KafkaConfig(emptyMap(), emptyMap()),
+                kafkaConfig = ApplicationConfig.KafkaConfig(
+                    emptyMap(), ApplicationConfig.KafkaConfig.ProducerCfg((emptyMap()))
+                )
             )
         }
     }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/TestEnvironment.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/TestEnvironment.kt
@@ -76,7 +76,7 @@ val applicationConfig = ApplicationConfig(
         dkifUrl = "dkifUrl",
     ),
     frontendCallbackUrls = ApplicationConfig.FrontendCallbackUrls(frontendBaseUrl = "frontendBaseUrl"),
-    kafkaConfig = ApplicationConfig.KafkaConfig(emptyMap(), emptyMap())
+    kafkaConfig = ApplicationConfig.KafkaConfig(emptyMap(), ApplicationConfig.KafkaConfig.ProducerCfg(emptyMap()))
 )
 
 internal val jwtStub = JwtStub(applicationConfig)


### PR DESCRIPTION
- Oppretter ny producer dersom autorisasjon mot topic feiler.
- Tar vare på feilede meldinger, disse forsøkes resendes av repeterende task.