### PR TITLE
Fjern støy fra loggen

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -40,7 +40,7 @@ jobs:
             ORG_GRADLE_PROJECT_githubUser: x-access-token
             ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
         - name: Build and publish Docker image
-          if: github.ref == 'refs/heads/reduce-log-noise'
+          if: github.ref == 'refs/heads/BRANCH_NAME'
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           run: |
@@ -52,7 +52,7 @@ jobs:
       name: Deploy specific branch-name to dev
       needs: build
       runs-on: ubuntu-latest
-      if: github.ref == 'refs/heads/reduce-log-noise'
+      if: github.ref == 'refs/heads/BRANCH_NAME'
       steps:
         - uses: actions/checkout@v2
         - uses: nais/deploy/actions/deploy@v1

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -40,7 +40,7 @@ jobs:
             ORG_GRADLE_PROJECT_githubUser: x-access-token
             ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
         - name: Build and publish Docker image
-          if: github.ref == 'refs/heads/kafka_rotating_credentials'
+          if: github.ref == 'refs/heads/reduce-log-noise'
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           run: |
@@ -52,7 +52,7 @@ jobs:
       name: Deploy specific branch-name to dev
       needs: build
       runs-on: ubuntu-latest
-      if: github.ref == 'refs/heads/kafka_rotating_credentials'
+      if: github.ref == 'refs/heads/reduce-log-noise'
       steps:
         - uses: actions/checkout@v2
         - uses: nais/deploy/actions/deploy@v1

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/oppdrag/IbmMqPublisher.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/oppdrag/IbmMqPublisher.kt
@@ -37,11 +37,7 @@ class IbmMqPublisher(
                             }
                         )
                     }
-                    log.info("${messages.size} meldinger sendt, kaller commit()")
-                    val start = System.currentTimeMillis()
                     context.commit()
-                    log.info("commit() tok: ${System.currentTimeMillis() - start} ms")
-                    Unit
                 }.mapLeft {
                     log.error("Kunne ikke sende meldinger med config $publisherConfig, kaller rollback()", it)
                     context.rollback()

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/person/PersonClient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/person/PersonClient.kt
@@ -24,6 +24,7 @@ class PersonClient(
 
     override fun person(fnr: Fnr): Either<KunneIkkeHentePerson, Person> = pdlClient.person(fnr).map { toPerson(it) }
     override fun aktørId(fnr: Fnr): Either<KunneIkkeHentePerson, AktørId> = pdlClient.aktørId(fnr)
+    override fun sjekkTilgangTilPerson(fnr: Fnr): Either<KunneIkkeHentePerson, Unit> = pdlClient.person(fnr).map {}
 
     private fun toPerson(pdlData: PdlData) =
         Person(

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/person/PersonOppslagStub.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/person/PersonOppslagStub.kt
@@ -48,4 +48,5 @@ object PersonOppslagStub :
 
     override fun person(fnr: Fnr): Either<KunneIkkeHentePerson, Person> = nyTestPerson(fnr).right()
     override fun aktørId(fnr: Fnr) = AktørId("2437280977705").right()
+    override fun sjekkTilgangTilPerson(fnr: Fnr): Either<KunneIkkeHentePerson, Unit> = Unit.right()
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/person/PersonOppslag.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/person/PersonOppslag.kt
@@ -8,6 +8,7 @@ import no.nav.su.se.bakover.domain.Person
 interface PersonOppslag {
     fun person(fnr: Fnr): Either<KunneIkkeHentePerson, Person>
     fun aktørId(fnr: Fnr): Either<KunneIkkeHentePerson, AktørId>
+    fun sjekkTilgangTilPerson(fnr: Fnr): Either<KunneIkkeHentePerson, Unit>
 }
 
 sealed class KunneIkkeHentePerson {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
@@ -315,6 +315,10 @@ class AccessCheckProxy(
 
                     return services.person.hentAktørId(fnr)
                 }
+
+                override fun sjekkTilgangTilPerson(fnr: Fnr): Either<KunneIkkeHentePerson, Unit> {
+                    return services.person.sjekkTilgangTilPerson(fnr)
+                }
             },
             statistikk = object : StatistikkService {
                 override fun publiser(statistikk: Statistikk) {
@@ -333,7 +337,7 @@ class AccessCheckProxy(
         throw IllegalStateException("This should only be called from another service")
 
     private fun assertHarTilgangTilPerson(fnr: Fnr) {
-        services.person.hentPerson(fnr)
+        services.person.sjekkTilgangTilPerson(fnr)
             .getOrHandle {
                 throw Tilgangssjekkfeil(it, fnr)
             }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/behandling/IverksettBehandlingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/behandling/IverksettBehandlingService.kt
@@ -219,23 +219,23 @@ class IverksettBehandlingService(
                     behandling.saksnummer
                 )
                     .mapLeft {
-                        log.error("Journalføring av iverksettingsbrev feilet for behandling ${behandling.id}. Dette må gjøres manuelt.")
+                        log.error("Journalføring av innvilgelsesbrev feilet for behandling ${behandling.id}. Dette må gjøres manuelt.")
                         IverksattBehandling.MedMangler.KunneIkkeJournalføreBrev(behandling)
                     }
                     .flatMap {
                         behandling.oppdaterIverksattJournalpostId(it)
                         behandlingRepo.oppdaterIverksattJournalpostId(behandling.id, it)
-                        log.info("Journalført iverksettingsbrev $it for behandling ${behandling.id}")
+                        log.info("Journalført innvilgelsesbrev $it for behandling ${behandling.id}")
                         behandlingMetrics.incrementInnvilgetCounter(BehandlingMetrics.InnvilgetHandlinger.JOURNALFØRT)
                         brevService.distribuerBrev(it)
                             .mapLeft {
-                                log.error("Bestilling av iverksettingsbrev feilet for behandling ${behandling.id}. Dette må gjøres manuelt.")
+                                log.error("Bestilling av innvilgelsesbrev feilet for behandling ${behandling.id}. Dette må gjøres manuelt.")
                                 IverksattBehandling.MedMangler.KunneIkkeDistribuereBrev(behandling)
                             }
                             .map { brevbestillingId ->
                                 behandling.oppdaterIverksattBrevbestillingId(brevbestillingId)
                                 behandlingRepo.oppdaterIverksattBrevbestillingId(behandling.id, brevbestillingId)
-                                log.info("Bestilt iverksettingsbrev $brevbestillingId for behandling ${behandling.id}")
+                                log.info("Bestilt innvilgelsesbrev $brevbestillingId for behandling ${behandling.id}")
                                 behandlingMetrics.incrementInnvilgetCounter(BehandlingMetrics.InnvilgetHandlinger.DISTRIBUERT_BREV)
                                 IverksattBehandling.UtenMangler(behandling)
                             }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/person/PersonService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/person/PersonService.kt
@@ -10,6 +10,7 @@ import no.nav.su.se.bakover.domain.person.PersonOppslag
 interface PersonService {
     fun hentPerson(fnr: Fnr): Either<KunneIkkeHentePerson, Person>
     fun hentAktørId(fnr: Fnr): Either<KunneIkkeHentePerson, AktørId>
+    fun sjekkTilgangTilPerson(fnr: Fnr): Either<KunneIkkeHentePerson, Unit>
 }
 
 class PersonServiceImpl(
@@ -21,5 +22,9 @@ class PersonServiceImpl(
 
     override fun hentAktørId(fnr: Fnr): Either<KunneIkkeHentePerson, AktørId> {
         return personOppslag.aktørId(fnr)
+    }
+
+    override fun sjekkTilgangTilPerson(fnr: Fnr): Either<KunneIkkeHentePerson, Unit> {
+        return personOppslag.sjekkTilgangTilPerson(fnr)
     }
 }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/SøknadServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/SøknadServiceImpl.kt
@@ -172,7 +172,7 @@ internal class SøknadServiceImpl(
             log.error("Ny søknad: Kunne ikke opprette journalpost. Originalfeil: $it")
             return KunneIkkeOppretteJournalpost(søknad.sakId, søknad.id, "Kunne ikke opprette journalpost").left()
         }
-        log.info("Ny søknad: Opprettet journalpost med id $journalpostId")
+
         return søknad.journalfør(journalpostId).also {
             søknadRepo.oppdaterjournalpostId(søknad.id, journalpostId)
             søknadMetrics.incrementNyCounter(SøknadMetrics.NyHandlinger.JOURNALFØRT)
@@ -195,8 +195,6 @@ internal class SøknadServiceImpl(
             log.error("Ny søknad: Kunne ikke opprette oppgave. Originalfeil: $it")
             KunneIkkeOppretteOppgave(søknad.sakId, søknad.id, søknad.journalpostId, "Kunne ikke opprette oppgave")
         }.map { oppgaveId ->
-            log.info("Ny søknad: Opprettet oppgave med id $oppgaveId.")
-
             return søknad.medOppgave(oppgaveId).also {
                 søknadRepo.oppdaterOppgaveId(søknad.id, oppgaveId)
                 søknadMetrics.incrementNyCounter(SøknadMetrics.NyHandlinger.OPPRETTET_OPPGAVE)

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/AccessCheckProxyTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/AccessCheckProxyTest.kt
@@ -7,7 +7,6 @@ import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import io.kotest.assertions.throwables.shouldThrow
-import no.nav.su.se.bakover.client.stubs.person.PersonOppslagStub
 import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.database.person.PersonRepo
 import no.nav.su.se.bakover.domain.Fnr
@@ -62,6 +61,7 @@ internal class AccessCheckProxyTest {
                     person = object : PersonService {
                         override fun hentPerson(fnr: Fnr) = Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
                         override fun hentAktørId(fnr: Fnr) = throw NotImplementedError()
+                        override fun sjekkTilgangTilPerson(fnr: Fnr) = Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
                     }
                 )
             ).proxy()
@@ -79,6 +79,7 @@ internal class AccessCheckProxyTest {
                     person = object : PersonService {
                         override fun hentPerson(fnr: Fnr) = Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
                         override fun hentAktørId(fnr: Fnr) = throw NotImplementedError()
+                        override fun sjekkTilgangTilPerson(fnr: Fnr) = Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
                     }
                 )
             ).proxy()
@@ -96,6 +97,7 @@ internal class AccessCheckProxyTest {
                     person = object : PersonService {
                         override fun hentPerson(fnr: Fnr) = Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
                         override fun hentAktørId(fnr: Fnr) = throw NotImplementedError()
+                        override fun sjekkTilgangTilPerson(fnr: Fnr) = Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
                     },
                 )
             ).proxy()
@@ -113,6 +115,7 @@ internal class AccessCheckProxyTest {
                     person = object : PersonService {
                         override fun hentPerson(fnr: Fnr) = Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
                         override fun hentAktørId(fnr: Fnr) = throw NotImplementedError()
+                        override fun sjekkTilgangTilPerson(fnr: Fnr) = Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
                     }
                 )
             ).proxy()
@@ -130,6 +133,7 @@ internal class AccessCheckProxyTest {
                     person = object : PersonService {
                         override fun hentPerson(fnr: Fnr) = Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
                         override fun hentAktørId(fnr: Fnr) = throw NotImplementedError()
+                        override fun sjekkTilgangTilPerson(fnr: Fnr) = Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
                     }
                 )
             ).proxy()
@@ -176,9 +180,7 @@ internal class AccessCheckProxyTest {
             },
             services = servicesReturningSak.copy(
                 person = mock {
-                    on { hentPerson(any()) } doAnswer { fnr: Fnr ->
-                        PersonOppslagStub.nyTestPerson(fnr).right()
-                    }
+                    on { sjekkTilgangTilPerson(any()) } doReturn Unit.right()
                 }
             )
         ).proxy()

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/RoutesTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/RoutesTest.kt
@@ -91,6 +91,7 @@ class RoutesTest {
                         PersonOppslag {
                         override fun person(fnr: Fnr): Either<KunneIkkeHentePerson, Person> = throw RuntimeException("thrown exception")
                         override fun aktørId(fnr: Fnr) = throw RuntimeException("thrown exception")
+                        override fun sjekkTilgangTilPerson(fnr: Fnr): Either<KunneIkkeHentePerson, Unit> = throw RuntimeException("thrown exception")
                     }
                 )
             )

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/person/PersonRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/person/PersonRoutesKtTest.kt
@@ -134,7 +134,10 @@ internal class PersonRoutesKtTest {
             fnr.toString() -> PersonOppslagStub.nyTestPerson(fnr).right()
             else -> feil.left()
         }
-
         override fun aktørId(fnr: Fnr): Either<KunneIkkeHentePerson, AktørId> = throw NotImplementedError()
+        override fun sjekkTilgangTilPerson(fnr: Fnr): Either<KunneIkkeHentePerson, Unit> = when (testIdent) {
+            fnr.toString() -> Unit.right()
+            else -> feil.left()
+        }
     }
 }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutesKtTest.kt
@@ -64,7 +64,6 @@ import no.nav.su.se.bakover.web.routes.søknad.SøknadInnholdJson.Companion.toS�
 import no.nav.su.se.bakover.web.routes.søknad.lukk.LukketJson
 import no.nav.su.se.bakover.web.testSusebakover
 import org.junit.jupiter.api.Test
-import org.mockito.internal.verification.Times
 import java.util.UUID
 import kotlin.test.assertEquals
 
@@ -182,6 +181,7 @@ internal class SøknadRoutesKtTest {
         val personOppslag: PersonOppslag = mock {
             on { person(any()) } doReturn PersonOppslagStub.person(fnr)
             on { aktørId(any()) } doReturn PersonOppslagStub.aktørId(fnr)
+            on { sjekkTilgangTilPerson(any()) } doReturn PersonOppslagStub.sjekkTilgangTilPerson(fnr)
         }
         val oppgaveClient: OppgaveClient = mock {
             on { opprettOppgave(any<OppgaveConfig.Saksbehandling>()) } doReturn OppgaveId("11").right()
@@ -219,7 +219,7 @@ internal class SøknadRoutesKtTest {
                 verify(pdfGenerator).genererPdf(any<SøknadPdfInnhold>())
                 verify(dokArkiv).opprettJournalpost(any())
                 // Kalles én gang i AccessCheckProxy og én gang eksplisitt i søknadService
-                verify(personOppslag, Times(2)).person(argThat { it shouldBe fnr })
+                verify(personOppslag).person(argThat { it shouldBe fnr })
                 verify(personOppslag).aktørId(argThat { it shouldBe fnr })
                 verify(oppgaveClient).opprettOppgave(any())
             }


### PR DESCRIPTION
Fjernet litt forskjellig støy fra loggen, hvor de største endringene var å sørge for at tilgangssjekken vår for person ikke kaller på det dekorerte person-endepunktet (som også kaller på kodeverk, skjermingstjenesten og DKIF), og å fjerne OPTIONS-kall fra request-loggingen.