### PR TITLE
Specify su-se-framover as a pre-authorized app

### DIFF
--- a/nais.yml
+++ b/nais.yml
@@ -13,6 +13,10 @@ spec:
       replyURLs:
         - "http://localhost:8080/callback"
         - {{ env.BACKEND_CALLBACK_URL }}
+  accessPolicy:
+    inbound:
+      rules:
+        - application: su-se-framover
   image: {{ image }}
   liveness:
     path: /isalive


### PR DESCRIPTION
This is to prepare for the new authentication flow, where su-se-framover
will call us with on-behalf-of tokens. Ref.
https://doc.nais.io/security/auth/azure-ad/#pre-authorization_1