### PR TITLE
Bruk defaultverdier på Person for å gjøre instansiering i tester enklere

### DIFF
--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Person.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Person.kt
@@ -6,16 +6,16 @@ import java.time.Period
 data class Person(
     val ident: Ident,
     val navn: Navn,
-    val telefonnummer: Telefonnummer?,
-    val adresse: List<Adresse>?,
-    val statsborgerskap: String?,
-    val kjønn: String?,
-    val fødselsdato: LocalDate?,
-    val adressebeskyttelse: String?,
-    val skjermet: Boolean?,
-    val kontaktinfo: Kontaktinfo?,
-    val vergemål: Boolean?,
-    val fullmakt: Boolean?
+    val telefonnummer: Telefonnummer? = null,
+    val adresse: List<Adresse>? = null,
+    val statsborgerskap: String? = null,
+    val kjønn: String? = null,
+    val fødselsdato: LocalDate? = null,
+    val adressebeskyttelse: String? = null,
+    val skjermet: Boolean? = null,
+    val kontaktinfo: Kontaktinfo? = null,
+    val vergemål: Boolean? = null,
+    val fullmakt: Boolean? = null
 ) {
     fun getAlder(påDato: LocalDate) = fødselsdato?.let { Period.between(it, påDato).years }
 

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/brev/søknad/lukk/AvvistSøknadBrevRequestTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/brev/søknad/lukk/AvvistSøknadBrevRequestTest.kt
@@ -25,17 +25,7 @@ internal class AvvistSøknadBrevRequestTest {
             fnr = Fnr(fnr = "12345678901"),
             aktørId = AktørId(aktørId = "123")
         ),
-        navn = Navn(fornavn = "Tore", mellomnavn = "Johnas", etternavn = "Strømøy"),
-        telefonnummer = null,
-        adresse = null,
-        statsborgerskap = null,
-        kjønn = null,
-        fødselsdato = null,
-        adressebeskyttelse = null,
-        skjermet = null,
-        kontaktinfo = null,
-        vergemål = null,
-        fullmakt = null,
+        navn = Navn(fornavn = "Tore", mellomnavn = "Johnas", etternavn = "Strømøy")
     )
 
     @Test

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/behandling/BehandlingTestUtils.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/behandling/BehandlingTestUtils.kt
@@ -76,17 +76,7 @@ object BehandlingTestUtils {
             fnr = fnr,
             aktørId = AktørId(aktørId = "123")
         ),
-        navn = Navn(fornavn = "Tore", mellomnavn = "Johnas", etternavn = "Strømøy"),
-        telefonnummer = null,
-        adresse = null,
-        statsborgerskap = null,
-        kjønn = null,
-        fødselsdato = null,
-        adressebeskyttelse = null,
-        skjermet = null,
-        kontaktinfo = null,
-        vergemål = null,
-        fullmakt = null,
+        navn = Navn(fornavn = "Tore", mellomnavn = "Johnas", etternavn = "Strømøy")
     )
 
     internal fun createOpprettetBehandling(): Behandling {

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/behandling/LagBrevUtkastForBehandlingTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/behandling/LagBrevUtkastForBehandlingTest.kt
@@ -54,17 +54,7 @@ internal class LagBrevUtkastForBehandlingTest {
             fnr = Fnr(fnr = "12345678901"),
             aktørId = AktørId(aktørId = "123")
         ),
-        navn = Navn(fornavn = "Tore", mellomnavn = "Johnas", etternavn = "Strømøy"),
-        telefonnummer = null,
-        adresse = null,
-        statsborgerskap = null,
-        kjønn = null,
-        fødselsdato = null,
-        adressebeskyttelse = null,
-        skjermet = null,
-        kontaktinfo = null,
-        vergemål = null,
-        fullmakt = null,
+        navn = Navn(fornavn = "Tore", mellomnavn = "Johnas", etternavn = "Strømøy")
     )
 
     @Test

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/behandling/OpprettManglendeJournalpostOgBrevForIverksettingerTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/behandling/OpprettManglendeJournalpostOgBrevForIverksettingerTest.kt
@@ -45,17 +45,7 @@ internal class OpprettManglendeJournalpostOgBrevForIverksettingerTest {
             fnr = fnr,
             aktørId = AktørId(aktørId = "123")
         ),
-        navn = Person.Navn(fornavn = "Tore", mellomnavn = "Johnas", etternavn = "Strømøy"),
-        telefonnummer = null,
-        adresse = null,
-        statsborgerskap = null,
-        kjønn = null,
-        fødselsdato = null,
-        adressebeskyttelse = null,
-        skjermet = null,
-        kontaktinfo = null,
-        vergemål = null,
-        fullmakt = null,
+        navn = Person.Navn(fornavn = "Tore", mellomnavn = "Johnas", etternavn = "Strømøy")
     )
     private val sakIdJournalpost = UUID.randomUUID()
     private val sakIdBestiltBrev = UUID.randomUUID()

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/brev/BrevServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/brev/BrevServiceImplTest.kt
@@ -35,17 +35,7 @@ internal class BrevServiceImplTest {
                 fnr = fnr,
                 aktørId = AktørId(aktørId = "123")
             ),
-            navn = Person.Navn(fornavn = "Tore", mellomnavn = null, etternavn = "Strømøy"),
-            telefonnummer = null,
-            adresse = null,
-            statsborgerskap = null,
-            kjønn = null,
-            fødselsdato = null,
-            adressebeskyttelse = null,
-            skjermet = null,
-            kontaktinfo = null,
-            vergemål = null,
-            fullmakt = null,
+            navn = Person.Navn(fornavn = "Tore", mellomnavn = null, etternavn = "Strømøy")
         )
     }
 

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/HentSøknadPdfTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/HentSøknadPdfTest.kt
@@ -57,17 +57,7 @@ class HentSøknadPdfTest {
             fnr = Fnr(fnr = "12345678901"),
             aktørId = AktørId(aktørId = "1234")
         ),
-        navn = Person.Navn(fornavn = "Tore", mellomnavn = "Johnas", etternavn = "Strømøy"),
-        telefonnummer = null,
-        adresse = listOf(),
-        statsborgerskap = null,
-        kjønn = null,
-        fødselsdato = null,
-        adressebeskyttelse = null,
-        skjermet = null,
-        kontaktinfo = null,
-        vergemål = null,
-        fullmakt = null
+        navn = Person.Navn(fornavn = "Tore", mellomnavn = "Johnas", etternavn = "Strømøy")
     )
 
     @Test

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/OpprettManglendeJournalpostOgOppgaveTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/OpprettManglendeJournalpostOgOppgaveTest.kt
@@ -61,17 +61,7 @@ class OpprettManglendeJournalpostOgOppgaveTest {
             fnr = fnr,
             aktørId = AktørId(aktørId = "123")
         ),
-        navn = Person.Navn(fornavn = "Tore", mellomnavn = "Johnas", etternavn = "Strømøy"),
-        telefonnummer = null,
-        adresse = null,
-        statsborgerskap = null,
-        kjønn = null,
-        fødselsdato = null,
-        adressebeskyttelse = null,
-        skjermet = null,
-        kontaktinfo = null,
-        vergemål = null,
-        fullmakt = null,
+        navn = Person.Navn(fornavn = "Tore", mellomnavn = "Johnas", etternavn = "Strømøy")
     )
 
     @Test

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/lukk/LukkSøknadServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/lukk/LukkSøknadServiceImplTest.kt
@@ -66,17 +66,7 @@ internal class LukkSøknadServiceImplTest {
             fnr = fnr,
             aktørId = AktørId(aktørId = "123")
         ),
-        navn = Navn(fornavn = "Tore", mellomnavn = "Johnas", etternavn = "Strømøy"),
-        telefonnummer = null,
-        adresse = null,
-        statsborgerskap = null,
-        kjønn = null,
-        fødselsdato = null,
-        adressebeskyttelse = null,
-        skjermet = null,
-        kontaktinfo = null,
-        vergemål = null,
-        fullmakt = null,
+        navn = Navn(fornavn = "Tore", mellomnavn = "Johnas", etternavn = "Strømøy")
     )
     private val sak = Sak(
         id = sakId,


### PR DESCRIPTION
Vi har en del sånne rundt omkring i testene våre, som er ganske kjipe å oppdatere når man legger til et felt i personalia:

```   
private val person = Person(
        ident = Ident(
            fnr = Fnr(fnr = "12345678901"),
            aktørId = AktørId(aktørId = "123")
        ),
        navn = Navn(fornavn = "Tore", mellomnavn = "Johnas", etternavn = "Strømøy"),
        telefonnummer = null,
        adresse = null,
        statsborgerskap = null,
        kjønn = null,
        fødselsdato = null,
        adressebeskyttelse = null,
        skjermet = null,
        kontaktinfo = null,
        vergemål = null,
        fullmakt = null,
    )
```

Har ikke tenkt noe særlig på om defaultene kan/bør være noe annet enn `null`, men det kan jo også settes etterhvert hvis man finner noe bedre.
