### PR TITLE
Bruk gjeldende tidssone for utskriftstidspunkt i søknads-PDF

### DIFF
--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknad/SøknadPdfInnhold.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknad/SøknadPdfInnhold.kt
@@ -31,7 +31,7 @@ data class SøknadPdfInnhold private constructor(
             saksnummer = saksnummer,
             søknadsId = søknadsId,
             navn = navn,
-            dagensDatoOgTidspunkt = LocalDateTime.now(clock).format(DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm")),
+            dagensDatoOgTidspunkt = LocalDateTime.now(clock.withZone(zoneIdOslo)).format(DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm")),
             søknadOpprettet = søknadOpprettet.toLocalDate(zoneIdOslo).ddMMyyyy(),
             søknadInnhold = søknadInnhold,
         )

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknad/SøknadPdfInnholdJsonTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknad/SøknadPdfInnholdJsonTest.kt
@@ -12,15 +12,12 @@ import no.nav.su.se.bakover.domain.fnrUnder67
 import org.junit.jupiter.api.Test
 import org.skyscreamer.jsonassert.JSONAssert
 import java.time.Clock
-import java.time.LocalDateTime
 import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 class SøknadPdfInnholdJsonTest {
     private val fixedClock: Clock = Clock.fixed(1.januar(2021).startOfDay().instant, ZoneOffset.UTC)
     private val søknadsId = UUID.randomUUID()
-    private val dagensDatoOgTidspunkt = LocalDateTime.now(fixedClock).format(DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm"))
     private val søknadPdfInnhold = SøknadPdfInnhold.create(
         saksnummer = Saksnummer(2021),
         søknadsId = søknadsId,
@@ -43,7 +40,7 @@ class SøknadPdfInnholdJsonTest {
                     "mellomnavn": "Johnas",
                     "etternavn": "Strømøy"
                   },
-                  "dagensDatoOgTidspunkt": "$dagensDatoOgTidspunkt",
+                  "dagensDatoOgTidspunkt": "01.01.2021 00:00",
                   "søknadOpprettet": "01.01.2021",
                   "søknadInnhold": {
                       "uførevedtak":{
@@ -217,7 +214,7 @@ class SøknadPdfInnholdJsonTest {
                     "mellomnavn": "Johnas",
                     "etternavn": "Strømøy"
                   },
-                  "dagensDatoOgTidspunkt": "$dagensDatoOgTidspunkt",
+                  "dagensDatoOgTidspunkt": "01.01.2021 00:00",
                   "søknadOpprettet": "01.01.2021",
                   "søknadInnhold": {
                       "uførevedtak":{
@@ -396,7 +393,7 @@ class SøknadPdfInnholdJsonTest {
                     "mellomnavn": "Johnas",
                     "etternavn": "Strømøy"
                   },
-                  "dagensDatoOgTidspunkt": "$dagensDatoOgTidspunkt",
+                  "dagensDatoOgTidspunkt": "01.01.2021 00:00",
                   "søknadOpprettet": "01.01.2021",
                   "søknadInnhold": {
                       "uførevedtak":{


### PR DESCRIPTION
Denne viste tidligere frem UTC-tidspunktet, altså en time før korrekt tidspunkt.