### PR TITLE
Bump unleash client to a version that uses slf4j instead of log4j2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ allprojects {
         implementation("io.github.cdimascio:dotenv-kotlin:6.2.2")
         implementation("org.apache.kafka:kafka-clients:2.7.0")
         implementation("com.networknt:json-schema-validator:1.0.45")
-        implementation("no.finn.unleash:unleash-client-java:3.3.4")
+        implementation("no.finn.unleash:unleash-client-java:4.0.1")
 
         // The 9.2.1.0 version fails to connect to the MQ server (hostname becomes null?)
         implementation("com.ibm.mq:com.ibm.mq.allclient:9.2.0.1")


### PR DESCRIPTION
https://github.com/Unleash/unleash-client-java/commit/5e4bb2e0cedb57e9134efff8ec48d8c370c054b5