### PR TITLE
Endre SimuleringStub til å oppføre seg som det faktiske simuleringssystemet

### DIFF
--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/person/PdlClient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/person/PdlClient.kt
@@ -13,7 +13,6 @@ import no.nav.su.se.bakover.client.person.PdlData.Navn
 import no.nav.su.se.bakover.client.person.Variables.Companion.AKTORID
 import no.nav.su.se.bakover.client.person.Variables.Companion.FOLKEREGISTERIDENT
 import no.nav.su.se.bakover.client.sts.TokenOppslag
-import no.nav.su.se.bakover.common.filterMap
 import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.domain.AktørId
 import no.nav.su.se.bakover.domain.Fnr
@@ -64,7 +63,7 @@ internal class PdlClient(
                 person.bostedsadresse,
                 person.oppholdsadresse,
                 person.kontaktadresse
-            ).filterMap { it.firstOrNull() }.finnRiktigAdresseformatOgMapTilPdlAdresse()
+            ).mapNotNull { it.firstOrNull() }.finnRiktigAdresseformatOgMapTilPdlAdresse()
 
             PdlData(
                 ident = Ident(pdlIdent.fnr, pdlIdent.aktørId),

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/oppdrag/SimuleringStub.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/oppdrag/SimuleringStub.kt
@@ -2,7 +2,6 @@ package no.nav.su.se.bakover.client.stubs.oppdrag
 
 import arrow.core.Either
 import arrow.core.right
-import no.nav.su.se.bakover.common.filterMap
 import no.nav.su.se.bakover.common.idag
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.Saksnummer
@@ -27,7 +26,7 @@ object SimuleringStub : SimuleringClient {
 
     private fun simulerNyUtbetaling(utbetaling: Utbetaling, saksnummer: Saksnummer): Simulering {
         val perioder = utbetaling.utbetalingslinjer.flatMap { utbetalingslinje ->
-            Periode.create(utbetalingslinje.fraOgMed, utbetalingslinje.tilOgMed).tilMånedsperioder().filterMap {
+            Periode.create(utbetalingslinje.fraOgMed, utbetalingslinje.tilOgMed).tilMånedsperioder().mapNotNull {
                 if (utbetalingslinje.beløp > 0) {
                     SimulertPeriode(
                         fraOgMed = it.getFraOgMed(),

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/oppdrag/SimuleringStub.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/oppdrag/SimuleringStub.kt
@@ -2,6 +2,7 @@ package no.nav.su.se.bakover.client.stubs.oppdrag
 
 import arrow.core.Either
 import arrow.core.right
+import no.nav.su.se.bakover.common.filterMap
 import no.nav.su.se.bakover.common.idag
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.Saksnummer
@@ -26,24 +27,28 @@ object SimuleringStub : SimuleringClient {
 
     private fun simulerNyUtbetaling(utbetaling: Utbetaling, saksnummer: Saksnummer): Simulering {
         val perioder = utbetaling.utbetalingslinjer.flatMap { utbetalingslinje ->
-            Periode.create(utbetalingslinje.fraOgMed, utbetalingslinje.tilOgMed).tilMånedsperioder().map {
-                SimulertPeriode(
-                    fraOgMed = it.getFraOgMed(),
-                    tilOgMed = it.getTilOgMed(),
-                    utbetaling = listOf(
-                        SimulertUtbetaling(
-                            fagSystemId = saksnummer.toString(),
-                            feilkonto = false,
-                            forfall = it.getTilOgMed(),
-                            utbetalesTilId = utbetaling.fnr,
-                            utbetalesTilNavn = "MYGG LUR",
-                            detaljer = listOf(
-                                createYtelse(it.getFraOgMed(), it.getTilOgMed(), utbetalingslinje.beløp),
-                                createForskuddsskatt(it.getFraOgMed(), it.getTilOgMed(), utbetalingslinje.beløp)
+            Periode.create(utbetalingslinje.fraOgMed, utbetalingslinje.tilOgMed).tilMånedsperioder().filterMap {
+                if (utbetalingslinje.beløp > 0) {
+                    SimulertPeriode(
+                        fraOgMed = it.getFraOgMed(),
+                        tilOgMed = it.getTilOgMed(),
+                        utbetaling = listOf(
+                            SimulertUtbetaling(
+                                fagSystemId = saksnummer.toString(),
+                                feilkonto = false,
+                                forfall = it.getTilOgMed(),
+                                utbetalesTilId = utbetaling.fnr,
+                                utbetalesTilNavn = "MYGG LUR",
+                                detaljer = listOf(
+                                    createYtelse(it.getFraOgMed(), it.getTilOgMed(), utbetalingslinje.beløp),
+                                    createForskuddsskatt(it.getFraOgMed(), it.getTilOgMed(), utbetalingslinje.beløp)
+                                )
                             )
                         )
                     )
-                )
+                } else {
+                    null
+                }
             }
         }
 

--- a/common/src/main/kotlin/no/nav/su/se/bakover/common/Extensions.kt
+++ b/common/src/main/kotlin/no/nav/su/se/bakover/common/Extensions.kt
@@ -14,17 +14,6 @@ fun <A> Either.Companion.unsafeCatch(f: () -> A) =
         catch { f() }
     }
 
-// Lager vår egen her fordi Arrow sin filterMap bruker Option, som Arrow selv sier er deprecated (noe som feiler bygget vårt)
-fun <A, B> List<A>.filterMap(predicate: Function1<A, B?>): List<B> =
-    fold(emptyList()) { acc, a ->
-        predicate(a).let {
-            when (it) {
-                null -> acc
-                else -> acc.plus(it)
-            }
-        }
-    }
-
 fun Double.positiveOrZero() = max(0.0, this)
 fun Double.limitedUpwardsTo(limit: Double) = min(limit, this)
 fun Double.roundToDecimals(decimals: Int) = BigDecimal(this).setScale(decimals, RoundingMode.HALF_UP).toDouble()

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/Application.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/Application.kt
@@ -32,7 +32,6 @@ import no.nav.su.se.bakover.client.ProdClientsBuilder
 import no.nav.su.se.bakover.client.StubClientsBuilder
 import no.nav.su.se.bakover.common.ApplicationConfig
 import no.nav.su.se.bakover.common.JmsConfig
-import no.nav.su.se.bakover.common.filterMap
 import no.nav.su.se.bakover.common.log
 import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.database.DatabaseBuilder
@@ -197,7 +196,7 @@ internal fun Application.susebakover(
     install(Authorization) {
         getRoller { principal ->
             getGroupsFromJWT(applicationConfig, principal)
-                .filterMap { azureGroupMapper.fromAzureGroup(it) }
+                .mapNotNull { azureGroupMapper.fromAzureGroup(it) }
                 .toSet()
         }
     }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/me/MeRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/me/MeRoutes.kt
@@ -7,7 +7,6 @@ import io.ktor.response.respond
 import io.ktor.routing.Route
 import io.ktor.routing.get
 import no.nav.su.se.bakover.common.ApplicationConfig
-import no.nav.su.se.bakover.common.filterMap
 import no.nav.su.se.bakover.common.serialize
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.web.AzureGroupMapper
@@ -25,7 +24,7 @@ internal fun Route.meRoutes(applicationConfig: ApplicationConfig, azureGroupMapp
     get("/me") {
         val roller =
             getGroupsFromJWT(applicationConfig, call.authentication.principal)
-                .filterMap { azureGroupMapper.fromAzureGroup(it) }
+                .mapNotNull { azureGroupMapper.fromAzureGroup(it) }
 
         call.respond(
             HttpStatusCode.OK,


### PR DESCRIPTION
Når vi får perioder med nullutbetaling vil de relle simuleringene ikke inneholde disse periodene.
SimuleringStub vil nå også gjøre dette, i stedet for å legge til perioder med nullutbetaling.