### PR TITLE
Legg til endepunkt for å hente et eksisterende revurderingsbrev

### DIFF
--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
@@ -366,6 +366,11 @@ open class AccessCheckProxy(
                     return services.revurdering.lagBrevutkast(revurderingId, fritekst)
                 }
 
+                override fun hentBrevutkast(revurderingId: UUID): Either<KunneIkkeLageBrevutkastForRevurdering, ByteArray> {
+                    assertHarTilgangTilSak(revurderingId)
+                    return services.revurdering.hentBrevutkast(revurderingId)
+                }
+
                 override fun iverksett(revurderingId: UUID, attestant: NavIdentBruker.Attestant): Either<KunneIkkeIverksetteRevurdering, IverksattRevurdering> {
                     assertHarTilgangTilSak(revurderingId)
                     return services.revurdering.iverksett(revurderingId, attestant)

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
@@ -41,6 +41,7 @@ interface RevurderingService {
     ): Either<KunneIkkeSendeRevurderingTilAttestering, Revurdering>
 
     fun lagBrevutkast(revurderingId: UUID, fritekst: String): Either<KunneIkkeLageBrevutkastForRevurdering, ByteArray>
+    fun hentBrevutkast(revurderingId: UUID): Either<KunneIkkeLageBrevutkastForRevurdering, ByteArray>
     fun iverksett(
         revurderingId: UUID,
         attestant: NavIdentBruker.Attestant

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -254,6 +254,17 @@ internal class RevurderingServiceImpl(
         revurderingId: UUID,
         fritekst: String
     ): Either<KunneIkkeLageBrevutkastForRevurdering, ByteArray> {
+        return hentBrevutkast(revurderingId, fritekst)
+    }
+
+    override fun hentBrevutkast(revurderingId: UUID): Either<KunneIkkeLageBrevutkastForRevurdering, ByteArray> {
+        return hentBrevutkast(revurderingId, null)
+    }
+
+    private fun hentBrevutkast(
+        revurderingId: UUID,
+        fritekst: String?
+    ): Either<KunneIkkeLageBrevutkastForRevurdering, ByteArray> {
         val revurdering = revurderingRepo.hent(revurderingId)
             ?: return KunneIkkeLageBrevutkastForRevurdering.FantIkkeRevurdering.left()
 
@@ -268,7 +279,12 @@ internal class RevurderingServiceImpl(
             },
             clock = clock
         ).let {
-            revurdering.medFritekst(fritekst).accept(it)
+            val r = if (fritekst != null) {
+                revurdering.medFritekst(fritekst)
+            } else {
+                revurdering
+            }
+            r.accept(it)
             it.brevRequest
         }.mapLeft {
             when (it) {

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BrevutkastForRevurderingRoute.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BrevutkastForRevurderingRoute.kt
@@ -5,6 +5,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode.Companion.InternalServerError
 import io.ktor.response.respondBytes
 import io.ktor.routing.Route
+import io.ktor.routing.get
 import io.ktor.routing.post
 import io.ktor.util.KtorExperimentalAPI
 import no.nav.su.se.bakover.domain.Brukerrolle
@@ -29,6 +30,17 @@ internal fun Route.brevutkastForRevurdering(
 
         data class Body(val fritekst: String)
 
+        get("$revurderingPath/{revurderingId}/brevutkast") {
+            call.withRevurderingId { revurderingId ->
+                revurderingService.hentBrevutkast(revurderingId).fold(
+                    ifLeft = { call.svar(it.tilResultat()) },
+                    ifRight = {
+                        call.audit("Hentet brevutkast for revurdering med id $revurderingId")
+                        call.respondBytes(it, ContentType.Application.Pdf)
+                    },
+                )
+            }
+        }
         post("$revurderingPath/{revurderingId}/brevutkast") {
             call.withRevurderingId { revurderingId ->
                 call.withBody<Body> { body ->


### PR DESCRIPTION
Dette er gjort som et eget endepunkt for å (forhåpentligvis) forhindre at man sender inn tom fritekst uten at man mener det.