### PR TITLE
Lag enkel G-reguleringsflyt i revurderings-flyten

### DIFF
--- a/common/src/main/kotlin/no/nav/su/se/bakover/common/Tidspunkt.kt
+++ b/common/src/main/kotlin/no/nav/su/se/bakover/common/Tidspunkt.kt
@@ -57,6 +57,7 @@ class Tidspunkt @JsonCreator(mode = JsonCreator.Mode.DELEGATING) constructor(
 
     override fun hashCode() = instant.hashCode()
     override fun plus(amount: Long, unit: TemporalUnit): Tidspunkt = instant.plus(amount, unit).toTidspunkt()
+    override fun minus(amount: Long, unit: TemporalUnit): Tidspunkt = instant.minus(amount, unit).toTidspunkt()
     fun toLocalDate(zoneId: ZoneId): LocalDate = LocalDate.ofInstant(instant, zoneId)
 }
 

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/beregning/BeregningMapper.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/beregning/BeregningMapper.kt
@@ -36,6 +36,19 @@ internal data class PersistertBeregning(
     override fun getBegrunnelse(): String? = begrunnelse
 
     override fun getPeriode(): Periode = periode
+
+    override fun equals(other: Any?) = (other as? Beregning)?.let { this.equals(other) } ?: false
+
+    override fun hashCode(): Int {
+        var result = sats.hashCode()
+        result = 31 * result + månedsberegninger.hashCode()
+        result = 31 * result + fradrag.hashCode()
+        result = 31 * result + sumYtelse
+        result = 31 * result + sumFradrag.hashCode()
+        result = 31 * result + periode.hashCode()
+        result = 31 * result + fradragStrategyName.hashCode()
+        return result
+    }
 }
 
 internal data class PersistertMånedsberegning(
@@ -54,6 +67,19 @@ internal data class PersistertMånedsberegning(
     override fun getSatsbeløp(): Double = satsbeløp
     override fun getFradrag(): List<Fradrag> = fradrag
     override fun getPeriode(): Periode = periode
+
+    override fun equals(other: Any?) = (other as? Månedsberegning)?.let { this.equals(other) } ?: false
+
+    override fun hashCode(): Int {
+        var result = sumYtelse
+        result = 31 * result + sumFradrag.hashCode()
+        result = 31 * result + benyttetGrunnbeløp
+        result = 31 * result + sats.hashCode()
+        result = 31 * result + satsbeløp.hashCode()
+        result = 31 * result + fradrag.hashCode()
+        result = 31 * result + periode.hashCode()
+        return result
+    }
 }
 
 internal data class PersistertFradrag(
@@ -64,12 +90,24 @@ internal data class PersistertFradrag(
     private val tilhører: FradragTilhører
 ) : Fradrag {
     override fun getFradragstype(): Fradragstype = fradragstype
+
     @JsonAlias("totaltFradrag")
     override fun getMånedsbeløp(): Double = månedsbeløp
     override fun getUtenlandskInntekt(): UtenlandskInntekt? = utenlandskInntekt
     override fun getTilhører(): FradragTilhører = tilhører
 
     override fun getPeriode(): Periode = periode
+
+    override fun equals(other: Any?) = (other as? Fradrag)?.let { this.equals(other) } ?: false
+
+    override fun hashCode(): Int {
+        var result = fradragstype.hashCode()
+        result = 31 * result + månedsbeløp.hashCode()
+        result = 31 * result + (utenlandskInntekt?.hashCode() ?: 0)
+        result = 31 * result + periode.hashCode()
+        result = 31 * result + tilhører.hashCode()
+        return result
+    }
 }
 
 internal fun Beregning.toSnapshot() = PersistertBeregning(

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/revurdering/RevurderingPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/revurdering/RevurderingPostgresRepo.kt
@@ -2,6 +2,7 @@ package no.nav.su.se.bakover.database.revurdering
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import kotliquery.Row
+import no.nav.su.se.bakover.common.deserialize
 import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.database.Session
@@ -17,6 +18,7 @@ import no.nav.su.se.bakover.database.vedtak.VedtakRepo
 import no.nav.su.se.bakover.database.withSession
 import no.nav.su.se.bakover.domain.NavIdentBruker.Saksbehandler
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.revurdering.BeregnetRevurdering
@@ -133,6 +135,8 @@ internal class RevurderingPostgresRepo(
         )
         val skalFøreTilBrevutsending = boolean("skalFøreTilBrevutsending")
 
+        val behandlingsinformasjon: Behandlingsinformasjon = deserialize(string("behandlingsinformasjon"))
+
         return when (RevurderingsType.valueOf(string("revurderingsType"))) {
             RevurderingsType.UNDERKJENT_INNVILGET -> UnderkjentRevurdering.Innvilget(
                 id = id,
@@ -146,6 +150,7 @@ internal class RevurderingPostgresRepo(
                 attestering = attestering!! as Attestering.Underkjent,
                 fritekstTilBrev = fritekstTilBrev ?: "",
                 revurderingsårsak = revurderingsårsak,
+                behandlingsinformasjon = behandlingsinformasjon,
             )
             RevurderingsType.UNDERKJENT_OPPHØRT -> UnderkjentRevurdering.Opphørt(
                 id = id,
@@ -159,6 +164,7 @@ internal class RevurderingPostgresRepo(
                 attestering = attestering!! as Attestering.Underkjent,
                 fritekstTilBrev = fritekstTilBrev ?: "",
                 revurderingsårsak = revurderingsårsak,
+                behandlingsinformasjon = behandlingsinformasjon,
             )
             RevurderingsType.IVERKSATT_INNVILGET -> IverksattRevurdering.Innvilget(
                 id = id,
@@ -172,6 +178,7 @@ internal class RevurderingPostgresRepo(
                 attestering = attestering!! as Attestering.Iverksatt,
                 fritekstTilBrev = fritekstTilBrev ?: "",
                 revurderingsårsak = revurderingsårsak,
+                behandlingsinformasjon = behandlingsinformasjon,
             )
             RevurderingsType.IVERKSATT_OPPHØRT -> IverksattRevurdering.Opphørt(
                 id = id,
@@ -185,6 +192,7 @@ internal class RevurderingPostgresRepo(
                 attestering = attestering!! as Attestering.Iverksatt,
                 fritekstTilBrev = fritekstTilBrev ?: "",
                 revurderingsårsak = revurderingsårsak,
+                behandlingsinformasjon = behandlingsinformasjon,
             )
             RevurderingsType.TIL_ATTESTERING_INNVILGET -> RevurderingTilAttestering.Innvilget(
                 id = id,
@@ -197,6 +205,7 @@ internal class RevurderingPostgresRepo(
                 oppgaveId = OppgaveId(oppgaveId!!),
                 fritekstTilBrev = fritekstTilBrev ?: "",
                 revurderingsårsak = revurderingsårsak,
+                behandlingsinformasjon = behandlingsinformasjon,
             )
             RevurderingsType.TIL_ATTESTERING_OPPHØRT -> RevurderingTilAttestering.Opphørt(
                 id = id,
@@ -209,6 +218,7 @@ internal class RevurderingPostgresRepo(
                 oppgaveId = OppgaveId(oppgaveId!!),
                 fritekstTilBrev = fritekstTilBrev ?: "",
                 revurderingsårsak = revurderingsårsak,
+                behandlingsinformasjon = behandlingsinformasjon,
             )
             RevurderingsType.SIMULERT_INNVILGET -> SimulertRevurdering.Innvilget(
                 id = id,
@@ -221,6 +231,7 @@ internal class RevurderingPostgresRepo(
                 oppgaveId = OppgaveId(oppgaveId!!),
                 fritekstTilBrev = fritekstTilBrev ?: "",
                 revurderingsårsak = revurderingsårsak,
+                behandlingsinformasjon = behandlingsinformasjon,
             )
             RevurderingsType.SIMULERT_OPPHØRT -> SimulertRevurdering.Opphørt(
                 id = id,
@@ -233,6 +244,7 @@ internal class RevurderingPostgresRepo(
                 oppgaveId = OppgaveId(oppgaveId!!),
                 fritekstTilBrev = fritekstTilBrev ?: "",
                 revurderingsårsak = revurderingsårsak,
+                behandlingsinformasjon = behandlingsinformasjon,
             )
             RevurderingsType.BEREGNET_INNVILGET -> BeregnetRevurdering.Innvilget(
                 id = id,
@@ -244,6 +256,7 @@ internal class RevurderingPostgresRepo(
                 oppgaveId = OppgaveId(oppgaveId!!),
                 fritekstTilBrev = fritekstTilBrev ?: "",
                 revurderingsårsak = revurderingsårsak,
+                behandlingsinformasjon = behandlingsinformasjon,
             )
             RevurderingsType.BEREGNET_OPPHØRT -> BeregnetRevurdering.Opphørt(
                 id = id,
@@ -255,6 +268,7 @@ internal class RevurderingPostgresRepo(
                 oppgaveId = OppgaveId(oppgaveId!!),
                 fritekstTilBrev = fritekstTilBrev ?: "",
                 revurderingsårsak = revurderingsårsak,
+                behandlingsinformasjon = behandlingsinformasjon,
             )
             RevurderingsType.OPPRETTET -> OpprettetRevurdering(
                 id = id,
@@ -265,6 +279,7 @@ internal class RevurderingPostgresRepo(
                 oppgaveId = OppgaveId(oppgaveId!!),
                 fritekstTilBrev = fritekstTilBrev ?: "",
                 revurderingsårsak = revurderingsårsak,
+                behandlingsinformasjon = behandlingsinformasjon,
             )
             RevurderingsType.BEREGNET_INGEN_ENDRING -> BeregnetRevurdering.IngenEndring(
                 id = id,
@@ -276,6 +291,7 @@ internal class RevurderingPostgresRepo(
                 oppgaveId = OppgaveId(oppgaveId!!),
                 fritekstTilBrev = fritekstTilBrev ?: "",
                 revurderingsårsak = revurderingsårsak,
+                behandlingsinformasjon = behandlingsinformasjon,
             )
             RevurderingsType.TIL_ATTESTERING_INGEN_ENDRING -> RevurderingTilAttestering.IngenEndring(
                 id = id,
@@ -288,6 +304,7 @@ internal class RevurderingPostgresRepo(
                 fritekstTilBrev = fritekstTilBrev ?: "",
                 revurderingsårsak = revurderingsårsak,
                 skalFøreTilBrevutsending = skalFøreTilBrevutsending,
+                behandlingsinformasjon = behandlingsinformasjon,
             )
             RevurderingsType.IVERKSATT_INGEN_ENDRING -> IverksattRevurdering.IngenEndring(
                 id = id,
@@ -301,6 +318,7 @@ internal class RevurderingPostgresRepo(
                 revurderingsårsak = revurderingsårsak,
                 attestering = attestering!! as Attestering.Iverksatt,
                 skalFøreTilBrevutsending = skalFøreTilBrevutsending,
+                behandlingsinformasjon = behandlingsinformasjon,
             )
             RevurderingsType.UNDERKJENT_INGEN_ENDRING -> UnderkjentRevurdering.IngenEndring(
                 id = id,
@@ -314,6 +332,7 @@ internal class RevurderingPostgresRepo(
                 revurderingsårsak = revurderingsårsak,
                 attestering = attestering!! as Attestering.Underkjent,
                 skalFøreTilBrevutsending = skalFøreTilBrevutsending,
+                behandlingsinformasjon = behandlingsinformasjon,
             )
         }
     }
@@ -335,7 +354,8 @@ internal class RevurderingPostgresRepo(
                         vedtakSomRevurderesId,
                         fritekstTilBrev,
                         årsak,
-                        begrunnelse
+                        begrunnelse,
+                        behandlingsinformasjon
                     ) values (
                         :id,
                         :opprettet,
@@ -349,7 +369,8 @@ internal class RevurderingPostgresRepo(
                         :vedtakSomRevurderesId,
                         :fritekstTilBrev,
                         :arsak,
-                        :begrunnelse
+                        :begrunnelse,
+                        to_json(:behandlingsinformasjon::json)
                     )
                         ON CONFLICT(id) do update set
                         id=:id,
@@ -364,7 +385,8 @@ internal class RevurderingPostgresRepo(
                         vedtakSomRevurderesId=:vedtakSomRevurderesId,
                         fritekstTilBrev=:fritekstTilBrev,
                         årsak=:arsak,
-                        begrunnelse=:begrunnelse
+                        begrunnelse=:begrunnelse,
+                        behandlingsinformasjon=to_json(:behandlingsinformasjon::json)
                 """.trimIndent()
                 ).oppdatering(
                 mapOf(
@@ -377,6 +399,7 @@ internal class RevurderingPostgresRepo(
                     "fritekstTilBrev" to revurdering.fritekstTilBrev,
                     "arsak" to revurdering.revurderingsårsak.årsak.toString(),
                     "begrunnelse" to revurdering.revurderingsårsak.begrunnelse.toString(),
+                    "behandlingsinformasjon" to objectMapper.writeValueAsString(revurdering.behandlingsinformasjon),
                 ),
                 session,
             )
@@ -394,7 +417,8 @@ internal class RevurderingPostgresRepo(
                         revurderingsType = :revurderingsType,
                         saksbehandler = :saksbehandler,
                         årsak = :arsak,
-                        begrunnelse =:begrunnelse
+                        begrunnelse = :begrunnelse,
+                        behandlingsinformasjon = to_json(:behandlingsinformasjon::json)
                     where
                         id = :id
                 """.trimIndent()
@@ -410,6 +434,7 @@ internal class RevurderingPostgresRepo(
                     },
                     "arsak" to revurdering.revurderingsårsak.årsak.toString(),
                     "begrunnelse" to revurdering.revurderingsårsak.begrunnelse.toString(),
+                    "behandlingsinformasjon" to objectMapper.writeValueAsString(revurdering.behandlingsinformasjon),
                 ),
                 session,
             )
@@ -427,7 +452,8 @@ internal class RevurderingPostgresRepo(
                         simulering = to_json(:simulering::json),
                         revurderingsType = :revurderingsType,
                         årsak = :arsak,
-                        begrunnelse =:begrunnelse
+                        begrunnelse =:begrunnelse,
+                        behandlingsinformasjon = to_json(:behandlingsinformasjon::json)
                     where
                         id = :id
                 """.trimIndent()
@@ -443,6 +469,7 @@ internal class RevurderingPostgresRepo(
                         is SimulertRevurdering.Innvilget -> RevurderingsType.SIMULERT_INNVILGET
                         is SimulertRevurdering.Opphørt -> RevurderingsType.SIMULERT_OPPHØRT
                     },
+                    "behandlingsinformasjon" to objectMapper.writeValueAsString(revurdering.behandlingsinformasjon),
                 ),
                 session,
             )
@@ -463,7 +490,8 @@ internal class RevurderingPostgresRepo(
                         årsak = :arsak,
                         begrunnelse =:begrunnelse,
                         revurderingsType = :revurderingsType,
-                        skalFøreTilBrevutsending = :skalFoereTilBrevutsending
+                        skalFøreTilBrevutsending = :skalFoereTilBrevutsending,
+                        behandlingsinformasjon = to_json(:behandlingsinformasjon::json)
                     where
                         id = :id
                 """.trimIndent()
@@ -491,6 +519,7 @@ internal class RevurderingPostgresRepo(
                         is RevurderingTilAttestering.Innvilget -> true
                         is RevurderingTilAttestering.Opphørt -> true
                     },
+                    "behandlingsinformasjon" to objectMapper.writeValueAsString(revurdering.behandlingsinformasjon),
                 ),
                 session,
             )
@@ -510,7 +539,8 @@ internal class RevurderingPostgresRepo(
                         attestering = to_json(:attestering::json),
                         årsak = :arsak,
                         begrunnelse =:begrunnelse,
-                        revurderingsType = :revurderingsType
+                        revurderingsType = :revurderingsType,
+                        behandlingsinformasjon = to_json(:behandlingsinformasjon::json)
                     where
                         id = :id
                 """.trimIndent()
@@ -533,6 +563,7 @@ internal class RevurderingPostgresRepo(
                         is IverksattRevurdering.Innvilget -> RevurderingsType.IVERKSATT_INNVILGET
                         is IverksattRevurdering.Opphørt -> RevurderingsType.IVERKSATT_OPPHØRT
                     },
+                    "behandlingsinformasjon" to objectMapper.writeValueAsString(revurdering.behandlingsinformasjon),
                 ),
                 session,
             )
@@ -549,7 +580,8 @@ internal class RevurderingPostgresRepo(
                         attestering = to_json(:attestering::json),
                         årsak = :arsak,
                         begrunnelse =:begrunnelse,
-                        revurderingsType = :revurderingsType
+                        revurderingsType = :revurderingsType,
+                        behandlingsinformasjon = to_json(:behandlingsinformasjon::json)
                     where
                         id = :id
                 """.trimIndent()
@@ -565,6 +597,7 @@ internal class RevurderingPostgresRepo(
                         is UnderkjentRevurdering.Innvilget -> RevurderingsType.UNDERKJENT_INNVILGET
                         is UnderkjentRevurdering.Opphørt -> RevurderingsType.UNDERKJENT_OPPHØRT
                     },
+                    "behandlingsinformasjon" to objectMapper.writeValueAsString(revurdering.behandlingsinformasjon),
                 ),
                 session,
             )

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPosgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPosgresRepo.kt
@@ -159,7 +159,6 @@ internal class VedtakPosgresRepo(
             VedtakType.SØKNAD,
             VedtakType.ENDRING,
             VedtakType.OPPHØR,
-            VedtakType.REGULER_GRUNNBELØP, // TODO blir dette riktig?
             -> {
                 Vedtak.EndringIYtelse(
                     id = id,

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPosgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPosgresRepo.kt
@@ -159,6 +159,7 @@ internal class VedtakPosgresRepo(
             VedtakType.SØKNAD,
             VedtakType.ENDRING,
             VedtakType.OPPHØR,
+            VedtakType.REGULER_GRUNNBELØP, // TODO blir dette riktig?
             -> {
                 Vedtak.EndringIYtelse(
                     id = id,

--- a/database/src/main/resources/db/migration/V79__revurdering_behandlingsinformasjon.sql
+++ b/database/src/main/resources/db/migration/V79__revurdering_behandlingsinformasjon.sql
@@ -1,0 +1,4 @@
+alter table revurdering add column if not exists behandlingsinformasjon jsonb;
+
+update revurdering
+set behandlingsinformasjon = ( select behandlingsinformasjon from vedtak v where vedtaksomrevurderesid = v.id )

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/RevurderingPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/RevurderingPostgresRepoTest.kt
@@ -61,6 +61,7 @@ internal class RevurderingPostgresRepoTest {
         oppgaveId = oppgaveId,
         fritekstTilBrev = "",
         revurderingsårsak = revurderingsårsak,
+        behandlingsinformasjon = vedtak.behandlingsinformasjon,
     )
 
     private fun beregnetIngenEndring(
@@ -76,6 +77,7 @@ internal class RevurderingPostgresRepoTest {
         fritekstTilBrev = opprettet.fritekstTilBrev,
         revurderingsårsak = opprettet.revurderingsårsak,
         beregning = vedtak.beregning,
+        behandlingsinformasjon = vedtak.behandlingsinformasjon,
     )
 
     private fun beregnetInnvilget(
@@ -91,6 +93,7 @@ internal class RevurderingPostgresRepoTest {
         oppgaveId = opprettet.oppgaveId,
         fritekstTilBrev = opprettet.fritekstTilBrev,
         revurderingsårsak = opprettet.revurderingsårsak,
+        behandlingsinformasjon = vedtak.behandlingsinformasjon,
     )
 
     private fun beregnetOpphørt(
@@ -106,6 +109,7 @@ internal class RevurderingPostgresRepoTest {
         oppgaveId = opprettet.oppgaveId,
         fritekstTilBrev = opprettet.fritekstTilBrev,
         revurderingsårsak = opprettet.revurderingsårsak,
+        behandlingsinformasjon = vedtak.behandlingsinformasjon,
     )
 
     private fun simulertInnvilget(beregnet: BeregnetRevurdering.Innvilget) = SimulertRevurdering.Innvilget(
@@ -119,6 +123,7 @@ internal class RevurderingPostgresRepoTest {
         simulering = simulering,
         fritekstTilBrev = beregnet.fritekstTilBrev,
         revurderingsårsak = beregnet.revurderingsårsak,
+        behandlingsinformasjon = beregnet.behandlingsinformasjon,
     )
 
     private fun simulertOpphørt(beregnet: BeregnetRevurdering.Opphørt) = SimulertRevurdering.Opphørt(
@@ -132,6 +137,7 @@ internal class RevurderingPostgresRepoTest {
         simulering = simulering,
         fritekstTilBrev = beregnet.fritekstTilBrev,
         revurderingsårsak = beregnet.revurderingsårsak,
+        behandlingsinformasjon = beregnet.behandlingsinformasjon,
     )
 
     @Test
@@ -327,6 +333,7 @@ internal class RevurderingPostgresRepoTest {
                 oppgaveId = oppgaveId,
                 fritekstTilBrev = "",
                 revurderingsårsak = revurderingsårsak,
+                behandlingsinformasjon = vedtak.behandlingsinformasjon,
             )
 
             repo.lagre(tilAttestering)
@@ -418,6 +425,7 @@ internal class RevurderingPostgresRepoTest {
                     Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
                     "kommentar",
                 ),
+                behandlingsinformasjon = opprettet.behandlingsinformasjon,
             )
 
             repo.lagre(underkjent)
@@ -446,6 +454,7 @@ internal class RevurderingPostgresRepoTest {
                 revurderingsårsak = opprettet.revurderingsårsak,
                 beregning = vedtak.beregning,
                 simulering = simulering,
+                behandlingsinformasjon = opprettet.behandlingsinformasjon,
             )
 
             repo.lagre(underkjent)
@@ -481,6 +490,7 @@ internal class RevurderingPostgresRepoTest {
                 attestering = Attestering.Iverksatt(
                     attestant,
                 ),
+                behandlingsinformasjon = opprettet.behandlingsinformasjon,
             )
 
             repo.lagre(underkjent)
@@ -508,7 +518,8 @@ internal class RevurderingPostgresRepoTest {
                 fritekstTilBrev = opprettet.fritekstTilBrev,
                 revurderingsårsak = opprettet.revurderingsårsak,
                 beregning = vedtak.beregning,
-                skalFøreTilBrevutsending = false
+                skalFøreTilBrevutsending = false,
+                behandlingsinformasjon = opprettet.behandlingsinformasjon,
             )
             repo.lagre(underkjentTilAttestering)
             val underkjent = UnderkjentRevurdering.IngenEndring(
@@ -526,7 +537,8 @@ internal class RevurderingPostgresRepoTest {
                     Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
                     "kommentar",
                 ),
-                skalFøreTilBrevutsending = false
+                skalFøreTilBrevutsending = false,
+                behandlingsinformasjon = opprettet.behandlingsinformasjon,
             )
 
             repo.lagre(underkjent)
@@ -553,7 +565,8 @@ internal class RevurderingPostgresRepoTest {
                 fritekstTilBrev = opprettet.fritekstTilBrev,
                 revurderingsårsak = opprettet.revurderingsårsak,
                 beregning = vedtak.beregning,
-                skalFøreTilBrevutsending = true
+                skalFøreTilBrevutsending = true,
+                behandlingsinformasjon = opprettet.behandlingsinformasjon,
             )
 
             repo.lagre(underkjent)
@@ -580,7 +593,8 @@ internal class RevurderingPostgresRepoTest {
                 fritekstTilBrev = opprettet.fritekstTilBrev,
                 revurderingsårsak = opprettet.revurderingsårsak,
                 beregning = vedtak.beregning,
-                skalFøreTilBrevutsending = false
+                skalFøreTilBrevutsending = false,
+                behandlingsinformasjon = opprettet.behandlingsinformasjon,
             )
             repo.lagre(revurderingTilAttestering)
             val underkjent = IverksattRevurdering.IngenEndring(
@@ -596,7 +610,8 @@ internal class RevurderingPostgresRepoTest {
                 attestering = Attestering.Iverksatt(
                     attestant,
                 ),
-                skalFøreTilBrevutsending = false
+                skalFøreTilBrevutsending = false,
+                behandlingsinformasjon = opprettet.behandlingsinformasjon,
             )
 
             repo.lagre(underkjent)

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/RevurderingPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/RevurderingPostgresRepoTest.kt
@@ -406,7 +406,7 @@ internal class RevurderingPostgresRepoTest {
             val simulert = simulertOpphørt(beregnet)
             repo.lagre(simulert)
             repo.hent(opprettet.id) shouldBe simulert
-            val tilAttestering = simulert.tilAttestering(opprettet.oppgaveId, opprettet.saksbehandler, opprettet.fritekstTilBrev)
+            val tilAttestering = simulert.tilAttestering(opprettet.oppgaveId, opprettet.saksbehandler, opprettet.fritekstTilBrev).orNull()!!
             repo.lagre(tilAttestering)
 
             val underkjent = UnderkjentRevurdering.Opphørt(
@@ -473,7 +473,7 @@ internal class RevurderingPostgresRepoTest {
             repo.lagre(beregnet)
             val simulert = simulertOpphørt(beregnet)
             repo.lagre(simulert)
-            val tilAttestering = simulert.tilAttestering(opprettet.oppgaveId, opprettet.saksbehandler, opprettet.fritekstTilBrev)
+            val tilAttestering = simulert.tilAttestering(opprettet.oppgaveId, opprettet.saksbehandler, opprettet.fritekstTilBrev).orNull()!!
             repo.lagre(tilAttestering)
 
             val underkjent = IverksattRevurdering.Opphørt(

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
@@ -285,6 +285,7 @@ internal class TestDataHelper(
                 Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
                 Revurderingsårsak.Begrunnelse.create("Ny informasjon"),
             ),
+            behandlingsinformasjon = innvilget.behandlingsinformasjon,
         ).also {
             revurderingRepo.lagre(it)
         }

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
@@ -5,6 +5,7 @@ import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.periode.Periode
+import no.nav.su.se.bakover.database.beregning.PersistertBeregning
 import no.nav.su.se.bakover.database.beregning.PersistertMånedsberegning
 import no.nav.su.se.bakover.database.beregning.TestBeregning
 import no.nav.su.se.bakover.database.beregning.toSnapshot
@@ -67,17 +68,18 @@ internal val journalpostId = JournalpostId("journalpostId")
 internal fun beregning(periode: Periode = stønadsperiode.periode) =
     TestBeregning.toSnapshot().copy(periode = periode)
 
-internal val avslåttBeregning = beregning().copy(
+internal val persistertMånedsberegning = PersistertMånedsberegning(
+    sumYtelse = 0,
+    sumFradrag = 0.0,
+    benyttetGrunnbeløp = 0,
+    sats = Sats.ORDINÆR,
+    satsbeløp = 0.0,
+    fradrag = listOf(),
+    periode = Periode.create(1.januar(2020), 31.desember(2020)),
+)
+internal val avslåttBeregning: PersistertBeregning = beregning().copy(
     månedsberegninger = listOf(
-        PersistertMånedsberegning(
-            sumYtelse = 0,
-            sumFradrag = 0.0,
-            benyttetGrunnbeløp = 0,
-            sats = Sats.ORDINÆR,
-            satsbeløp = 0.0,
-            fradrag = listOf(),
-            periode = Periode.create(1.januar(2020), 31.desember(2020)),
-        ),
+        persistertMånedsberegning,
     ),
 )
 

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/beregning/TestBeregning.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/beregning/TestBeregning.kt
@@ -26,6 +26,7 @@ internal object TestBeregning : Beregning {
     override fun getPeriode(): Periode = Periode.create(1.januar(2021), 31.januar(2021))
     override fun getFradragStrategyName(): FradragStrategyName = FradragStrategyName.Enslig
     override fun getBegrunnelse(): String? = null
+    override fun equals(other: Any?) = (other as? Beregning)?.let { this.equals(other) } ?: false
 }
 
 internal object TestMånedsberegning : Månedsberegning {
@@ -36,6 +37,7 @@ internal object TestMånedsberegning : Månedsberegning {
     override fun getSatsbeløp(): Double = 20637.32
     override fun getFradrag(): List<Fradrag> = listOf(TestFradrag)
     override fun getPeriode(): Periode = Periode.create(1.januar(2021), 31.januar(2021))
+    override fun equals(other: Any?) = (other as? Månedsberegning)?.let { this.equals(other) } ?: false
 }
 
 internal object TestFradrag : Fradrag {
@@ -44,4 +46,5 @@ internal object TestFradrag : Fradrag {
     override fun getUtenlandskInntekt(): UtenlandskInntekt? = null
     override fun getTilhører(): FradragTilhører = FradragTilhører.BRUKER
     override fun getPeriode(): Periode = Periode.create(1.januar(2021), 31.januar(2021))
+    override fun equals(other: Any?) = (other as? Fradrag)?.let { this.equals(other) } ?: false
 }

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPosgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPosgresRepoTest.kt
@@ -86,6 +86,7 @@ internal class VedtakPosgresRepoTest {
                     Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
                     Revurderingsårsak.Begrunnelse.create("Ny informasjon"),
                 ),
+                behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
             )
             testDataHelper.revurderingRepo.lagre(iverksattRevurdering)
 
@@ -229,6 +230,7 @@ internal class VedtakPosgresRepoTest {
                     Revurderingsårsak.Begrunnelse.create("Ny informasjon"),
                 ),
                 skalFøreTilBrevutsending = true,
+                behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
             )
             testDataHelper.revurderingRepo.lagre(atteststertRevurdering)
             val iverksattRevurdering = IverksattRevurdering.IngenEndring(
@@ -246,6 +248,7 @@ internal class VedtakPosgresRepoTest {
                     Revurderingsårsak.Begrunnelse.create("Ny informasjon"),
                 ),
                 skalFøreTilBrevutsending = true,
+                behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
             )
             testDataHelper.revurderingRepo.lagre(iverksattRevurdering)
 

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Beregning.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Beregning.kt
@@ -16,4 +16,27 @@ interface Beregning : PeriodisertInformasjon {
     fun getSumFradrag(): Double
     fun getFradragStrategyName(): FradragStrategyName
     fun getBegrunnelse(): String?
+
+    /**
+     * Sammenligner alle metodene  bortsett fraikke getId(), getOpprettet() og getBegrunnelse().
+     * Laget for å kalles fra sub-klassene sine `override fun equals(other: Any?): Boolean` metoder.
+     */
+    fun equals(other: Beregning?): Boolean {
+        if (this === other) return true
+        if (other == null) return false
+
+        if (getSats() != other.getSats()) return false
+        if (getMånedsberegninger() != other.getMånedsberegninger()) return false
+        if (getMånedsberegninger() != other.getMånedsberegninger()) return false
+        if (getFradrag() != other.getFradrag()) return false
+        if (getSumYtelse() != other.getSumYtelse()) return false
+        if (getFradragStrategyName() != other.getFradragStrategyName()) return false
+        return true
+    }
+
+    /**
+     * Det er ikke lov å ha default implementasjon i interfaces for Any.
+     * Denne vil tvinge sub-klassene til å override.
+     */
+    override fun equals(other: Any?): Boolean
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/BeregningMedFradragBeregnetMånedsvis.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/BeregningMedFradragBeregnetMånedsvis.kt
@@ -42,23 +42,23 @@ internal data class BeregningMedFradragBeregnetMånedsvis(
 
         val beregnetPeriodisertFradrag = fradragStrategy.beregn(fradrag, periode)
 
-        return perioder.map {
-            it to MånedsberegningFactory.ny(
+        return perioder.associateWith {
+            MånedsberegningFactory.ny(
                 periode = it,
                 sats = sats,
-                fradrag = beregnetPeriodisertFradrag[it] ?: emptyList()
+                fradrag = beregnetPeriodisertFradrag[it] ?: emptyList(),
             ).let { månedsberegning ->
                 when (månedsberegning.ytelseStørreEnn0MenMindreEnnToProsentAvHøySats()) {
                     true -> MånedsberegningFactory.ny(
                         periode = månedsberegning.getPeriode(),
                         sats = sats,
                         fradrag = månedsberegning.getFradrag()
-                            .plus(månedsberegning.lagFradragForBeløpUnderMinstegrense())
+                            .plus(månedsberegning.lagFradragForBeløpUnderMinstegrense()),
                     )
                     false -> månedsberegning
                 }
             }
-        }.toMap()
+        }
     }
 
     private fun Månedsberegning.lagFradragForBeløpUnderMinstegrense() = FradragFactory.periodiser(
@@ -68,7 +68,7 @@ internal data class BeregningMedFradragBeregnetMånedsvis(
             periode = getPeriode(),
             utenlandskInntekt = null,
             tilhører = FradragTilhører.BRUKER
-        )
+        ),
     )
 
     private fun Månedsberegning.ytelseStørreEnn0MenMindreEnnToProsentAvHøySats() =
@@ -80,4 +80,6 @@ internal data class BeregningMedFradragBeregnetMånedsvis(
     override fun getBegrunnelse(): String? = begrunnelse
 
     override fun getPeriode(): Periode = periode
+
+    override fun equals(other: Any?) = (other as? Beregning)?.let { this.equals(other) } ?: false
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Månedsberegning.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Månedsberegning.kt
@@ -12,6 +12,32 @@ interface Månedsberegning : PeriodisertInformasjon {
     fun getSatsbeløp(): Double
     fun getFradrag(): List<Fradrag>
 
-    fun erFradragForEpsBenyttetIBeregning() = getFradrag().any { it.getFradragstype() == Fradragstype.BeregnetFradragEPS }
-    fun erSumYtelseUnderMinstebeløp() = getSumYtelse() == 0 && getFradrag().any { it.getFradragstype() == Fradragstype.UnderMinstenivå }
+    fun erFradragForEpsBenyttetIBeregning() =
+        getFradrag().any { it.getFradragstype() == Fradragstype.BeregnetFradragEPS }
+
+    fun erSumYtelseUnderMinstebeløp() =
+        getSumYtelse() == 0 && getFradrag().any { it.getFradragstype() == Fradragstype.UnderMinstenivå }
+
+    /**
+     * Sammenligner alle metodene.
+     * Laget for å kalles fra sub-klassene sine `override fun equals(other: Any?): Boolean` metoder.
+     */
+    fun equals(other: Månedsberegning?): Boolean {
+        if (this === other) return true
+        if (other == null) return false
+
+        if (getSumYtelse() != other.getSumYtelse()) return false
+        if (getSumFradrag() != other.getSumFradrag()) return false
+        if (getBenyttetGrunnbeløp() != other.getBenyttetGrunnbeløp()) return false
+        if (getSats() != other.getSats()) return false
+        if (getSatsbeløp() != other.getSatsbeløp()) return false
+        if (getFradrag() != other.getFradrag()) return false
+        return true
+    }
+
+    /**
+     * Det er ikke lov å ha default implementasjon i interfaces for Any.
+     * Denne vil tvinge sub-klassene til å override.
+     */
+    override fun equals(other: Any?): Boolean
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/PeriodisertBeregning.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/PeriodisertBeregning.kt
@@ -30,4 +30,6 @@ internal data class PeriodisertBeregning(
     override fun getSatsbeløp(): Double = sats.periodiser(periode).getValue(periode)
     override fun getFradrag(): List<Fradrag> = fradrag
     override fun getPeriode(): Periode = periode
+
+    override fun equals(other: Any?) = (other as? Månedsberegning)?.let { this.equals(other) } ?: false
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/RevurdertBeregning.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/RevurdertBeregning.kt
@@ -17,29 +17,27 @@ import no.nav.su.se.bakover.domain.beregning.fradrag.FradragStrategy
  *
  * Det kan hende vi vil gi denne navnet: EndretBeregning (dersom den er gjenbrukbar for klage, anke og automatiske/recurring endringer som grunnbeløpsendring.
  */
-internal class RevurdertBeregning private constructor(revurdertBeregning: Beregning) : Beregning by revurdertBeregning {
+internal object RevurdertBeregning {
 
-    companion object {
-        fun fraSøknadsbehandling(
-            vedtattBeregning: Beregning,
-            beregningsgrunnlag: Beregningsgrunnlag,
-            beregningsstrategi: BeregningStrategy,
-            beregnMedVirkningNesteMånedDersomStønadenGårNed: Boolean = false,
-        ): Either<KanIkkeVelgeSisteMånedVedNedgangIStønaden, Beregning> {
-            val revurdertBeregning = beregningsstrategi.beregn(beregningsgrunnlag)
-            if (!beregnMedVirkningNesteMånedDersomStønadenGårNed) {
-                return revurdertBeregning.right()
-            }
+    fun fraSøknadsbehandling(
+        vedtattBeregning: Beregning,
+        beregningsgrunnlag: Beregningsgrunnlag,
+        beregningsstrategi: BeregningStrategy,
+        beregnMedVirkningNesteMånedDersomStønadenGårNed: Boolean = false,
+    ): Either<KanIkkeVelgeSisteMånedVedNedgangIStønaden, Beregning> {
+        val revurdertBeregning = beregningsstrategi.beregn(beregningsgrunnlag)
+        if (!beregnMedVirkningNesteMånedDersomStønadenGårNed) {
+            return revurdertBeregning.right()
+        }
 
-            return when {
-                revurdertBeregning.getMånedsberegninger().first()
-                    .getSumYtelse() > vedtattBeregning.getMånedsberegninger().first()
-                    .getSumYtelse() -> revurdertBeregning.right()
-                revurdertBeregning.getMånedsberegninger().first()
-                    .getSumYtelse() < vedtattBeregning.getMånedsberegninger().first()
-                    .getSumYtelse() -> beregnMedVirkningFraOgMedMånedenEtter(revurdertBeregning)
-                else -> revurdertBeregning.right()
-            }
+        return when {
+            revurdertBeregning.getMånedsberegninger().first()
+                .getSumYtelse() > vedtattBeregning.getMånedsberegninger().first()
+                .getSumYtelse() -> revurdertBeregning.right()
+            revurdertBeregning.getMånedsberegninger().first()
+                .getSumYtelse() < vedtattBeregning.getMånedsberegninger().first()
+                .getSumYtelse() -> beregnMedVirkningFraOgMedMånedenEtter(revurdertBeregning)
+            else -> revurdertBeregning.right()
         }
     }
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Sats.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Sats.kt
@@ -8,15 +8,17 @@ enum class Sats(val grunnbeløp: Grunnbeløp) {
     ORDINÆR(Grunnbeløp.`2,28G`),
     HØY(Grunnbeløp.`2,48G`);
 
-    fun årsbeløp(dato: LocalDate) = satsSomÅrsbeløp(dato)
+    fun årsbeløp(dato: LocalDate): Double = satsSomÅrsbeløp(dato)
+
     fun månedsbeløp(dato: LocalDate): Double = satsSomMånedsbeløp(dato)
-    fun periodiser(periode: Periode): Map<Periode, Double> = periode.tilMånedsperioder()
-        .map { it to satsSomMånedsbeløp(it.getFraOgMed()) }
-        .toMap()
 
-    private fun satsSomÅrsbeløp(dato: LocalDate) = grunnbeløp.fraDato(dato)
+    fun periodiser(periode: Periode): Map<Periode, Double> {
+        return periode.tilMånedsperioder().associateWith { satsSomMånedsbeløp(it.getFraOgMed()) }
+    }
 
-    private fun satsSomMånedsbeløp(dato: LocalDate) = grunnbeløp.fraDato(dato) / 12
+    private fun satsSomÅrsbeløp(dato: LocalDate): Double = grunnbeløp.fraDato(dato)
+
+    private fun satsSomMånedsbeløp(dato: LocalDate): Double = grunnbeløp.fraDato(dato) / 12
 
     companion object {
         fun toProsentAvHøy(periode: Periode): Double = periode.tilMånedsperioder()

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/SlåSammenEkvivalenteMånedsberegningerTilBeregningsperioder.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/SlåSammenEkvivalenteMånedsberegningerTilBeregningsperioder.kt
@@ -87,6 +87,8 @@ internal data class EkvivalenteMånedsberegninger(
 ) : Månedsberegning by månedsberegninger.first() {
     override fun getPeriode(): Periode = Periode.create(
         fraOgMed = månedsberegninger.minOf { it.getPeriode().getFraOgMed() },
-        tilOgMed = månedsberegninger.maxOf { it.getPeriode().getTilOgMed() }
+        tilOgMed = månedsberegninger.maxOf { it.getPeriode().getTilOgMed() },
     )
+
+    override fun equals(other: Any?) = (other as? Månedsberegning)?.let { this.equals(other) } ?: false
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/Fradrag.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/Fradrag.kt
@@ -7,6 +7,27 @@ interface Fradrag : PeriodisertInformasjon {
     fun getMånedsbeløp(): Double
     fun getUtenlandskInntekt(): UtenlandskInntekt? // TODO can we pls do something about this one?
     fun getTilhører(): FradragTilhører
+
+    /**
+     * Sammenligner alle metodene.
+     * Laget for å kalles fra sub-klassene sine `override fun equals(other: Any?): Boolean` metoder.
+     */
+    fun equals(other: Fradrag?): Boolean {
+        if (this === other) return true
+        if (other == null) return false
+
+        if (getFradragstype() != other.getFradragstype()) return false
+        if (getMånedsbeløp() != other.getMånedsbeløp()) return false
+        if (getUtenlandskInntekt() != other.getUtenlandskInntekt()) return false
+        if (getTilhører() != other.getTilhører()) return false
+        return true
+    }
+
+    /**
+     * Det er ikke lov å ha default implementasjon i interfaces for Any.
+     * Denne vil tvinge sub-klassene til å override.
+     */
+    override fun equals(other: Any?): Boolean
 }
 
 enum class FradragTilhører {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/IkkePeriodisertFradrag.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/IkkePeriodisertFradrag.kt
@@ -18,4 +18,6 @@ internal data class IkkePeriodisertFradrag(
     override fun getMånedsbeløp(): Double = månedsbeløp
     override fun getUtenlandskInntekt(): UtenlandskInntekt? = utenlandskInntekt
     override fun getPeriode(): Periode = periode
+
+    override fun equals(other: Any?) = (other as? Fradrag)?.let { this.equals(other) } ?: false
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/PeriodisertFradrag.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/PeriodisertFradrag.kt
@@ -19,4 +19,6 @@ internal data class PeriodisertFradrag(
     override fun getMånedsbeløp(): Double = månedsbeløp
     override fun getUtenlandskInntekt(): UtenlandskInntekt? = utenlandskInntekt
     override fun getPeriode(): Periode = periode
+
+    override fun equals(other: Any?) = (other as? Fradrag)?.let { this.equals(other) } ?: false
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurdering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurdering.kt
@@ -134,8 +134,11 @@ sealed class Revurdering : Behandling, Visitable<RevurderingVisitor> {
                         opphør(revurdertBeregning)
                     }
                     AvslagGrunnetBeregning.Nei -> {
-                        // todo her bør vi sjekke på ingen endring
-                        innvilget(revurdertBeregning)
+                        if (revurdertBeregning.equals(tilRevurdering.beregning)) {
+                            ingenEndring(revurdertBeregning)
+                        } else {
+                            innvilget(revurdertBeregning)
+                        }
                     }
                 }.right()
             }
@@ -863,7 +866,7 @@ private fun endringerAvUtbetalingerErStørreEllerLik10Prosent(
     vedtattBeregning: Beregning,
     revurdertBeregning: Beregning,
 ): Boolean {
-    val vedtattBeregningsperioder = vedtattBeregning.getMånedsberegninger().map { it.getPeriode() to it }.toMap()
+    val vedtattBeregningsperioder = vedtattBeregning.getMånedsberegninger().associateBy { it.getPeriode() }
 
     return revurdertBeregning.getMånedsberegninger().let {
         val førsteUtbetaling = it.first()

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurdering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurdering.kt
@@ -648,7 +648,7 @@ sealed class IverksattRevurdering : Revurdering() {
 
     abstract override fun accept(visitor: RevurderingVisitor)
 
-    override fun oppdaterBehandlingsinformasjon(behandlingsinformasjon: Behandlingsinformasjon) = throw IllegalStateException("Ikke lov å oppdatere behandlingsinformasjon i status Iversatt")
+    override fun oppdaterBehandlingsinformasjon(behandlingsinformasjon: Behandlingsinformasjon) = throw IllegalStateException("Ikke lov å oppdatere behandlingsinformasjon i status Iverksatt")
 
     data class Innvilget(
         override val id: UUID,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurdering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurdering.kt
@@ -395,19 +395,22 @@ sealed class SimulertRevurdering : Revurdering() {
             attesteringsoppgaveId: OppgaveId,
             saksbehandler: Saksbehandler,
             fritekstTilBrev: String,
-        ) = RevurderingTilAttestering.Opphørt(
-            id = id,
-            periode = periode,
-            opprettet = opprettet,
-            tilRevurdering = tilRevurdering,
-            saksbehandler = saksbehandler,
-            beregning = beregning,
-            simulering = simulering,
-            oppgaveId = attesteringsoppgaveId,
-            fritekstTilBrev = fritekstTilBrev,
-            revurderingsårsak = revurderingsårsak,
-            behandlingsinformasjon = behandlingsinformasjon,
-        )
+        ): RevurderingTilAttestering.Opphørt {
+            if (revurderingsårsak.årsak == Revurderingsårsak.Årsak.REGULER_GRUNNBELØP) throw IllegalStateException("Kan ikke sende en opphørt g-regulering til attestering")
+            return RevurderingTilAttestering.Opphørt(
+                id = id,
+                periode = periode,
+                opprettet = opprettet,
+                tilRevurdering = tilRevurdering,
+                saksbehandler = saksbehandler,
+                beregning = beregning,
+                simulering = simulering,
+                oppgaveId = attesteringsoppgaveId,
+                fritekstTilBrev = fritekstTilBrev,
+                revurderingsårsak = revurderingsårsak,
+                behandlingsinformasjon = behandlingsinformasjon,
+            )
+        }
     }
 
     fun oppdater(
@@ -776,19 +779,22 @@ sealed class UnderkjentRevurdering : Revurdering() {
             oppgaveId: OppgaveId,
             saksbehandler: Saksbehandler,
             fritekstTilBrev: String,
-        ) = RevurderingTilAttestering.Opphørt(
-            id = id,
-            periode = periode,
-            opprettet = opprettet,
-            tilRevurdering = tilRevurdering,
-            saksbehandler = saksbehandler,
-            beregning = beregning,
-            simulering = simulering,
-            oppgaveId = oppgaveId,
-            fritekstTilBrev = fritekstTilBrev,
-            revurderingsårsak = revurderingsårsak,
-            behandlingsinformasjon = behandlingsinformasjon,
-        )
+        ): RevurderingTilAttestering.Opphørt {
+            if (revurderingsårsak.årsak == Revurderingsårsak.Årsak.REGULER_GRUNNBELØP) throw IllegalStateException("Kan ikke sende en opphørt g-regulering til attestering")
+            return RevurderingTilAttestering.Opphørt(
+                id = id,
+                periode = periode,
+                opprettet = opprettet,
+                tilRevurdering = tilRevurdering,
+                saksbehandler = saksbehandler,
+                beregning = beregning,
+                simulering = simulering,
+                oppgaveId = oppgaveId,
+                fritekstTilBrev = fritekstTilBrev,
+                revurderingsårsak = revurderingsårsak,
+                behandlingsinformasjon = behandlingsinformasjon,
+            )
+        }
     }
 
     data class IngenEndring(

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurderingsårsak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurderingsårsak.kt
@@ -16,6 +16,7 @@ data class Revurderingsårsak(
         INFORMASJON_FRA_KONTROLLSAMTALE,
         DØDSFALL,
         ANDRE_KILDER,
+        REGULER_GRUNNBELØP,
 
         /* Reservert for migrering */
         MIGRERT;

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/Vedtak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/Vedtak.kt
@@ -18,6 +18,7 @@ import no.nav.su.se.bakover.domain.eksterneiverksettingssteg.KunneIkkeJournalfø
 import no.nav.su.se.bakover.domain.journal.JournalpostId
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
 import no.nav.su.se.bakover.domain.revurdering.IverksattRevurdering
+import no.nav.su.se.bakover.domain.revurdering.Revurderingsårsak
 import no.nav.su.se.bakover.domain.søknadsbehandling.ErAvslag
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
 import no.nav.su.se.bakover.domain.visitor.Visitable
@@ -30,6 +31,7 @@ enum class VedtakType {
     ENDRING,
     INGEN_ENDRING,
     OPPHØR,
+    REGULER_GRUNNBELØP,
 }
 
 interface VedtakFelles {
@@ -69,7 +71,7 @@ sealed class Vedtak : VedtakFelles, Visitable<VedtakVisitor> {
             id = UUID.randomUUID(),
             opprettet = Tidspunkt.now(clock),
             behandling = revurdering,
-            behandlingsinformasjon = revurdering.tilRevurdering.behandlingsinformasjon,
+            behandlingsinformasjon = revurdering.behandlingsinformasjon,
             periode = revurdering.periode,
             beregning = revurdering.beregning,
             saksbehandler = revurdering.saksbehandler,
@@ -81,7 +83,7 @@ sealed class Vedtak : VedtakFelles, Visitable<VedtakVisitor> {
             id = UUID.randomUUID(),
             opprettet = Tidspunkt.now(),
             behandling = revurdering,
-            behandlingsinformasjon = revurdering.tilRevurdering.behandlingsinformasjon,
+            behandlingsinformasjon = revurdering.behandlingsinformasjon,
             periode = revurdering.periode,
             beregning = revurdering.beregning,
             simulering = revurdering.simulering,
@@ -89,14 +91,14 @@ sealed class Vedtak : VedtakFelles, Visitable<VedtakVisitor> {
             attestant = revurdering.attestering.attestant,
             utbetalingId = utbetalingId,
             journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.IkkeJournalførtEllerDistribuert,
-            vedtakType = VedtakType.ENDRING,
+            vedtakType = if (revurdering.revurderingsårsak.årsak == Revurderingsårsak.Årsak.REGULER_GRUNNBELØP) VedtakType.REGULER_GRUNNBELØP else VedtakType.ENDRING,
         )
 
         fun from(revurdering: IverksattRevurdering.Opphørt, utbetalingId: UUID30) = EndringIYtelse(
             id = UUID.randomUUID(),
             opprettet = Tidspunkt.now(),
             behandling = revurdering,
-            behandlingsinformasjon = revurdering.tilRevurdering.behandlingsinformasjon,
+            behandlingsinformasjon = revurdering.behandlingsinformasjon,
             periode = revurdering.periode,
             beregning = revurdering.beregning,
             simulering = revurdering.simulering,
@@ -124,13 +126,21 @@ sealed class Vedtak : VedtakFelles, Visitable<VedtakVisitor> {
     ) : Vedtak() {
 
         override fun journalfør(journalfør: () -> Either<KunneIkkeJournalføreOgDistribuereBrev.KunneIkkeJournalføre.FeilVedJournalføring, JournalpostId>): Either<KunneIkkeJournalføreOgDistribuereBrev.KunneIkkeJournalføre, EndringIYtelse> {
-            return journalføringOgBrevdistribusjon.journalfør(journalfør)
-                .map { copy(journalføringOgBrevdistribusjon = it) }
+            return if (vedtakType == VedtakType.SØKNAD || vedtakType == VedtakType.ENDRING || vedtakType == VedtakType.OPPHØR) {
+                journalføringOgBrevdistribusjon.journalfør(journalfør)
+                    .map { copy(journalføringOgBrevdistribusjon = it) }
+            } else {
+                this.right()
+            }
         }
 
         override fun distribuerBrev(distribuerBrev: (journalpostId: JournalpostId) -> Either<KunneIkkeJournalføreOgDistribuereBrev.KunneIkkeDistribuereBrev.FeilVedDistribueringAvBrev, BrevbestillingId>): Either<KunneIkkeJournalføreOgDistribuereBrev.KunneIkkeDistribuereBrev, EndringIYtelse> {
-            return journalføringOgBrevdistribusjon.distribuerBrev(distribuerBrev)
-                .map { copy(journalføringOgBrevdistribusjon = it) }
+            return if (vedtakType == VedtakType.SØKNAD || vedtakType == VedtakType.ENDRING || vedtakType == VedtakType.OPPHØR) {
+                journalføringOgBrevdistribusjon.distribuerBrev(distribuerBrev)
+                    .map { copy(journalføringOgBrevdistribusjon = it) }
+            } else {
+                this.right()
+            }
         }
 
         override fun accept(visitor: VedtakVisitor) {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/Vedtak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/Vedtak.kt
@@ -48,7 +48,7 @@ sealed class Vedtak : VedtakFelles, Visitable<VedtakVisitor> {
 
     abstract fun journalfør(journalfør: () -> Either<KunneIkkeJournalføreOgDistribuereBrev.KunneIkkeJournalføre.FeilVedJournalføring, JournalpostId>): Either<KunneIkkeJournalføreOgDistribuereBrev.KunneIkkeJournalføre, Vedtak>
     abstract fun distribuerBrev(distribuerBrev: (journalpostId: JournalpostId) -> Either<KunneIkkeJournalføreOgDistribuereBrev.KunneIkkeDistribuereBrev.FeilVedDistribueringAvBrev, BrevbestillingId>): Either<KunneIkkeJournalføreOgDistribuereBrev.KunneIkkeDistribuereBrev, Vedtak>
-    fun skalFerdigstille() = (this.behandling as? IverksattRevurdering.Innvilget)?.revurderingsårsak?.årsak != Revurderingsårsak.Årsak.REGULER_GRUNNBELØP
+    fun skalSendeBrev() = (this.behandling as? IverksattRevurdering.Innvilget)?.revurderingsårsak?.årsak != Revurderingsårsak.Årsak.REGULER_GRUNNBELØP
 
     companion object {
         fun fromSøknadsbehandling(søknadsbehandling: Søknadsbehandling.Iverksatt.Innvilget, utbetalingId: UUID30) =

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitor.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitor.kt
@@ -214,7 +214,6 @@ class LagBrevRequestVisitor(
             }
             VedtakType.AVSLAG,
             VedtakType.INGEN_ENDRING,
-            VedtakType.REGULER_GRUNNBELØP,
             -> {
                 throw KunneIkkeLageBrevRequest.UgyldigKombinasjonAvVedtakOgTypeException(vedtak::class, vedtak.vedtakType)
             }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitor.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitor.kt
@@ -214,6 +214,7 @@ class LagBrevRequestVisitor(
             }
             VedtakType.AVSLAG,
             VedtakType.INGEN_ENDRING,
+            VedtakType.REGULER_GRUNNBELØP,
             -> {
                 throw KunneIkkeLageBrevRequest.UgyldigKombinasjonAvVedtakOgTypeException(vedtak::class, vedtak.vedtakType)
             }
@@ -314,7 +315,7 @@ class LagBrevRequestVisitor(
                 personOgNavn = it,
                 beregning = beregning,
                 fritekst = revurdering.fritekstTilBrev,
-                harEktefelle = revurdering.tilRevurdering.behandlingsinformasjon.harEktefelle(),
+                harEktefelle = revurdering.behandlingsinformasjon.harEktefelle(),
             )
         }
 
@@ -347,7 +348,7 @@ class LagBrevRequestVisitor(
                 attestantNavn = it.attestantNavn,
                 revurdertBeregning = beregning,
                 fritekst = revurdering.fritekstTilBrev,
-                harEktefelle = revurdering.tilRevurdering.behandlingsinformasjon.harEktefelle(),
+                harEktefelle = revurdering.behandlingsinformasjon.harEktefelle(),
             )
         }
 
@@ -362,7 +363,7 @@ class LagBrevRequestVisitor(
         ).map {
             LagBrevRequest.Opphørsvedtak(
                 person = it.person,
-                behandlingsinformasjon = revurdering.tilRevurdering.behandlingsinformasjon,
+                behandlingsinformasjon = revurdering.behandlingsinformasjon,
                 beregning = beregning,
                 fritekst = revurdering.fritekstTilBrev,
                 saksbehandlerNavn = it.saksbehandlerNavn,

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/DomainTestdata.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/DomainTestdata.kt
@@ -1,0 +1,10 @@
+package no.nav.su.se.bakover.domain
+
+import no.nav.su.se.bakover.common.Tidspunkt
+import no.nav.su.se.bakover.common.januar
+import java.time.Clock
+import java.time.ZoneOffset
+
+internal val fixedClock: Clock =
+    Clock.fixed(1.januar(2021).atTime(1, 2, 3, 456789000).toInstant(ZoneOffset.UTC), ZoneOffset.UTC)
+internal val fixedTidspunkt: Tidspunkt = Tidspunkt.now(fixedClock)

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/FinnAttestantVisitorTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/FinnAttestantVisitorTest.kt
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test
 import java.util.UUID
 
 internal class FinnAttestantVisitorTest {
+
     @Test
     fun `finner attestant for både søknadsbehandlinger og revurderinger`() {
         FinnAttestantVisitor().let {
@@ -139,12 +140,15 @@ internal class FinnAttestantVisitorTest {
         stønadsperiode = ValgtStønadsperiode(Periode.create(1.januar(2021), 31.desember(2021))),
     )
 
+    private val behandlingsinformasjonMedAlleVilkårOppfylt = Behandlingsinformasjon.lagTomBehandlingsinformasjon()
+        .withAlleVilkårOppfylt()
+
     private val vilkårsvurdertInnvilgetSøknadsbehandling = søknadsbehandling.tilVilkårsvurdert(
-        Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
+        behandlingsinformasjonMedAlleVilkårOppfylt,
     )
 
     private val vilkårsvurdertAvslagSøknadsbehandling = søknadsbehandling.tilVilkårsvurdert(
-        Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
+        behandlingsinformasjonMedAlleVilkårOppfylt,
     )
 
     private val månedsberegningAvslagMock = mock<Månedsberegning> { on { getSumYtelse() } doReturn 0 }
@@ -208,8 +212,8 @@ internal class FinnAttestantVisitorTest {
         periode = Periode.create(1.januar(2021), 31.januar(2021)),
         opprettet = Tidspunkt.now(),
         tilRevurdering = mock() {
-            on { behandlingsinformasjon } doReturn Behandlingsinformasjon.lagTomBehandlingsinformasjon()
-                .withAlleVilkårOppfylt()
+
+            on { behandlingsinformasjon } doReturn behandlingsinformasjonMedAlleVilkårOppfylt
             on { beregning } doReturn beregningMock
         },
         saksbehandler = NavIdentBruker.Saksbehandler("Petter"),
@@ -219,6 +223,7 @@ internal class FinnAttestantVisitorTest {
             Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
             Revurderingsårsak.Begrunnelse.create("Ny informasjon"),
         ),
+        behandlingsinformasjon = behandlingsinformasjonMedAlleVilkårOppfylt,
     )
 
     private val beregnetRevurdering = when (val a = revurdering.beregn(emptyList()).orNull()!!) {

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitorTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitorTest.kt
@@ -616,6 +616,7 @@ internal class LagBrevRequestVisitorTest {
                 Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
                 Revurderingsårsak.Begrunnelse.create("Ny informasjon"),
             ),
+            behandlingsinformasjon = søknadsbehandling.behandlingsinformasjon,
         )
 
         val avslåttVedtak = Vedtak.from(revurdering, utbetalingId)
@@ -668,6 +669,7 @@ internal class LagBrevRequestVisitorTest {
                 Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
                 Revurderingsårsak.Begrunnelse.create("Ny informasjon"),
             ),
+            behandlingsinformasjon = søknadsbehandling.behandlingsinformasjon,
         )
 
         val opphørsvedtak = Vedtak.from(revurdering, utbetalingId)
@@ -688,7 +690,7 @@ internal class LagBrevRequestVisitorTest {
         brevRevurdering.brevRequest shouldBe LagBrevRequest.Opphørsvedtak(
             person = person,
             beregning = revurdering.beregning,
-            behandlingsinformasjon = revurdering.tilRevurdering.behandlingsinformasjon,
+            behandlingsinformasjon = revurdering.behandlingsinformasjon,
             saksbehandlerNavn = saksbehandlerNavn,
             attestantNavn = attestantNavn,
             fritekst = "FRITEKST REVURDERING",
@@ -720,6 +722,7 @@ internal class LagBrevRequestVisitorTest {
                 Revurderingsårsak.Begrunnelse.create("Ny informasjon"),
             ),
             skalFøreTilBrevutsending = false,
+            behandlingsinformasjon = søknadsbehandling.behandlingsinformasjon,
         )
 
         val vedtakIngenEndring = Vedtak.from(revurdering, clock)
@@ -751,7 +754,7 @@ internal class LagBrevRequestVisitorTest {
                 saksbehandlerNavn = saksbehandlerNavn,
                 attestantNavn = attestantNavn,
                 fritekst = "EN FIN FRITEKST",
-                harEktefelle = revurdering.tilRevurdering.behandlingsinformasjon.harEktefelle(),
+                harEktefelle = revurdering.behandlingsinformasjon.harEktefelle(),
             )
 
             it.lagBrevInnhold(personalia) should beOfType<BrevInnhold.VedtakIngenEndring>()

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
@@ -359,12 +359,14 @@ open class AccessCheckProxy(
                     revurderingId: UUID,
                     saksbehandler: NavIdentBruker.Saksbehandler,
                     fradrag: List<Fradrag>,
+                    forventetInntekt: Int?,
                 ): Either<KunneIkkeBeregneOgSimulereRevurdering, Revurdering> {
                     assertHarTilgangTilSak(revurderingId)
                     return services.revurdering.beregnOgSimuler(
                         revurderingId = revurderingId,
                         saksbehandler = saksbehandler,
                         fradrag = fradrag,
+                        forventetInntekt = forventetInntekt
                     )
                 }
 

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
@@ -353,11 +353,11 @@ open class AccessCheckProxy(
                     return services.revurdering.opprettRevurdering(opprettRevurderingRequest)
                 }
 
-                override fun oppdaterRevurderingsperiode(
+                override fun oppdaterRevurdering(
                     oppdaterRevurderingRequest: OppdaterRevurderingRequest,
                 ): Either<KunneIkkeOppdatereRevurderingsperiode, OpprettetRevurdering> {
                     assertHarTilgangTilRevurdering(oppdaterRevurderingRequest.revurderingId)
-                    return services.revurdering.oppdaterRevurderingsperiode(oppdaterRevurderingRequest)
+                    return services.revurdering.oppdaterRevurdering(oppdaterRevurderingRequest)
                 }
 
                 override fun beregnOgSimuler(

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
@@ -26,6 +26,7 @@ interface RevurderingService {
         revurderingId: UUID,
         saksbehandler: NavIdentBruker.Saksbehandler,
         fradrag: List<Fradrag>,
+        forventetInntekt: Int? = null,
     ): Either<KunneIkkeBeregneOgSimulereRevurdering, Revurdering>
 
     fun sendTilAttestering(
@@ -76,6 +77,7 @@ sealed class KunneIkkeOppdatereRevurderingsperiode {
 }
 
 sealed class KunneIkkeBeregneOgSimulereRevurdering {
+    object MåSendeGrunnbeløpReguleringSomÅrsakSammenMedForventetInntekt : KunneIkkeBeregneOgSimulereRevurdering()
     object FantIkkeRevurdering : KunneIkkeBeregneOgSimulereRevurdering()
     object SimuleringFeilet : KunneIkkeBeregneOgSimulereRevurdering()
     object KanIkkeVelgeSisteMånedVedNedgangIStønaden : KunneIkkeBeregneOgSimulereRevurdering()

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
@@ -19,7 +19,7 @@ interface RevurderingService {
         opprettRevurderingRequest: OpprettRevurderingRequest,
     ): Either<KunneIkkeOppretteRevurdering, Revurdering>
 
-    fun oppdaterRevurderingsperiode(
+    fun oppdaterRevurdering(
         oppdaterRevurderingRequest: OppdaterRevurderingRequest,
     ): Either<KunneIkkeOppdatereRevurderingsperiode, OpprettetRevurdering>
 

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
@@ -92,6 +92,7 @@ sealed class KunneIkkeSendeRevurderingTilAttestering {
     object FantIkkeRevurdering : KunneIkkeSendeRevurderingTilAttestering()
     object FantIkkeAktørId : KunneIkkeSendeRevurderingTilAttestering()
     object KunneIkkeOppretteOppgave : KunneIkkeSendeRevurderingTilAttestering()
+    object KanIkkeRegulereGrunnbeløpTilOpphør : KunneIkkeSendeRevurderingTilAttestering()
     data class UgyldigTilstand(val fra: KClass<out Revurdering>, val til: KClass<out Revurdering>) :
         KunneIkkeSendeRevurderingTilAttestering()
 }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -287,11 +287,18 @@ internal class RevurderingServiceImpl(
                 request.fritekstTilBrev,
                 if (revurdering.revurderingsårsak.årsak == REGULER_GRUNNBELØP) false else request.skalFøreTilBrevutsending,
             )
-            is SimulertRevurdering -> revurdering.tilAttestering(
+            is SimulertRevurdering.Innvilget -> revurdering.tilAttestering(
                 oppgaveId,
                 request.saksbehandler,
                 request.fritekstTilBrev,
             )
+            is SimulertRevurdering.Opphørt -> revurdering.tilAttestering(
+                oppgaveId,
+                request.saksbehandler,
+                request.fritekstTilBrev,
+            ).getOrElse {
+                return KunneIkkeSendeRevurderingTilAttestering.KanIkkeRegulereGrunnbeløpTilOpphør.left()
+            }
             is UnderkjentRevurdering.IngenEndring -> revurdering.tilAttestering(
                 oppgaveId,
                 request.saksbehandler,
@@ -302,7 +309,9 @@ internal class RevurderingServiceImpl(
                 oppgaveId,
                 request.saksbehandler,
                 request.fritekstTilBrev,
-            )
+            ).getOrElse {
+                return KunneIkkeSendeRevurderingTilAttestering.KanIkkeRegulereGrunnbeløpTilOpphør.left()
+            }
             is UnderkjentRevurdering.Innvilget -> revurdering.tilAttestering(
                 oppgaveId,
                 request.saksbehandler,

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -134,7 +134,7 @@ internal class RevurderingServiceImpl(
         }
     }
 
-    override fun oppdaterRevurderingsperiode(
+    override fun oppdaterRevurdering(
         oppdaterRevurderingRequest: OppdaterRevurderingRequest,
     ): Either<KunneIkkeOppdatereRevurderingsperiode, OpprettetRevurdering> {
         val revurderingsårsak = oppdaterRevurderingRequest.revurderingsårsak.getOrHandle {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -282,7 +282,7 @@ internal class RevurderingServiceImpl(
                 oppgaveId,
                 request.saksbehandler,
                 request.fritekstTilBrev,
-                request.skalFøreTilBrevutsending,
+                if (revurdering.revurderingsårsak.årsak == REGULER_GRUNNBELØP) false else request.skalFøreTilBrevutsending,
             )
             is SimulertRevurdering -> revurdering.tilAttestering(
                 oppgaveId,
@@ -293,7 +293,7 @@ internal class RevurderingServiceImpl(
                 oppgaveId,
                 request.saksbehandler,
                 request.fritekstTilBrev,
-                request.skalFøreTilBrevutsending,
+                if (revurdering.revurderingsårsak.årsak == REGULER_GRUNNBELØP) false else request.skalFøreTilBrevutsending,
             )
             is UnderkjentRevurdering.Opphørt -> revurdering.tilAttestering(
                 oppgaveId,

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/vedtak/FerdigstillVedtakService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/vedtak/FerdigstillVedtakService.kt
@@ -110,10 +110,8 @@ internal class FerdigstillVedtakServiceImpl(
      */
     override fun ferdigstillVedtakEtterUtbetaling(utbetalingId: UUID30) {
         val vedtak = vedtakRepo.hentForUtbetaling(utbetalingId)
-        if (vedtak.skalFerdigstille()) {
-            ferdigstillVedtak(vedtak).getOrHandle {
-                throw KunneIkkeFerdigstilleVedtakException(vedtak, it)
-            }
+        ferdigstillVedtak(vedtak).getOrHandle {
+            throw KunneIkkeFerdigstilleVedtakException(vedtak, it)
         }
     }
 
@@ -123,7 +121,7 @@ internal class FerdigstillVedtakServiceImpl(
     override fun opprettManglendeJournalposterOgBrevbestillinger(): FerdigstillVedtakService.OpprettManglendeJournalpostOgBrevdistribusjonResultat {
         val alleUtenJournalpost = vedtakRepo.hentUtenJournalpost()
         val innvilgetUtenJournalpost = alleUtenJournalpost.filterIsInstance<Vedtak.EndringIYtelse>()
-            .filter { it.skalFerdigstille() }
+            .filter { it.skalSendeBrev() }
             /**
              * Unngår å journalføre og distribuere brev for innvilgelser hvor vi ikke har mottatt kvittering,
              * eller mottatt kvittering ikke er ok.
@@ -166,7 +164,7 @@ internal class FerdigstillVedtakServiceImpl(
 
         val innvilgetUtenBrevbestilling = alleUtenBrevbestilling.filterIsInstance<Vedtak.EndringIYtelse>()
             .filter {
-                it.skalFerdigstille()
+                it.skalSendeBrev()
             }
             /**
              * Unngår å journalføre og distribuere brev for innvilgelser hvor vi ikke har mottatt kvittering,
@@ -203,7 +201,7 @@ internal class FerdigstillVedtakServiceImpl(
     }
 
     private fun ferdigstillVedtak(vedtak: Vedtak): Either<KunneIkkeFerdigstilleVedtak, Vedtak> {
-        if (vedtak.skalFerdigstille()) {
+        if (vedtak.skalSendeBrev()) {
             val journalførtVedtak = journalførOgLagre(vedtak).getOrHandle { feilVedJournalføring ->
                 when (feilVedJournalføring) {
                     is KunneIkkeFerdigstilleVedtak.KunneIkkeJournalføreBrev.AlleredeJournalført -> vedtak

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/vedtak/FerdigstillVedtakService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/vedtak/FerdigstillVedtakService.kt
@@ -19,6 +19,7 @@ import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppgave.KunneIkkeLukkeOppgave
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.revurdering.IverksattRevurdering
+import no.nav.su.se.bakover.domain.revurdering.Revurderingsårsak
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
 import no.nav.su.se.bakover.domain.vedtak.Vedtak
 import no.nav.su.se.bakover.domain.visitor.LagBrevRequestVisitor
@@ -110,8 +111,11 @@ internal class FerdigstillVedtakServiceImpl(
      */
     override fun ferdigstillVedtakEtterUtbetaling(utbetalingId: UUID30) {
         val vedtak = vedtakRepo.hentForUtbetaling(utbetalingId)
-        ferdigstillVedtak(vedtak).getOrHandle {
-            throw KunneIkkeFerdigstilleVedtakException(vedtak, it)
+        val skalFerdigstille = (vedtak.behandling as? IverksattRevurdering.Innvilget)?.revurderingsårsak?.årsak != Revurderingsårsak.Årsak.REGULER_GRUNNBELØP
+        if (skalFerdigstille) {
+            ferdigstillVedtak(vedtak).getOrHandle {
+                throw KunneIkkeFerdigstilleVedtakException(vedtak, it)
+            }
         }
     }
 

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/ServiceTestUtils.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/ServiceTestUtils.kt
@@ -4,7 +4,9 @@ import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.startOfDay
 import java.time.Clock
+import java.time.LocalDate
 import java.time.ZoneOffset
 
 internal val fixedClock: Clock = Clock.fixed(1.januar(2021).startOfDay(ZoneOffset.UTC).instant, ZoneOffset.UTC)
 internal val fixedTidspunkt: Tidspunkt = Tidspunkt.now(fixedClock)
+internal val fixedLocalDate: LocalDate = LocalDate.now(fixedClock)

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/beregning/TestBeregning.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/beregning/TestBeregning.kt
@@ -26,6 +26,7 @@ internal object TestBeregning : Beregning {
     override fun getPeriode(): Periode = Periode.create(1.januar(2020), 31.januar(2020))
     override fun getFradragStrategyName(): FradragStrategyName = FradragStrategyName.Enslig
     override fun getBegrunnelse(): String? = null
+    override fun equals(other: Any?) = (other as? Beregning)?.let { this.equals(other) } ?: false
 }
 
 internal object TestMånedsberegning : Månedsberegning {
@@ -36,6 +37,7 @@ internal object TestMånedsberegning : Månedsberegning {
     override fun getSatsbeløp(): Double = 20637.32
     override fun getFradrag(): List<Fradrag> = listOf(TestFradrag)
     override fun getPeriode(): Periode = Periode.create(1.januar(2020), 31.januar(2020))
+    override fun equals(other: Any?) = (other as? Månedsberegning)?.let { this.equals(other) } ?: false
 }
 
 internal object TestBeregningSomGirOpphør : Beregning {
@@ -51,6 +53,7 @@ internal object TestBeregningSomGirOpphør : Beregning {
     override fun getPeriode(): Periode = Periode.create(1.januar(2020), 31.januar(2020))
     override fun getFradragStrategyName(): FradragStrategyName = FradragStrategyName.Enslig
     override fun getBegrunnelse(): String? = null
+    override fun equals(other: Any?) = (other as? Beregning)?.let { this.equals(other) } ?: false
 }
 
 internal object TestMånedsberegningSomGirOpphør : Månedsberegning {
@@ -61,6 +64,7 @@ internal object TestMånedsberegningSomGirOpphør : Månedsberegning {
     override fun getSatsbeløp(): Double = 20637.32
     override fun getFradrag(): List<Fradrag> = listOf(TestFradrag)
     override fun getPeriode(): Periode = Periode.create(1.januar(2020), 31.januar(2020))
+    override fun equals(other: Any?) = (other as? Månedsberegning)?.let { this.equals(other) } ?: false
 }
 
 internal object TestFradrag : Fradrag {
@@ -69,4 +73,5 @@ internal object TestFradrag : Fradrag {
     override fun getUtenlandskInntekt(): UtenlandskInntekt? = null
     override fun getTilhører(): FradragTilhører = FradragTilhører.BRUKER
     override fun getPeriode(): Periode = Periode.create(1.januar(2020), 31.januar(2020))
+    override fun equals(other: Any?) = (other as? Fradrag)?.let { this.equals(other) } ?: false
 }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OppdaterRevurderingServiceTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OppdaterRevurderingServiceTest.kt
@@ -1,0 +1,189 @@
+package no.nav.su.se.bakover.service.revurdering
+
+import arrow.core.left
+import arrow.core.right
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.inOrder
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.common.endOfMonth
+import no.nav.su.se.bakover.common.periode.Periode
+import no.nav.su.se.bakover.database.revurdering.RevurderingRepo
+import no.nav.su.se.bakover.domain.NavIdentBruker
+import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
+import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
+import no.nav.su.se.bakover.domain.oppgave.OppgaveId
+import no.nav.su.se.bakover.domain.revurdering.OpprettetRevurdering
+import no.nav.su.se.bakover.domain.revurdering.Revurderingsårsak
+import no.nav.su.se.bakover.service.argThat
+import no.nav.su.se.bakover.service.fixedLocalDate
+import no.nav.su.se.bakover.service.fixedTidspunkt
+import no.nav.su.se.bakover.service.revurdering.RevurderingTestUtils.søknadsbehandlingVedtak
+import org.junit.jupiter.api.Test
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+
+val oppgaveId = OppgaveId("oppgaveId")
+
+internal class OppdaterRevurderingServiceTest {
+    private val behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt()
+
+    private val opprettetFraOgMed = fixedLocalDate
+    private val opprettetTilOgMed = fixedLocalDate.plus(11, ChronoUnit.MONTHS).endOfMonth()
+    private val periode = Periode.create(
+        fraOgMed = opprettetFraOgMed,
+        tilOgMed = opprettetTilOgMed,
+    )
+    private val saksbehandler = NavIdentBruker.Saksbehandler("Sak S. behandler")
+    private val revurderingId = UUID.randomUUID()
+
+    private val revurderingsårsak = Revurderingsårsak(
+        Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
+        Revurderingsårsak.Begrunnelse.create("Ny informasjon"),
+    )
+
+    private val tilRevurdering = søknadsbehandlingVedtak.copy(periode = periode)
+    private val opprettetRevurdering = OpprettetRevurdering(
+        id = revurderingId,
+        periode = periode,
+        opprettet = fixedTidspunkt,
+        tilRevurdering = tilRevurdering,
+        saksbehandler = saksbehandler,
+        oppgaveId = oppgaveId,
+        fritekstTilBrev = "",
+        revurderingsårsak = revurderingsårsak,
+        behandlingsinformasjon = behandlingsinformasjon,
+    )
+
+    @Test
+    fun `ugyldig begrunnelse`() {
+        val mocks = RevurderingServiceMocks()
+        val actual = mocks.revurderingService.oppdaterRevurderingsperiode(
+            OppdaterRevurderingRequest(
+                revurderingId = revurderingId,
+                fraOgMed = opprettetFraOgMed,
+                årsak = "MELDING_FRA_BRUKER",
+                begrunnelse = "",
+                saksbehandler = saksbehandler,
+            ),
+        )
+        actual shouldBe KunneIkkeOppdatereRevurderingsperiode.UgyldigBegrunnelse.left()
+        mocks.verifyNoMoreInteractions()
+    }
+
+    @Test
+    fun `ugyldig årsak`() {
+        val mocks = RevurderingServiceMocks()
+        val actual = mocks.revurderingService.oppdaterRevurderingsperiode(
+            OppdaterRevurderingRequest(
+                revurderingId = revurderingId,
+                fraOgMed = opprettetFraOgMed,
+                årsak = "UGYLDIG_ÅRSAK",
+                begrunnelse = "gyldig begrunnelse",
+                saksbehandler = saksbehandler,
+            ),
+        )
+        actual shouldBe KunneIkkeOppdatereRevurderingsperiode.UgyldigÅrsak.left()
+        mocks.verifyNoMoreInteractions()
+    }
+
+    @Test
+    fun `Fant ikke revurdering`() {
+        val revurderingRepoMock = mock<RevurderingRepo> {
+            on { hent(any()) } doReturn null
+        }
+        val mocks = RevurderingServiceMocks(revurderingRepo = revurderingRepoMock)
+        val actual = mocks.revurderingService.oppdaterRevurderingsperiode(
+            OppdaterRevurderingRequest(
+                revurderingId = revurderingId,
+                fraOgMed = opprettetFraOgMed,
+                årsak = "MELDING_FRA_BRUKER",
+                begrunnelse = "gyldig begrunnelse",
+                saksbehandler = saksbehandler,
+            ),
+        )
+        actual shouldBe KunneIkkeOppdatereRevurderingsperiode.FantIkkeRevurdering.left()
+        verify(revurderingRepoMock).hent(argThat { it shouldBe revurderingId })
+        mocks.verifyNoMoreInteractions()
+    }
+
+    @Test
+    fun `Perioden må være innenfor allerede valgt stønadsperiode`() {
+        val revurderingRepoMock = mock<RevurderingRepo> {
+            on { hent(any()) } doReturn opprettetRevurdering
+        }
+        val mocks = RevurderingServiceMocks(revurderingRepo = revurderingRepoMock)
+        val actual = mocks.revurderingService.oppdaterRevurderingsperiode(
+            OppdaterRevurderingRequest(
+                revurderingId = revurderingId,
+                fraOgMed = periode.getFraOgMed().minus(1, ChronoUnit.MONTHS),
+                årsak = "MELDING_FRA_BRUKER",
+                begrunnelse = "gyldig begrunnelse",
+                saksbehandler = saksbehandler,
+            ),
+        )
+        actual shouldBe KunneIkkeOppdatereRevurderingsperiode.PeriodenMåVæreInnenforAlleredeValgtStønadsperiode(periode)
+            .left()
+        verify(revurderingRepoMock).hent(argThat { it shouldBe revurderingId })
+        mocks.verifyNoMoreInteractions()
+    }
+
+    @Test
+    fun `Ugyldig periode - fra og med dato må være første dag i måneden`() {
+        val revurderingRepoMock = mock<RevurderingRepo> {
+            on { hent(any()) } doReturn opprettetRevurdering
+        }
+        val mocks = RevurderingServiceMocks(revurderingRepo = revurderingRepoMock)
+        val actual = mocks.revurderingService.oppdaterRevurderingsperiode(
+            OppdaterRevurderingRequest(
+                revurderingId = revurderingId,
+                fraOgMed = periode.getFraOgMed().plus(1, ChronoUnit.DAYS),
+                årsak = "MELDING_FRA_BRUKER",
+                begrunnelse = "gyldig begrunnelse",
+                saksbehandler = saksbehandler,
+            ),
+        )
+        actual shouldBe KunneIkkeOppdatereRevurderingsperiode.UgyldigPeriode(Periode.UgyldigPeriode.FraOgMedDatoMåVæreFørsteDagIMåneden)
+            .left()
+        verify(revurderingRepoMock).hent(argThat { it shouldBe revurderingId })
+        mocks.verifyNoMoreInteractions()
+    }
+
+    @Test
+    fun `oppdater en revurdering`() {
+        val revurderingRepoMock = mock<RevurderingRepo> {
+            on { hent(any()) } doReturn opprettetRevurdering
+        }
+
+        val mocks = RevurderingServiceMocks(revurderingRepo = revurderingRepoMock)
+        val actual = mocks.revurderingService.oppdaterRevurderingsperiode(
+            OppdaterRevurderingRequest(
+                revurderingId = revurderingId,
+                fraOgMed = periode.getFraOgMed(),
+                årsak = "MELDING_FRA_BRUKER",
+                begrunnelse = "Ny informasjon",
+                saksbehandler = saksbehandler,
+            ),
+        ).orNull()!!
+
+        actual shouldBe OpprettetRevurdering(
+            id = actual.id,
+            periode = periode,
+            opprettet = actual.opprettet,
+            tilRevurdering = tilRevurdering,
+            saksbehandler = saksbehandler,
+            oppgaveId = oppgaveId,
+            fritekstTilBrev = "",
+            revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = tilRevurdering.behandlingsinformasjon,
+        )
+        inOrder(revurderingRepoMock) {
+            verify(revurderingRepoMock).hent(argThat { it shouldBe revurderingId })
+            verify(revurderingRepoMock).lagre(argThat { it.right() shouldBe actual.right() })
+        }
+        verifyNoMoreInteractions(revurderingRepoMock)
+    }
+}

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OpprettRevurderingServiceTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OpprettRevurderingServiceTest.kt
@@ -7,25 +7,17 @@ import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.inOrder
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import io.kotest.assertions.arrow.either.shouldBeRight
 import io.kotest.matchers.shouldBe
-import no.nav.su.se.bakover.client.person.MicrosoftGraphApiClient
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.UUID30
-import no.nav.su.se.bakover.common.april
 import no.nav.su.se.bakover.common.desember
-import no.nav.su.se.bakover.common.februar
 import no.nav.su.se.bakover.common.januar
-import no.nav.su.se.bakover.common.juni
 import no.nav.su.se.bakover.common.mai
 import no.nav.su.se.bakover.common.mars
 import no.nav.su.se.bakover.common.periode.Periode
-import no.nav.su.se.bakover.common.startOfDay
 import no.nav.su.se.bakover.common.toTidspunkt
-import no.nav.su.se.bakover.common.zoneIdOslo
 import no.nav.su.se.bakover.database.revurdering.RevurderingRepo
-import no.nav.su.se.bakover.database.vedtak.VedtakRepo
 import no.nav.su.se.bakover.domain.AktørId
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Sak
@@ -50,17 +42,13 @@ import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
 import no.nav.su.se.bakover.domain.vedtak.Vedtak
 import no.nav.su.se.bakover.service.FnrGenerator
 import no.nav.su.se.bakover.service.argThat
-import no.nav.su.se.bakover.service.brev.BrevService
-import no.nav.su.se.bakover.service.doNothing
-import no.nav.su.se.bakover.service.fixedClock
+import no.nav.su.se.bakover.service.fixedLocalDate
+import no.nav.su.se.bakover.service.fixedTidspunkt
 import no.nav.su.se.bakover.service.oppgave.OppgaveService
 import no.nav.su.se.bakover.service.person.PersonService
 import no.nav.su.se.bakover.service.sak.FantIkkeSak
 import no.nav.su.se.bakover.service.sak.SakService
-import no.nav.su.se.bakover.service.utbetaling.UtbetalingService
-import no.nav.su.se.bakover.service.vedtak.FerdigstillVedtakService
 import org.junit.jupiter.api.Test
-import java.time.Clock
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import java.util.UUID
@@ -69,7 +57,7 @@ internal class OpprettRevurderingServiceTest {
 
     private val sakId: UUID = UUID.randomUUID()
 
-    private val dagensDato = LocalDate.now().let {
+    private val denFørsteInneværendeMåned = fixedLocalDate.let {
         LocalDate.of(
             it.year,
             it.month,
@@ -78,8 +66,8 @@ internal class OpprettRevurderingServiceTest {
     }
     private val nesteMåned =
         LocalDate.of(
-            dagensDato.year,
-            dagensDato.month.plus(1),
+            denFørsteInneværendeMåned.year,
+            denFørsteInneværendeMåned.month.plus(1),
             1,
         )
     private val periode = Periode.create(
@@ -143,7 +131,7 @@ internal class OpprettRevurderingServiceTest {
     private fun createSak() = Sak(
         id = sakId,
         saksnummer = saksnummer,
-        opprettet = Tidspunkt.now(),
+        opprettet = fixedTidspunkt,
         fnr = fnr,
         søknader = listOf(),
         behandlinger = listOf(createInnvilgetBehandling()),
@@ -164,9 +152,7 @@ internal class OpprettRevurderingServiceTest {
         val sakServiceMock = mock<SakService> {
             on { hentSak(sakId) } doReturn sak.right()
         }
-        val revurderingRepoMock = mock<RevurderingRepo> {
-            on { lagre(any()) }.doNothing()
-        }
+        val revurderingRepoMock = mock<RevurderingRepo>()
 
         val personServiceMock = mock<PersonService> {
             on { hentAktørId(any()) } doReturn aktørId.right()
@@ -175,13 +161,13 @@ internal class OpprettRevurderingServiceTest {
         val oppgaveServiceMock = mock<OppgaveService> {
             on { opprettOppgave(any()) } doReturn OppgaveId("oppgaveId").right()
         }
-
-        val actual = createRevurderingService(
+        val mocks = RevurderingServiceMocks(
             sakService = sakServiceMock,
             revurderingRepo = revurderingRepoMock,
             oppgaveService = oppgaveServiceMock,
             personService = personServiceMock,
-        ).opprettRevurdering(
+        )
+        val actual = mocks.revurderingService.opprettRevurdering(
             OpprettRevurderingRequest(
                 sakId = sakId,
                 fraOgMed = periode.getFraOgMed(),
@@ -218,12 +204,13 @@ internal class OpprettRevurderingServiceTest {
             verify(revurderingRepoMock).lagre(argThat { it.right() shouldBe actual.right() })
         }
 
-        verifyNoMoreInteractions(sakServiceMock, personServiceMock, oppgaveServiceMock, revurderingRepoMock)
+        mocks.verifyNoMoreInteractions()
     }
 
     @Test
     fun `oppretter ikke en revurdering hvis perioden er i samme måned`() {
-        val actual = createRevurderingService().opprettRevurdering(
+        val mocks = RevurderingServiceMocks()
+        val actual = mocks.revurderingService.opprettRevurdering(
             OpprettRevurderingRequest(
                 sakId = sakId,
                 fraOgMed = 1.januar(2021),
@@ -234,6 +221,7 @@ internal class OpprettRevurderingServiceTest {
         )
 
         actual shouldBe KunneIkkeOppretteRevurdering.KanIkkeRevurdereInneværendeMånedEllerTidligere.left()
+        mocks.verifyNoMoreInteractions()
     }
 
     @Test
@@ -241,9 +229,10 @@ internal class OpprettRevurderingServiceTest {
         val sakServiceMock = mock<SakService> {
             on { hentSak(sakId) } doReturn FantIkkeSak.left()
         }
-        val actual = createRevurderingService(
+        val mocks = RevurderingServiceMocks(
             sakService = sakServiceMock,
-        ).opprettRevurdering(
+        )
+        val actual = mocks.revurderingService.opprettRevurdering(
             OpprettRevurderingRequest(
                 sakId = sakId,
                 fraOgMed = periode.getFraOgMed(),
@@ -254,7 +243,7 @@ internal class OpprettRevurderingServiceTest {
         )
         actual shouldBe KunneIkkeOppretteRevurdering.FantIkkeSak.left()
         verify(sakServiceMock).hentSak(sakId)
-        verifyNoMoreInteractions(sakServiceMock)
+        mocks.verifyNoMoreInteractions()
     }
 
     @Test
@@ -266,10 +255,10 @@ internal class OpprettRevurderingServiceTest {
         val sakServiceMock = mock<SakService> {
             on { hentSak(sakId) } doReturn sak.right()
         }
-
-        val actual = createRevurderingService(
+        val mocks = RevurderingServiceMocks(
             sakService = sakServiceMock,
-        ).opprettRevurdering(
+        )
+        val actual = mocks.revurderingService.opprettRevurdering(
             OpprettRevurderingRequest(
                 sakId = sakId,
                 fraOgMed = periode.getFraOgMed(),
@@ -281,7 +270,7 @@ internal class OpprettRevurderingServiceTest {
 
         actual shouldBe KunneIkkeOppretteRevurdering.FantIngentingSomKanRevurderes.left()
         verify(sakServiceMock).hentSak(sakId)
-        verifyNoMoreInteractions(sakServiceMock)
+        mocks.verifyNoMoreInteractions()
     }
 
     @Test
@@ -296,7 +285,7 @@ internal class OpprettRevurderingServiceTest {
         val sak = Sak(
             id = sakId,
             saksnummer = saksnummer,
-            opprettet = Tidspunkt.now(),
+            opprettet = fixedTidspunkt,
             fnr = fnr,
             søknader = listOf(),
             behandlinger = listOf(behandling),
@@ -307,9 +296,10 @@ internal class OpprettRevurderingServiceTest {
             on { hentSak(sakId) } doReturn sak.right()
         }
 
-        val actual = createRevurderingService(
+        val mocks = RevurderingServiceMocks(
             sakService = sakServiceMock,
-        ).opprettRevurdering(
+        )
+        val actual = mocks.revurderingService.opprettRevurdering(
             OpprettRevurderingRequest(
                 sakId = sakId,
                 fraOgMed = periode.getFraOgMed(),
@@ -321,7 +311,7 @@ internal class OpprettRevurderingServiceTest {
 
         actual shouldBe KunneIkkeOppretteRevurdering.FantIngentingSomKanRevurderes.left()
         verify(sakServiceMock).hentSak(sakId)
-        verifyNoMoreInteractions(sakServiceMock)
+        mocks.verifyNoMoreInteractions()
     }
 
     @Test
@@ -331,28 +321,31 @@ internal class OpprettRevurderingServiceTest {
             on { saksnummer } doReturn Saksnummer(1337)
         }
         val vedtakForFørsteJanuarLagetNå = mock<Vedtak.EndringIYtelse> {
-            on { opprettet } doReturn Tidspunkt.now()
-            on { periode } doReturn Periode.create(1.januar(2020), 31.desember(2020))
+            on { opprettet } doReturn fixedTidspunkt
+            on { periode } doReturn Periode.create(1.januar(2021), 31.desember(2021))
             on { behandling } doReturn behandlingMock
-            on { behandlingsinformasjon } doReturn Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt()
+            on { behandlingsinformasjon } doReturn Behandlingsinformasjon.lagTomBehandlingsinformasjon()
+                .withAlleVilkårOppfylt()
         }
         val vedtakForFørsteMarsLagetNå = mock<Vedtak.EndringIYtelse> {
-            on { opprettet } doReturn Tidspunkt.now()
-            on { periode } doReturn Periode.create(1.mars(2020), 31.desember(2020))
+            on { opprettet } doReturn fixedTidspunkt.plus(1, ChronoUnit.SECONDS)
+            on { periode } doReturn Periode.create(1.mars(2021), 31.desember(2021))
             on { behandling } doReturn behandlingMock
-            on { behandlingsinformasjon } doReturn Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt()
+            on { behandlingsinformasjon } doReturn Behandlingsinformasjon.lagTomBehandlingsinformasjon()
+                .withAlleVilkårOppfylt()
         }
         val vedtakForFørsteJanuarLagetForLengeSiden = mock<Vedtak.EndringIYtelse> {
-            on { opprettet } doReturn Tidspunkt.now().instant.minus(2, ChronoUnit.HALF_DAYS).toTidspunkt()
-            on { periode } doReturn Periode.create(1.januar(2020), 31.desember(2020))
+            on { opprettet } doReturn fixedTidspunkt.instant.minus(2, ChronoUnit.HALF_DAYS).toTidspunkt()
+            on { periode } doReturn Periode.create(1.januar(2021), 31.desember(2021))
             on { behandling } doReturn behandlingMock
-            on { behandlingsinformasjon } doReturn Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt()
+            on { behandlingsinformasjon } doReturn Behandlingsinformasjon.lagTomBehandlingsinformasjon()
+                .withAlleVilkårOppfylt()
         }
 
         val sak = Sak(
             id = sakId,
             saksnummer = saksnummer,
-            opprettet = Tidspunkt.now(),
+            opprettet = fixedTidspunkt,
             fnr = fnr,
             søknader = listOf(),
             behandlinger = emptyList(),
@@ -367,20 +360,20 @@ internal class OpprettRevurderingServiceTest {
         val sakServiceMock = mock<SakService> {
             on { hentSak(sakId) } doReturn sak.right()
         }
-
-        val revurderingForFebruar = createRevurderingService(
+        val mocks = RevurderingServiceMocks(
+            // clock = Clock.fixed(1.januar(2020).startOfDay(zoneIdOslo).instant, zoneIdOslo),
             sakService = sakServiceMock,
-            clock = Clock.fixed(1.januar(2020).startOfDay(zoneIdOslo).instant, zoneIdOslo),
             oppgaveService = mock {
-                on { opprettOppgave(any()) } doReturn OppgaveId("oppgav1").right()
+                on { opprettOppgave(any()) } doReturn oppgaveId.right()
             },
             personService = mock {
-                on { hentAktørId(any()) } doReturn AktørId("aktør1").right()
+                on { hentAktørId(any()) } doReturn aktørId.right()
             },
-        ).opprettRevurdering(
+        )
+        val revurderingForFebruar = mocks.revurderingService.opprettRevurdering(
             OpprettRevurderingRequest(
                 sakId = sakId,
-                fraOgMed = 1.februar(2020),
+                fraOgMed = fixedLocalDate.plus(1, ChronoUnit.MONTHS),
                 årsak = "MELDING_FRA_BRUKER",
                 begrunnelse = "Ny informasjon",
                 saksbehandler = saksbehandler,
@@ -391,19 +384,10 @@ internal class OpprettRevurderingServiceTest {
             it.tilRevurdering shouldBe vedtakForFørsteJanuarLagetNå
         }
 
-        val revurderingForApril = createRevurderingService(
-            sakService = sakServiceMock,
-            clock = Clock.fixed(1.januar(2020).startOfDay(zoneIdOslo).instant, zoneIdOslo),
-            oppgaveService = mock {
-                on { opprettOppgave(any()) } doReturn OppgaveId("oppgav1").right()
-            },
-            personService = mock {
-                on { hentAktørId(any()) } doReturn AktørId("aktør1").right()
-            },
-        ).opprettRevurdering(
+        val revurderingForApril = mocks.revurderingService.opprettRevurdering(
             OpprettRevurderingRequest(
                 sakId = sakId,
-                fraOgMed = 1.april(2020),
+                fraOgMed = fixedLocalDate.plus(3, ChronoUnit.MONTHS),
                 årsak = "MELDING_FRA_BRUKER",
                 begrunnelse = "Ny informasjon",
                 saksbehandler = saksbehandler,
@@ -446,20 +430,24 @@ internal class OpprettRevurderingServiceTest {
         val sakServiceMock = mock<SakService> {
             on { hentSak(sakId) } doReturn sak.right()
         }
+        val revurderingRepoMock = mock<RevurderingRepo>()
 
-        val actual = createRevurderingService(
+        val oppgaveServiceMock = mock<OppgaveService> {
+            on { opprettOppgave(any()) } doReturn oppgaveId.right()
+        }
+        val personServiceMock = mock<PersonService> {
+            on { hentAktørId(any()) } doReturn aktørId.right()
+        }
+        val mocks = RevurderingServiceMocks(
             sakService = sakServiceMock,
-            clock = Clock.fixed(1.februar(2021).startOfDay(zoneIdOslo).instant, zoneIdOslo),
-            personService = mock {
-                on { hentAktørId(any()) } doReturn AktørId("aktør1").right()
-            },
-            oppgaveService = mock {
-                on { opprettOppgave(any()) } doReturn OppgaveId("oppgav1").right()
-            },
-        ).opprettRevurdering(
+            personService = personServiceMock,
+            oppgaveService = oppgaveServiceMock,
+            revurderingRepo = revurderingRepoMock,
+        )
+        val actual = mocks.revurderingService.opprettRevurdering(
             OpprettRevurderingRequest(
                 sakId = sakId,
-                fraOgMed = 1.juni(2021),
+                fraOgMed = periode.getFraOgMed(),
                 årsak = "MELDING_FRA_BRUKER",
                 begrunnelse = "Ny informasjon",
                 saksbehandler = saksbehandler,
@@ -472,7 +460,18 @@ internal class OpprettRevurderingServiceTest {
         }
 
         verify(sakServiceMock).hentSak(sakId)
-        verifyNoMoreInteractions(sakServiceMock)
+        verify(personServiceMock).hentAktørId(argThat { it shouldBe fnr })
+        verify(revurderingRepoMock).lagre(argThat { it.right() shouldBe actual })
+        verify(oppgaveServiceMock).opprettOppgave(
+            argThat {
+                it shouldBe OppgaveConfig.Revurderingsbehandling(
+                    saksnummer = saksnummer,
+                    aktørId = aktørId,
+                    tilordnetRessurs = null,
+                )
+            },
+        )
+        mocks.verifyNoMoreInteractions()
     }
 
     @Test
@@ -483,14 +482,14 @@ internal class OpprettRevurderingServiceTest {
             on { hentSak(sakId) } doReturn sak.right()
         }
 
-        val actual = createRevurderingService(
+        val mocks = RevurderingServiceMocks(
             sakService = sakServiceMock,
-            clock = Clock.fixed(1.februar(2021).startOfDay(zoneIdOslo).instant, zoneIdOslo),
-        ).opprettRevurdering(
+        )
+        val actual = mocks.revurderingService.opprettRevurdering(
             OpprettRevurderingRequest(
                 sakId = sakId,
                 // tester at fraOgMed må starte på 1.
-                fraOgMed = 2.juni(2021),
+                fraOgMed = periode.getTilOgMed(),
                 årsak = "MELDING_FRA_BRUKER",
                 begrunnelse = "Ny informasjon",
                 saksbehandler = saksbehandler,
@@ -500,7 +499,7 @@ internal class OpprettRevurderingServiceTest {
         actual shouldBe KunneIkkeOppretteRevurdering.UgyldigPeriode(Periode.UgyldigPeriode.FraOgMedDatoMåVæreFørsteDagIMåneden)
             .left()
         verify(sakServiceMock).hentSak(sakId)
-        verifyNoMoreInteractions(sakServiceMock)
+        mocks.verifyNoMoreInteractions()
     }
 
     @Test
@@ -515,14 +514,14 @@ internal class OpprettRevurderingServiceTest {
             on { hentAktørId(any()) } doReturn KunneIkkeHentePerson.FantIkkePerson.left()
         }
 
-        val actual = createRevurderingService(
+        val mocks = RevurderingServiceMocks(
             sakService = sakServiceMock,
-            clock = Clock.fixed(1.februar(2021).startOfDay(zoneIdOslo).instant, zoneIdOslo),
             personService = personServiceMock,
-        ).opprettRevurdering(
+        )
+        val actual = mocks.revurderingService.opprettRevurdering(
             OpprettRevurderingRequest(
                 sakId = sakId,
-                fraOgMed = 1.juni(2021),
+                fraOgMed = periode.getFraOgMed(),
                 årsak = "MELDING_FRA_BRUKER",
                 begrunnelse = "Ny informasjon",
                 saksbehandler = saksbehandler,
@@ -532,6 +531,7 @@ internal class OpprettRevurderingServiceTest {
         actual shouldBe KunneIkkeOppretteRevurdering.FantIkkeAktørId.left()
         verify(sakServiceMock).hentSak(sakId)
         verify(personServiceMock).hentAktørId(argThat { it shouldBe fnr })
+        mocks.verifyNoMoreInteractions()
     }
 
     @Test
@@ -550,15 +550,15 @@ internal class OpprettRevurderingServiceTest {
             on { opprettOppgave(any()) } doReturn KunneIkkeOppretteOppgave.left()
         }
 
-        val actual = createRevurderingService(
+        val mocks = RevurderingServiceMocks(
             sakService = sakServiceMock,
-            clock = Clock.fixed(1.februar(2021).startOfDay(zoneIdOslo).instant, zoneIdOslo),
             personService = personServiceMock,
             oppgaveService = oppgaveServiceMock,
-        ).opprettRevurdering(
+        )
+        val actual = mocks.revurderingService.opprettRevurdering(
             OpprettRevurderingRequest(
                 sakId = sakId,
-                fraOgMed = 1.juni(2021),
+                fraOgMed = periode.getFraOgMed(),
                 årsak = "MELDING_FRA_BRUKER",
                 begrunnelse = "Ny informasjon",
                 saksbehandler = saksbehandler,
@@ -576,31 +576,6 @@ internal class OpprettRevurderingServiceTest {
                 )
             },
         )
-        verifyNoMoreInteractions(sakServiceMock, personServiceMock)
+        mocks.verifyNoMoreInteractions()
     }
-
-    private fun createRevurderingService(
-        sakService: SakService = mock(),
-        utbetalingService: UtbetalingService = mock(),
-        revurderingRepo: RevurderingRepo = mock(),
-        oppgaveService: OppgaveService = mock(),
-        personService: PersonService = mock(),
-        microsoftGraphApiClient: MicrosoftGraphApiClient = mock(),
-        brevService: BrevService = mock(),
-        vedtakRepo: VedtakRepo = mock(),
-        clock: Clock = fixedClock,
-        ferdigstillVedtakService: FerdigstillVedtakService = mock(),
-    ) =
-        RevurderingServiceImpl(
-            sakService = sakService,
-            utbetalingService = utbetalingService,
-            revurderingRepo = revurderingRepo,
-            oppgaveService = oppgaveService,
-            personService = personService,
-            microsoftGraphApiClient = microsoftGraphApiClient,
-            brevService = brevService,
-            vedtakRepo = vedtakRepo,
-            clock = clock,
-            ferdigstillVedtakService = ferdigstillVedtakService,
-        )
 }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OpprettRevurderingServiceTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OpprettRevurderingServiceTest.kt
@@ -34,6 +34,7 @@ import no.nav.su.se.bakover.domain.ValgtStønadsperiode
 import no.nav.su.se.bakover.domain.behandling.Attestering
 import no.nav.su.se.bakover.domain.behandling.Behandling
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
+import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.beregning.Beregning
 import no.nav.su.se.bakover.domain.beregning.MånedsberegningFactory
 import no.nav.su.se.bakover.domain.beregning.Sats
@@ -190,15 +191,17 @@ internal class OpprettRevurderingServiceTest {
             ),
         ).orNull()!!
 
+        val tilRevurdering = sak.vedtakListe.first() as Vedtak.EndringIYtelse
         actual shouldBe OpprettetRevurdering(
             id = actual.id,
             periode = periode,
             opprettet = actual.opprettet,
-            tilRevurdering = sak.vedtakListe.first() as Vedtak.EndringIYtelse,
+            tilRevurdering = tilRevurdering,
             saksbehandler = saksbehandler,
             oppgaveId = OppgaveId("oppgaveId"),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = tilRevurdering.behandlingsinformasjon,
         )
         inOrder(sakServiceMock, personServiceMock, oppgaveServiceMock, revurderingRepoMock) {
             verify(sakServiceMock).hentSak(sakId)
@@ -331,16 +334,19 @@ internal class OpprettRevurderingServiceTest {
             on { opprettet } doReturn Tidspunkt.now()
             on { periode } doReturn Periode.create(1.januar(2020), 31.desember(2020))
             on { behandling } doReturn behandlingMock
+            on { behandlingsinformasjon } doReturn Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt()
         }
         val vedtakForFørsteMarsLagetNå = mock<Vedtak.EndringIYtelse> {
             on { opprettet } doReturn Tidspunkt.now()
             on { periode } doReturn Periode.create(1.mars(2020), 31.desember(2020))
             on { behandling } doReturn behandlingMock
+            on { behandlingsinformasjon } doReturn Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt()
         }
         val vedtakForFørsteJanuarLagetForLengeSiden = mock<Vedtak.EndringIYtelse> {
             on { opprettet } doReturn Tidspunkt.now().instant.minus(2, ChronoUnit.HALF_DAYS).toTidspunkt()
             on { periode } doReturn Periode.create(1.januar(2020), 31.desember(2020))
             on { behandling } doReturn behandlingMock
+            on { behandlingsinformasjon } doReturn Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt()
         }
 
         val sak = Sak(
@@ -425,6 +431,7 @@ internal class OpprettRevurderingServiceTest {
                 attestering = Attestering.Iverksatt(opprinneligVedtak.attestant),
                 fritekstTilBrev = "",
                 revurderingsårsak = revurderingsårsak,
+                behandlingsinformasjon = opprinneligVedtak.behandlingsinformasjon,
             )
             it.copy(
                 revurderinger = listOf(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RegulerGrunnbeløpServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RegulerGrunnbeløpServiceImplTest.kt
@@ -1,0 +1,492 @@
+package no.nav.su.se.bakover.service.revurdering
+
+import arrow.core.left
+import arrow.core.right
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.inOrder
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.beOfType
+import no.nav.su.se.bakover.common.Tidspunkt
+import no.nav.su.se.bakover.database.revurdering.RevurderingRepo
+import no.nav.su.se.bakover.database.vedtak.VedtakRepo
+import no.nav.su.se.bakover.domain.NavIdentBruker
+import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
+import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
+import no.nav.su.se.bakover.domain.beregning.fradrag.FradragFactory
+import no.nav.su.se.bakover.domain.beregning.fradrag.FradragTilhører
+import no.nav.su.se.bakover.domain.beregning.fradrag.Fradragstype
+import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
+import no.nav.su.se.bakover.domain.oppgave.OppgaveId
+import no.nav.su.se.bakover.domain.revurdering.BeregnetRevurdering
+import no.nav.su.se.bakover.domain.revurdering.IverksattRevurdering
+import no.nav.su.se.bakover.domain.revurdering.OpprettetRevurdering
+import no.nav.su.se.bakover.domain.revurdering.RevurderingTilAttestering
+import no.nav.su.se.bakover.domain.revurdering.SimulertRevurdering
+import no.nav.su.se.bakover.domain.revurdering.UnderkjentRevurdering
+import no.nav.su.se.bakover.domain.vedtak.Vedtak
+import no.nav.su.se.bakover.domain.vedtak.VedtakType
+import no.nav.su.se.bakover.service.argThat
+import no.nav.su.se.bakover.service.beregning.TestBeregning
+import no.nav.su.se.bakover.service.oppgave.OppgaveService
+import no.nav.su.se.bakover.service.person.PersonService
+import no.nav.su.se.bakover.service.revurdering.KunneIkkeBeregneOgSimulereRevurdering.MåSendeGrunnbeløpReguleringSomÅrsakSammenMedForventetInntekt
+import no.nav.su.se.bakover.service.revurdering.RevurderingTestUtils.createRevurderingService
+import no.nav.su.se.bakover.service.revurdering.RevurderingTestUtils.periode
+import no.nav.su.se.bakover.service.revurdering.RevurderingTestUtils.revurderingId
+import no.nav.su.se.bakover.service.revurdering.RevurderingTestUtils.revurderingsårsak
+import no.nav.su.se.bakover.service.revurdering.RevurderingTestUtils.revurderingsårsakRegulerGrunnbeløp
+import no.nav.su.se.bakover.service.revurdering.RevurderingTestUtils.saksbehandler
+import no.nav.su.se.bakover.service.revurdering.RevurderingTestUtils.søknadsbehandlingVedtak
+import no.nav.su.se.bakover.service.statistikk.Event
+import no.nav.su.se.bakover.service.statistikk.EventObserver
+import no.nav.su.se.bakover.service.utbetaling.UtbetalingService
+import org.junit.jupiter.api.Test
+
+internal class RegulerGrunnbeløpServiceImplTest {
+
+    @Test
+    fun `kan ikke beregne og simulere reguler grunnbeløp med feil årsak`() {
+        val opprettetRevurdering = OpprettetRevurdering(
+            id = revurderingId,
+            periode = periode,
+            opprettet = Tidspunkt.EPOCH,
+            tilRevurdering = søknadsbehandlingVedtak,
+            saksbehandler = saksbehandler,
+            oppgaveId = OppgaveId("oppgaveid"),
+            fritekstTilBrev = "",
+            revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
+        )
+
+        val revurderingRepoMock = mock<RevurderingRepo> {
+            on { hent(revurderingId) } doReturn opprettetRevurdering
+        }
+        val simulertUtbetaling = mock<Utbetaling.SimulertUtbetaling> {
+            on { simulering } doReturn mock()
+        }
+        val utbetalingServiceMock = mock<UtbetalingService> {
+            on { simulerUtbetaling(any(), any(), any()) } doReturn simulertUtbetaling.right()
+        }
+
+        val actual = createRevurderingService(
+            revurderingRepo = revurderingRepoMock,
+            utbetalingService = utbetalingServiceMock,
+        ).beregnOgSimuler(
+            revurderingId = revurderingId,
+            saksbehandler = saksbehandler,
+            fradrag = listOf(
+                FradragFactory.ny(
+                    type = Fradragstype.Arbeidsinntekt,
+                    månedsbeløp = 10000.0,
+                    periode = søknadsbehandlingVedtak.periode,
+                    utenlandskInntekt = null,
+                    tilhører = FradragTilhører.BRUKER,
+                ),
+            ),
+            forventetInntekt = 1,
+        )
+
+        actual shouldBe MåSendeGrunnbeløpReguleringSomÅrsakSammenMedForventetInntekt.left()
+
+        inOrder(revurderingRepoMock, utbetalingServiceMock) {
+            verify(revurderingRepoMock).hent(revurderingId)
+        }
+        verifyNoMoreInteractions(revurderingRepoMock, utbetalingServiceMock)
+    }
+
+    @Test
+    fun `oppdaterer behandlingsinformasjon med forventet inntekt`() {
+        val opprettetRevurdering = OpprettetRevurdering(
+            id = revurderingId,
+            periode = periode,
+            opprettet = Tidspunkt.EPOCH,
+            tilRevurdering = søknadsbehandlingVedtak,
+            saksbehandler = saksbehandler,
+            oppgaveId = OppgaveId("oppgaveid"),
+            fritekstTilBrev = "",
+            revurderingsårsak = revurderingsårsakRegulerGrunnbeløp,
+            behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
+        )
+
+        val revurderingRepoMock = mock<RevurderingRepo> {
+            on { hent(revurderingId) } doReturn opprettetRevurdering
+        }
+        val simulertUtbetaling = mock<Utbetaling.SimulertUtbetaling> {
+            on { simulering } doReturn mock()
+        }
+        val utbetalingServiceMock = mock<UtbetalingService> {
+            on { simulerUtbetaling(any(), any(), any()) } doReturn simulertUtbetaling.right()
+        }
+
+        val actual = createRevurderingService(
+            revurderingRepo = revurderingRepoMock,
+            utbetalingService = utbetalingServiceMock,
+        ).beregnOgSimuler(
+            revurderingId = revurderingId,
+            saksbehandler = saksbehandler,
+            fradrag = listOf(
+                FradragFactory.ny(
+                    type = Fradragstype.Arbeidsinntekt,
+                    månedsbeløp = 10000.0,
+                    periode = søknadsbehandlingVedtak.periode,
+                    utenlandskInntekt = null,
+                    tilhører = FradragTilhører.BRUKER,
+                ),
+            ),
+            forventetInntekt = 1,
+        ).orNull()!! as SimulertRevurdering.Innvilget
+
+        actual shouldBe SimulertRevurdering.Innvilget(
+            tilRevurdering = søknadsbehandlingVedtak,
+            id = revurderingId,
+            periode = periode,
+            opprettet = Tidspunkt.EPOCH,
+            beregning = actual.beregning,
+            saksbehandler = saksbehandler,
+            oppgaveId = OppgaveId("oppgaveid"),
+            fritekstTilBrev = "",
+            revurderingsårsak = revurderingsårsakRegulerGrunnbeløp,
+            behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt().copy(
+                uførhet = opprettetRevurdering.behandlingsinformasjon.uførhet!!.copy(
+                    forventetInntekt = 1,
+                ),
+            ),
+            simulering = simulertUtbetaling.simulering,
+        )
+
+        inOrder(revurderingRepoMock, utbetalingServiceMock) {
+            verify(revurderingRepoMock).hent(argThat { it shouldBe revurderingId })
+            verify(utbetalingServiceMock).simulerUtbetaling(any(), any(), any())
+            verify(revurderingRepoMock).lagre(argThat { it shouldBe actual })
+        }
+        verifyNoMoreInteractions(revurderingRepoMock, utbetalingServiceMock)
+    }
+
+    @Test
+    fun `Ikke lov å sende en Simulert Opphørt til attestering`() {
+        val simulertRevurdering = SimulertRevurdering.Opphørt(
+            id = revurderingId,
+            periode = periode,
+            opprettet = Tidspunkt.EPOCH,
+            tilRevurdering = søknadsbehandlingVedtak,
+            saksbehandler = saksbehandler,
+            oppgaveId = OppgaveId("oppgaveid"),
+            fritekstTilBrev = "",
+            revurderingsårsak = revurderingsårsakRegulerGrunnbeløp,
+            behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
+            beregning = mock(),
+            simulering = mock(),
+        )
+
+        val revurderingRepoMock = mock<RevurderingRepo> {
+            on { hent(revurderingId) } doReturn simulertRevurdering
+            on { hentEventuellTidligereAttestering(any()) } doReturn mock()
+        }
+        val personServiceMock = mock<PersonService> {
+            on { hentAktørId(any()) } doReturn RevurderingTestUtils.aktørId.right()
+        }
+        val oppgaveServiceMock = mock<OppgaveService> {
+            on { opprettOppgave(any()) } doReturn OppgaveId("oppgaveid").right()
+            on { lukkOppgave(any()) } doReturn Unit.right()
+        }
+
+        shouldThrow<IllegalStateException> {
+            createRevurderingService(
+                revurderingRepo = revurderingRepoMock,
+                personService = personServiceMock,
+                oppgaveService = oppgaveServiceMock,
+            ).sendTilAttestering(
+                SendTilAttesteringRequest(
+                    revurderingId = revurderingId,
+                    saksbehandler = saksbehandler,
+                    fritekstTilBrev = "Fritekst",
+                    skalFøreTilBrevutsending = true,
+                ),
+            )
+        }.message shouldBe "Kan ikke sende en opphørt g-regulering til attestering"
+
+        inOrder(revurderingRepoMock, personServiceMock, oppgaveServiceMock) {
+            verify(revurderingRepoMock).hent(revurderingId)
+            verify(personServiceMock).hentAktørId(argThat { it shouldBe RevurderingTestUtils.fnr })
+
+            verify(revurderingRepoMock).hentEventuellTidligereAttestering(revurderingId)
+
+            verify(oppgaveServiceMock).opprettOppgave(any())
+            verify(oppgaveServiceMock).lukkOppgave(any())
+        }
+        verifyNoMoreInteractions(revurderingRepoMock, personServiceMock, oppgaveServiceMock)
+    }
+
+    @Test
+    fun `Ikke lov å sende en Underkjent Opphørt til attestering`() {
+        val simulertRevurdering = UnderkjentRevurdering.Opphørt(
+            id = revurderingId,
+            periode = periode,
+            opprettet = Tidspunkt.EPOCH,
+            tilRevurdering = søknadsbehandlingVedtak,
+            saksbehandler = saksbehandler,
+            oppgaveId = OppgaveId("oppgaveid"),
+            fritekstTilBrev = "",
+            revurderingsårsak = revurderingsårsakRegulerGrunnbeløp,
+            behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
+            beregning = mock(),
+            simulering = mock(),
+            attestering = mock(),
+        )
+
+        val revurderingRepoMock = mock<RevurderingRepo> {
+            on { hent(revurderingId) } doReturn simulertRevurdering
+            on { hentEventuellTidligereAttestering(any()) } doReturn mock()
+        }
+        val personServiceMock = mock<PersonService> {
+            on { hentAktørId(any()) } doReturn RevurderingTestUtils.aktørId.right()
+        }
+        val oppgaveServiceMock = mock<OppgaveService> {
+            on { opprettOppgave(any()) } doReturn OppgaveId("oppgaveid").right()
+            on { lukkOppgave(any()) } doReturn Unit.right()
+        }
+
+        shouldThrow<IllegalStateException> {
+            createRevurderingService(
+                revurderingRepo = revurderingRepoMock,
+                personService = personServiceMock,
+                oppgaveService = oppgaveServiceMock,
+            ).sendTilAttestering(
+                SendTilAttesteringRequest(
+                    revurderingId = revurderingId,
+                    saksbehandler = saksbehandler,
+                    fritekstTilBrev = "Fritekst",
+                    skalFøreTilBrevutsending = true,
+                ),
+            )
+        }.message shouldBe "Kan ikke sende en opphørt g-regulering til attestering"
+
+        inOrder(revurderingRepoMock, personServiceMock, oppgaveServiceMock) {
+            verify(revurderingRepoMock).hent(revurderingId)
+            verify(personServiceMock).hentAktørId(argThat { it shouldBe RevurderingTestUtils.fnr })
+
+            verify(revurderingRepoMock).hentEventuellTidligereAttestering(revurderingId)
+
+            verify(oppgaveServiceMock).opprettOppgave(any())
+            verify(oppgaveServiceMock).lukkOppgave(any())
+        }
+        verifyNoMoreInteractions(revurderingRepoMock, personServiceMock, oppgaveServiceMock)
+    }
+
+    @Test
+    fun `En attestert beregnet revurdering skal ikke sende brev`() {
+        val beregnetRevurdering = BeregnetRevurdering.IngenEndring(
+            id = revurderingId,
+            periode = periode,
+            opprettet = Tidspunkt.EPOCH,
+            tilRevurdering = søknadsbehandlingVedtak,
+            saksbehandler = saksbehandler,
+            oppgaveId = OppgaveId("oppgaveid"),
+            fritekstTilBrev = "",
+            revurderingsårsak = revurderingsårsakRegulerGrunnbeløp,
+            behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
+            beregning = mock(),
+        )
+
+        val revurderingRepoMock = mock<RevurderingRepo> {
+            on { hent(revurderingId) } doReturn beregnetRevurdering
+            on { hentEventuellTidligereAttestering(any()) } doReturn mock()
+        }
+        val personServiceMock = mock<PersonService> {
+            on { hentAktørId(any()) } doReturn RevurderingTestUtils.aktørId.right()
+        }
+        val oppgaveServiceMock = mock<OppgaveService> {
+            on { opprettOppgave(any()) } doReturn OppgaveId("oppgaveid").right()
+            on { lukkOppgave(any()) } doReturn Unit.right()
+        }
+
+        val actual = createRevurderingService(
+            revurderingRepo = revurderingRepoMock,
+            personService = personServiceMock,
+            oppgaveService = oppgaveServiceMock,
+        ).sendTilAttestering(
+            SendTilAttesteringRequest(
+                revurderingId = revurderingId,
+                saksbehandler = saksbehandler,
+                fritekstTilBrev = "Fritekst",
+                skalFøreTilBrevutsending = true,
+            ),
+        ).orNull()!! as RevurderingTilAttestering.IngenEndring
+
+        actual shouldBe RevurderingTilAttestering.IngenEndring(
+            tilRevurdering = søknadsbehandlingVedtak,
+            id = revurderingId,
+            periode = periode,
+            opprettet = Tidspunkt.EPOCH,
+            saksbehandler = saksbehandler,
+            oppgaveId = OppgaveId("oppgaveid"),
+            fritekstTilBrev = "Fritekst",
+            revurderingsårsak = revurderingsårsakRegulerGrunnbeløp,
+            behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
+            beregning = actual.beregning,
+            skalFøreTilBrevutsending = false,
+        )
+
+        inOrder(revurderingRepoMock, personServiceMock, oppgaveServiceMock) {
+            verify(revurderingRepoMock).hent(revurderingId)
+            verify(personServiceMock).hentAktørId(argThat { it shouldBe RevurderingTestUtils.fnr })
+
+            verify(revurderingRepoMock).hentEventuellTidligereAttestering(revurderingId)
+
+            verify(oppgaveServiceMock).opprettOppgave(any())
+            verify(oppgaveServiceMock).lukkOppgave(any())
+
+            verify(revurderingRepoMock).lagre(argThat { it shouldBe actual })
+        }
+        verifyNoMoreInteractions(revurderingRepoMock, personServiceMock, oppgaveServiceMock)
+    }
+
+    @Test
+    fun `En attestert underkjent revurdering skal ikke sende brev`() {
+        val underkjentRevurdering = UnderkjentRevurdering.IngenEndring(
+            id = revurderingId,
+            periode = periode,
+            opprettet = Tidspunkt.EPOCH,
+            tilRevurdering = søknadsbehandlingVedtak,
+            saksbehandler = saksbehandler,
+            oppgaveId = OppgaveId("oppgaveid"),
+            fritekstTilBrev = "",
+            revurderingsårsak = revurderingsårsakRegulerGrunnbeløp,
+            behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
+            beregning = mock(),
+            attestering = mock(),
+            skalFøreTilBrevutsending = true,
+        )
+
+        val revurderingRepoMock = mock<RevurderingRepo> {
+            on { hent(revurderingId) } doReturn underkjentRevurdering
+            on { hentEventuellTidligereAttestering(any()) } doReturn mock()
+        }
+        val personServiceMock = mock<PersonService> {
+            on { hentAktørId(any()) } doReturn RevurderingTestUtils.aktørId.right()
+        }
+        val oppgaveServiceMock = mock<OppgaveService> {
+            on { opprettOppgave(any()) } doReturn OppgaveId("oppgaveid").right()
+            on { lukkOppgave(any()) } doReturn Unit.right()
+        }
+
+        val actual = createRevurderingService(
+            revurderingRepo = revurderingRepoMock,
+            personService = personServiceMock,
+            oppgaveService = oppgaveServiceMock,
+        ).sendTilAttestering(
+            SendTilAttesteringRequest(
+                revurderingId = revurderingId,
+                saksbehandler = saksbehandler,
+                fritekstTilBrev = "Fritekst",
+                skalFøreTilBrevutsending = true,
+            ),
+        ).orNull()!! as RevurderingTilAttestering.IngenEndring
+
+        actual shouldBe RevurderingTilAttestering.IngenEndring(
+            tilRevurdering = søknadsbehandlingVedtak,
+            id = revurderingId,
+            periode = periode,
+            opprettet = Tidspunkt.EPOCH,
+            saksbehandler = saksbehandler,
+            oppgaveId = OppgaveId("oppgaveid"),
+            fritekstTilBrev = "Fritekst",
+            revurderingsårsak = revurderingsårsakRegulerGrunnbeløp,
+            behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
+            beregning = actual.beregning,
+            skalFøreTilBrevutsending = false,
+        )
+
+        inOrder(revurderingRepoMock, personServiceMock, oppgaveServiceMock) {
+            verify(revurderingRepoMock).hent(revurderingId)
+            verify(personServiceMock).hentAktørId(argThat { it shouldBe RevurderingTestUtils.fnr })
+
+            verify(revurderingRepoMock).hentEventuellTidligereAttestering(revurderingId)
+
+            verify(oppgaveServiceMock).opprettOppgave(any())
+            verify(oppgaveServiceMock).lukkOppgave(any())
+
+            verify(revurderingRepoMock).lagre(argThat { it shouldBe actual })
+        }
+        verifyNoMoreInteractions(revurderingRepoMock, personServiceMock, oppgaveServiceMock)
+    }
+
+    @Test
+    fun `iverksetter endring av ytelse`() {
+        val attestant = NavIdentBruker.Attestant("attestant")
+
+        val iverksattRevurdering = IverksattRevurdering.IngenEndring(
+            id = revurderingId,
+            periode = periode,
+            opprettet = Tidspunkt.EPOCH,
+            tilRevurdering = søknadsbehandlingVedtak,
+            saksbehandler = saksbehandler,
+            oppgaveId = OppgaveId(value = "OppgaveId"),
+            beregning = TestBeregning,
+            attestering = Attestering.Iverksatt(attestant),
+            fritekstTilBrev = "",
+            revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
+            skalFøreTilBrevutsending = false,
+        )
+        val revurderingTilAttestering = RevurderingTilAttestering.IngenEndring(
+            id = revurderingId,
+            periode = periode,
+            opprettet = Tidspunkt.EPOCH,
+            tilRevurdering = søknadsbehandlingVedtak,
+            oppgaveId = OppgaveId(value = "OppgaveId"),
+            beregning = TestBeregning,
+            saksbehandler = saksbehandler,
+            fritekstTilBrev = "",
+            revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
+            skalFøreTilBrevutsending = false,
+        )
+
+        val revurderingRepoMock = mock<RevurderingRepo> {
+            on { hent(any()) } doReturn revurderingTilAttestering
+        }
+
+        val vedtakRepoMock = mock<VedtakRepo>()
+        val eventObserver: EventObserver = mock()
+
+        createRevurderingService(
+            revurderingRepo = revurderingRepoMock,
+            vedtakRepo = vedtakRepoMock,
+        ).apply { addObserver(eventObserver) }
+            .iverksett(
+                revurderingId = revurderingTilAttestering.id,
+                attestant = attestant,
+            ) shouldBe iverksattRevurdering.right()
+
+        inOrder(
+            revurderingRepoMock,
+            vedtakRepoMock,
+            eventObserver,
+        ) {
+            verify(revurderingRepoMock).hent(argThat { it shouldBe revurderingId })
+            verify(vedtakRepoMock).lagre(
+                argThat {
+                    it should beOfType<Vedtak.IngenEndringIYtelse>()
+                    it.vedtakType shouldBe VedtakType.INGEN_ENDRING
+                },
+            )
+            verify(revurderingRepoMock).lagre(argThat { it shouldBe iverksattRevurdering })
+            verify(eventObserver).handle(
+                argThat {
+                    it shouldBe Event.Statistikk.RevurderingStatistikk.RevurderingIverksatt(iverksattRevurdering)
+                },
+            )
+        }
+        verifyNoMoreInteractions(
+            revurderingRepoMock,
+            vedtakRepoMock,
+        )
+    }
+}

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RegulerGrunnbeløpServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RegulerGrunnbeløpServiceImplTest.kt
@@ -7,7 +7,7 @@ import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.inOrder
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
-import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.arrow.either.shouldBeLeft
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.beOfType
@@ -309,20 +309,18 @@ internal class RegulerGrunnbeløpServiceImplTest {
             on { lukkOppgave(any()) } doReturn Unit.right()
         }
 
-        shouldThrow<IllegalStateException> {
-            createRevurderingService(
-                revurderingRepo = revurderingRepoMock,
-                personService = personServiceMock,
-                oppgaveService = oppgaveServiceMock,
-            ).sendTilAttestering(
-                SendTilAttesteringRequest(
-                    revurderingId = revurderingId,
-                    saksbehandler = saksbehandler,
-                    fritekstTilBrev = "Fritekst",
-                    skalFøreTilBrevutsending = true,
-                ),
-            )
-        }.message shouldBe "Kan ikke sende en opphørt g-regulering til attestering"
+        createRevurderingService(
+            revurderingRepo = revurderingRepoMock,
+            personService = personServiceMock,
+            oppgaveService = oppgaveServiceMock,
+        ).sendTilAttestering(
+            SendTilAttesteringRequest(
+                revurderingId = revurderingId,
+                saksbehandler = saksbehandler,
+                fritekstTilBrev = "Fritekst",
+                skalFøreTilBrevutsending = true,
+            ),
+        ) shouldBeLeft KunneIkkeSendeRevurderingTilAttestering.KanIkkeRegulereGrunnbeløpTilOpphør
 
         inOrder(revurderingRepoMock, personServiceMock, oppgaveServiceMock) {
             verify(revurderingRepoMock).hent(revurderingId)
@@ -365,20 +363,18 @@ internal class RegulerGrunnbeløpServiceImplTest {
             on { lukkOppgave(any()) } doReturn Unit.right()
         }
 
-        shouldThrow<IllegalStateException> {
-            createRevurderingService(
-                revurderingRepo = revurderingRepoMock,
-                personService = personServiceMock,
-                oppgaveService = oppgaveServiceMock,
-            ).sendTilAttestering(
-                SendTilAttesteringRequest(
-                    revurderingId = revurderingId,
-                    saksbehandler = saksbehandler,
-                    fritekstTilBrev = "Fritekst",
-                    skalFøreTilBrevutsending = true,
-                ),
-            )
-        }.message shouldBe "Kan ikke sende en opphørt g-regulering til attestering"
+        createRevurderingService(
+            revurderingRepo = revurderingRepoMock,
+            personService = personServiceMock,
+            oppgaveService = oppgaveServiceMock,
+        ).sendTilAttestering(
+            SendTilAttesteringRequest(
+                revurderingId = revurderingId,
+                saksbehandler = saksbehandler,
+                fritekstTilBrev = "Fritekst",
+                skalFøreTilBrevutsending = true,
+            ),
+        ) shouldBeLeft KunneIkkeSendeRevurderingTilAttestering.KanIkkeRegulereGrunnbeløpTilOpphør
 
         inOrder(revurderingRepoMock, personServiceMock, oppgaveServiceMock) {
             verify(revurderingRepoMock).hent(revurderingId)

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
@@ -44,6 +44,7 @@ import no.nav.su.se.bakover.service.vedtak.FerdigstillVedtakService
 import org.junit.jupiter.api.Test
 
 class RevurderingIngenEndringTest {
+
     @Test
     fun `Revurderingen går ikke gjennom hvis endring av utbetaling er under ti prosent`() {
         val opprettetRevurdering = OpprettetRevurdering(
@@ -85,13 +86,13 @@ class RevurderingIngenEndringTest {
         actual.shouldBeEqualToIgnoringFields(beregnetRevurdering, BeregnetRevurdering.IngenEndring::beregning)
 
         inOrder(
-            revurderingRepoMock
+            revurderingRepoMock,
         ) {
             verify(revurderingRepoMock).hent(argThat { it shouldBe revurderingId })
             verify(revurderingRepoMock).lagre(argThat { it shouldBe actual })
         }
         verifyNoMoreInteractions(
-            revurderingRepoMock
+            revurderingRepoMock,
         )
     }
 

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
@@ -58,32 +58,34 @@ class RevurderingIngenEndringTest {
             revurderingsårsak = revurderingsårsak,
             behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
-        val beregnetRevurdering = BeregnetRevurdering.IngenEndring(
-            id = revurderingId,
-            periode = periode,
-            opprettet = fixedTidspunkt,
-            tilRevurdering = søknadsbehandlingVedtak,
-            oppgaveId = søknadOppgaveId,
-            beregning = TestBeregning,
-            saksbehandler = saksbehandler,
-            fritekstTilBrev = "",
-            revurderingsårsak = revurderingsårsak,
-            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
-        )
+
         val revurderingRepoMock = mock<RevurderingRepo> {
             on { hent(revurderingId) } doReturn opprettetRevurdering
         }
 
         val actual = createRevurderingService(
-            revurderingRepo = revurderingRepoMock
+            revurderingRepo = revurderingRepoMock,
         ).beregnOgSimuler(
             revurderingId = revurderingId,
             saksbehandler = saksbehandler,
             fradrag = listOf(),
         ).orNull()!! as BeregnetRevurdering.IngenEndring
-
-        // beregningstypen er internal i domene modulen
-        actual.shouldBeEqualToIgnoringFields(beregnetRevurdering, BeregnetRevurdering.IngenEndring::beregning)
+        actual.shouldBeEqualToIgnoringFields(
+            BeregnetRevurdering.IngenEndring(
+                id = revurderingId,
+                periode = periode,
+                opprettet = fixedTidspunkt,
+                tilRevurdering = søknadsbehandlingVedtak,
+                oppgaveId = søknadOppgaveId,
+                beregning = TestBeregning,
+                saksbehandler = saksbehandler,
+                fritekstTilBrev = "",
+                revurderingsårsak = revurderingsårsak,
+                behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
+            ),
+            // beregningstypen er internal i domene modulen
+            BeregnetRevurdering.IngenEndring::beregning,
+        )
 
         inOrder(
             revurderingRepoMock,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
@@ -55,6 +55,7 @@ class RevurderingIngenEndringTest {
             oppgaveId = søknadOppgaveId,
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
         val beregnetRevurdering = BeregnetRevurdering.IngenEndring(
             id = revurderingId,
@@ -66,6 +67,7 @@ class RevurderingIngenEndringTest {
             saksbehandler = saksbehandler,
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
         val revurderingRepoMock = mock<RevurderingRepo> {
             on { hent(revurderingId) } doReturn opprettetRevurdering
@@ -105,6 +107,7 @@ class RevurderingIngenEndringTest {
             saksbehandler = RevurderingTestUtils.saksbehandler,
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
         val endretSaksbehandler = NavIdentBruker.Saksbehandler("endretSaksbehandler")
         val revurderingTilAttestering = RevurderingTilAttestering.IngenEndring(
@@ -117,7 +120,8 @@ class RevurderingIngenEndringTest {
             saksbehandler = endretSaksbehandler,
             fritekstTilBrev = "endret fritekst",
             revurderingsårsak = revurderingsårsak,
-            skalFøreTilBrevutsending = true
+            skalFøreTilBrevutsending = true,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
         val revurderingRepoMock = mock<RevurderingRepo> {
             on { hent(any()) } doReturn beregnetRevurdering
@@ -193,7 +197,8 @@ class RevurderingIngenEndringTest {
             saksbehandler = saksbehandler,
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
-            skalFøreTilBrevutsending = false
+            skalFøreTilBrevutsending = false,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
         val underkjentRevurdering = UnderkjentRevurdering.IngenEndring(
             id = revurderingId,
@@ -206,7 +211,8 @@ class RevurderingIngenEndringTest {
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
             attestering = attesteringUnderkjent,
-            skalFøreTilBrevutsending = false
+            skalFøreTilBrevutsending = false,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
         val revurderingRepoMock = mock<RevurderingRepo> {
             on { hent(any()) } doReturn revurderingTilAttestering
@@ -277,7 +283,8 @@ class RevurderingIngenEndringTest {
             saksbehandler = RevurderingTestUtils.saksbehandler,
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
-            skalFøreTilBrevutsending = true
+            skalFøreTilBrevutsending = true,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
         val attestant = NavIdentBruker.Attestant("ATTT")
         val iverksattRevurdering = revurderingTilAttestering.tilIverksatt(attestant).orNull()!!
@@ -335,7 +342,8 @@ class RevurderingIngenEndringTest {
             saksbehandler = RevurderingTestUtils.saksbehandler,
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
-            skalFøreTilBrevutsending = false
+            skalFøreTilBrevutsending = false,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
         val attestant = NavIdentBruker.Attestant("ATTT")
         val iverksattRevurdering = revurderingTilAttestering.tilIverksatt(attestant).orNull()!!

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
@@ -223,6 +223,7 @@ internal class RevurderingServiceImplTest {
             oppgaveId = OppgaveId("oppgaveid"),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -278,6 +279,7 @@ internal class RevurderingServiceImplTest {
             oppgaveId = mock(),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -312,6 +314,7 @@ internal class RevurderingServiceImplTest {
             oppgaveId = OppgaveId("oppgaveid"),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -542,6 +545,7 @@ internal class RevurderingServiceImplTest {
             attestering = Attestering.Iverksatt(attestant),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
         val revurderingTilAttestering = RevurderingTilAttestering.Innvilget(
             id = revurderingId,
@@ -554,6 +558,7 @@ internal class RevurderingServiceImplTest {
             saksbehandler = saksbehandler,
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -625,16 +630,17 @@ internal class RevurderingServiceImplTest {
             saksbehandler = saksbehandler,
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
         val attestant = NavIdentBruker.Attestant("ATTT")
 
         val revurderingRepoMock = mock<RevurderingRepo> {
             on { hent(any()) } doReturn revurderingTilAttestering
         }
-        val utbetalingMock = mock<Utbetaling.OversendtUtbetaling.UtenKvittering>() {
+        val utbetalingMock = mock<Utbetaling.OversendtUtbetaling.UtenKvittering> {
             on { id } doReturn UUID30.randomUUID()
         }
-        val utbetalingServiceMock = mock<UtbetalingService>() {
+        val utbetalingServiceMock = mock<UtbetalingService> {
             on { opphør(any(), any(), any(), any()) } doReturn utbetalingMock.right()
         }
         val vedtakRepoMock = mock<VedtakRepo>()
@@ -688,6 +694,7 @@ internal class RevurderingServiceImplTest {
             oppgaveId = OppgaveId("oppgaveId"),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
 
         val attestering = Attestering.Underkjent(
@@ -770,6 +777,7 @@ internal class RevurderingServiceImplTest {
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
             attestering = attestering,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -852,6 +860,7 @@ internal class RevurderingServiceImplTest {
             oppgaveId = OppgaveId("oppgaveid"),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -929,6 +938,7 @@ internal class RevurderingServiceImplTest {
             ),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -979,6 +989,7 @@ internal class RevurderingServiceImplTest {
             ),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -1037,6 +1048,7 @@ internal class RevurderingServiceImplTest {
             ),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -1092,6 +1104,7 @@ internal class RevurderingServiceImplTest {
             oppgaveId = OppgaveId("oppgaveid"),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
         val revurderingRepoMock = mock<RevurderingRepo> {
             on { hent(any()) } doReturn opprettetRevurdering
@@ -1122,6 +1135,7 @@ internal class RevurderingServiceImplTest {
             oppgaveId = OppgaveId("oppgaveid"),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
         )
         val revurderingRepoMock = mock<RevurderingRepo> {
             on { hent(any()) } doReturn beregnetRevurdering

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
@@ -71,6 +71,7 @@ import no.nav.su.se.bakover.service.revurdering.RevurderingTestUtils.sak
 import no.nav.su.se.bakover.service.revurdering.RevurderingTestUtils.sakId
 import no.nav.su.se.bakover.service.revurdering.RevurderingTestUtils.saksbehandler
 import no.nav.su.se.bakover.service.revurdering.RevurderingTestUtils.saksnummer
+import no.nav.su.se.bakover.service.revurdering.RevurderingTestUtils.simulertRevurderingInnvilget
 import no.nav.su.se.bakover.service.revurdering.RevurderingTestUtils.søknadsbehandlingVedtak
 import no.nav.su.se.bakover.service.sak.SakService
 import no.nav.su.se.bakover.service.statistikk.Event
@@ -352,18 +353,7 @@ internal class RevurderingServiceImplTest {
 
     @Test
     fun `sender til attestering`() {
-        val simulertRevurdering = mock<SimulertRevurdering> {
-            on { fnr } doReturn fnr
-            on { saksnummer } doReturn saksnummer
-            on { id } doReturn revurderingId
-            on { periode } doReturn periode
-            on { tilRevurdering } doReturn søknadsbehandlingVedtak
-            on { opprettet } doReturn Tidspunkt.EPOCH
-            on { beregning } doReturn mock()
-            on { simulering } doReturn mock()
-            on { tilAttestering(any(), any(), any()) } doReturn mock()
-            on { oppgaveId } doReturn OppgaveId("oppgaveid")
-        }
+        val simulertRevurdering = simulertRevurderingInnvilget
 
         val revurderingRepoMock = mock<RevurderingRepo> {
             on { hent(revurderingId) } doReturn simulertRevurdering

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceMocks.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceMocks.kt
@@ -1,0 +1,52 @@
+package no.nav.su.se.bakover.service.revurdering
+
+import com.nhaarman.mockitokotlin2.mock
+import no.nav.su.se.bakover.client.person.MicrosoftGraphApiClient
+import no.nav.su.se.bakover.database.revurdering.RevurderingRepo
+import no.nav.su.se.bakover.database.vedtak.VedtakRepo
+import no.nav.su.se.bakover.service.brev.BrevService
+import no.nav.su.se.bakover.service.fixedClock
+import no.nav.su.se.bakover.service.oppgave.OppgaveService
+import no.nav.su.se.bakover.service.person.PersonService
+import no.nav.su.se.bakover.service.sak.SakService
+import no.nav.su.se.bakover.service.utbetaling.UtbetalingService
+import no.nav.su.se.bakover.service.vedtak.FerdigstillVedtakService
+
+internal data class RevurderingServiceMocks(
+    val sakService: SakService = mock(),
+    val utbetalingService: UtbetalingService = mock(),
+    val revurderingRepo: RevurderingRepo = mock(),
+    val oppgaveService: OppgaveService = mock(),
+    val personService: PersonService = mock(),
+    val microsoftGraphApiClient: MicrosoftGraphApiClient = mock(),
+    val brevService: BrevService = mock(),
+    val vedtakRepo: VedtakRepo = mock(),
+    val ferdigstillVedtakService: FerdigstillVedtakService = mock(),
+) {
+    val revurderingService = RevurderingServiceImpl(
+        sakService = sakService,
+        utbetalingService = utbetalingService,
+        revurderingRepo = revurderingRepo,
+        oppgaveService = oppgaveService,
+        personService = personService,
+        microsoftGraphApiClient = microsoftGraphApiClient,
+        brevService = brevService,
+        vedtakRepo = vedtakRepo,
+        ferdigstillVedtakService = ferdigstillVedtakService,
+        clock = fixedClock,
+    )
+
+    fun verifyNoMoreInteractions() {
+        com.nhaarman.mockitokotlin2.verifyNoMoreInteractions(
+            sakService,
+            utbetalingService,
+            revurderingRepo,
+            oppgaveService,
+            personService,
+            microsoftGraphApiClient,
+            brevService,
+            vedtakRepo,
+            ferdigstillVedtakService,
+        )
+    }
+}

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingTestUtils.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingTestUtils.kt
@@ -84,6 +84,11 @@ object RevurderingTestUtils {
         Revurderingsårsak.Begrunnelse.create("Ny informasjon"),
     )
 
+    internal val revurderingsårsakRegulerGrunnbeløp = Revurderingsårsak(
+        Revurderingsårsak.Årsak.REGULER_GRUNNBELØP,
+        Revurderingsårsak.Begrunnelse.create("Nytt Grunnbeløp"),
+    )
+
     internal val søknadsbehandlingVedtak = Vedtak.fromSøknadsbehandling(
         Søknadsbehandling.Iverksatt.Innvilget(
             id = mock(),

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingTestUtils.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingTestUtils.kt
@@ -18,12 +18,15 @@ import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.beregning.Beregning
 import no.nav.su.se.bakover.domain.beregning.MånedsberegningFactory
 import no.nav.su.se.bakover.domain.beregning.Sats
+import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.revurdering.Revurderingsårsak
+import no.nav.su.se.bakover.domain.revurdering.SimulertRevurdering
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
 import no.nav.su.se.bakover.domain.vedtak.Vedtak
 import no.nav.su.se.bakover.service.FnrGenerator
 import no.nav.su.se.bakover.service.brev.BrevService
 import no.nav.su.se.bakover.service.fixedClock
+import no.nav.su.se.bakover.service.fixedTidspunkt
 import no.nav.su.se.bakover.service.oppgave.OppgaveService
 import no.nav.su.se.bakover.service.person.PersonService
 import no.nav.su.se.bakover.service.sak.SakService
@@ -116,6 +119,20 @@ object RevurderingTestUtils {
         ),
         UUID30.randomUUID(),
     )
+    internal val simulertRevurderingInnvilget = SimulertRevurdering.Innvilget(
+        id = revurderingId,
+        periode = periode,
+        opprettet = fixedTidspunkt,
+        tilRevurdering = søknadsbehandlingVedtak,
+        saksbehandler = saksbehandler,
+        oppgaveId = OppgaveId("Oppgaveid"),
+        fritekstTilBrev = "",
+        revurderingsårsak = revurderingsårsak,
+        behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
+        simulering = mock(),
+        beregning = beregningMock,
+    )
+
     internal val sak = Sak(
         id = sakId,
         saksnummer = saksnummer,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/RevurderingStatistikkMapperTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/RevurderingStatistikkMapperTest.kt
@@ -16,6 +16,7 @@ import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.revurdering.IverksattRevurdering
 import no.nav.su.se.bakover.domain.revurdering.OpprettetRevurdering
 import no.nav.su.se.bakover.domain.revurdering.Revurderingsårsak
+import no.nav.su.se.bakover.service.revurdering.RevurderingTestUtils
 import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.util.UUID
@@ -45,6 +46,7 @@ internal class RevurderingStatistikkMapperTest {
             oppgaveId = OppgaveId("oppgaveid"),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = RevurderingTestUtils.søknadsbehandlingVedtak.behandlingsinformasjon,
         )
 
         RevurderingStatistikkMapper(fixedClock).map(opprettetRevurdering) shouldBe Statistikk.Behandling(
@@ -112,6 +114,7 @@ internal class RevurderingStatistikkMapperTest {
             attestering = Attestering.Iverksatt(NavIdentBruker.Attestant(navIdent = "2")),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = RevurderingTestUtils.søknadsbehandlingVedtak.behandlingsinformasjon,
         )
         RevurderingStatistikkMapper(fixedClock).map(iverksattRevurdering) shouldBe Statistikk.Behandling(
             funksjonellTid = iverksattRevurdering.opprettet,
@@ -177,7 +180,8 @@ internal class RevurderingStatistikkMapperTest {
             attestering = Attestering.Iverksatt(NavIdentBruker.Attestant(navIdent = "2")),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
-            skalFøreTilBrevutsending = true
+            skalFøreTilBrevutsending = true,
+            behandlingsinformasjon = RevurderingTestUtils.søknadsbehandlingVedtak.behandlingsinformasjon,
         )
         RevurderingStatistikkMapper(fixedClock).map(iverksattRevurdering) shouldBe Statistikk.Behandling(
             funksjonellTid = iverksattRevurdering.opprettet,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/StatistikkServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/StatistikkServiceImplTest.kt
@@ -45,6 +45,7 @@ import no.nav.su.se.bakover.service.beregning.TestBeregning
 import no.nav.su.se.bakover.service.doNothing
 import no.nav.su.se.bakover.service.fixedClock
 import no.nav.su.se.bakover.service.person.PersonService
+import no.nav.su.se.bakover.service.revurdering.RevurderingTestUtils
 import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.LocalDate
@@ -425,6 +426,7 @@ internal class StatistikkServiceImplTest {
             oppgaveId = OppgaveId("oppgaveid"),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = RevurderingTestUtils.søknadsbehandlingVedtak.behandlingsinformasjon,
         )
 
         val expected = Statistikk.Behandling(
@@ -488,6 +490,7 @@ internal class StatistikkServiceImplTest {
             oppgaveId = OppgaveId("55"),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = RevurderingTestUtils.søknadsbehandlingVedtak.behandlingsinformasjon,
         )
 
         val expected = Statistikk.Behandling(
@@ -552,6 +555,7 @@ internal class StatistikkServiceImplTest {
             attestering = Attestering.Iverksatt(NavIdentBruker.Attestant("attestant")),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = RevurderingTestUtils.søknadsbehandlingVedtak.behandlingsinformasjon,
         )
 
         val expected = Statistikk.Behandling(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/vedtak/FerdigstillVedtakServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/vedtak/FerdigstillVedtakServiceImplTest.kt
@@ -45,6 +45,8 @@ import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppgave.KunneIkkeLukkeOppgave
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.person.KunneIkkeHentePerson
+import no.nav.su.se.bakover.domain.revurdering.IverksattRevurdering
+import no.nav.su.se.bakover.domain.revurdering.Revurderingsårsak
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
 import no.nav.su.se.bakover.domain.vedtak.Vedtak
 import no.nav.su.se.bakover.service.FnrGenerator
@@ -124,14 +126,14 @@ internal class FerdigstillVedtakServiceImplTest {
 
         val response = createService(
             personService = personServiceMock,
-            microsoftGraphApiClient = microsoftGraphApiOppslagMock
+            microsoftGraphApiClient = microsoftGraphApiOppslagMock,
         ).journalførOgLagre(vedtak)
 
         response shouldBe FerdigstillVedtakService.KunneIkkeFerdigstilleVedtak.KunneIkkeJournalføreBrev.FantIkkeNavnPåSaksbehandlerEllerAttestant.left()
 
         inOrder(
             personServiceMock,
-            microsoftGraphApiOppslagMock
+            microsoftGraphApiOppslagMock,
         ) {
             verify(personServiceMock).hentPersonMedSystembruker(argThat { it shouldBe vedtak.behandling.fnr })
             verify(microsoftGraphApiOppslagMock).hentBrukerinformasjonForNavIdent(argThat { it shouldBe vedtak.saksbehandler })
@@ -147,7 +149,7 @@ internal class FerdigstillVedtakServiceImplTest {
         val microsoftGraphApiOppslagMock = mock<MicrosoftGraphApiOppslag> {
             on { hentBrukerinformasjonForNavIdent(any()) } doReturnConsecutively listOf(
                 graphApiResponse.right(),
-                MicrosoftGraphApiOppslagFeil.FantIkkeBrukerForNavIdent.left()
+                MicrosoftGraphApiOppslagFeil.FantIkkeBrukerForNavIdent.left(),
             )
         }
 
@@ -155,14 +157,14 @@ internal class FerdigstillVedtakServiceImplTest {
 
         val response = createService(
             personService = personServiceMock,
-            microsoftGraphApiClient = microsoftGraphApiOppslagMock
+            microsoftGraphApiClient = microsoftGraphApiOppslagMock,
         ).journalførOgLagre(vedtak)
 
         response shouldBe FerdigstillVedtakService.KunneIkkeFerdigstilleVedtak.KunneIkkeJournalføreBrev.FantIkkeNavnPåSaksbehandlerEllerAttestant.left()
 
         inOrder(
             personServiceMock,
-            microsoftGraphApiOppslagMock
+            microsoftGraphApiOppslagMock,
         ) {
             verify(personServiceMock).hentPersonMedSystembruker(argThat { it shouldBe vedtak.behandling.fnr })
             verify(microsoftGraphApiOppslagMock, times(2)).hentBrukerinformasjonForNavIdent(any())
@@ -188,7 +190,7 @@ internal class FerdigstillVedtakServiceImplTest {
         val response = createService(
             personService = personServiceMock,
             microsoftGraphApiClient = microsoftGraphApiOppslagMock,
-            brevService = brevServiceMock
+            brevService = brevServiceMock,
         ).journalførOgLagre(vedtak)
 
         response shouldBe FerdigstillVedtakService.KunneIkkeFerdigstilleVedtak.KunneIkkeJournalføreBrev.FeilVedJournalføring.left()
@@ -196,7 +198,7 @@ internal class FerdigstillVedtakServiceImplTest {
         inOrder(
             personServiceMock,
             microsoftGraphApiOppslagMock,
-            brevServiceMock
+            brevServiceMock,
         ) {
             verify(personServiceMock).hentPersonMedSystembruker(argThat { it shouldBe vedtak.behandling.fnr })
             verify(microsoftGraphApiOppslagMock, times(2)).hentBrukerinformasjonForNavIdent(any())
@@ -236,7 +238,7 @@ internal class FerdigstillVedtakServiceImplTest {
             vedtakRepoMock,
             personServiceMock,
             microsoftGraphApiOppslagMock,
-            brevServiceMock
+            brevServiceMock,
         ) {
             verify(vedtakRepoMock).hentForUtbetaling(vedtak.utbetalingId)
             verify(personServiceMock).hentPersonMedSystembruker(vedtak.behandling.fnr)
@@ -266,15 +268,17 @@ internal class FerdigstillVedtakServiceImplTest {
             microsoftGraphApiClient = microsoftGraphApiOppslagMock,
             vedtakRepo = vedtakRepoMock,
             brevService = brevServiceMock,
-            behandlingMetrics = behandlingMetricsMock
+            behandlingMetrics = behandlingMetricsMock,
         ).journalførOgLagre(vedtak)
 
-        response shouldBe FerdigstillVedtakService.KunneIkkeFerdigstilleVedtak.KunneIkkeJournalføreBrev.AlleredeJournalført(iverksattJournalpostId).left()
+        response shouldBe FerdigstillVedtakService.KunneIkkeFerdigstilleVedtak.KunneIkkeJournalføreBrev.AlleredeJournalført(
+            iverksattJournalpostId,
+        ).left()
 
         inOrder(
             personServiceMock,
             microsoftGraphApiOppslagMock,
-            vedtakRepoMock
+            vedtakRepoMock,
         ) {
             verify(personServiceMock).hentPersonMedSystembruker(argThat { it shouldBe vedtak.behandling.fnr })
             verify(microsoftGraphApiOppslagMock, times(2)).hentBrukerinformasjonForNavIdent(any())
@@ -314,7 +318,7 @@ internal class FerdigstillVedtakServiceImplTest {
             microsoftGraphApiClient = microsoftGraphApiOppslagMock,
             brevService = brevServiceMock,
             oppgaveService = oppgaveServiceMock,
-            behandlingMetrics = behandlingMetricsMock
+            behandlingMetrics = behandlingMetricsMock,
         ).ferdigstillVedtakEtterUtbetaling(vedtak.utbetalingId)
 
         inOrder(
@@ -323,7 +327,7 @@ internal class FerdigstillVedtakServiceImplTest {
             microsoftGraphApiOppslagMock,
             brevServiceMock,
             oppgaveServiceMock,
-            behandlingMetricsMock
+            behandlingMetricsMock,
         ) {
             verify(vedtakRepoMock).hentForUtbetaling(vedtak.utbetalingId)
             verify(personServiceMock).hentPersonMedSystembruker(vedtak.behandling.fnr)
@@ -366,7 +370,7 @@ internal class FerdigstillVedtakServiceImplTest {
             microsoftGraphApiClient = microsoftGraphApiOppslagMock,
             brevService = brevServiceMock,
             oppgaveService = oppgaveServiceMock,
-            behandlingMetrics = behandlingMetricsMock
+            behandlingMetrics = behandlingMetricsMock,
         ).ferdigstillVedtakEtterUtbetaling(vedtak.utbetalingId)
 
         inOrder(
@@ -425,7 +429,7 @@ internal class FerdigstillVedtakServiceImplTest {
             microsoftGraphApiClient = microsoftGraphApiOppslagMock,
             brevService = brevServiceMock,
             oppgaveService = oppgaveServiceMock,
-            behandlingMetrics = behandlingMetricsMock
+            behandlingMetrics = behandlingMetricsMock,
         ).ferdigstillVedtakEtterUtbetaling(vedtak.utbetalingId)
 
         inOrder(
@@ -450,7 +454,7 @@ internal class FerdigstillVedtakServiceImplTest {
                         fritekst = "",
                     )
                 },
-                argThat { vedtak.behandling.saksnummer }
+                argThat { vedtak.behandling.saksnummer },
             )
             verify(behandlingMetricsMock).incrementInnvilgetCounter(BehandlingMetrics.InnvilgetHandlinger.JOURNALFØRT)
             verify(brevServiceMock).distribuerBrev(iverksattJournalpostId)
@@ -458,6 +462,56 @@ internal class FerdigstillVedtakServiceImplTest {
             verify(oppgaveServiceMock).lukkOppgaveMedSystembruker(vedtak.behandling.oppgaveId)
             verify(behandlingMetricsMock).incrementInnvilgetCounter(BehandlingMetrics.InnvilgetHandlinger.LUKKET_OPPGAVE)
         }
+    }
+
+    @Test
+    fun `ferdigstillelse av regulering av grunnbeløp etter utbetaling skal ikke sende brev`() {
+        val vedtak = innvilgetRevurdertVedtak()
+
+        val personServiceMock = mock<PersonService> ()
+
+        val microsoftGraphApiOppslagMock = mock<MicrosoftGraphApiOppslag> ()
+
+        val brevServiceMock = mock<BrevService>()
+
+        val vedtakRepoMock = mock<VedtakRepo>() {
+            on { hentForUtbetaling(any()) } doReturn vedtak
+        }
+
+        val oppgaveServiceMock = mock<OppgaveService>() {
+            on { lukkOppgaveMedSystembruker(any()) } doReturn Unit.right()
+        }
+
+        val behandlingMetricsMock = mock<BehandlingMetrics>()
+
+        createService(
+            vedtakRepo = vedtakRepoMock,
+            personService = personServiceMock,
+            microsoftGraphApiClient = microsoftGraphApiOppslagMock,
+            brevService = brevServiceMock,
+            oppgaveService = oppgaveServiceMock,
+            behandlingMetrics = behandlingMetricsMock,
+        ).ferdigstillVedtakEtterUtbetaling(vedtak.utbetalingId)
+
+        inOrder(
+            vedtakRepoMock,
+            personServiceMock,
+            microsoftGraphApiOppslagMock,
+            brevServiceMock,
+            oppgaveServiceMock,
+            behandlingMetricsMock,
+        ) {
+            verify(vedtakRepoMock).hentForUtbetaling(vedtak.utbetalingId)
+            verify(oppgaveServiceMock).lukkOppgaveMedSystembruker(vedtak.behandling.oppgaveId)
+        }
+        verifyNoMoreInteractions(
+            vedtakRepoMock,
+            personServiceMock,
+            microsoftGraphApiOppslagMock,
+            brevServiceMock,
+            oppgaveServiceMock,
+            behandlingMetricsMock,
+        )
     }
 
     @Test
@@ -488,10 +542,14 @@ internal class FerdigstillVedtakServiceImplTest {
             microsoftGraphApiClient = microsoftGraphApiOppslagMock,
             brevService = brevServiceMock,
             vedtakRepo = vedtakRepoMock,
-            behandlingMetrics = behandlingMetricsMock
+            behandlingMetrics = behandlingMetricsMock,
         ).journalførOgLagre(vedtak)
 
-        response shouldBe vedtak.copy(journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.Journalført(iverksattJournalpostId)).right()
+        response shouldBe vedtak.copy(
+            journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.Journalført(
+                iverksattJournalpostId,
+            ),
+        ).right()
 
         inOrder(
             personServiceMock,
@@ -506,15 +564,26 @@ internal class FerdigstillVedtakServiceImplTest {
                 argThat {
                     it shouldBe AvslagBrevRequest(
                         person = person,
-                        avslag = Avslag(Tidspunkt.now(fixedClock), avslagsgrunner = vedtak.avslagsgrunner, harEktefelle = false, beregning = vedtak.beregning),
+                        avslag = Avslag(
+                            Tidspunkt.now(fixedClock),
+                            avslagsgrunner = vedtak.avslagsgrunner,
+                            harEktefelle = false,
+                            beregning = vedtak.beregning,
+                        ),
                         saksbehandlerNavn = vedtak.saksbehandler.navIdent,
                         attestantNavn = vedtak.attestant.navIdent,
                         fritekst = "",
                     )
                 },
-                argThat { it shouldBe vedtak.behandling.saksnummer }
+                argThat { it shouldBe vedtak.behandling.saksnummer },
             )
-            verify(vedtakRepoMock).lagre(vedtak.copy(journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.Journalført(iverksattJournalpostId)))
+            verify(vedtakRepoMock).lagre(
+                vedtak.copy(
+                    journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.Journalført(
+                        iverksattJournalpostId,
+                    ),
+                ),
+            )
             verify(behandlingMetricsMock).incrementAvslåttCounter(BehandlingMetrics.AvslåttHandlinger.JOURNALFØRT)
         }
     }
@@ -531,7 +600,9 @@ internal class FerdigstillVedtakServiceImplTest {
             brevService = brevServiceMock,
         ).distribuerOgLagre(vedtak)
 
-        response shouldBe FerdigstillVedtakService.KunneIkkeFerdigstilleVedtak.KunneIkkeDistribuereBrev.FeilVedDistribusjon(iverksattJournalpostId).left()
+        response shouldBe FerdigstillVedtakService.KunneIkkeFerdigstilleVedtak.KunneIkkeDistribuereBrev.FeilVedDistribusjon(
+            iverksattJournalpostId,
+        ).left()
 
         inOrder(brevServiceMock) {
             verify(brevServiceMock).distribuerBrev(iverksattJournalpostId)
@@ -554,7 +625,7 @@ internal class FerdigstillVedtakServiceImplTest {
 
         inOrder(
             vedtakRepoMock,
-            brevServiceMock
+            brevServiceMock,
         ) {
             verifyZeroInteractions(vedtakRepoMock, brevServiceMock)
         }
@@ -572,11 +643,13 @@ internal class FerdigstillVedtakServiceImplTest {
             brevService = brevServiceMock,
         ).distribuerOgLagre(vedtak)
 
-        response shouldBe FerdigstillVedtakService.KunneIkkeFerdigstilleVedtak.KunneIkkeDistribuereBrev.AlleredeDistribuert(iverksattJournalpostId).left()
+        response shouldBe FerdigstillVedtakService.KunneIkkeFerdigstilleVedtak.KunneIkkeDistribuereBrev.AlleredeDistribuert(
+            iverksattJournalpostId,
+        ).left()
 
         inOrder(
             vedtakRepoMock,
-            brevServiceMock
+            brevServiceMock,
         ) {
             verifyZeroInteractions(vedtakRepoMock, brevServiceMock)
         }
@@ -597,10 +670,15 @@ internal class FerdigstillVedtakServiceImplTest {
         val response = createService(
             brevService = brevServiceMock,
             vedtakRepo = vedtakRepoMock,
-            behandlingMetrics = behandlingMetricsMock
+            behandlingMetrics = behandlingMetricsMock,
         ).distribuerOgLagre(vedtak)
 
-        response shouldBe vedtak.copy(journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.JournalførtOgDistribuertBrev(iverksattJournalpostId, iverksattBrevbestillingId)).right()
+        response shouldBe vedtak.copy(
+            journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.JournalførtOgDistribuertBrev(
+                iverksattJournalpostId,
+                iverksattBrevbestillingId,
+            ),
+        ).right()
 
         inOrder(
             brevServiceMock,
@@ -608,7 +686,14 @@ internal class FerdigstillVedtakServiceImplTest {
             behandlingMetricsMock,
         ) {
             verify(brevServiceMock).distribuerBrev(iverksattJournalpostId)
-            verify(vedtakRepoMock).lagre(vedtak.copy(journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.JournalførtOgDistribuertBrev(iverksattJournalpostId, iverksattBrevbestillingId)))
+            verify(vedtakRepoMock).lagre(
+                vedtak.copy(
+                    journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.JournalførtOgDistribuertBrev(
+                        iverksattJournalpostId,
+                        iverksattBrevbestillingId,
+                    ),
+                ),
+            )
             verify(behandlingMetricsMock).incrementAvslåttCounter(BehandlingMetrics.AvslåttHandlinger.DISTRIBUERT_BREV)
         }
     }
@@ -625,7 +710,7 @@ internal class FerdigstillVedtakServiceImplTest {
 
         val response = createService(
             oppgaveService = oppgaveServiceMock,
-            behandlingMetrics = behandlingMetricsMock
+            behandlingMetrics = behandlingMetricsMock,
         ).lukkOppgaveMedBruker(vedtak)
 
         response shouldBe FerdigstillVedtakService.KunneIkkeFerdigstilleVedtak.KunneIkkeLukkeOppgave.left()
@@ -650,16 +735,16 @@ internal class FerdigstillVedtakServiceImplTest {
 
         val response = createService(
             vedtakRepo = vedtakRepoMock,
-            behandlingMetrics = behandlingMetricsMock
+            behandlingMetrics = behandlingMetricsMock,
         ).opprettManglendeJournalposterOgBrevbestillinger()
 
         response shouldBe FerdigstillVedtakService.OpprettManglendeJournalpostOgBrevdistribusjonResultat(
             journalpostresultat = emptyList(),
-            brevbestillingsresultat = emptyList()
+            brevbestillingsresultat = emptyList(),
         )
 
         inOrder(
-            vedtakRepoMock
+            vedtakRepoMock,
         ) {
             verify(vedtakRepoMock).hentUtenJournalpost()
             verify(vedtakRepoMock).hentUtenBrevbestilling()
@@ -703,28 +788,33 @@ internal class FerdigstillVedtakServiceImplTest {
                 FerdigstillVedtakService.KunneIkkeOppretteJournalpostForIverksetting(
                     sakId = vedtak.behandling.sakId,
                     behandlingId = vedtak.behandling.id,
-                    grunn = "FeilVedJournalføring"
-                ).left()
+                    grunn = "FeilVedJournalføring",
+                ).left(),
             ),
-            brevbestillingsresultat = emptyList()
+            brevbestillingsresultat = emptyList(),
         )
 
         inOrder(
             vedtakRepoMock,
-            brevServiceMock
+            brevServiceMock,
         ) {
             verify(vedtakRepoMock).hentUtenJournalpost()
             verify(brevServiceMock).journalførBrev(
                 argThat {
                     it shouldBe AvslagBrevRequest(
                         person = person,
-                        avslag = Avslag(Tidspunkt.now(fixedClock), avslagsgrunner = vedtak.avslagsgrunner, harEktefelle = false, beregning = vedtak.beregning),
+                        avslag = Avslag(
+                            Tidspunkt.now(fixedClock),
+                            avslagsgrunner = vedtak.avslagsgrunner,
+                            harEktefelle = false,
+                            beregning = vedtak.beregning,
+                        ),
                         saksbehandlerNavn = "saksa",
                         attestantNavn = "atta",
                         fritekst = "",
                     )
                 },
-                argThat { it shouldBe vedtak.behandling.saksnummer }
+                argThat { it shouldBe vedtak.behandling.saksnummer },
             )
             verify(vedtakRepoMock).hentUtenBrevbestilling()
         }
@@ -767,10 +857,10 @@ internal class FerdigstillVedtakServiceImplTest {
                 FerdigstillVedtakService.OpprettetJournalpostForIverksetting(
                     sakId = avslagsVedtak.behandling.sakId,
                     behandlingId = avslagsVedtak.behandling.id,
-                    journalpostId = iverksattJournalpostId
-                ).right()
+                    journalpostId = iverksattJournalpostId,
+                ).right(),
             ),
-            brevbestillingsresultat = emptyList()
+            brevbestillingsresultat = emptyList(),
         )
 
         inOrder(
@@ -782,8 +872,12 @@ internal class FerdigstillVedtakServiceImplTest {
             verify(brevServiceMock).journalførBrev(any(), any())
             verify(vedtakRepoMock).lagre(
                 argThat {
-                    it shouldBe avslagsVedtak.copy(journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.Journalført(iverksattJournalpostId))
-                }
+                    it shouldBe avslagsVedtak.copy(
+                        journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.Journalført(
+                            iverksattJournalpostId,
+                        ),
+                    )
+                },
             )
             verify(behandlingMetricsMock).incrementAvslåttCounter(BehandlingMetrics.AvslåttHandlinger.JOURNALFØRT)
             verify(vedtakRepoMock).hentUtenBrevbestilling()
@@ -826,9 +920,9 @@ internal class FerdigstillVedtakServiceImplTest {
                     sakId = innvilgelseUtenBrevbestilling.behandling.sakId,
                     behandlingId = innvilgelseUtenBrevbestilling.behandling.id,
                     journalpostId = iverksattJournalpostId,
-                    brevbestillingId = iverksattBrevbestillingId
-                ).right()
-            )
+                    brevbestillingId = iverksattBrevbestillingId,
+                ).right(),
+            ),
         )
 
         inOrder(
@@ -843,8 +937,13 @@ internal class FerdigstillVedtakServiceImplTest {
             verify(brevServiceMock).distribuerBrev(iverksattJournalpostId)
             verify(vedtakRepoMock).lagre(
                 argThat {
-                    it shouldBe innvilgelseUtenBrevbestilling.copy(journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.JournalførtOgDistribuertBrev(iverksattJournalpostId, iverksattBrevbestillingId))
-                }
+                    it shouldBe innvilgelseUtenBrevbestilling.copy(
+                        journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.JournalførtOgDistribuertBrev(
+                            iverksattJournalpostId,
+                            iverksattBrevbestillingId,
+                        ),
+                    )
+                },
             )
             verify(behandlingMetricsMock).incrementInnvilgetCounter(BehandlingMetrics.InnvilgetHandlinger.DISTRIBUERT_BREV)
             verifyNoMoreInteractions(vedtakRepoMock, brevServiceMock, utbetalingRepoMock)
@@ -871,7 +970,7 @@ internal class FerdigstillVedtakServiceImplTest {
 
         val response = createService(
             vedtakRepo = vedtakRepoMock,
-            utbetalingRepo = utbetalingRepoMock
+            utbetalingRepo = utbetalingRepoMock,
         ).opprettManglendeJournalposterOgBrevbestillinger()
 
         response shouldBe FerdigstillVedtakService.OpprettManglendeJournalpostOgBrevdistribusjonResultat(
@@ -881,9 +980,9 @@ internal class FerdigstillVedtakServiceImplTest {
                     sakId = innvilgelseUtenBrevbestilling.behandling.sakId,
                     behandlingId = innvilgelseUtenBrevbestilling.behandling.id,
                     journalpostId = null,
-                    grunn = "MåJournalføresFørst"
-                ).left()
-            )
+                    grunn = "MåJournalføresFørst",
+                ).left(),
+            ),
         )
 
         inOrder(
@@ -909,7 +1008,10 @@ internal class FerdigstillVedtakServiceImplTest {
 
         val vedtakRepoMock = mock<VedtakRepo> {
             on { hentUtenJournalpost() } doReturn emptyList()
-            on { hentUtenBrevbestilling() } doReturn listOf(innvilgetVedtakUkvittertUtbetaling, innvilgetVedtakKvitteringMedFeil)
+            on { hentUtenBrevbestilling() } doReturn listOf(
+                innvilgetVedtakUkvittertUtbetaling,
+                innvilgetVedtakKvitteringMedFeil,
+            )
         }
 
         val utbetalingRepoMock = mock<UtbetalingRepo> {
@@ -927,13 +1029,13 @@ internal class FerdigstillVedtakServiceImplTest {
 
         response shouldBe FerdigstillVedtakService.OpprettManglendeJournalpostOgBrevdistribusjonResultat(
             journalpostresultat = emptyList(),
-            brevbestillingsresultat = emptyList()
+            brevbestillingsresultat = emptyList(),
         )
 
         inOrder(
             vedtakRepoMock,
             utbetalingRepoMock,
-            brevServiceMock
+            brevServiceMock,
         ) {
             verify(vedtakRepoMock).hentUtenJournalpost()
             verify(vedtakRepoMock).hentUtenBrevbestilling()
@@ -960,7 +1062,7 @@ internal class FerdigstillVedtakServiceImplTest {
         brevService = brevService,
         vedtakRepo = vedtakRepo,
         utbetalingRepo = utbetalingRepo,
-        behandlingMetrics = behandlingMetrics
+        behandlingMetrics = behandlingMetrics,
     )
 
     private fun avslagsVedtak() =
@@ -976,7 +1078,7 @@ internal class FerdigstillVedtakServiceImplTest {
                     sakId = UUID.randomUUID(),
                     søknadInnhold = SøknadInnholdTestdataBuilder.build(),
                     oppgaveId = BehandlingTestUtils.søknadOppgaveId,
-                    journalpostId = BehandlingTestUtils.søknadJournalpostId
+                    journalpostId = BehandlingTestUtils.søknadJournalpostId,
                 ),
                 oppgaveId = oppgaveId,
                 behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
@@ -986,11 +1088,23 @@ internal class FerdigstillVedtakServiceImplTest {
                 saksbehandler = saksbehandler,
                 fritekstTilBrev = "",
                 stønadsperiode = ValgtStønadsperiode(Periode.create(1.januar(2021), 31.desember(2021))),
-            )
+            ),
         )
 
-    private fun journalførtAvslagsVedtak() = avslagsVedtak().copy(journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.Journalført(iverksattJournalpostId))
-    private fun journalførtOgDistribuertAvslagsVedtak() = avslagsVedtak().copy(journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.JournalførtOgDistribuertBrev(iverksattJournalpostId, iverksattBrevbestillingId))
+    private fun journalførtAvslagsVedtak() =
+        avslagsVedtak().copy(
+            journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.Journalført(
+                iverksattJournalpostId,
+            ),
+        )
+
+    private fun journalførtOgDistribuertAvslagsVedtak() =
+        avslagsVedtak().copy(
+            journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.JournalførtOgDistribuertBrev(
+                iverksattJournalpostId,
+                iverksattBrevbestillingId,
+            ),
+        )
 
     private fun innvilgetVedtak() =
         Vedtak.fromSøknadsbehandling(
@@ -1005,7 +1119,7 @@ internal class FerdigstillVedtakServiceImplTest {
                     sakId = UUID.randomUUID(),
                     søknadInnhold = SøknadInnholdTestdataBuilder.build(),
                     oppgaveId = BehandlingTestUtils.søknadOppgaveId,
-                    journalpostId = BehandlingTestUtils.søknadJournalpostId
+                    journalpostId = BehandlingTestUtils.søknadJournalpostId,
                 ),
                 oppgaveId = oppgaveId,
                 behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
@@ -1017,18 +1131,52 @@ internal class FerdigstillVedtakServiceImplTest {
                 fritekstTilBrev = "",
                 stønadsperiode = ValgtStønadsperiode(Periode.create(1.januar(2021), 31.desember(2021))),
             ),
-            UUID30.randomUUID()
+            UUID30.randomUUID(),
         )
 
-    private fun journalførtInnvilgetVedtak() = innvilgetVedtak().copy(journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.Journalført(iverksattJournalpostId))
-    private fun journalførtOgDistribuertInnvilgetVedtak() = innvilgetVedtak().copy(journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.JournalførtOgDistribuertBrev(iverksattJournalpostId, iverksattBrevbestillingId))
+    private fun innvilgetRevurdertVedtak() =
+        Vedtak.from(
+            IverksattRevurdering.Innvilget(
+                id = UUID.randomUUID(),
+                opprettet = Tidspunkt.now(),
+                oppgaveId = oppgaveId,
+                behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
+                beregning = TestBeregning,
+                simulering = mock(),
+                saksbehandler = saksbehandler,
+                attestering = Attestering.Iverksatt(attestant),
+                fritekstTilBrev = "",
+                periode = Periode.create(1.januar(2021), 31.desember(2021)),
+                tilRevurdering = innvilgetVedtak(),
+                revurderingsårsak = Revurderingsårsak(
+                    Revurderingsårsak.Årsak.REGULER_GRUNNBELØP,
+                    Revurderingsårsak.Begrunnelse.create("regulert grunnbeløp"),
+                ),
+            ),
+            UUID30.randomUUID(),
+        )
+
+    private fun journalførtInnvilgetVedtak() =
+        innvilgetVedtak().copy(
+            journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.Journalført(
+                iverksattJournalpostId,
+            ),
+        )
+
+    private fun journalførtOgDistribuertInnvilgetVedtak() =
+        innvilgetVedtak().copy(
+            journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.JournalførtOgDistribuertBrev(
+                iverksattJournalpostId,
+                iverksattBrevbestillingId,
+            ),
+        )
 
     private val person = Person(
         ident = Ident(
             fnr = BehandlingTestUtils.fnr,
-            aktørId = AktørId(aktørId = "123")
+            aktørId = AktørId(aktørId = "123"),
         ),
-        navn = Person.Navn(fornavn = "Tore", mellomnavn = "Johnas", etternavn = "Strømøy")
+        navn = Person.Navn(fornavn = "Tore", mellomnavn = "Johnas", etternavn = "Strømøy"),
     )
     private val iverksattJournalpostId = JournalpostId("j")
     private val iverksattBrevbestillingId = BrevbestillingId("b")
@@ -1044,6 +1192,6 @@ internal class FerdigstillVedtakServiceImplTest {
         surname = "",
         userPrincipalName = "",
         id = "",
-        jobTitle = ""
+        jobTitle = "",
     )
 }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BeregnOgSimulerRevurderingRoute.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BeregnOgSimulerRevurderingRoute.kt
@@ -42,6 +42,7 @@ internal fun Route.beregnOgSimulerRevurdering(
     data class BeregningForRevurderingBody(
         val periode: PeriodeJson,
         val fradrag: List<FradragJson>,
+        val forventetInntekt: Int?,
     ) {
         fun toDomain(): Either<Resultat, List<Fradrag>> =
             periode.toPeriode()
@@ -58,6 +59,7 @@ internal fun Route.beregnOgSimulerRevurdering(
                                     revurderingId = revurderingId,
                                     saksbehandler = NavIdentBruker.Saksbehandler(call.suUserContext.navIdent),
                                     fradrag = fradrag,
+                                    forventetInntekt = body.forventetInntekt,
                                 ).mapLeft {
                                     it.tilResultat()
                                 }.map { revurdering ->
@@ -91,6 +93,10 @@ private fun KunneIkkeBeregneOgSimulereRevurdering.tilResultat(): Resultat {
         is KunneIkkeBeregneOgSimulereRevurdering.UfullstendigBehandlingsinformasjon -> InternalServerError.errorJson(
             "Ufullstendig behandlingsinformasjon",
             "ufullstendig_behandlingsinformasjon",
+        )
+        KunneIkkeBeregneOgSimulereRevurdering.MåSendeGrunnbeløpReguleringSomÅrsakSammenMedForventetInntekt -> InternalServerError.errorJson(
+            "Forventet inntekt kan kun sendes sammen med regulering av grunnbeløp",
+            "grunnbelop_forventetinntekt",
         )
     }
 }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/GenerelleRevurderingsfeilresponser.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/GenerelleRevurderingsfeilresponser.kt
@@ -26,6 +26,10 @@ internal object GenerelleRevurderingsfeilresponser {
         "Fant ikke revurdering",
         "fant_ikke_revurdering",
     )
+    val kanIkkeRegulereGrunnbeløpTilOppør = NotFound.errorJson(
+        "Kan Ikke Regulere Grunnbeløp Til Oppør",
+        "Kan Ikke Regulere Grunnbeløp Til Oppør",
+    )
 
     fun ugyldigPeriode(ugyldigPeriode: UgyldigPeriode): Resultat {
         return BadRequest.errorJson(

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OppdaterRevurderingsperiodeRoute.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OppdaterRevurderingsperiodeRoute.kt
@@ -42,7 +42,7 @@ internal fun Route.oppdaterRevurderingRoute(
                 call.withBody<Body> { body ->
                     val navIdent = call.suUserContext.navIdent
 
-                    revurderingService.oppdaterRevurderingsperiode(
+                    revurderingService.oppdaterRevurdering(
                         OppdaterRevurderingRequest(
                             revurderingId = revurderingId,
                             fraOgMed = body.fraOgMed,

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingJson.kt
@@ -9,6 +9,8 @@ import no.nav.su.se.bakover.domain.revurdering.RevurderingTilAttestering
 import no.nav.su.se.bakover.domain.revurdering.SimulertRevurdering
 import no.nav.su.se.bakover.domain.revurdering.UnderkjentRevurdering
 import no.nav.su.se.bakover.web.routes.behandling.AttesteringJson
+import no.nav.su.se.bakover.web.routes.behandling.BehandlingsinformasjonJson
+import no.nav.su.se.bakover.web.routes.behandling.BehandlingsinformasjonJson.Companion.toJson
 import no.nav.su.se.bakover.web.routes.behandling.UnderkjennelseJson
 import no.nav.su.se.bakover.web.routes.behandling.beregning.BeregningJson
 import no.nav.su.se.bakover.web.routes.behandling.beregning.PeriodeJson
@@ -50,6 +52,7 @@ internal data class OpprettetRevurderingJson(
     val fritekstTilBrev: String,
     val årsak: String,
     val begrunnelse: String,
+    val behandlingsinformasjon: BehandlingsinformasjonJson,
 ) : RevurderingJson() {
     @JsonInclude
     val status = RevurderingsStatus.OPPRETTET
@@ -66,6 +69,7 @@ internal data class BeregnetRevurderingJson(
     val årsak: String,
     val begrunnelse: String,
     val status: RevurderingsStatus,
+    val behandlingsinformasjon: BehandlingsinformasjonJson,
 ) : RevurderingJson()
 
 internal data class SimulertRevurderingJson(
@@ -79,6 +83,7 @@ internal data class SimulertRevurderingJson(
     val årsak: String,
     val begrunnelse: String,
     val status: RevurderingsStatus,
+    val behandlingsinformasjon: BehandlingsinformasjonJson,
 ) : RevurderingJson()
 
 internal data class TilAttesteringJson(
@@ -93,6 +98,7 @@ internal data class TilAttesteringJson(
     val årsak: String,
     val begrunnelse: String,
     val status: RevurderingsStatus,
+    val behandlingsinformasjon: BehandlingsinformasjonJson,
 ) : RevurderingJson()
 
 internal data class IverksattRevurderingJson(
@@ -108,6 +114,7 @@ internal data class IverksattRevurderingJson(
     val begrunnelse: String,
     val attestant: String,
     val status: RevurderingsStatus,
+    val behandlingsinformasjon: BehandlingsinformasjonJson,
 ) : RevurderingJson()
 
 internal data class UnderkjentRevurderingJson(
@@ -123,6 +130,7 @@ internal data class UnderkjentRevurderingJson(
     val begrunnelse: String,
     val attestering: AttesteringJson,
     val status: RevurderingsStatus,
+    val behandlingsinformasjon: BehandlingsinformasjonJson,
 ) : RevurderingJson()
 
 internal fun Revurdering.toJson(): RevurderingJson = when (this) {
@@ -135,6 +143,7 @@ internal fun Revurdering.toJson(): RevurderingJson = when (this) {
         fritekstTilBrev = fritekstTilBrev,
         årsak = revurderingsårsak.årsak.toString(),
         begrunnelse = revurderingsårsak.begrunnelse.toString(),
+        behandlingsinformasjon = behandlingsinformasjon.toJson(),
     )
     is SimulertRevurdering -> SimulertRevurderingJson(
         id = id.toString(),
@@ -150,6 +159,7 @@ internal fun Revurdering.toJson(): RevurderingJson = when (this) {
         årsak = revurderingsårsak.årsak.toString(),
         begrunnelse = revurderingsårsak.begrunnelse.toString(),
         status = InstansTilStatusMapper(this).status,
+        behandlingsinformasjon = behandlingsinformasjon.toJson(),
     )
     is RevurderingTilAttestering -> TilAttesteringJson(
         id = id.toString(),
@@ -170,6 +180,7 @@ internal fun Revurdering.toJson(): RevurderingJson = when (this) {
         årsak = revurderingsårsak.årsak.toString(),
         begrunnelse = revurderingsårsak.begrunnelse.toString(),
         status = InstansTilStatusMapper(this).status,
+        behandlingsinformasjon = behandlingsinformasjon.toJson(),
     )
     is IverksattRevurdering -> IverksattRevurderingJson(
         id = id.toString(),
@@ -191,6 +202,7 @@ internal fun Revurdering.toJson(): RevurderingJson = when (this) {
         begrunnelse = revurderingsårsak.begrunnelse.toString(),
         attestant = attestering.attestant.toString(),
         status = InstansTilStatusMapper(this).status,
+        behandlingsinformasjon = behandlingsinformasjon.toJson(),
     )
     is UnderkjentRevurdering -> UnderkjentRevurderingJson(
         id = id.toString(),
@@ -218,6 +230,7 @@ internal fun Revurdering.toJson(): RevurderingJson = when (this) {
         årsak = revurderingsårsak.årsak.toString(),
         begrunnelse = revurderingsårsak.begrunnelse.toString(),
         status = InstansTilStatusMapper(this).status,
+        behandlingsinformasjon = behandlingsinformasjon.toJson(),
     )
     is BeregnetRevurdering -> BeregnetRevurderingJson(
         id = id.toString(),
@@ -233,6 +246,7 @@ internal fun Revurdering.toJson(): RevurderingJson = when (this) {
         årsak = revurderingsårsak.årsak.toString(),
         begrunnelse = revurderingsårsak.begrunnelse.toString(),
         status = InstansTilStatusMapper(this).status,
+        behandlingsinformasjon = behandlingsinformasjon.toJson(),
     )
 }
 

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/SendRevurderingTilAttestering.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/SendRevurderingTilAttestering.kt
@@ -18,6 +18,7 @@ import no.nav.su.se.bakover.web.features.authorize
 import no.nav.su.se.bakover.web.features.suUserContext
 import no.nav.su.se.bakover.web.routes.revurdering.GenerelleRevurderingsfeilresponser.fantIkkeAktørId
 import no.nav.su.se.bakover.web.routes.revurdering.GenerelleRevurderingsfeilresponser.fantIkkeRevurdering
+import no.nav.su.se.bakover.web.routes.revurdering.GenerelleRevurderingsfeilresponser.kanIkkeRegulereGrunnbeløpTilOppør
 import no.nav.su.se.bakover.web.routes.revurdering.GenerelleRevurderingsfeilresponser.kunneIkkeOppretteOppgave
 import no.nav.su.se.bakover.web.routes.revurdering.GenerelleRevurderingsfeilresponser.ugyldigTilstand
 import no.nav.su.se.bakover.web.sikkerlogg
@@ -66,5 +67,6 @@ private fun KunneIkkeSendeRevurderingTilAttestering.tilResultat(): Resultat {
         is KunneIkkeSendeRevurderingTilAttestering.UgyldigTilstand -> ugyldigTilstand(this.fra, this.til)
         is KunneIkkeSendeRevurderingTilAttestering.FantIkkeAktørId -> fantIkkeAktørId
         is KunneIkkeSendeRevurderingTilAttestering.KunneIkkeOppretteOppgave -> kunneIkkeOppretteOppgave
+        is KunneIkkeSendeRevurderingTilAttestering.KanIkkeRegulereGrunnbeløpTilOpphør -> kanIkkeRegulereGrunnbeløpTilOppør
     }
 }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/behandling/beregning/BeregningTestUtils.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/behandling/beregning/BeregningTestUtils.kt
@@ -29,6 +29,7 @@ internal object TestBeregning : Beregning {
     override fun getPeriode(): Periode = Periode.create(1.august(2020), 31.august(2020))
     override fun getFradragStrategyName(): FradragStrategyName = FradragStrategyName.Enslig
     override fun getBegrunnelse(): String? = null
+    override fun equals(other: Any?) = (other as? Beregning)?.let { this.equals(other) } ?: false
 }
 
 internal object TestMånedsberegning : Månedsberegning {
@@ -39,6 +40,7 @@ internal object TestMånedsberegning : Månedsberegning {
     override fun getSatsbeløp(): Double = 20637.32
     override fun getFradrag(): List<Fradrag> = listOf(TestFradrag, TestFradragEps)
     override fun getPeriode(): Periode = Periode.create(1.august(2020), 31.august(2020))
+    override fun equals(other: Any?) = (other as? Månedsberegning)?.let { this.equals(other) } ?: false
 }
 
 internal object TestFradrag : Fradrag {
@@ -47,6 +49,7 @@ internal object TestFradrag : Fradrag {
     override fun getUtenlandskInntekt(): UtenlandskInntekt? = null
     override fun getTilhører(): FradragTilhører = FradragTilhører.BRUKER
     override fun getPeriode(): Periode = Periode.create(1.august(2020), 31.august(2020))
+    override fun equals(other: Any?) = (other as? Fradrag)?.let { this.equals(other) } ?: false
 }
 
 internal object TestFradragEps : Fradrag {
@@ -55,4 +58,5 @@ internal object TestFradragEps : Fradrag {
     override fun getUtenlandskInntekt(): UtenlandskInntekt? = null
     override fun getTilhører(): FradragTilhører = FradragTilhører.EPS
     override fun getPeriode(): Periode = Periode.create(1.august(2020), 31.august(2020))
+    override fun equals(other: Any?) = (other as? Fradrag)?.let { this.equals(other) } ?: false
 }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BeregnOgSimulerRevurderingRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BeregnOgSimulerRevurderingRouteKtTest.kt
@@ -4,6 +4,7 @@ import arrow.core.left
 import arrow.core.right
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -115,6 +116,7 @@ internal class BeregnOgSimulerRevurderingRouteKtTest {
                 Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
                 Revurderingsårsak.Begrunnelse.create("Ny informasjon"),
             ),
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         ).beregn(
             listOf(
                 FradragFactory.ny(
@@ -144,7 +146,7 @@ internal class BeregnOgSimulerRevurderingRouteKtTest {
         }
 
         val revurderingServiceMock = mock<RevurderingService> {
-            on { beregnOgSimuler(any(), any(), any()) } doReturn simulertRevurdering.right()
+            on { beregnOgSimuler(any(), any(), any(), anyOrNull()) } doReturn simulertRevurdering.right()
         }
 
         withTestApplication(
@@ -165,6 +167,7 @@ internal class BeregnOgSimulerRevurderingRouteKtTest {
                     argThat { it shouldBe simulertRevurdering.id },
                     argThat { it shouldBe NavIdentBruker.Saksbehandler("Z990Lokal") },
                     argThat { it shouldBe emptyList() },
+                    anyOrNull(),
                 )
                 verifyNoMoreInteractions(revurderingServiceMock)
                 actualResponse.id shouldBe simulertRevurdering.id.toString()
@@ -241,7 +244,7 @@ internal class BeregnOgSimulerRevurderingRouteKtTest {
         expectedJsonResponse: String,
     ) {
         val revurderingServiceMock = mock<RevurderingService> {
-            on { beregnOgSimuler(any(), any(), any()) } doReturn error.left()
+            on { beregnOgSimuler(any(), any(), any(), anyOrNull()) } doReturn error.left()
         }
 
         withTestApplication(

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/IverksettRevurderingRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/IverksettRevurderingRouteKtTest.kt
@@ -87,6 +87,7 @@ internal class IverksettRevurderingRouteKtTest {
                 Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
                 Revurderingsårsak.Begrunnelse.create("Ny informasjon"),
             ),
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
 
         val revurderingServiceMock = mock<RevurderingService> {

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OppdaterRevurderingsperiodeRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OppdaterRevurderingsperiodeRouteKtTest.kt
@@ -89,7 +89,7 @@ internal class OppdaterRevurderingsperiodeRouteKtTest {
             behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
         val revurderingServiceMock = mock<RevurderingService> {
-            on { oppdaterRevurderingsperiode(any()) } doReturn opprettetRevurdering.right()
+            on { oppdaterRevurdering(any()) } doReturn opprettetRevurdering.right()
         }
 
         withTestApplication(
@@ -197,7 +197,7 @@ internal class OppdaterRevurderingsperiodeRouteKtTest {
         expectedJsonResponse: String,
     ) {
         val revurderingServiceMock = mock<RevurderingService> {
-            on { oppdaterRevurderingsperiode(any()) } doReturn error.left()
+            on { oppdaterRevurdering(any()) } doReturn error.left()
         }
 
         withTestApplication(

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OppdaterRevurderingsperiodeRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OppdaterRevurderingsperiodeRouteKtTest.kt
@@ -86,6 +86,7 @@ internal class OppdaterRevurderingsperiodeRouteKtTest {
                 Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
                 Revurderingsårsak.Begrunnelse.create("Ny informasjon"),
             ),
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
         val revurderingServiceMock = mock<RevurderingService> {
             on { oppdaterRevurderingsperiode(any()) } doReturn opprettetRevurdering.right()

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OpprettRevurderingRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OpprettRevurderingRouteKtTest.kt
@@ -83,6 +83,7 @@ internal class OpprettRevurderingRouteKtTest {
                 Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
                 Revurderingsårsak.Begrunnelse.create("Ny informasjon"),
             ),
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
         val revurderingServiceMock = mock<RevurderingService> {
             on { opprettRevurdering(any()) } doReturn opprettetRevurdering.right()

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingJsonTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingJsonTest.kt
@@ -18,6 +18,7 @@ import no.nav.su.se.bakover.domain.revurdering.RevurderingTilAttestering
 import no.nav.su.se.bakover.domain.revurdering.Revurderingsårsak
 import no.nav.su.se.bakover.domain.revurdering.SimulertRevurdering
 import no.nav.su.se.bakover.domain.revurdering.UnderkjentRevurdering
+import no.nav.su.se.bakover.web.routes.behandling.BehandlingsinformasjonJson.Companion.toJson
 import no.nav.su.se.bakover.web.routes.behandling.TestBeregning
 import no.nav.su.se.bakover.web.routes.behandling.beregning.toJson
 import no.nav.su.se.bakover.web.routes.revurdering.RevurderingRoutesTestData.vedtak
@@ -45,6 +46,7 @@ internal class RevurderingJsonTest {
             oppgaveId = OppgaveId("oppgaveid"),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
 
         val revurderingJson =
@@ -62,7 +64,8 @@ internal class RevurderingJsonTest {
                 "saksbehandler": "Petter",
                 "fritekstTilBrev": "",
                 "årsak": "MELDING_FRA_BRUKER",
-                "begrunnelse": "Ny informasjon"
+                "begrunnelse": "Ny informasjon",
+                "behandlingsinformasjon": ${serialize(vedtak.behandlingsinformasjon.toJson())}
             }
             """.trimIndent()
 
@@ -86,6 +89,7 @@ internal class RevurderingJsonTest {
             oppgaveId = OppgaveId("oppgaveid"),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
 
         val revurderingJson =
@@ -108,7 +112,8 @@ internal class RevurderingJsonTest {
                 },
                 "fritekstTilBrev": "",
                 "årsak": "MELDING_FRA_BRUKER",
-                "begrunnelse": "Ny informasjon"
+                "begrunnelse": "Ny informasjon",
+                "behandlingsinformasjon": ${serialize(vedtak.behandlingsinformasjon.toJson())}
             }
             """.trimIndent()
 
@@ -132,6 +137,7 @@ internal class RevurderingJsonTest {
             oppgaveId = OppgaveId("oppgaveid"),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
 
         val revurderingJson =
@@ -154,7 +160,8 @@ internal class RevurderingJsonTest {
                 },
                 "fritekstTilBrev": "",
                 "årsak": "MELDING_FRA_BRUKER",
-                "begrunnelse": "Ny informasjon"
+                "begrunnelse": "Ny informasjon",
+                "behandlingsinformasjon": ${serialize(vedtak.behandlingsinformasjon.toJson())}
             }
             """.trimIndent()
 
@@ -178,6 +185,7 @@ internal class RevurderingJsonTest {
             oppgaveId = OppgaveId("oppgaveid"),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
 
         val revurderingJson =
@@ -200,7 +208,8 @@ internal class RevurderingJsonTest {
                 },
                 "fritekstTilBrev": "",
                 "årsak": "MELDING_FRA_BRUKER",
-                "begrunnelse": "Ny informasjon"
+                "begrunnelse": "Ny informasjon",
+                "behandlingsinformasjon": ${serialize(vedtak.behandlingsinformasjon.toJson())}
             }
             """.trimIndent()
 
@@ -225,6 +234,7 @@ internal class RevurderingJsonTest {
             oppgaveId = OppgaveId("oppgaveid"),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
 
         val revurderingJson =
@@ -247,7 +257,8 @@ internal class RevurderingJsonTest {
                 },
                 "fritekstTilBrev": "",
                 "årsak": "MELDING_FRA_BRUKER",
-                "begrunnelse": "Ny informasjon"
+                "begrunnelse": "Ny informasjon",
+                "behandlingsinformasjon": ${serialize(vedtak.behandlingsinformasjon.toJson())}
             }
             """.trimIndent()
 
@@ -272,6 +283,7 @@ internal class RevurderingJsonTest {
             oppgaveId = OppgaveId("oppgaveid"),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
 
         val revurderingJson =
@@ -294,7 +306,8 @@ internal class RevurderingJsonTest {
                 },
                 "fritekstTilBrev": "",
                 "årsak": "MELDING_FRA_BRUKER",
-                "begrunnelse": "Ny informasjon"
+                "begrunnelse": "Ny informasjon",
+                "behandlingsinformasjon": ${serialize(vedtak.behandlingsinformasjon.toJson())}
             }
             """.trimIndent()
 
@@ -319,6 +332,7 @@ internal class RevurderingJsonTest {
             oppgaveId = OppgaveId("OppgaveId"),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
 
         val revurderingJson =
@@ -342,7 +356,8 @@ internal class RevurderingJsonTest {
                 "fritekstTilBrev": "",
                 "skalFøreTilBrevutsending": true,
                 "årsak": "MELDING_FRA_BRUKER",
-                "begrunnelse": "Ny informasjon"
+                "begrunnelse": "Ny informasjon",
+                "behandlingsinformasjon": ${serialize(vedtak.behandlingsinformasjon.toJson())}
             }
             """.trimIndent()
 
@@ -367,6 +382,7 @@ internal class RevurderingJsonTest {
             oppgaveId = OppgaveId("OppgaveId"),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
 
         val revurderingJson =
@@ -390,7 +406,8 @@ internal class RevurderingJsonTest {
                 "fritekstTilBrev": "",
                 "skalFøreTilBrevutsending": true,
                 "årsak": "MELDING_FRA_BRUKER",
-                "begrunnelse": "Ny informasjon"
+                "begrunnelse": "Ny informasjon",
+                "behandlingsinformasjon": ${serialize(vedtak.behandlingsinformasjon.toJson())}
             }
             """.trimIndent()
 
@@ -414,7 +431,8 @@ internal class RevurderingJsonTest {
             oppgaveId = OppgaveId("OppgaveId"),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
-            skalFøreTilBrevutsending = false
+            skalFøreTilBrevutsending = false,
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
 
         val revurderingJson =
@@ -438,7 +456,8 @@ internal class RevurderingJsonTest {
                 "fritekstTilBrev": "",
                 "skalFøreTilBrevutsending": false,
                 "årsak": "MELDING_FRA_BRUKER",
-                "begrunnelse": "Ny informasjon"
+                "begrunnelse": "Ny informasjon",
+                "behandlingsinformasjon": ${serialize(vedtak.behandlingsinformasjon.toJson())}
             }
             """.trimIndent()
 
@@ -468,6 +487,7 @@ internal class RevurderingJsonTest {
             ),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
 
         val expected =
@@ -498,7 +518,8 @@ internal class RevurderingJsonTest {
                 "fritekstTilBrev": "",
                 "skalFøreTilBrevutsending": true,
                 "årsak": "MELDING_FRA_BRUKER",
-                "begrunnelse": "Ny informasjon"
+                "begrunnelse": "Ny informasjon",
+                "behandlingsinformasjon": ${serialize(vedtak.behandlingsinformasjon.toJson())}
             }
             """.trimIndent()
 
@@ -528,6 +549,7 @@ internal class RevurderingJsonTest {
             ),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
 
         val expected =
@@ -558,7 +580,8 @@ internal class RevurderingJsonTest {
                 "fritekstTilBrev": "",
                 "skalFøreTilBrevutsending": true,
                 "årsak": "MELDING_FRA_BRUKER",
-                "begrunnelse": "Ny informasjon"
+                "begrunnelse": "Ny informasjon",
+                "behandlingsinformasjon": ${serialize(vedtak.behandlingsinformasjon.toJson())}
             }
             """.trimIndent()
 
@@ -588,6 +611,7 @@ internal class RevurderingJsonTest {
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
             skalFøreTilBrevutsending = false,
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
 
         val expected =
@@ -618,7 +642,8 @@ internal class RevurderingJsonTest {
                 "fritekstTilBrev": "",
                 "skalFøreTilBrevutsending": false,
                 "årsak": "MELDING_FRA_BRUKER",
-                "begrunnelse": "Ny informasjon"
+                "begrunnelse": "Ny informasjon",
+                "behandlingsinformasjon": ${serialize(vedtak.behandlingsinformasjon.toJson())}
             }
             """.trimIndent()
 
@@ -644,6 +669,7 @@ internal class RevurderingJsonTest {
             attestering = Attestering.Iverksatt(NavIdentBruker.Attestant("attestant")),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
 
         val revurderingJson =
@@ -668,7 +694,8 @@ internal class RevurderingJsonTest {
                 "fritekstTilBrev": "",
                 "skalFøreTilBrevutsending": true,
                 "årsak": "MELDING_FRA_BRUKER",
-                "begrunnelse": "Ny informasjon"
+                "begrunnelse": "Ny informasjon",
+                "behandlingsinformasjon": ${serialize(vedtak.behandlingsinformasjon.toJson())}
             }
             """.trimIndent()
 
@@ -694,6 +721,7 @@ internal class RevurderingJsonTest {
             attestering = Attestering.Iverksatt(NavIdentBruker.Attestant("attestant")),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
 
         val revurderingJson =
@@ -718,7 +746,8 @@ internal class RevurderingJsonTest {
                 "fritekstTilBrev": "",
                 "skalFøreTilBrevutsending": true,
                 "årsak": "MELDING_FRA_BRUKER",
-                "begrunnelse": "Ny informasjon"
+                "begrunnelse": "Ny informasjon",
+                "behandlingsinformasjon": ${serialize(vedtak.behandlingsinformasjon.toJson())}
             }
             """.trimIndent()
 
@@ -744,6 +773,7 @@ internal class RevurderingJsonTest {
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
             skalFøreTilBrevutsending = true,
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
 
         val revurderingJson =
@@ -768,7 +798,8 @@ internal class RevurderingJsonTest {
                 "fritekstTilBrev": "",
                 "skalFøreTilBrevutsending": true,
                 "årsak": "MELDING_FRA_BRUKER",
-                "begrunnelse": "Ny informasjon"
+                "begrunnelse": "Ny informasjon",
+                "behandlingsinformasjon": ${serialize(vedtak.behandlingsinformasjon.toJson())}
             }
             """.trimIndent()
 

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/SendRevurderingTilAttesteringRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/SendRevurderingTilAttesteringRouteKtTest.kt
@@ -87,6 +87,7 @@ internal class SendRevurderingTilAttesteringRouteKtTest {
                 Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
                 Revurderingsårsak.Begrunnelse.create("Ny informasjon"),
             ),
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
 
         val revurderingServiceMock = mock<RevurderingService> {
@@ -128,7 +129,8 @@ internal class SendRevurderingTilAttesteringRouteKtTest {
                 Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
                 Revurderingsårsak.Begrunnelse.create("Ny informasjon"),
             ),
-            skalFøreTilBrevutsending = false
+            skalFøreTilBrevutsending = false,
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
 
         val revurderingServiceMock = mock<RevurderingService> {
@@ -172,7 +174,8 @@ internal class SendRevurderingTilAttesteringRouteKtTest {
                 Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
                 Revurderingsårsak.Begrunnelse.create("Ny informasjon"),
             ),
-            skalFøreTilBrevutsending = true
+            skalFøreTilBrevutsending = true,
+            behandlingsinformasjon = vedtak.behandlingsinformasjon,
         )
 
         val revurderingServiceMock = mock<RevurderingService> {


### PR DESCRIPTION
I frontend: Lagt til en ny revurderingsårsak: GRUNNBELØP_REGULERING og dersom man velger den, skal man få opp et input-felt for forventetInntekt.

I backend: Lagt på et nytt felt i endepunktet beregnOgSimuler (forventetInntekt). Lagt til behandlingsinformasjon på revurdering (når vi før laget et vedtak fra en revurdering, kopierte vi denne direkte fra forrige vedtak). Slik at denne nå er eksplisitt og kan endres. Da henger søknadsbehandlinga med beregning og behandlingsinformasjon mer sammen med revurderinga som har de samme feltene.