### PR TITLE
Fix forhåndsvarsel ved oppdatering til G-regulering

### DIFF
--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurdering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurdering.kt
@@ -253,6 +253,7 @@ data class OpprettetRevurdering(
         periode = periode,
         revurderingsårsak = revurderingsårsak,
         behandlingsinformasjon = tilRevurdering.behandlingsinformasjon,
+        forhåndsvarsel = if (revurderingsårsak.årsak == Revurderingsårsak.Årsak.REGULER_GRUNNBELØP) Forhåndsvarsel.IngenForhåndsvarsel else null,
     )
 }
 
@@ -273,7 +274,7 @@ sealed class BeregnetRevurdering : Revurdering() {
         oppgaveId = oppgaveId,
         fritekstTilBrev = fritekstTilBrev,
         revurderingsårsak = revurderingsårsak,
-        forhåndsvarsel = forhåndsvarsel,
+        forhåndsvarsel = if (revurderingsårsak.årsak == Revurderingsårsak.Årsak.REGULER_GRUNNBELØP) Forhåndsvarsel.IngenForhåndsvarsel else null,
         behandlingsinformasjon = tilRevurdering.behandlingsinformasjon,
     )
 
@@ -492,7 +493,7 @@ sealed class SimulertRevurdering : Revurdering() {
         oppgaveId = oppgaveId,
         fritekstTilBrev = fritekstTilBrev,
         revurderingsårsak = revurderingsårsak,
-        forhåndsvarsel = forhåndsvarsel,
+        forhåndsvarsel = if (revurderingsårsak.årsak == Revurderingsårsak.Årsak.REGULER_GRUNNBELØP) Forhåndsvarsel.IngenForhåndsvarsel else null,
         behandlingsinformasjon = tilRevurdering.behandlingsinformasjon,
     )
 }
@@ -941,7 +942,7 @@ sealed class UnderkjentRevurdering : Revurdering() {
         oppgaveId = oppgaveId,
         fritekstTilBrev = fritekstTilBrev,
         revurderingsårsak = revurderingsårsak,
-        forhåndsvarsel = forhåndsvarsel,
+        forhåndsvarsel = if (revurderingsårsak.årsak == Revurderingsårsak.Årsak.REGULER_GRUNNBELØP) Forhåndsvarsel.IngenForhåndsvarsel else null,
         behandlingsinformasjon = tilRevurdering.behandlingsinformasjon,
     )
 }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
@@ -46,7 +46,7 @@ import no.nav.su.se.bakover.service.revurdering.KunneIkkeBeregneOgSimulereRevurd
 import no.nav.su.se.bakover.service.revurdering.KunneIkkeForhåndsvarsle
 import no.nav.su.se.bakover.service.revurdering.KunneIkkeIverksetteRevurdering
 import no.nav.su.se.bakover.service.revurdering.KunneIkkeLageBrevutkastForRevurdering
-import no.nav.su.se.bakover.service.revurdering.KunneIkkeOppdatereRevurderingsperiode
+import no.nav.su.se.bakover.service.revurdering.KunneIkkeOppdatereRevurdering
 import no.nav.su.se.bakover.service.revurdering.KunneIkkeOppretteRevurdering
 import no.nav.su.se.bakover.service.revurdering.KunneIkkeSendeRevurderingTilAttestering
 import no.nav.su.se.bakover.service.revurdering.KunneIkkeUnderkjenneRevurdering
@@ -359,7 +359,7 @@ open class AccessCheckProxy(
 
                 override fun oppdaterRevurdering(
                     oppdaterRevurderingRequest: OppdaterRevurderingRequest,
-                ): Either<KunneIkkeOppdatereRevurderingsperiode, OpprettetRevurdering> {
+                ): Either<KunneIkkeOppdatereRevurdering, OpprettetRevurdering> {
                     assertHarTilgangTilRevurdering(oppdaterRevurderingRequest.revurderingId)
                     return services.revurdering.oppdaterRevurdering(oppdaterRevurderingRequest)
                 }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
@@ -21,7 +21,7 @@ interface RevurderingService {
 
     fun oppdaterRevurdering(
         oppdaterRevurderingRequest: OppdaterRevurderingRequest,
-    ): Either<KunneIkkeOppdatereRevurderingsperiode, OpprettetRevurdering>
+    ): Either<KunneIkkeOppdatereRevurdering, OpprettetRevurdering>
 
     fun beregnOgSimuler(
         revurderingId: UUID,
@@ -115,16 +115,17 @@ sealed class KunneIkkeOppretteRevurdering {
     object UgyldigBegrunnelse : KunneIkkeOppretteRevurdering()
 }
 
-sealed class KunneIkkeOppdatereRevurderingsperiode {
-    object FantIkkeRevurdering : KunneIkkeOppdatereRevurderingsperiode()
+sealed class KunneIkkeOppdatereRevurdering {
+    object FantIkkeRevurdering : KunneIkkeOppdatereRevurdering()
     data class PeriodenMåVæreInnenforAlleredeValgtStønadsperiode(val periode: Periode) :
-        KunneIkkeOppdatereRevurderingsperiode()
+        KunneIkkeOppdatereRevurdering()
 
-    data class UgyldigPeriode(val subError: Periode.UgyldigPeriode) : KunneIkkeOppdatereRevurderingsperiode()
-    object UgyldigÅrsak : KunneIkkeOppdatereRevurderingsperiode()
-    object UgyldigBegrunnelse : KunneIkkeOppdatereRevurderingsperiode()
+    data class UgyldigPeriode(val subError: Periode.UgyldigPeriode) : KunneIkkeOppdatereRevurdering()
+    object UgyldigÅrsak : KunneIkkeOppdatereRevurdering()
+    object UgyldigBegrunnelse : KunneIkkeOppdatereRevurdering()
     data class UgyldigTilstand(val fra: KClass<out Revurdering>, val til: KClass<out Revurdering>) :
-        KunneIkkeOppdatereRevurderingsperiode()
+        KunneIkkeOppdatereRevurdering()
+    object KanIkkeOppdatereRevurderingSomErForhåndsvarslet : KunneIkkeOppdatereRevurdering()
 }
 
 sealed class KunneIkkeBeregneOgSimulereRevurdering {

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OppdaterRevurderingsperiodeRoute.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OppdaterRevurderingsperiodeRoute.kt
@@ -9,7 +9,7 @@ import no.nav.su.se.bakover.common.serialize
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.revurdering.Revurderingsårsak
-import no.nav.su.se.bakover.service.revurdering.KunneIkkeOppdatereRevurderingsperiode
+import no.nav.su.se.bakover.service.revurdering.KunneIkkeOppdatereRevurdering
 import no.nav.su.se.bakover.service.revurdering.OppdaterRevurderingRequest
 import no.nav.su.se.bakover.service.revurdering.RevurderingService
 import no.nav.su.se.bakover.web.AuditLogEvent
@@ -64,24 +64,28 @@ internal fun Route.oppdaterRevurderingRoute(
     }
 }
 
-private fun KunneIkkeOppdatereRevurderingsperiode.tilResultat(): Resultat {
+private fun KunneIkkeOppdatereRevurdering.tilResultat(): Resultat {
     return when (this) {
-        is KunneIkkeOppdatereRevurderingsperiode.UgyldigPeriode -> GenerelleRevurderingsfeilresponser.ugyldigPeriode(
+        is KunneIkkeOppdatereRevurdering.UgyldigPeriode -> GenerelleRevurderingsfeilresponser.ugyldigPeriode(
             this.subError,
         )
-        is KunneIkkeOppdatereRevurderingsperiode.FantIkkeRevurdering -> fantIkkeRevurdering
-        is KunneIkkeOppdatereRevurderingsperiode.UgyldigTilstand -> ugyldigTilstand(this.fra, this.til)
-        is KunneIkkeOppdatereRevurderingsperiode.PeriodenMåVæreInnenforAlleredeValgtStønadsperiode -> HttpStatusCode.BadRequest.errorJson(
+        is KunneIkkeOppdatereRevurdering.FantIkkeRevurdering -> fantIkkeRevurdering
+        is KunneIkkeOppdatereRevurdering.UgyldigTilstand -> ugyldigTilstand(this.fra, this.til)
+        is KunneIkkeOppdatereRevurdering.PeriodenMåVæreInnenforAlleredeValgtStønadsperiode -> HttpStatusCode.BadRequest.errorJson(
             "Perioden må være innenfor allerede valgt stønadsperiode",
             "perioden_må_være_innenfor_stønadsperioden",
         )
-        KunneIkkeOppdatereRevurderingsperiode.UgyldigBegrunnelse -> HttpStatusCode.BadRequest.errorJson(
+        KunneIkkeOppdatereRevurdering.UgyldigBegrunnelse -> HttpStatusCode.BadRequest.errorJson(
             "Begrunnelse kan ikke være tom",
             "begrunnelse_kan_ikke_være_tom",
         )
-        KunneIkkeOppdatereRevurderingsperiode.UgyldigÅrsak -> HttpStatusCode.BadRequest.errorJson(
+        KunneIkkeOppdatereRevurdering.UgyldigÅrsak -> HttpStatusCode.BadRequest.errorJson(
             "Ugyldig årsak, må være en av: ${Revurderingsårsak.Årsak.values()}",
             "ugyldig_årsak",
+        )
+        KunneIkkeOppdatereRevurdering.KanIkkeOppdatereRevurderingSomErForhåndsvarslet -> HttpStatusCode.BadRequest.errorJson(
+            "Kan ikke oppdatere revurdering som er forhåndsvarslet",
+            "kan_ikke_oppdatere_revurdering_som_er_forhåndsvarslet",
         )
     }
 }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OppdaterRevurderingsperiodeRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OppdaterRevurderingsperiodeRouteKtTest.kt
@@ -21,7 +21,7 @@ import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.revurdering.IverksattRevurdering
 import no.nav.su.se.bakover.domain.revurdering.OpprettetRevurdering
 import no.nav.su.se.bakover.domain.revurdering.Revurderingsårsak
-import no.nav.su.se.bakover.service.revurdering.KunneIkkeOppdatereRevurderingsperiode
+import no.nav.su.se.bakover.service.revurdering.KunneIkkeOppdatereRevurdering
 import no.nav.su.se.bakover.service.revurdering.RevurderingService
 import no.nav.su.se.bakover.web.defaultRequest
 import no.nav.su.se.bakover.web.routes.revurdering.RevurderingRoutesTestData.periode
@@ -125,7 +125,7 @@ internal class OppdaterRevurderingsperiodeRouteKtTest {
     @Test
     fun `ugyldig fraOgMed dato`() {
         shouldMapErrorCorrectly(
-            error = KunneIkkeOppdatereRevurderingsperiode.UgyldigPeriode(
+            error = KunneIkkeOppdatereRevurdering.UgyldigPeriode(
                 Periode.UgyldigPeriode.FraOgMedDatoMåVæreFørsteDagIMåneden,
             ),
             expectedStatusCode = HttpStatusCode.BadRequest,
@@ -142,7 +142,7 @@ internal class OppdaterRevurderingsperiodeRouteKtTest {
     @Test
     fun `fant ikke revurdering`() {
         shouldMapErrorCorrectly(
-            error = KunneIkkeOppdatereRevurderingsperiode.FantIkkeRevurdering,
+            error = KunneIkkeOppdatereRevurdering.FantIkkeRevurdering,
             expectedStatusCode = HttpStatusCode.NotFound,
             expectedJsonResponse = """
                 {
@@ -157,7 +157,7 @@ internal class OppdaterRevurderingsperiodeRouteKtTest {
     @Test
     fun `perioden må være innenfor allerede valgt stønadsperiode`() {
         shouldMapErrorCorrectly(
-            error = KunneIkkeOppdatereRevurderingsperiode.PeriodenMåVæreInnenforAlleredeValgtStønadsperiode(
+            error = KunneIkkeOppdatereRevurdering.PeriodenMåVæreInnenforAlleredeValgtStønadsperiode(
                 Periode.create(
                     fraOgMed = 1.januar(2020),
                     tilOgMed = 31.januar(2020),
@@ -177,7 +177,7 @@ internal class OppdaterRevurderingsperiodeRouteKtTest {
     @Test
     fun `ugyldig tilstand`() {
         shouldMapErrorCorrectly(
-            error = KunneIkkeOppdatereRevurderingsperiode.UgyldigTilstand(
+            error = KunneIkkeOppdatereRevurdering.UgyldigTilstand(
                 fra = IverksattRevurdering::class,
                 til = OpprettetRevurdering::class,
             ),
@@ -193,7 +193,7 @@ internal class OppdaterRevurderingsperiodeRouteKtTest {
     }
 
     private fun shouldMapErrorCorrectly(
-        error: KunneIkkeOppdatereRevurderingsperiode,
+        error: KunneIkkeOppdatereRevurdering,
         expectedStatusCode: HttpStatusCode,
         expectedJsonResponse: String,
     ) {


### PR DESCRIPTION
Dersom man oppretter en revurdering og aldri går lenger enn beregnings/simuleringssteget, vil man at forhåndsvarsling skal være "IngenForhåndsvarsling" for G-regulering, men null for de andre årsakene.

Så hvis saksbehandler årsaken fra/til G-regulering, burde forhåndsvarling følge etter.

Legger og inn en guard, slik at vi ikke kan oppdatere revurderinger vi allerede har forhåndsvarslet.