### PR TITLE
Legg til fiktiv G-verdi (kun aktiv i utviklings- og testmiljø)

### DIFF
--- a/common/src/main/kotlin/no/nav/su/se/bakover/common/Config.kt
+++ b/common/src/main/kotlin/no/nav/su/se/bakover/common/Config.kt
@@ -441,5 +441,6 @@ data class ApplicationConfig(
             }
 
         fun isRunningLocally() = naisCluster() == null
+        fun isNotProd() = isRunningLocally() || naisCluster() == NaisCluster.Dev
     }
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Grunnbeløp.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Grunnbeløp.kt
@@ -1,16 +1,22 @@
 package no.nav.su.se.bakover.domain
 
 import com.fasterxml.jackson.annotation.JsonValue
+import no.nav.su.se.bakover.common.ApplicationConfig
+import no.nav.su.se.bakover.common.log
 import java.time.LocalDate
 import java.time.Month
 
 class Grunnbeløp private constructor(private val multiplier: Double) {
-    private val datoToBeløp: Map<LocalDate, Int> = mapOf(
+    private val datoToBeløp: Map<LocalDate, Int> = listOfNotNull(
         LocalDate.of(2017, Month.MAY, 1) to 93634,
         LocalDate.of(2018, Month.MAY, 1) to 96883,
         LocalDate.of(2019, Month.MAY, 1) to 99858,
-        LocalDate.of(2020, Month.MAY, 1) to 101351
-    )
+        LocalDate.of(2020, Month.MAY, 1) to 101351,
+        if (ApplicationConfig.isNotProd()) {
+            log.warn("Inkluderer fiktiv G-verdi for 2021. Skal ikke dukke opp i prod!")
+            LocalDate.of(2021, Month.MAY, 1) to 104463
+        } else null,
+    ).toMap()
 
     fun fraDato(dato: LocalDate): Double = datoToBeløp.entries
         .sortedByDescending { it.key }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/GrunnbeløpTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/GrunnbeløpTest.kt
@@ -39,12 +39,12 @@ internal class GrunnbeløpTest {
     }
 
     @Test
-    fun høy2020for2025() {
-        Grunnbeløp.`2,48G`.fraDato(LocalDate.of(2025, MAY, 1)) shouldBe 2.48 * 101351
+    fun fiktivHøy2021for2021() {
+        Grunnbeløp.`2,48G`.fraDato(LocalDate.of(2021, MAY, 1)) shouldBe 2.48 * 104463
     }
 
     @Test
-    fun ordinær2020for2025() {
-        Grunnbeløp.`2,28G`.fraDato(LocalDate.of(2025, MAY, 1)) shouldBe 2.28 * 101351
+    fun fiktivOrdinær2021for2021() {
+        Grunnbeløp.`2,28G`.fraDato(LocalDate.of(2021, MAY, 1)) shouldBe 2.28 * 104463
     }
 }


### PR DESCRIPTION
Legger til en G-verdi for 2021 hvis vi er i et ikke-produksjonsmiljø. Logger dersom verdien er aktiv, slik at vi kan sjekke at logg-innslaget ikke finnes i produksjon når vi deployer.