### PR TITLE
Legg til saksbehandlernavn i forhåndsvarselbrev

### DIFF
--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/BrevInnhold.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/BrevInnhold.kt
@@ -134,6 +134,7 @@ abstract class BrevInnhold {
 
     data class Forhåndsvarsel(
         val personalia: Personalia,
+        val saksbehandlerNavn: String,
         val fritekst: String,
     ) : BrevInnhold() {
         override val brevTemplate = BrevTemplate.Forhåndsvarsel

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/LagBrevRequest.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/LagBrevRequest.kt
@@ -127,6 +127,7 @@ interface LagBrevRequest {
 
     data class Forhåndsvarsel(
         private val person: Person,
+        private val saksbehandlerNavn: String,
         private val fritekst: String,
     ) : LagBrevRequest {
         override fun getPerson(): Person = person
@@ -134,6 +135,7 @@ interface LagBrevRequest {
         override fun lagBrevInnhold(personalia: BrevInnhold.Personalia): BrevInnhold {
             return BrevInnhold.Forhåndsvarsel(
                 personalia = personalia,
+                saksbehandlerNavn = saksbehandlerNavn,
                 fritekst = fritekst,
             )
         }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
@@ -164,6 +164,7 @@ sealed class KunneIkkeForhåndsvarsle {
     object KunneIkkeJournalføre : KunneIkkeForhåndsvarsle()
     object KunneIkkeDistribuere : KunneIkkeForhåndsvarsle()
     object KunneIkkeOppretteOppgave : KunneIkkeForhåndsvarsle()
+    object KunneIkkeHenteNavnForSaksbehandler : KunneIkkeForhåndsvarsle()
     data class UgyldigTilstand(val fra: KClass<out Revurdering>, val til: KClass<out Revurdering>) :
         KunneIkkeForhåndsvarsle()
 

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -399,8 +399,15 @@ internal class RevurderingServiceImpl(
             return KunneIkkeLageBrevutkastForRevurdering.FantIkkePerson.left()
         }
 
+        val saksbehandlerNavn = microsoftGraphApiClient.hentNavnForNavIdent(revurdering.saksbehandler).getOrElse {
+            log.error("Fant ikke saksbehandlernavn for saksbehandler: ${revurdering.saksbehandler}")
+            return KunneIkkeLageBrevutkastForRevurdering.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant.left()
+        }
+
         val brevRequest = LagBrevRequest.Forhåndsvarsel(
-            person = person, fritekst = fritekst,
+            person = person,
+            fritekst = fritekst,
+            saksbehandlerNavn = saksbehandlerNavn,
         )
 
         return brevService.lagBrev(brevRequest)
@@ -770,9 +777,15 @@ internal class RevurderingServiceImpl(
             return KunneIkkeForhåndsvarsle.FantIkkePerson.left()
         }
 
+        val saksbehandlerNavn = microsoftGraphApiClient.hentNavnForNavIdent(revurdering.saksbehandler).getOrElse {
+            log.error("Fant ikke saksbehandlernavn for saksbehandler: ${revurdering.saksbehandler}")
+            return KunneIkkeForhåndsvarsle.KunneIkkeHenteNavnForSaksbehandler.left()
+        }
+
         brevService.journalførBrev(
             request = LagBrevRequest.Forhåndsvarsel(
                 person = person,
+                saksbehandlerNavn = saksbehandlerNavn,
                 fritekst = fritekst,
             ),
             saksnummer = revurdering.saksnummer,

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/lukk/LukkSøknadServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/lukk/LukkSøknadServiceImpl.kt
@@ -153,8 +153,7 @@ internal class LukkSøknadServiceImpl(
     }
 
     private fun hentNavnForNavIdent(navIdent: NavIdentBruker): Either<MicrosoftGraphApiOppslagFeil, String> {
-        return microsoftGraphApiClient.hentBrukerinformasjonForNavIdent(navIdent)
-            .map { it.displayName }
+        return microsoftGraphApiClient.hentNavnForNavIdent(navIdent)
     }
 
     private fun hentSøknad(søknadId: UUID): Either<KunneIkkeLukkeSøknad.FantIkkeSøknad, Søknad> {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceImpl.kt
@@ -435,8 +435,7 @@ internal class SøknadsbehandlingServiceImpl(
     }
 
     private fun hentNavnForNavIdent(navIdent: NavIdentBruker): Either<MicrosoftGraphApiOppslagFeil, String> {
-        return microsoftGraphApiClient.hentBrukerinformasjonForNavIdent(navIdent)
-            .map { it.displayName }
+        return microsoftGraphApiClient.hentNavnForNavIdent(navIdent)
     }
 
     override fun hent(request: SøknadsbehandlingService.HentRequest): Either<SøknadsbehandlingService.FantIkkeBehandling, Søknadsbehandling> {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/vedtak/FerdigstillVedtakService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/vedtak/FerdigstillVedtakService.kt
@@ -323,9 +323,8 @@ internal class FerdigstillVedtakServiceImpl(
     )
 
     private fun hentNavnForNavIdent(navIdent: NavIdentBruker): Either<KunneIkkeFerdigstilleVedtak.KunneIkkeJournalføreBrev.FantIkkeNavnPåSaksbehandlerEllerAttestant, String> {
-        return microsoftGraphApiOppslag.hentBrukerinformasjonForNavIdent(navIdent)
+        return microsoftGraphApiOppslag.hentNavnForNavIdent(navIdent)
             .mapLeft { KunneIkkeFerdigstilleVedtak.KunneIkkeJournalføreBrev.FantIkkeNavnPåSaksbehandlerEllerAttestant }
-            .map { it.displayName }
     }
 
     private fun lukkOppgaveMedSystembruker(vedtak: Vedtak): Either<KunneIkkeFerdigstilleVedtak.KunneIkkeLukkeOppgave, Vedtak> {

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
@@ -1268,11 +1268,16 @@ internal class RevurderingServiceImplTest {
             on { opprettOppgave(any()) } doReturn OppgaveId("oppgaveId").right()
         }
 
+        val microsoftGraphApiClientMock = mock<MicrosoftGraphApiClient> {
+            on { hentNavnForNavIdent(any()) } doReturn saksbehandler.navIdent.right()
+        }
+
         val revurdering = createRevurderingService(
             revurderingRepo = revurderingRepoMock,
             personService = personServiceMock,
             brevService = brevServiceMock,
             oppgaveService = oppgaveServiceMock,
+            microsoftGraphApiClient = microsoftGraphApiClientMock,
         ).forhåndsvarsleEllerSendTilAttestering(
             revurderingId = revurderingId,
             saksbehandler = saksbehandler,
@@ -1290,6 +1295,7 @@ internal class RevurderingServiceImplTest {
                 argThat {
                     it shouldBe LagBrevRequest.Forhåndsvarsel(
                         person = person,
+                        saksbehandlerNavn = "Sak S. behandler",
                         fritekst = "",
                     )
                 },
@@ -1460,10 +1466,15 @@ internal class RevurderingServiceImplTest {
             on { journalførBrev(any(), any()) } doReturn KunneIkkeJournalføreBrev.KunneIkkeOppretteJournalpost.left()
         }
 
+        val microsoftGraphApiClientMock = mock<MicrosoftGraphApiClient> {
+            on { hentNavnForNavIdent(any()) } doReturn saksbehandler.navIdent.right()
+        }
+
         createRevurderingService(
             revurderingRepo = revurderingRepoMock,
             personService = personServiceMock,
             brevService = brevServiceMock,
+            microsoftGraphApiClient = microsoftGraphApiClientMock,
         ).forhåndsvarsleEllerSendTilAttestering(
             revurderingId = revurderingId,
             saksbehandler = saksbehandler,
@@ -1492,10 +1503,15 @@ internal class RevurderingServiceImplTest {
             on { distribuerBrev(any()) } doReturn KunneIkkeDistribuereBrev.left()
         }
 
+        val microsoftGraphApiClientMock = mock<MicrosoftGraphApiClient> {
+            on { hentNavnForNavIdent(any()) } doReturn saksbehandler.navIdent.right()
+        }
+
         createRevurderingService(
             revurderingRepo = revurderingRepoMock,
             personService = personServiceMock,
             brevService = brevServiceMock,
+            microsoftGraphApiClient = microsoftGraphApiClientMock,
         ).forhåndsvarsleEllerSendTilAttestering(
             revurderingId = revurderingId,
             saksbehandler = saksbehandler,
@@ -1527,11 +1543,16 @@ internal class RevurderingServiceImplTest {
             on { opprettOppgave(any()) } doReturn KunneIkkeOppretteOppgave.left()
         }
 
+        val microsoftGraphApiClientMock = mock<MicrosoftGraphApiClient> {
+            on { hentNavnForNavIdent(any()) } doReturn saksbehandler.navIdent.right()
+        }
+
         createRevurderingService(
             revurderingRepo = revurderingRepoMock,
             personService = personServiceMock,
             brevService = brevServiceMock,
             oppgaveService = oppgaveServiceMock,
+            microsoftGraphApiClient = microsoftGraphApiClientMock,
         ).forhåndsvarsleEllerSendTilAttestering(
             revurderingId = revurderingId,
             saksbehandler = saksbehandler,
@@ -1750,10 +1771,15 @@ internal class RevurderingServiceImplTest {
             on { lagBrev(any()) } doReturn KunneIkkeLageBrev.KunneIkkeGenererePDF.left()
         }
 
+        val microsoftGraphApiClientMock = mock<MicrosoftGraphApiClient> {
+            on { hentNavnForNavIdent(any()) } doReturn saksbehandler.navIdent.right()
+        }
+
         createRevurderingService(
             revurderingRepo = revurderingRepoMock,
             personService = personServiceMock,
             brevService = brevServiceMock,
+            microsoftGraphApiClient = microsoftGraphApiClientMock,
         ).lagBrevutkastForForhåndsvarsling(
             UUID.randomUUID(),
             "fritekst til forhåndsvarsling",

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceBrevTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceBrevTest.kt
@@ -109,7 +109,7 @@ internal class SøknadsbehandlingServiceBrevTest {
         }
 
         val microsoftGraphApiOppslagMock = mock<MicrosoftGraphApiOppslag> {
-            on { hentBrukerinformasjonForNavIdent(any()) } doReturn MicrosoftGraphApiOppslagFeil.FantIkkeBrukerForNavIdent.left()
+            on { hentNavnForNavIdent(any()) } doReturn MicrosoftGraphApiOppslagFeil.FantIkkeBrukerForNavIdent.left()
         }
 
         createSøknadsbehandlingService(
@@ -132,7 +132,7 @@ internal class SøknadsbehandlingServiceBrevTest {
         }
 
         val microsoftGraphApiOppslagMock = mock<MicrosoftGraphApiOppslag> {
-            on { hentBrukerinformasjonForNavIdent(any()) } doReturn BehandlingTestUtils.microsoftGraphMock.response.right()
+            on { hentNavnForNavIdent(any()) } doReturn BehandlingTestUtils.microsoftGraphMock.response.displayName.right()
         }
 
         val brevServiceMock = mock<BrevService> {
@@ -160,7 +160,7 @@ internal class SøknadsbehandlingServiceBrevTest {
         }
 
         val microsoftGraphApiOppslagMock = mock<MicrosoftGraphApiOppslag> {
-            on { hentBrukerinformasjonForNavIdent(any()) } doReturn BehandlingTestUtils.microsoftGraphMock.response.right()
+            on { hentNavnForNavIdent(any()) } doReturn BehandlingTestUtils.microsoftGraphMock.response.displayName.right()
         }
 
         val pdf = "".toByteArray()

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/vedtak/FerdigstillVedtakServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/vedtak/FerdigstillVedtakServiceImplTest.kt
@@ -148,7 +148,7 @@ internal class FerdigstillVedtakServiceImplTest {
         }
 
         val microsoftGraphApiOppslagMock = mock<MicrosoftGraphApiOppslag> {
-            on { hentBrukerinformasjonForNavIdent(any()) } doReturn graphApiResponse.right()
+            on { hentNavnForNavIdent(any()) } doReturn graphApiResponse.displayName.right()
         }
 
         val brevServiceMock = mock<BrevService> {
@@ -181,7 +181,7 @@ internal class FerdigstillVedtakServiceImplTest {
         ) {
             verify(vedtakRepoMock).hentForUtbetaling(vedtak.utbetalingId)
             verify(personServiceMock).hentPersonMedSystembruker(vedtak.behandling.fnr)
-            verify(microsoftGraphApiOppslagMock, times(2)).hentBrukerinformasjonForNavIdent(any())
+            verify(microsoftGraphApiOppslagMock, times(2)).hentNavnForNavIdent(any())
             verify(brevServiceMock).journalførBrev(any(), any())
         }
     }
@@ -195,7 +195,7 @@ internal class FerdigstillVedtakServiceImplTest {
         }
 
         val microsoftGraphApiOppslagMock = mock<MicrosoftGraphApiOppslag> {
-            on { hentBrukerinformasjonForNavIdent(any()) } doReturn graphApiResponse.right()
+            on { hentNavnForNavIdent(any()) } doReturn graphApiResponse.displayName.right()
         }
 
         val brevServiceMock = mock<BrevService> {
@@ -229,7 +229,7 @@ internal class FerdigstillVedtakServiceImplTest {
         ) {
             verify(vedtakRepoMock).hentForUtbetaling(vedtak.utbetalingId)
             verify(personServiceMock).hentPersonMedSystembruker(vedtak.behandling.fnr)
-            verify(microsoftGraphApiOppslagMock, times(2)).hentBrukerinformasjonForNavIdent(any())
+            verify(microsoftGraphApiOppslagMock, times(2)).hentNavnForNavIdent(any())
             verify(brevServiceMock).journalførBrev(any(), any())
             verify(brevServiceMock).distribuerBrev(any())
         }
@@ -244,7 +244,7 @@ internal class FerdigstillVedtakServiceImplTest {
         }
 
         val microsoftGraphApiOppslagMock = mock<MicrosoftGraphApiOppslag> {
-            on { hentBrukerinformasjonForNavIdent(any()) } doReturn graphApiResponse.right()
+            on { hentNavnForNavIdent(any()) } doReturn graphApiResponse.displayName.right()
         }
 
         val brevServiceMock = mock<BrevService>() {
@@ -286,7 +286,7 @@ internal class FerdigstillVedtakServiceImplTest {
         ) {
             verify(vedtakRepoMock).hentForUtbetaling(vedtak.utbetalingId)
             verify(personServiceMock).hentPersonMedSystembruker(vedtak.behandling.fnr)
-            verify(microsoftGraphApiOppslagMock, times(2)).hentBrukerinformasjonForNavIdent(any())
+            verify(microsoftGraphApiOppslagMock, times(2)).hentNavnForNavIdent(any())
             verify(brevServiceMock, never()).journalførBrev(any(), any())
             verify(brevServiceMock).distribuerBrev(iverksattJournalpostId)
             verify(behandlingMetricsMock).incrementInnvilgetCounter(BehandlingMetrics.InnvilgetHandlinger.DISTRIBUERT_BREV)
@@ -304,7 +304,7 @@ internal class FerdigstillVedtakServiceImplTest {
         }
 
         val microsoftGraphApiOppslagMock = mock<MicrosoftGraphApiOppslag> {
-            on { hentBrukerinformasjonForNavIdent(any()) } doReturn graphApiResponse.right()
+            on { hentNavnForNavIdent(any()) } doReturn graphApiResponse.displayName.right()
         }
 
         val brevServiceMock = mock<BrevService>()
@@ -344,7 +344,7 @@ internal class FerdigstillVedtakServiceImplTest {
         ) {
             verify(vedtakRepoMock).hentForUtbetaling(vedtak.utbetalingId)
             verify(personServiceMock).hentPersonMedSystembruker(vedtak.behandling.fnr)
-            verify(microsoftGraphApiOppslagMock, times(2)).hentBrukerinformasjonForNavIdent(any())
+            verify(microsoftGraphApiOppslagMock, times(2)).hentNavnForNavIdent(any())
             verify(brevServiceMock, never()).journalførBrev(any(), any())
             verify(brevServiceMock, never()).distribuerBrev(any())
             verify(oppgaveServiceMock).lukkOppgaveMedSystembruker(vedtak.behandling.oppgaveId)
@@ -363,9 +363,9 @@ internal class FerdigstillVedtakServiceImplTest {
         }
 
         val microsoftGraphApiOppslagMock = mock<MicrosoftGraphApiOppslag> {
-            on { hentBrukerinformasjonForNavIdent(any()) } doReturnConsecutively listOf(
-                graphApiResponse.copy(displayName = saksbehandler.navIdent).right(),
-                graphApiResponse.copy(displayName = attestant.navIdent).right(),
+            on { hentNavnForNavIdent(any()) } doReturnConsecutively listOf(
+                saksbehandler.navIdent.right(),
+                attestant.navIdent.right(),
             )
         }
 
@@ -408,7 +408,7 @@ internal class FerdigstillVedtakServiceImplTest {
         ) {
             verify(vedtakRepoMock).hentForUtbetaling(vedtak.utbetalingId)
             verify(personServiceMock).hentPersonMedSystembruker(vedtak.behandling.fnr)
-            verify(microsoftGraphApiOppslagMock, times(2)).hentBrukerinformasjonForNavIdent(any())
+            verify(microsoftGraphApiOppslagMock, times(2)).hentNavnForNavIdent(any())
             verify(brevServiceMock).journalførBrev(
                 argThat {
                     LagBrevRequest.InnvilgetVedtak(
@@ -493,7 +493,7 @@ internal class FerdigstillVedtakServiceImplTest {
         }
 
         val microsoftGraphApiOppslagMock = mock<MicrosoftGraphApiOppslag> {
-            on { hentBrukerinformasjonForNavIdent(any()) } doReturn MicrosoftGraphApiOppslagFeil.FantIkkeBrukerForNavIdent.left()
+            on { hentNavnForNavIdent(any()) } doReturn MicrosoftGraphApiOppslagFeil.FantIkkeBrukerForNavIdent.left()
         }
 
         val vedtak = avslagsVedtak()
@@ -510,7 +510,7 @@ internal class FerdigstillVedtakServiceImplTest {
             microsoftGraphApiOppslagMock,
         ) {
             verify(personServiceMock).hentPersonMedSystembruker(argThat { it shouldBe vedtak.behandling.fnr })
-            verify(microsoftGraphApiOppslagMock).hentBrukerinformasjonForNavIdent(argThat { it shouldBe vedtak.saksbehandler })
+            verify(microsoftGraphApiOppslagMock).hentNavnForNavIdent(argThat { it shouldBe vedtak.saksbehandler })
         }
     }
 
@@ -540,8 +540,8 @@ internal class FerdigstillVedtakServiceImplTest {
         }
 
         val microsoftGraphApiOppslagMock = mock<MicrosoftGraphApiOppslag> {
-            on { hentBrukerinformasjonForNavIdent(any()) } doReturnConsecutively listOf(
-                graphApiResponse.right(),
+            on { hentNavnForNavIdent(any()) } doReturnConsecutively listOf(
+                graphApiResponse.displayName.right(),
                 MicrosoftGraphApiOppslagFeil.FantIkkeBrukerForNavIdent.left(),
             )
         }
@@ -560,7 +560,7 @@ internal class FerdigstillVedtakServiceImplTest {
             microsoftGraphApiOppslagMock,
         ) {
             verify(personServiceMock).hentPersonMedSystembruker(argThat { it shouldBe vedtak.behandling.fnr })
-            verify(microsoftGraphApiOppslagMock, times(2)).hentBrukerinformasjonForNavIdent(any())
+            verify(microsoftGraphApiOppslagMock, times(2)).hentNavnForNavIdent(any())
         }
     }
 
@@ -604,7 +604,7 @@ internal class FerdigstillVedtakServiceImplTest {
         }
 
         val microsoftGraphApiOppslagMock = mock<MicrosoftGraphApiOppslag> {
-            on { hentBrukerinformasjonForNavIdent(any()) } doReturn graphApiResponse.right()
+            on { hentNavnForNavIdent(any()) } doReturn graphApiResponse.displayName.right()
         }
 
         val brevServiceMock = mock<BrevService> {
@@ -627,7 +627,7 @@ internal class FerdigstillVedtakServiceImplTest {
             brevServiceMock,
         ) {
             verify(personServiceMock).hentPersonMedSystembruker(argThat { it shouldBe vedtak.behandling.fnr })
-            verify(microsoftGraphApiOppslagMock, times(2)).hentBrukerinformasjonForNavIdent(any())
+            verify(microsoftGraphApiOppslagMock, times(2)).hentNavnForNavIdent(any())
             verify(brevServiceMock).journalførBrev(any(), any())
         }
     }
@@ -639,7 +639,7 @@ internal class FerdigstillVedtakServiceImplTest {
         }
 
         val microsoftGraphApiOppslagMock = mock<MicrosoftGraphApiOppslag> {
-            on { hentBrukerinformasjonForNavIdent(any()) } doReturn graphApiResponse.right()
+            on { hentNavnForNavIdent(any()) } doReturn graphApiResponse.displayName.right()
         }
 
         val vedtakRepoMock = mock<VedtakRepo>()
@@ -666,7 +666,7 @@ internal class FerdigstillVedtakServiceImplTest {
             vedtakRepoMock,
         ) {
             verify(personServiceMock).hentPersonMedSystembruker(argThat { it shouldBe vedtak.behandling.fnr })
-            verify(microsoftGraphApiOppslagMock, times(2)).hentBrukerinformasjonForNavIdent(any())
+            verify(microsoftGraphApiOppslagMock, times(2)).hentNavnForNavIdent(any())
             verifyZeroInteractions(vedtakRepoMock, brevServiceMock, behandlingMetricsMock)
         }
     }
@@ -678,9 +678,9 @@ internal class FerdigstillVedtakServiceImplTest {
         }
 
         val microsoftGraphApiOppslagMock = mock<MicrosoftGraphApiOppslag> {
-            on { hentBrukerinformasjonForNavIdent(any()) } doReturnConsecutively listOf(
-                graphApiResponse.copy(displayName = saksbehandler.navIdent).right(),
-                graphApiResponse.copy(displayName = attestant.navIdent).right(),
+            on { hentNavnForNavIdent(any()) } doReturnConsecutively listOf(
+                saksbehandler.navIdent.right(),
+                attestant.navIdent.right(),
             )
         }
 
@@ -716,7 +716,7 @@ internal class FerdigstillVedtakServiceImplTest {
             behandlingMetricsMock,
         ) {
             verify(personServiceMock).hentPersonMedSystembruker(argThat { it shouldBe vedtak.behandling.fnr })
-            verify(microsoftGraphApiOppslagMock, times(2)).hentBrukerinformasjonForNavIdent(any())
+            verify(microsoftGraphApiOppslagMock, times(2)).hentNavnForNavIdent(any())
             verify(brevServiceMock).journalførBrev(
                 argThat {
                     it shouldBe AvslagBrevRequest(
@@ -923,9 +923,9 @@ internal class FerdigstillVedtakServiceImplTest {
         }
 
         val microsoftGraphApiOppslagMock = mock<MicrosoftGraphApiOppslag> {
-            on { hentBrukerinformasjonForNavIdent(any()) } doReturnConsecutively listOf(
-                graphApiResponse.copy(displayName = "saksa").right(),
-                graphApiResponse.copy(displayName = "atta").right(),
+            on { hentNavnForNavIdent(any()) } doReturnConsecutively listOf(
+                "saksa".right(),
+                "atta".right(),
             )
         }
 
@@ -987,7 +987,7 @@ internal class FerdigstillVedtakServiceImplTest {
         }
 
         val microsoftGraphApiOppslagMock = mock<MicrosoftGraphApiOppslag> {
-            on { hentBrukerinformasjonForNavIdent(any()) } doReturn graphApiResponse.right()
+            on { hentNavnForNavIdent(any()) } doReturn graphApiResponse.displayName.right()
         }
 
         val vedtakRepoMock = mock<VedtakRepo> {

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/Revurderingsfeilresponser.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/Revurderingsfeilresponser.kt
@@ -74,6 +74,10 @@ internal object Revurderingsfeilresponser {
         is KunneIkkeForhåndsvarsle.FantIkkeRevurdering -> fantIkkeRevurdering
         is KunneIkkeForhåndsvarsle.UgyldigTilstand -> ugyldigTilstand(this.fra, this.til)
         is KunneIkkeForhåndsvarsle.Attestering -> this.subError.tilResultat()
+        is KunneIkkeForhåndsvarsle.KunneIkkeHenteNavnForSaksbehandler -> InternalServerError.errorJson(
+            "Kunne ikke hente navn for saksbehandler eller attestant",
+            "navneoppslag_feilet",
+        )
     }
 
     fun KunneIkkeLageBrevutkastForRevurdering.tilResultat(): Resultat {


### PR DESCRIPTION
Tok også i bruk den enklere `hentNavnForNavIdent` andre steder vi bare trenger navn på saksbehandler/attestant, i stedet for `hentBrukerinformasjonForNavIdent` som henter ut hele objektet.