### PR TITLE
Oppgrader Gradle fra 6.8.3 til 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,18 +97,18 @@ Spør en fra teamet, eller hent de fra `Vault` under team-secrets for  `supstona
 ## Ktlint
 
 Hvordan kjøre Ktlint:
-* Fra IDEA: Kjør Gradle Task: su-se-bakover->Tasks->formatting->ktlintFormat
+* Fra IDEA: Kjør Gradle Task: su-se-bakover->Tasks->formatting->formatKotlin
 * Fra terminal:
-   * Kun formater: `./gradlew ktlintFormat`
-   * Formater og bygg: `./gradlew ktlintFormat build` eller kjør `./lint_and_build.sh`
-   * Hvis IntelliJ begynner å hikke, kan en kjøre `./gradlew clean ktlintFormat build`
+   * Kun formater: `./gradlew formatKotlin`
+   * Formater og bygg: `./gradlew formatKotlin build` eller kjør `./lint_and_build.sh`
+   * Hvis IntelliJ begynner å hikke, kan en kjøre `./gradlew clean formatKotlin build`
 
 Endre IntelliJ autoformateringskonfigurasjon for dette prosjektet:
-* `./gradlew ktlintApplyToIdea`
+* Installer ktlint https://github.com/pinterest/ktlint/releases/ (inntil plugin støtter dette. Kan vurdere legge binæren i prosjektet)
+* ktlint applyToIDEAProject
 
-Legg til pre-commit check/format hooks:
-* `./gradlew addKtlintCheckGitPreCommitHook`
-* `./gradlew addKtlintFormatGitPreCommitHook`
+Kjente feil:
+* Kjør `rm ./.git/hooks/pre-commit` for å slette gammel hook hvis den feiler ved commit
 
 ## Metrics
 Vi bruker Prometheus for å samle inn metrikker.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,8 @@ buildscript {
 
 plugins {
     id("org.jetbrains.kotlin.jvm") version "1.4.32"
-    id("org.jlleitschuh.gradle.ktlint") version "9.4.1"
+    // Støtter unicode filer (i motsetning til https://github.com/JLLeitschuh/ktlint-gradle 10.0.0) og har nyere dependencies som gradle. Virker som den oppdateres hyppigere.
+    id("org.jmailen.kotlinter") version "3.4.4"
     id("com.github.ben-manes.versions") version "0.36.0" // Finds latest versions
     id("se.patrikerdes.use-latest-versions") version "0.2.15"
 }
@@ -15,7 +16,7 @@ version = "0.0.1"
 
 allprojects {
     apply(plugin = "org.jetbrains.kotlin.jvm")
-    apply(plugin = "org.jlleitschuh.gradle.ktlint")
+    apply(plugin = "org.jmailen.kotlinter")
     apply(plugin = "com.github.ben-manes.versions")
     apply(plugin = "se.patrikerdes.use-latest-versions")
     repositories {
@@ -27,7 +28,6 @@ allprojects {
     val arrowVersion = "0.11.0"
     val kotestVersion = "4.4.1"
     val jacksonVersion = "2.12.1"
-    val ktlintVersion = "0.41.0"
     val bouncycastleVersion = "1.68"
     dependencies {
         api(kotlin("stdlib-jdk8"))
@@ -113,7 +113,7 @@ allprojects {
     }
 
     tasks.withType<Wrapper> {
-        gradleVersion = "6.8.3"
+        gradleVersion = "7.0"
     }
 
     tasks.named("dependencyUpdates", com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask::class.java)
@@ -125,8 +125,9 @@ allprojects {
             reportfileName = "report"
             revision = "release" // Not waterproof
         }
+}
 
-    ktlint {
-        this.version.set(ktlintVersion)
-    }
+tasks.check {
+    // Må ligge på root nivå
+    dependsOn("installKotlinterPrePushHook")
 }

--- a/clean_lint_and_build.sh
+++ b/clean_lint_and_build.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-./gradlew clean ktlintFormat build
+./gradlew clean formatKotlin build

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lint_and_build.sh
+++ b/lint_and_build.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-./gradlew ktlintFormat build
+./gradlew formatKotlin build


### PR DESCRIPTION
Et pre-steg for å bytte til java 16 (og senere java 17 som er LTS)
Måtte også bytte ktlint-plugin, da vi ikke kunne oppgradere den vi brukte lenger (vs. å begynne med issues/PRs inn der)

Det kan hende du må kjøre rm ./.git/hooks/pre-commit fra den gamle ktlint-pluginen