### PR TITLE
Revurdering av vilkår - retting av diverse småfeil og problemer.

### DIFF
--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/oppdrag/SimuleringStub.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/oppdrag/SimuleringStub.kt
@@ -6,6 +6,7 @@ import no.nav.su.se.bakover.common.idag
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
+import no.nav.su.se.bakover.domain.oppdrag.Utbetalingslinje
 import no.nav.su.se.bakover.domain.oppdrag.simulering.KlasseKode
 import no.nav.su.se.bakover.domain.oppdrag.simulering.KlasseType
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
@@ -70,18 +71,25 @@ object SimuleringStub : SimuleringClient {
         }
 
     private fun simulerIngenUtbetaling(utbetaling: Utbetaling): Simulering {
+        val simuleringsPeriode = when (val sisteUtbetalingslinje = utbetaling.sisteUtbetalingslinje()) {
+            is Utbetalingslinje.Endring -> SimulertPeriode(
+                fraOgMed = sisteUtbetalingslinje.statusendring.fraOgMed,
+                tilOgMed = utbetaling.senesteDato(),
+                utbetaling = emptyList(),
+            )
+            else -> SimulertPeriode(
+                fraOgMed = utbetaling.tidligsteDato(),
+                tilOgMed = utbetaling.senesteDato(),
+                utbetaling = emptyList(),
+            )
+        }
+
         return Simulering(
             gjelderId = utbetaling.fnr,
             gjelderNavn = "MYGG LUR",
             datoBeregnet = idag(),
             nettoBeløp = 0,
-            periodeList = listOf(
-                SimulertPeriode(
-                    fraOgMed = utbetaling.tidligsteDato(),
-                    tilOgMed = utbetaling.senesteDato(),
-                    utbetaling = emptyList(),
-                ),
-            ),
+            periodeList = listOf(simuleringsPeriode),
         )
     }
 

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/grunnlag/VilkårsvurderingPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/grunnlag/VilkårsvurderingPostgresRepo.kt
@@ -23,7 +23,7 @@ internal class VilkårsvurderingPostgresRepo(
     private val uføregrunnlagPostgresRepo: UføregrunnlagPostgresRepo,
 ) : VilkårsvurderingRepo {
 
-    override fun lagre(behandlingId: UUID, vilkår: Vilkår<Grunnlag.Uføregrunnlag>) {
+    override fun lagre(behandlingId: UUID, vilkår: Vilkår<Grunnlag.Uføregrunnlag?>) {
         dataSource.withTransaction { tx ->
             slettForBehandlingId(behandlingId, tx)
             when (vilkår) {
@@ -38,7 +38,7 @@ internal class VilkårsvurderingPostgresRepo(
         }
     }
 
-    private fun lagre(behandlingId: UUID, vurderingsperiode: Vurderingsperiode<Grunnlag.Uføregrunnlag>, session: Session) {
+    private fun lagre(behandlingId: UUID, vurderingsperiode: Vurderingsperiode<Grunnlag.Uføregrunnlag?>, session: Session) {
         """
                 insert into vilkårsvurdering_uføre
                 (
@@ -92,7 +92,7 @@ internal class VilkårsvurderingPostgresRepo(
             )
     }
 
-    override fun hent(behandlingId: UUID): Vilkår<Grunnlag.Uføregrunnlag> {
+    override fun hent(behandlingId: UUID): Vilkår<Grunnlag.Uføregrunnlag?> {
         val vurderingsperioder = dataSource.withSession { session ->
             """
                 select * from vilkårsvurdering_uføre where behandlingId = :behandlingId
@@ -112,8 +112,8 @@ internal class VilkårsvurderingPostgresRepo(
         }
     }
 
-    private fun Row.toVurderingsperioder(): Vurderingsperiode<Grunnlag.Uføregrunnlag> {
-        return Vurderingsperiode.Manuell.create(
+    private fun Row.toVurderingsperioder(): Vurderingsperiode<Grunnlag.Uføregrunnlag?> {
+        return Vurderingsperiode.Uføre.create(
             id = uuid("id"),
             opprettet = tidspunkt("opprettet"),
             resultat = ResultatDto.valueOf(string("resultat")).toDomain(),

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/grunnlag/VilkårsvurderingRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/grunnlag/VilkårsvurderingRepo.kt
@@ -5,6 +5,6 @@ import no.nav.su.se.bakover.domain.vilkår.Vilkår
 import java.util.UUID
 
 interface VilkårsvurderingRepo {
-    fun lagre(behandlingId: UUID, vilkår: Vilkår<Grunnlag.Uføregrunnlag>)
-    fun hent(behandlingId: UUID): Vilkår<Grunnlag.Uføregrunnlag>
+    fun lagre(behandlingId: UUID, vilkår: Vilkår<Grunnlag.Uføregrunnlag?>)
+    fun hent(behandlingId: UUID): Vilkår<Grunnlag.Uføregrunnlag?>
 }

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/grunnlag/VilkårsvurderingPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/grunnlag/VilkårsvurderingPostgresRepoTest.kt
@@ -28,7 +28,7 @@ internal class VilkårsvurderingPostgresRepoTest {
             val søknadsbehandling = testDataHelper.nySøknadsbehandling()
             val vurderingUførhet = Vilkår.Vurdert.Uførhet.create(
                 vurderingsperioder = Nel.of(
-                    Vurderingsperiode.Manuell.create(
+                    Vurderingsperiode.Uføre.create(
                         id = UUID.randomUUID(),
                         opprettet = Tidspunkt.now(fixedClock),
                         resultat = Resultat.Avslag,
@@ -59,7 +59,7 @@ internal class VilkårsvurderingPostgresRepoTest {
 
             val vurderingUførhet = Vilkår.Vurdert.Uførhet.create(
                 vurderingsperioder = Nel.of(
-                    Vurderingsperiode.Manuell.create(
+                    Vurderingsperiode.Uføre.create(
                         id = UUID.randomUUID(),
                         opprettet = Tidspunkt.now(fixedClock),
                         resultat = Resultat.Avslag,
@@ -90,7 +90,7 @@ internal class VilkårsvurderingPostgresRepoTest {
 
             val vurderingUførhet = Vilkår.Vurdert.Uførhet.create(
                 vurderingsperioder = Nel.of(
-                    Vurderingsperiode.Manuell.create(
+                    Vurderingsperiode.Uføre.create(
                         id = UUID.randomUUID(),
                         opprettet = Tidspunkt.now(fixedClock),
                         resultat = Resultat.Avslag,

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/søknadsbehandling/SøknadsbehandlingPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/søknadsbehandling/SøknadsbehandlingPostgresRepoTest.kt
@@ -458,7 +458,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
 
             val vurderingUførhet = Vilkår.Vurdert.Uførhet.create(
                 vurderingsperioder = Nel.of(
-                    Vurderingsperiode.Manuell.create(
+                    Vurderingsperiode.Uføre.create(
                         id = UUID.randomUUID(),
                         opprettet = Tidspunkt.now(fixedClock),
                         resultat = Resultat.Avslag,
@@ -500,7 +500,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                     vilkårsvurderinger = Vilkårsvurderinger(
                         uføre = Vilkår.Vurdert.Uførhet.create(
                             vurderingsperioder = Nel.of(
-                                Vurderingsperiode.Manuell.create(
+                                Vurderingsperiode.Uføre.create(
                                     id = vurderingUførhet.vurderingsperioder[0].id,
                                     opprettet = Tidspunkt.now(fixedClock),
                                     resultat = Resultat.Avslag,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vilkår/Vilkår.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vilkår/Vilkår.kt
@@ -30,7 +30,7 @@ sealed class Inngangsvilkår {
 }
 
 data class Vilkårsvurderinger(
-    val uføre: Vilkår<Grunnlag.Uføregrunnlag> = Vilkår.IkkeVurdert.Uførhet,
+    val uføre: Vilkår<Grunnlag.Uføregrunnlag?> = Vilkår.IkkeVurdert.Uførhet,
 ) {
     companion object {
         val EMPTY = Vilkårsvurderinger()
@@ -71,17 +71,17 @@ sealed class Vilkårsvurderingsresultat {
 /**
  * Vurderingen av et vilkår mot en eller flere grunnlagsdata
  */
-sealed class Vilkår<T : Grunnlag> {
+sealed class Vilkår<T : Grunnlag?> {
 
-    sealed class IkkeVurdert<T : Grunnlag> : Vilkår<T>() {
-        object Uførhet : Vilkår<Grunnlag.Uføregrunnlag>() {
+    sealed class IkkeVurdert<T : Grunnlag?> : Vilkår<T>() {
+        object Uførhet : Vilkår<Grunnlag.Uføregrunnlag?>() {
             override val resultat: Resultat = Resultat.Uavklart
         }
     }
 
     abstract val resultat: Resultat
 
-    sealed class Vurdert<T : Grunnlag> : Vilkår<T>() {
+    sealed class Vurdert<T : Grunnlag?> : Vilkår<T>() {
         abstract val vilkår: Inngangsvilkår
         abstract val grunnlag: List<T>
         abstract val vurderingsperioder: List<Vurderingsperiode<T>>
@@ -99,8 +99,8 @@ sealed class Vilkår<T : Grunnlag> {
         }
 
         data class Uførhet private constructor(
-            override val vurderingsperioder: Nel<Vurderingsperiode<Grunnlag.Uføregrunnlag>>,
-        ) : Vurdert<Grunnlag.Uføregrunnlag>() {
+            override val vurderingsperioder: Nel<Vurderingsperiode<Grunnlag.Uføregrunnlag?>>,
+        ) : Vurdert<Grunnlag.Uføregrunnlag?>() {
             override val vilkår = Inngangsvilkår.Uførhet
             override val grunnlag: List<Grunnlag.Uføregrunnlag> = vurderingsperioder.mapNotNull {
                 it.grunnlag
@@ -108,11 +108,11 @@ sealed class Vilkår<T : Grunnlag> {
 
             companion object {
                 fun create(
-                    vurderingsperioder: Nel<Vurderingsperiode<Grunnlag.Uføregrunnlag>>,
+                    vurderingsperioder: Nel<Vurderingsperiode<Grunnlag.Uføregrunnlag?>>,
                 ): Uførhet = tryCreate(vurderingsperioder).getOrHandle { throw IllegalArgumentException(it.toString()) }
 
                 fun tryCreate(
-                    vurderingsperioder: Nel<Vurderingsperiode<Grunnlag.Uføregrunnlag>>,
+                    vurderingsperioder: Nel<Vurderingsperiode<Grunnlag.Uføregrunnlag?>>,
                 ): Either<UgyldigUførevilkår, Uførhet> {
                     if (vurderingsperioder.forAll { v1 ->
                         vurderingsperioder.minus(v1).any { v2 -> v1.periode overlapper v2.periode }
@@ -131,7 +131,7 @@ sealed class Vilkår<T : Grunnlag> {
     }
 }
 
-sealed class Vurderingsperiode<T : Grunnlag> : KanPlasseresPåTidslinje<Vurderingsperiode<T>> {
+sealed class Vurderingsperiode<T : Grunnlag?> : KanPlasseresPåTidslinje<Vurderingsperiode<T>> {
     abstract val id: UUID
     abstract override val opprettet: Tidspunkt
     abstract val resultat: Resultat
@@ -139,60 +139,59 @@ sealed class Vurderingsperiode<T : Grunnlag> : KanPlasseresPåTidslinje<Vurderin
     abstract override val periode: Periode
     abstract val begrunnelse: String?
 
-    data class Manuell<T : Grunnlag> private constructor(
+    data class Uføre private constructor(
         override val id: UUID = UUID.randomUUID(),
         override val opprettet: Tidspunkt = Tidspunkt.now(),
         override val resultat: Resultat,
-        override val grunnlag: T?,
+        override val grunnlag: Grunnlag.Uføregrunnlag?,
         override val periode: Periode,
         override val begrunnelse: String?,
-    ) : Vurderingsperiode<T>() {
+    ) : Vurderingsperiode<Grunnlag.Uføregrunnlag?>() {
 
-        @Suppress("UNCHECKED_CAST")
-        override fun copy(args: CopyArgs.Tidslinje): Manuell<T> = when (args) {
+        override fun copy(args: CopyArgs.Tidslinje): Uføre = when (args) {
             CopyArgs.Tidslinje.Full -> {
                 copy(
                     id = UUID.randomUUID(),
-                    grunnlag = grunnlag?.copy(args) as T,
+                    grunnlag = grunnlag?.copy(args),
                 )
             }
             is CopyArgs.Tidslinje.NyPeriode -> {
                 copy(
                     id = UUID.randomUUID(),
                     periode = args.periode,
-                    grunnlag = grunnlag?.copy(args) as T,
+                    grunnlag = grunnlag?.copy(args),
                 )
             }
         }
 
         companion object {
-            fun <T : Grunnlag> create(
+            fun create(
                 id: UUID = UUID.randomUUID(),
                 opprettet: Tidspunkt = Tidspunkt.now(),
                 resultat: Resultat,
-                grunnlag: T?,
+                grunnlag: Grunnlag.Uføregrunnlag?,
                 periode: Periode,
                 begrunnelse: String?,
-            ): Manuell<T> {
+            ): Uføre {
                 return tryCreate(id, opprettet, resultat, grunnlag, periode, begrunnelse).getOrHandle {
                     throw IllegalArgumentException(it.toString())
                 }
             }
 
-            fun <T : Grunnlag> tryCreate(
+            fun tryCreate(
                 id: UUID = UUID.randomUUID(),
                 opprettet: Tidspunkt = Tidspunkt.now(),
                 resultat: Resultat,
-                grunnlag: T?,
+                grunnlag: Grunnlag.Uføregrunnlag?,
                 vurderingsperiode: Periode,
                 begrunnelse: String?,
-            ): Either<UgyldigVurderingsperiode, Manuell<T>> {
+            ): Either<UgyldigVurderingsperiode, Uføre> {
 
                 grunnlag?.let {
                     if (vurderingsperiode != it.periode) return UgyldigVurderingsperiode.PeriodeForGrunnlagOgVurderingErForskjellig.left()
                 }
 
-                return Manuell(
+                return Uføre(
                     id = id,
                     opprettet = opprettet,
                     resultat = resultat,

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/RevurderingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/RevurderingTest.kt
@@ -46,7 +46,7 @@ internal class RevurderingTest {
             vilkårsvurderinger = Vilkårsvurderinger(
                 uføre = Vilkår.Vurdert.Uførhet.create(
                     vurderingsperioder = Nel.of(
-                        Vurderingsperiode.Manuell.create(
+                        Vurderingsperiode.Uføre.create(
                             id = UUID.randomUUID(),
                             opprettet = Tidspunkt.now(),
                             resultat = Resultat.Avslag,
@@ -66,7 +66,7 @@ internal class RevurderingTest {
             vilkårsvurderinger = Vilkårsvurderinger(
                 uføre = Vilkår.Vurdert.Uførhet.create(
                     vurderingsperioder = Nel.of(
-                        Vurderingsperiode.Manuell.create(
+                        Vurderingsperiode.Uføre.create(
                             id = UUID.randomUUID(),
                             opprettet = Tidspunkt.now(),
                             resultat = Resultat.Innvilget,

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/RevurderingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/RevurderingTest.kt
@@ -1,0 +1,122 @@
+package no.nav.su.se.bakover.domain.revurdering
+
+import arrow.core.Nel
+import arrow.core.right
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import io.kotest.assertions.arrow.either.shouldBeLeft
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.beOfType
+import no.nav.su.se.bakover.common.Tidspunkt
+import no.nav.su.se.bakover.common.desember
+import no.nav.su.se.bakover.common.januar
+import no.nav.su.se.bakover.common.periode.Periode
+import no.nav.su.se.bakover.domain.NavIdentBruker
+import no.nav.su.se.bakover.domain.beregning.BeregningFactory
+import no.nav.su.se.bakover.domain.beregning.BeregningStrategy
+import no.nav.su.se.bakover.domain.beregning.Sats
+import no.nav.su.se.bakover.domain.beregning.fradrag.FradragFactory
+import no.nav.su.se.bakover.domain.beregning.fradrag.FradragStrategy
+import no.nav.su.se.bakover.domain.beregning.fradrag.FradragTilhører
+import no.nav.su.se.bakover.domain.beregning.fradrag.Fradragstype
+import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
+import no.nav.su.se.bakover.domain.oppgave.OppgaveId
+import no.nav.su.se.bakover.domain.vedtak.Vedtak
+import no.nav.su.se.bakover.domain.vilkår.Resultat
+import no.nav.su.se.bakover.domain.vilkår.Vilkår
+import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
+import no.nav.su.se.bakover.domain.vilkår.Vurderingsperiode
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+internal class RevurderingTest {
+    @Test
+    fun `beregning gir feilmelding hvis vilkår er uavklart`() {
+        lagRevurdering(
+            vilkårsvurderinger = Vilkårsvurderinger(
+                uføre = Vilkår.IkkeVurdert.Uførhet,
+            ),
+        ).beregn(emptyList()) shouldBeLeft Revurdering.KunneIkkeBeregneRevurdering.UfullstendigVilkårsvurdering
+    }
+
+    @Test
+    fun `beregning gir opphør hvis vilkår ikke er oppfylt`() {
+        lagRevurdering(
+            vilkårsvurderinger = Vilkårsvurderinger(
+                uføre = Vilkår.Vurdert.Uførhet.create(
+                    vurderingsperioder = Nel.of(
+                        Vurderingsperiode.Manuell.create(
+                            id = UUID.randomUUID(),
+                            opprettet = Tidspunkt.now(),
+                            resultat = Resultat.Avslag,
+                            grunnlag = null,
+                            periode = Periode.create(1.januar(2021), 31.desember(2021)),
+                            begrunnelse = null,
+                        ),
+                    ),
+                ),
+            ),
+        ).beregn(emptyList()).orNull()!! shouldBe beOfType<BeregnetRevurdering.Opphørt>()
+    }
+
+    @Test
+    fun `beregning gir ikke opphør hvis vilkår er oppfylt`() {
+        lagRevurdering(
+            vilkårsvurderinger = Vilkårsvurderinger(
+                uføre = Vilkår.Vurdert.Uførhet.create(
+                    vurderingsperioder = Nel.of(
+                        Vurderingsperiode.Manuell.create(
+                            id = UUID.randomUUID(),
+                            opprettet = Tidspunkt.now(),
+                            resultat = Resultat.Innvilget,
+                            grunnlag = null,
+                            periode = Periode.create(1.januar(2021), 31.desember(2021)),
+                            begrunnelse = null,
+                        ),
+                    ),
+                ),
+            ),
+        ).beregn(emptyList()).orNull()!! shouldNotBe beOfType<BeregnetRevurdering.Opphørt>()
+    }
+
+    private fun lagRevurdering(
+        tilRevurdering: Vedtak.EndringIYtelse = tilRevurderingMock,
+        vilkårsvurderinger: Vilkårsvurderinger,
+    ) = OpprettetRevurdering(
+        id = UUID.randomUUID(),
+        periode = Periode.create(1.januar(2021), 31.desember(2021)),
+        opprettet = Tidspunkt.now(),
+        tilRevurdering = tilRevurdering,
+        saksbehandler = NavIdentBruker.Saksbehandler(navIdent = ""),
+        oppgaveId = OppgaveId(value = ""),
+        fritekstTilBrev = "",
+        revurderingsårsak = Revurderingsårsak(årsak = Revurderingsårsak.Årsak.INFORMASJON_FRA_KONTROLLSAMTALE, begrunnelse = Revurderingsårsak.Begrunnelse.create(value = "b")),
+        forhåndsvarsel = null,
+        behandlingsinformasjon = mock() {
+            on { getBeregningStrategy() } doReturn BeregningStrategy.BorAlene.right()
+        },
+        grunnlagsdata = Grunnlagsdata(uføregrunnlag = listOf()),
+        vilkårsvurderinger = vilkårsvurderinger,
+    )
+
+    private val tilRevurderingMock: Vedtak.EndringIYtelse = mock() {
+        on { beregning } doReturn BeregningFactory.ny(
+            id = UUID.randomUUID(),
+            opprettet = Tidspunkt.now(),
+            periode = Periode.create(1.januar(2021), 31.desember(2021)),
+            sats = Sats.HØY,
+            fradrag = listOf(
+                FradragFactory.ny(
+                    type = Fradragstype.ForventetInntekt,
+                    månedsbeløp = 0.0,
+                    periode = Periode.create(1.januar(2021), 31.desember(2021)),
+                    utenlandskInntekt = null,
+                    tilhører = FradragTilhører.BRUKER,
+                ),
+            ),
+            fradragStrategy = FradragStrategy.Enslig,
+            begrunnelse = null,
+        )
+    }
+}

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakPåTidslinjeTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakPåTidslinjeTest.kt
@@ -37,7 +37,7 @@ internal class VedtakPåTidslinjeTest {
             forventetInntekt = 100,
         )
 
-        val vurderingsperiode = Vurderingsperiode.Manuell.create(
+        val vurderingsperiode = Vurderingsperiode.Uføre.create(
             id = UUID.randomUUID(),
             opprettet = fixedTidspunkt,
             resultat = Resultat.Innvilget,
@@ -97,7 +97,7 @@ internal class VedtakPåTidslinjeTest {
             forventetInntekt = 100,
         )
 
-        val vurderingsperiode = Vurderingsperiode.Manuell.create(
+        val vurderingsperiode = Vurderingsperiode.Uføre.create(
             id = UUID.randomUUID(),
             opprettet = fixedTidspunkt,
             resultat = Resultat.Innvilget,

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakTest.kt
@@ -112,7 +112,7 @@ internal class VedtakTest {
             fraDato = p1.fraOgMed,
             tilDato = p1.tilOgMed,
         )
-        val v1 = Vurderingsperiode.Manuell.create(
+        val v1 = Vurderingsperiode.Uføre.create(
             id = UUID.randomUUID(),
             opprettet = fixedTidspunkt,
             resultat = Resultat.Innvilget,
@@ -136,7 +136,7 @@ internal class VedtakTest {
             fraDato = p2.fraOgMed,
             tilDato = p2.tilOgMed,
         )
-        val v2 = Vurderingsperiode.Manuell.create(
+        val v2 = Vurderingsperiode.Uføre.create(
             id = UUID.randomUUID(),
             opprettet = fixedTidspunkt,
             resultat = Resultat.Avslag,
@@ -223,7 +223,7 @@ internal class VedtakTest {
             fraDato = p1.fraOgMed,
             tilDato = p1.tilOgMed,
         )
-        val v1 = Vurderingsperiode.Manuell.create(
+        val v1 = Vurderingsperiode.Uføre.create(
             id = UUID.randomUUID(),
             opprettet = fixedTidspunkt,
             resultat = Resultat.Innvilget,

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vilkår/UførhetTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vilkår/UførhetTest.kt
@@ -12,13 +12,13 @@ internal class UførhetTest {
     fun `validerer at vurderingsperioder ikke overlapper`() {
         Vilkår.Vurdert.Uførhet.tryCreate(
             vurderingsperioder = Nel.of(
-                Vurderingsperiode.Manuell.create(
+                Vurderingsperiode.Uføre.create(
                     resultat = Resultat.Innvilget,
                     grunnlag = null,
                     periode = Periode.create(1.januar(2021), 31.desember(2021)),
                     begrunnelse = "",
                 ),
-                Vurderingsperiode.Manuell.create(
+                Vurderingsperiode.Uføre.create(
                     resultat = Resultat.Avslag,
                     grunnlag = null,
                     periode = Periode.create(1.januar(2021), 31.desember(2021)),

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vilkår/VilkårsvurderingerTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vilkår/VilkårsvurderingerTest.kt
@@ -24,7 +24,7 @@ internal class VilkårsvurderingerTest {
         Vilkårsvurderinger(
             uføre = Vilkår.Vurdert.Uførhet.create(
                 vurderingsperioder = Nel.of(
-                    Vurderingsperiode.Manuell.create(
+                    Vurderingsperiode.Uføre.create(
                         resultat = Resultat.Innvilget,
                         grunnlag = uføregrunnlag,
                         periode = Periode.create(1.januar(2021), 31.desember(2021)),
@@ -40,7 +40,7 @@ internal class VilkårsvurderingerTest {
         Vilkårsvurderinger(
             uføre = Vilkår.Vurdert.Uførhet.create(
                 vurderingsperioder = Nel.of(
-                    Vurderingsperiode.Manuell.create(
+                    Vurderingsperiode.Uføre.create(
                         resultat = Resultat.Avslag,
                         grunnlag = uføregrunnlag,
                         periode = Periode.create(1.januar(2021), 31.desember(2021)),
@@ -63,7 +63,7 @@ internal class VilkårsvurderingerTest {
         Vilkårsvurderinger(
             uføre = Vilkår.Vurdert.Uførhet.create(
                 vurderingsperioder = Nel.of(
-                    Vurderingsperiode.Manuell.create(
+                    Vurderingsperiode.Uføre.create(
                         resultat = Resultat.Innvilget,
                         grunnlag = Grunnlag.Uføregrunnlag(
                             periode = Periode.create(1.januar(2021), 30.april(2021)),
@@ -73,7 +73,7 @@ internal class VilkårsvurderingerTest {
                         periode = Periode.create(1.januar(2021), 30.april(2021)),
                         begrunnelse = "",
                     ),
-                    Vurderingsperiode.Manuell.create(
+                    Vurderingsperiode.Uføre.create(
                         resultat = Resultat.Avslag,
                         grunnlag = Grunnlag.Uføregrunnlag(
                             periode = Periode.create(1.mai(2021), 31.desember(2021)),

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vilkår/VurderingsperiodeTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vilkår/VurderingsperiodeTest.kt
@@ -8,6 +8,7 @@ import no.nav.su.se.bakover.common.april
 import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.mai
+import no.nav.su.se.bakover.common.november
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.common.startOfDay
 import no.nav.su.se.bakover.domain.CopyArgs
@@ -25,7 +26,7 @@ internal class VurderingsperiodeTest {
 
     @Test
     fun `bevarer korrekte verdier ved kopiering for plassering på tidslinje - full kopi`() {
-        val original = Vurderingsperiode.Manuell.create(
+        val original = Vurderingsperiode.Uføre.create(
             id = UUID.randomUUID(),
             opprettet = Tidspunkt.now(fixedClock),
             resultat = Resultat.Innvilget,
@@ -59,7 +60,7 @@ internal class VurderingsperiodeTest {
 
     @Test
     fun `bevarer korrekte verdier ved kopiering for plassering på tidslinje - ny periode`() {
-        val original = Vurderingsperiode.Manuell.create(
+        val original = Vurderingsperiode.Uføre.create(
             id = UUID.randomUUID(),
             opprettet = Tidspunkt.now(fixedClock),
             resultat = Resultat.Innvilget,
@@ -92,7 +93,7 @@ internal class VurderingsperiodeTest {
 
     @Test
     fun `kan lage tidslinje for vurderingsperioder`() {
-        val a = Vurderingsperiode.Manuell.create(
+        val a = Vurderingsperiode.Uføre.create(
             id = UUID.randomUUID(),
             opprettet = Tidspunkt.now(fixedClock),
             resultat = Resultat.Innvilget,
@@ -107,7 +108,7 @@ internal class VurderingsperiodeTest {
             begrunnelse = "begrunnelsen a",
         )
 
-        val b = Vurderingsperiode.Manuell.create(
+        val b = Vurderingsperiode.Uføre.create(
             id = UUID.randomUUID(),
             opprettet = Tidspunkt.now(fixedClock).plus(1, ChronoUnit.DAYS),
             resultat = Resultat.Innvilget,
@@ -122,9 +123,18 @@ internal class VurderingsperiodeTest {
             begrunnelse = "begrunnelsen b",
         )
 
+        val c = Vurderingsperiode.Uføre.create(
+            id = UUID.randomUUID(),
+            opprettet = Tidspunkt.now(fixedClock).plus(2, ChronoUnit.DAYS),
+            resultat = Resultat.Innvilget,
+            grunnlag = null,
+            periode = Periode.create(1.desember(2021), 31.desember(2021)),
+            begrunnelse = "begrunnelsen b",
+        )
+
         Tidslinje(
             periode = Periode.create(1.januar(2021), 31.desember(2021)),
-            objekter = listOf(a, b),
+            objekter = listOf(a, b, c),
             clock = fixedClock,
         ).tidslinje.let {
             it[0].let { copy ->
@@ -142,7 +152,7 @@ internal class VurderingsperiodeTest {
             it[1].let { copy ->
                 copy.id shouldNotBe a.id
                 copy.id shouldNotBe b.id
-                copy.periode shouldBe Periode.create(1.mai(2021), 31.desember(2021))
+                copy.periode shouldBe Periode.create(1.mai(2021), 30.november(2021))
                 copy.begrunnelse shouldBe b.begrunnelse
                 copy.grunnlag!!.let { grunnlagCopy ->
                     grunnlagCopy.id shouldNotBe b.grunnlag!!.id
@@ -151,12 +161,20 @@ internal class VurderingsperiodeTest {
                     grunnlagCopy.forventetInntekt shouldBe b.grunnlag!!.forventetInntekt
                 }
             }
+            it[2].let { copy ->
+                copy.id shouldNotBe a.id
+                copy.id shouldNotBe b.id
+                copy.id shouldNotBe c.id
+                copy.periode shouldBe Periode.create(1.desember(2021), 31.desember(2021))
+                copy.begrunnelse shouldBe b.begrunnelse
+                copy.grunnlag shouldBe null
+            }
         }
     }
 
     @Test
     fun `krever samsvar med periode for grunnlag dersom det eksisterer`() {
-        Vurderingsperiode.Manuell.tryCreate(
+        Vurderingsperiode.Uføre.tryCreate(
             id = UUID.randomUUID(),
             opprettet = Tidspunkt.now(fixedClock),
             resultat = Resultat.Innvilget,
@@ -169,12 +187,12 @@ internal class VurderingsperiodeTest {
             ),
             vurderingsperiode = Periode.create(1.mai(2021), 31.desember(2021)),
             begrunnelse = "begrunnelsen",
-        ) shouldBeLeft Vurderingsperiode.Manuell.UgyldigVurderingsperiode.PeriodeForGrunnlagOgVurderingErForskjellig
+        ) shouldBeLeft Vurderingsperiode.Uføre.UgyldigVurderingsperiode.PeriodeForGrunnlagOgVurderingErForskjellig
     }
 
     @Test
     fun `kan opprettes selv om grunnlag ikke eksisterer`() {
-        Vurderingsperiode.Manuell.tryCreate(
+        Vurderingsperiode.Uføre.tryCreate(
             id = UUID.randomUUID(),
             opprettet = Tidspunkt.now(fixedClock),
             resultat = Resultat.Innvilget,

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/FinnAttestantVisitorTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/FinnAttestantVisitorTest.kt
@@ -246,7 +246,7 @@ internal class FinnAttestantVisitorTest {
         vilkårsvurderinger = Vilkårsvurderinger(
             uføre = Vilkår.Vurdert.Uførhet.create(
                 vurderingsperioder = Nel.of(
-                    Vurderingsperiode.Manuell.create(
+                    Vurderingsperiode.Uføre.create(
                         resultat = Resultat.Innvilget,
                         grunnlag = uføregrunnlag,
                         periode = Periode.create(1.januar(2021), 31.januar(2021)),

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/FinnAttestantVisitorTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/FinnAttestantVisitorTest.kt
@@ -1,5 +1,6 @@
 package no.nav.su.se.bakover.domain.visitor
 
+import arrow.core.Nel
 import arrow.core.right
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
@@ -31,7 +32,10 @@ import no.nav.su.se.bakover.domain.revurdering.OpprettetRevurdering
 import no.nav.su.se.bakover.domain.revurdering.Revurderingsårsak
 import no.nav.su.se.bakover.domain.søknadsbehandling.Stønadsperiode
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
+import no.nav.su.se.bakover.domain.vilkår.Resultat
+import no.nav.su.se.bakover.domain.vilkår.Vilkår
 import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
+import no.nav.su.se.bakover.domain.vilkår.Vurderingsperiode
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
@@ -213,6 +217,11 @@ internal class FinnAttestantVisitorTest {
             ),
         )
     }
+    private val uføregrunnlag = Grunnlag.Uføregrunnlag(
+        periode = Periode.create(1.januar(2021), 31.januar(2021)),
+        uføregrad = Uføregrad.parse(20),
+        forventetInntekt = 10,
+    )
     private val revurdering = OpprettetRevurdering(
         id = UUID.randomUUID(),
         periode = Periode.create(1.januar(2021), 31.januar(2021)),
@@ -232,15 +241,20 @@ internal class FinnAttestantVisitorTest {
         forhåndsvarsel = null,
         behandlingsinformasjon = behandlingsinformasjonMedAlleVilkårOppfylt,
         grunnlagsdata = Grunnlagsdata(
-            uføregrunnlag = listOf(
-                Grunnlag.Uføregrunnlag(
-                    periode = Periode.create(1.januar(2021), 31.januar(2021)),
-                    uføregrad = Uføregrad.parse(20),
-                    forventetInntekt = 10,
+            uføregrunnlag = listOf(uføregrunnlag),
+        ),
+        vilkårsvurderinger = Vilkårsvurderinger(
+            uføre = Vilkår.Vurdert.Uførhet.create(
+                vurderingsperioder = Nel.of(
+                    Vurderingsperiode.Manuell.create(
+                        resultat = Resultat.Innvilget,
+                        grunnlag = uføregrunnlag,
+                        periode = Periode.create(1.januar(2021), 31.januar(2021)),
+                        begrunnelse = null,
+                    ),
                 ),
             ),
         ),
-        vilkårsvurderinger = Vilkårsvurderinger.EMPTY,
     )
 
     private val beregnetRevurdering = when (val a = revurdering.beregn(emptyList()).orNull()!!) {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/grunnlag/VilkårsvurderingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/grunnlag/VilkårsvurderingService.kt
@@ -37,7 +37,7 @@ internal class VilkårsvurderingServiceImpl(
                 Tidslinje(
                     periode = periode,
                     objekter = vilkår.map { it.uføre }
-                        .filterIsInstance<Vilkår.Vurdert<Grunnlag.Uføregrunnlag>>()
+                        .filterIsInstance<Vilkår.Vurdert<Grunnlag.Uføregrunnlag?>>()
                         .flatMap { it.vurderingsperioder },
                     clock = clock,
                 )

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -36,7 +36,6 @@ import no.nav.su.se.bakover.domain.revurdering.UnderkjentRevurdering
 import no.nav.su.se.bakover.domain.revurdering.erKlarForAttestering
 import no.nav.su.se.bakover.domain.revurdering.medFritekst
 import no.nav.su.se.bakover.domain.vedtak.Vedtak
-import no.nav.su.se.bakover.domain.vilkår.Resultat
 import no.nav.su.se.bakover.domain.vilkår.Vilkår
 import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
 import no.nav.su.se.bakover.domain.visitor.LagBrevRequestVisitor
@@ -268,80 +267,48 @@ internal class RevurderingServiceImpl(
     ): Either<KunneIkkeBeregneOgSimulereRevurdering, Revurdering> {
         return when (val originalRevurdering = revurderingRepo.hent(revurderingId)) {
             is BeregnetRevurdering, is OpprettetRevurdering, is SimulertRevurdering, is UnderkjentRevurdering -> {
-                when (originalRevurdering.vilkårsvurderinger.resultat) {
-                    Resultat.Avslag -> {
-                        val opphør = BeregnetRevurdering.Opphørt(
-                            tilRevurdering = originalRevurdering.tilRevurdering,
-                            id = originalRevurdering.id,
-                            periode = originalRevurdering.periode,
-                            opprettet = originalRevurdering.opprettet,
-                            beregning = originalRevurdering.tilRevurdering.beregning,
+                when (
+                    val beregnetRevurdering = originalRevurdering.beregn(fradrag)
+                        .getOrHandle {
+                            return when (it) {
+                                is Revurdering.KunneIkkeBeregneRevurdering.KanIkkeVelgeSisteMånedVedNedgangIStønaden -> KunneIkkeBeregneOgSimulereRevurdering.KanIkkeVelgeSisteMånedVedNedgangIStønaden
+                                is Revurdering.KunneIkkeBeregneRevurdering.UfullstendigBehandlingsinformasjon -> KunneIkkeBeregneOgSimulereRevurdering.UfullstendigBehandlingsinformasjon
+                                is Revurdering.KunneIkkeBeregneRevurdering.UgyldigBeregningsgrunnlag -> KunneIkkeBeregneOgSimulereRevurdering.UgyldigBeregningsgrunnlag(it.reason)
+                                is Revurdering.KunneIkkeBeregneRevurdering.UfullstendigVilkårsvurdering -> KunneIkkeBeregneOgSimulereRevurdering.UfullstendigVilkårsvurdering
+                            }.left()
+                        }
+                ) {
+                    is BeregnetRevurdering.IngenEndring -> {
+                        revurderingRepo.lagre(beregnetRevurdering)
+                        beregnetRevurdering.right()
+                    }
+                    is BeregnetRevurdering.Innvilget -> {
+                        utbetalingService.simulerUtbetaling(
+                            sakId = beregnetRevurdering.sakId,
                             saksbehandler = saksbehandler,
-                            oppgaveId = originalRevurdering.oppgaveId,
-                            fritekstTilBrev = originalRevurdering.fritekstTilBrev,
-                            revurderingsårsak = originalRevurdering.revurderingsårsak,
-                            forhåndsvarsel = originalRevurdering.forhåndsvarsel,
-                            behandlingsinformasjon = originalRevurdering.behandlingsinformasjon,
-                            grunnlagsdata = originalRevurdering.grunnlagsdata,
-                            vilkårsvurderinger = originalRevurdering.vilkårsvurderinger,
-                        )
-                        utbetalingService.simulerOpphør(
-                            sakId = opphør.sakId,
-                            saksbehandler = opphør.saksbehandler,
-                            opphørsdato = opphør.periode.fraOgMed,
+                            beregning = beregnetRevurdering.beregning,
                         ).mapLeft {
                             KunneIkkeBeregneOgSimulereRevurdering.SimuleringFeilet
                         }.map {
-                            val simulert = opphør.toSimulert(it.simulering)
+                            val simulert = beregnetRevurdering.toSimulert(it.simulering)
                             revurderingRepo.lagre(simulert)
                             simulert
                         }
                     }
-                    Resultat.Innvilget -> {
-                        when (
-                            val beregnetRevurdering = originalRevurdering.beregn(fradrag)
-                                .getOrHandle {
-                                    return when (it) {
-                                        is Revurdering.KunneIkkeBeregneRevurdering.KanIkkeVelgeSisteMånedVedNedgangIStønaden -> KunneIkkeBeregneOgSimulereRevurdering.KanIkkeVelgeSisteMånedVedNedgangIStønaden
-                                        is Revurdering.KunneIkkeBeregneRevurdering.UfullstendigBehandlingsinformasjon -> KunneIkkeBeregneOgSimulereRevurdering.UfullstendigBehandlingsinformasjon
-                                        is Revurdering.KunneIkkeBeregneRevurdering.UgyldigBeregningsgrunnlag -> KunneIkkeBeregneOgSimulereRevurdering.UgyldigBeregningsgrunnlag(it.reason)
-                                    }.left()
-                                }
-                        ) {
-                            is BeregnetRevurdering.IngenEndring -> {
-                                revurderingRepo.lagre(beregnetRevurdering)
-                                beregnetRevurdering.right()
-                            }
-                            is BeregnetRevurdering.Innvilget -> {
-                                utbetalingService.simulerUtbetaling(
-                                    sakId = beregnetRevurdering.sakId,
-                                    saksbehandler = saksbehandler,
-                                    beregning = beregnetRevurdering.beregning,
-                                ).mapLeft {
-                                    KunneIkkeBeregneOgSimulereRevurdering.SimuleringFeilet
-                                }.map {
-                                    val simulert = beregnetRevurdering.toSimulert(it.simulering)
-                                    revurderingRepo.lagre(simulert)
-                                    simulert
-                                }
-                            }
 
-                            is BeregnetRevurdering.Opphørt -> {
-                                utbetalingService.simulerOpphør(
-                                    sakId = beregnetRevurdering.sakId,
-                                    saksbehandler = saksbehandler,
-                                    opphørsdato = beregnetRevurdering.periode.fraOgMed,
-                                ).mapLeft {
-                                    KunneIkkeBeregneOgSimulereRevurdering.SimuleringFeilet
-                                }.map {
-                                    val simulert = beregnetRevurdering.toSimulert(it.simulering)
-                                    revurderingRepo.lagre(simulert)
-                                    simulert
-                                }
-                            }
+                    is BeregnetRevurdering.Opphørt -> {
+                        utbetalingService.simulerOpphør(
+                            sakId = beregnetRevurdering.sakId,
+                            saksbehandler = saksbehandler,
+                            opphørsdato = beregnetRevurdering.periode.fraOgMed,
+                        ).mapLeft {
+                            KunneIkkeBeregneOgSimulereRevurdering.SimuleringFeilet
+                        }.map {
+                            val simulert = beregnetRevurdering.toSimulert(it.simulering)
+                            revurderingRepo.lagre(simulert)
+                            simulert
                         }
                     }
-                    Resultat.Uavklart -> return KunneIkkeBeregneOgSimulereRevurdering.UfullstendigVilkårsvurdering.left()
                 }
             }
             null -> return KunneIkkeBeregneOgSimulereRevurdering.FantIkkeRevurdering.left()

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/vilkår/LeggTilUførevurderingRequest.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/vilkår/LeggTilUførevurderingRequest.kt
@@ -31,12 +31,12 @@ data class LeggTilUførevurderingRequest(
     /**
      * @param behandlingsperiode Ved en søknadsbehandling kan det være støndadsperiode. Ved en revurdering kan det være revurderingsperioden.
      */
-    fun toVurderingsperiode(behandlingsperiode: Periode): Either<UgyldigUførevurdering, Vurderingsperiode<Grunnlag.Uføregrunnlag>> {
+    fun toVurderingsperiode(behandlingsperiode: Periode): Either<UgyldigUførevurdering, Vurderingsperiode<Grunnlag.Uføregrunnlag?>> {
         if (!(behandlingsperiode inneholder periode)) return UgyldigUførevurdering.VurderingsperiodenKanIkkeVæreUtenforBehandlingsperioden.left()
         return when (oppfylt) {
             Behandlingsinformasjon.Uførhet.Status.VilkårOppfylt -> {
                 if (uføregrad == null || forventetInntekt == null) return UgyldigUførevurdering.UføregradOgForventetInntektMangler.left()
-                Vurderingsperiode.Manuell.tryCreate(
+                Vurderingsperiode.Uføre.tryCreate(
                     resultat = Resultat.Innvilget,
                     grunnlag = Grunnlag.Uføregrunnlag(
                         periode = periode,
@@ -47,33 +47,21 @@ data class LeggTilUførevurderingRequest(
                     begrunnelse = begrunnelse,
                 )
             }
-            Behandlingsinformasjon.Uførhet.Status.VilkårIkkeOppfylt -> Vurderingsperiode.Manuell.tryCreate(
+            Behandlingsinformasjon.Uførhet.Status.VilkårIkkeOppfylt -> Vurderingsperiode.Uføre.tryCreate(
                 resultat = Resultat.Avslag,
-                grunnlag = if (uføregrad == null || forventetInntekt == null) null else {
-                    Grunnlag.Uføregrunnlag(
-                        periode = periode,
-                        uføregrad = uføregrad,
-                        forventetInntekt = forventetInntekt,
-                    )
-                },
+                grunnlag = null,
                 vurderingsperiode = periode,
                 begrunnelse = begrunnelse,
             )
-            Behandlingsinformasjon.Uførhet.Status.HarUføresakTilBehandling -> Vurderingsperiode.Manuell.tryCreate(
+            Behandlingsinformasjon.Uførhet.Status.HarUføresakTilBehandling -> Vurderingsperiode.Uføre.tryCreate(
                 resultat = Resultat.Uavklart,
-                grunnlag = if (uføregrad == null || forventetInntekt == null) null else {
-                    Grunnlag.Uføregrunnlag(
-                        periode = periode,
-                        uføregrad = uføregrad,
-                        forventetInntekt = forventetInntekt,
-                    )
-                },
+                grunnlag = null,
                 vurderingsperiode = periode,
                 begrunnelse = begrunnelse,
             )
         }.mapLeft {
             when (it) {
-                Vurderingsperiode.Manuell.UgyldigVurderingsperiode.PeriodeForGrunnlagOgVurderingErForskjellig -> UgyldigUførevurdering.PeriodeForGrunnlagOgVurderingErForskjellig
+                Vurderingsperiode.Uføre.UgyldigVurderingsperiode.PeriodeForGrunnlagOgVurderingErForskjellig -> UgyldigUførevurdering.PeriodeForGrunnlagOgVurderingErForskjellig
             }
         }
     }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RegulerGrunnbeløpServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RegulerGrunnbeløpServiceImplTest.kt
@@ -100,7 +100,7 @@ internal class RegulerGrunnbeløpServiceImplTest {
             vilkårsvurderinger = Vilkårsvurderinger(
                 uføre = Vilkår.Vurdert.Uførhet.create(
                     vurderingsperioder = Nel.of(
-                        Vurderingsperiode.Manuell.create(
+                        Vurderingsperiode.Uføre.create(
                             id = UUID.randomUUID(),
                             opprettet = fixedTidspunkt,
                             resultat = Resultat.Innvilget,
@@ -131,9 +131,11 @@ internal class RegulerGrunnbeløpServiceImplTest {
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsakRegulerGrunnbeløp,
             behandlingsinformasjon = opprettetRevurdering.behandlingsinformasjon.copy(
-                uførhet = opprettetRevurdering.behandlingsinformasjon.uførhet!!.copy(
-                    forventetInntekt = nyttUføregrunnlag.forventetInntekt,
+                uførhet = Behandlingsinformasjon.Uførhet(
+                    status = Behandlingsinformasjon.Uførhet.Status.VilkårOppfylt,
                     uføregrad = nyttUføregrunnlag.uføregrad.value,
+                    forventetInntekt = nyttUføregrunnlag.forventetInntekt,
+                    begrunnelse = "grunnbeløpet er høyere",
                 ),
             ),
             forhåndsvarsel = null,
@@ -166,7 +168,7 @@ internal class RegulerGrunnbeløpServiceImplTest {
                         uføregrad = nyttUføregrunnlag.uføregrad,
                         forventetInntekt = nyttUføregrunnlag.forventetInntekt,
                         oppfylt = Behandlingsinformasjon.Uførhet.Status.VilkårOppfylt,
-                        begrunnelse = "",
+                        begrunnelse = "grunnbeløpet er høyere",
                     ),
                 ),
             ),
@@ -265,7 +267,7 @@ internal class RegulerGrunnbeløpServiceImplTest {
             vilkårsvurderinger = Vilkårsvurderinger(
                 uføre = Vilkår.Vurdert.Uførhet.create(
                     vurderingsperioder = Nel.of(
-                        Vurderingsperiode.Manuell.create(
+                        Vurderingsperiode.Uføre.create(
                             id = UUID.randomUUID(),
                             opprettet = fixedTidspunkt,
                             resultat = Resultat.Innvilget,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
@@ -79,7 +79,7 @@ class RevurderingIngenEndringTest {
             vilkårsvurderinger = Vilkårsvurderinger(
                 uføre = Vilkår.Vurdert.Uførhet.create(
                     vurderingsperioder = Nel.of(
-                        Vurderingsperiode.Manuell.create(
+                        Vurderingsperiode.Uføre.create(
                             id = UUID.randomUUID(),
                             opprettet = fixedTidspunkt,
                             resultat = Resultat.Innvilget,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
@@ -273,7 +273,7 @@ internal class RevurderingServiceImplTest {
             vilkårsvurderinger = Vilkårsvurderinger(
                 uføre = Vilkår.Vurdert.Uførhet.create(
                     vurderingsperioder = Nel.of(
-                        Vurderingsperiode.Manuell.create(
+                        Vurderingsperiode.Uføre.create(
                             id = UUID.randomUUID(),
                             opprettet = fixedTidspunkt,
                             resultat = Resultat.Innvilget,
@@ -390,7 +390,7 @@ internal class RevurderingServiceImplTest {
             vilkårsvurderinger = Vilkårsvurderinger(
                 uføre = Vilkår.Vurdert.Uførhet.create(
                     vurderingsperioder = Nel.of(
-                        Vurderingsperiode.Manuell.create(
+                        Vurderingsperiode.Uføre.create(
                             id = UUID.randomUUID(),
                             opprettet = fixedTidspunkt,
                             resultat = Resultat.Innvilget,
@@ -880,7 +880,7 @@ internal class RevurderingServiceImplTest {
             vilkårsvurderinger = Vilkårsvurderinger(
                 uføre = Vilkår.Vurdert.Uførhet.create(
                     vurderingsperioder = Nel.of(
-                        Vurderingsperiode.Manuell.create(
+                        Vurderingsperiode.Uføre.create(
                             id = UUID.randomUUID(),
                             opprettet = fixedTidspunkt,
                             resultat = Resultat.Innvilget,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
@@ -1393,7 +1393,7 @@ internal class RevurderingServiceImplTest {
     @Test
     fun `forhåndsvarsler men hentAktørId failer`() {
         val simulertRevurdering = simulertRevurderingInnvilget.copy(
-            forhåndsvarsel = null
+            forhåndsvarsel = null,
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -1418,7 +1418,7 @@ internal class RevurderingServiceImplTest {
     @Test
     fun `forhåndsvarsler men hentPerson failer`() {
         val simulertRevurdering = simulertRevurderingInnvilget.copy(
-            forhåndsvarsel = null
+            forhåndsvarsel = null,
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -1444,7 +1444,7 @@ internal class RevurderingServiceImplTest {
     @Test
     fun `forhåndsvarsler men journalføring failer`() {
         val simulertRevurdering = simulertRevurderingInnvilget.copy(
-            forhåndsvarsel = null
+            forhåndsvarsel = null,
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -1475,7 +1475,7 @@ internal class RevurderingServiceImplTest {
     @Test
     fun `forhåndsvarsler men distribuering failer`() {
         val simulertRevurdering = simulertRevurderingInnvilget.copy(
-            forhåndsvarsel = null
+            forhåndsvarsel = null,
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -1507,7 +1507,7 @@ internal class RevurderingServiceImplTest {
     @Test
     fun `forhåndsvarsler men oppgave failer`() {
         val simulertRevurdering = simulertRevurderingInnvilget.copy(
-            forhåndsvarsel = null
+            forhåndsvarsel = null,
         )
         val revurderingRepoMock = mock<RevurderingRepo> {
             on { hent(any()) } doReturn simulertRevurdering
@@ -1794,22 +1794,7 @@ internal class RevurderingServiceImplTest {
             fradrag = emptyList(),
         ).orNull()!!
 
-        actual shouldBe SimulertRevurdering.Opphørt(
-            tilRevurdering = opprettetRevurdering.tilRevurdering,
-            id = opprettetRevurdering.id,
-            periode = opprettetRevurdering.periode,
-            opprettet = opprettetRevurdering.opprettet,
-            beregning = opprettetRevurdering.tilRevurdering.beregning,
-            simulering = simulertUtbetalingMock.simulering,
-            saksbehandler = NavIdentBruker.Saksbehandler("s1"),
-            oppgaveId = opprettetRevurdering.oppgaveId,
-            fritekstTilBrev = opprettetRevurdering.fritekstTilBrev,
-            revurderingsårsak = opprettetRevurdering.revurderingsårsak,
-            forhåndsvarsel = opprettetRevurdering.forhåndsvarsel,
-            behandlingsinformasjon = opprettetRevurdering.behandlingsinformasjon,
-            grunnlagsdata = opprettetRevurdering.grunnlagsdata,
-            vilkårsvurderinger = vilkårsvurderinger,
-        )
+        actual shouldBe beOfType<SimulertRevurdering.Opphørt>()
 
         inOrder(
             revurderingRepoMock,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingTestUtils.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingTestUtils.kt
@@ -185,7 +185,7 @@ object RevurderingTestUtils {
         forventetInntekt = 10,
     )
 
-    internal val vurderingsperiodeUføre = Vurderingsperiode.Manuell.create(
+    internal val vurderingsperiodeUføre = Vurderingsperiode.Uføre.create(
         id = UUID.randomUUID(),
         opprettet = fixedTidspunkt,
         resultat = Resultat.Avslag,

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/grunnlag/UførevilkårJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/grunnlag/UførevilkårJson.kt
@@ -15,7 +15,7 @@ internal data class UføreVilkårJson(
     val resultat: Behandlingsinformasjon.Uførhet.Status,
 )
 
-internal fun Vurderingsperiode<Grunnlag.Uføregrunnlag>.toJson() = VurderingsperiodeUføreJson(
+internal fun Vurderingsperiode<Grunnlag.Uføregrunnlag?>.toJson() = VurderingsperiodeUføreJson(
     id = id.toString(),
     opprettet = DateTimeFormatter.ISO_INSTANT.format(opprettet),
     resultat = resultat.toStatusString(),

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/LeggTilGrunnlagRevurderingRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/LeggTilGrunnlagRevurderingRoutes.kt
@@ -76,7 +76,7 @@ private data class Body(val vurderinger: List<Vurdering>) {
                 periode = periode,
                 uføregrad = validUføregrad,
                 forventetInntekt = forventetInntekt,
-                oppfylt = Behandlingsinformasjon.Uførhet.Status.VilkårOppfylt,
+                oppfylt = resultat,
                 begrunnelse = begrunnelse,
             ).right()
         }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/service/vilkår/LeggTilUførevurderingerRequestTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/service/vilkår/LeggTilUførevurderingerRequestTest.kt
@@ -197,7 +197,7 @@ internal class LeggTilUførevurderingerRequestTest {
         ).orNull()!!
         actual shouldBe Vilkår.Vurdert.Uførhet.create(
             vurderingsperioder = Nel.of(
-                Vurderingsperiode.Manuell.create(
+                Vurderingsperiode.Uføre.create(
                     id = actual.vurderingsperioder[0].id,
                     opprettet = actual.vurderingsperioder[0].opprettet,
                     resultat = Resultat.Innvilget,
@@ -211,7 +211,7 @@ internal class LeggTilUførevurderingerRequestTest {
                     periode = Periode.create(fraOgMed = 1.januar(2021), tilOgMed = 31.januar(2021)),
                     begrunnelse = null,
                 ),
-                Vurderingsperiode.Manuell.create(
+                Vurderingsperiode.Uføre.create(
                     id = actual.vurderingsperioder[1].id,
                     opprettet = actual.vurderingsperioder[1].opprettet,
                     resultat = Resultat.Innvilget,
@@ -240,7 +240,7 @@ internal class LeggTilUførevurderingerRequestTest {
                     periode = Periode.create(fraOgMed = 1.januar(2021), tilOgMed = 31.januar(2021)),
                     uføregrad = Uføregrad.parse(100),
                     forventetInntekt = 12000,
-                    oppfylt = Behandlingsinformasjon.Uførhet.Status.VilkårIkkeOppfylt,
+                    oppfylt = Behandlingsinformasjon.Uførhet.Status.VilkårOppfylt,
                     begrunnelse = null,
                 ),
                 LeggTilUførevurderingRequest(
@@ -248,7 +248,7 @@ internal class LeggTilUførevurderingerRequestTest {
                     periode = Periode.create(fraOgMed = 1.februar(2021), tilOgMed = 28.februar(2021)),
                     uføregrad = Uføregrad.parse(100),
                     forventetInntekt = 12000,
-                    oppfylt = Behandlingsinformasjon.Uførhet.Status.VilkårIkkeOppfylt,
+                    oppfylt = Behandlingsinformasjon.Uførhet.Status.VilkårOppfylt,
                     begrunnelse = null,
                 ),
             ),
@@ -260,10 +260,10 @@ internal class LeggTilUførevurderingerRequestTest {
         ).orNull()!!
         actual shouldBe Vilkår.Vurdert.Uførhet.create(
             vurderingsperioder = Nel.of(
-                Vurderingsperiode.Manuell.create(
+                Vurderingsperiode.Uføre.create(
                     id = actual.vurderingsperioder[0].id,
                     opprettet = actual.vurderingsperioder[0].opprettet,
-                    resultat = Resultat.Avslag,
+                    resultat = Resultat.Innvilget,
                     grunnlag = Grunnlag.Uføregrunnlag(
                         id = actual.vurderingsperioder[0].grunnlag!!.id,
                         opprettet = actual.vurderingsperioder[0].grunnlag!!.opprettet,
@@ -274,10 +274,10 @@ internal class LeggTilUførevurderingerRequestTest {
                     periode = Periode.create(fraOgMed = 1.januar(2021), tilOgMed = 31.januar(2021)),
                     begrunnelse = null,
                 ),
-                Vurderingsperiode.Manuell.create(
+                Vurderingsperiode.Uføre.create(
                     id = actual.vurderingsperioder[1].id,
                     opprettet = actual.vurderingsperioder[1].opprettet,
-                    resultat = Resultat.Avslag,
+                    resultat = Resultat.Innvilget,
                     grunnlag = Grunnlag.Uføregrunnlag(
                         id = actual.vurderingsperioder[1].grunnlag!!.id,
                         opprettet = actual.vurderingsperioder[1].grunnlag!!.opprettet,
@@ -290,5 +290,63 @@ internal class LeggTilUførevurderingerRequestTest {
                 ),
             ),
         )
+    }
+
+    @Test
+    fun `setter grunnlag til null dersom vilkår ikke er oppfylt`() {
+        val behandlingId = UUID.randomUUID()
+        LeggTilUførevurderingerRequest(
+            behandlingId = behandlingId,
+            vurderinger = Nel.of(
+                LeggTilUførevurderingRequest(
+                    behandlingId = behandlingId,
+                    periode = Periode.create(fraOgMed = 1.januar(2021), tilOgMed = 31.januar(2021)),
+                    uføregrad = Uføregrad.parse(100),
+                    forventetInntekt = 12000,
+                    oppfylt = Behandlingsinformasjon.Uførhet.Status.VilkårIkkeOppfylt,
+                    begrunnelse = "blah",
+                ),
+            ),
+        ).toVilkår(Periode.create(fraOgMed = 1.januar(2021), tilOgMed = 31.januar(2021))).orNull()!!.let { request ->
+            Vilkår.Vurdert.Uførhet.create(
+                vurderingsperioder = Nel.of(
+                    Vurderingsperiode.Uføre.create(
+                        id = request.vurderingsperioder[0].id,
+                        opprettet = request.vurderingsperioder[0].opprettet,
+                        resultat = Resultat.Innvilget,
+                        grunnlag = null,
+                        periode = Periode.create(fraOgMed = 1.januar(2021), tilOgMed = 31.januar(2021)),
+                        begrunnelse = "blah",
+                    ),
+                ),
+            )
+        }
+
+        LeggTilUførevurderingerRequest(
+            behandlingId = behandlingId,
+            vurderinger = Nel.of(
+                LeggTilUførevurderingRequest(
+                    behandlingId = behandlingId,
+                    periode = Periode.create(fraOgMed = 1.januar(2021), tilOgMed = 31.januar(2021)),
+                    uføregrad = Uføregrad.parse(100),
+                    forventetInntekt = 12000,
+                    oppfylt = Behandlingsinformasjon.Uførhet.Status.HarUføresakTilBehandling,
+                    begrunnelse = "blah",
+                ),
+            ),
+        ).toVilkår(Periode.create(fraOgMed = 1.januar(2021), tilOgMed = 31.januar(2021))).orNull()!!.let { request ->
+            Vilkår.Vurdert.Uførhet.create(
+                vurderingsperioder = Nel.of(
+                    Vurderingsperiode.Uføre.create(
+                        id = request.vurderingsperioder[0].id,
+                        opprettet = request.vurderingsperioder[0].opprettet,
+                        resultat = Resultat.Uavklart,
+                        grunnlag = null,
+                        periode = Periode.create(fraOgMed = 1.januar(2021), tilOgMed = 31.januar(2021)),
+                        begrunnelse = "blah",
+                    ),
+                ),
+            )
+        }
     }
 }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/grunnlag/GrunnlagsdataJsonTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/grunnlag/GrunnlagsdataJsonTest.kt
@@ -102,7 +102,7 @@ internal val grunnlagsdata = Grunnlagsdata(
     uføregrunnlag = listOf(uføregrunnlag),
 )
 
-internal val vurderingsperiodeUføre = Vurderingsperiode.Manuell.create(
+internal val vurderingsperiodeUføre = Vurderingsperiode.Uføre.create(
     id = vilkårsvurderingUføreId,
     opprettet = vilkårsvurderingUføreOpprettet,
     resultat = Resultat.Innvilget,

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BeregnOgSimulerRevurderingRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BeregnOgSimulerRevurderingRouteKtTest.kt
@@ -136,7 +136,7 @@ internal class BeregnOgSimulerRevurderingRouteKtTest {
             vilkårsvurderinger = Vilkårsvurderinger(
                 uføre = Vilkår.Vurdert.Uførhet.create(
                     vurderingsperioder = Nel.of(
-                        Vurderingsperiode.Manuell.create(
+                        Vurderingsperiode.Uføre.create(
                             resultat = Resultat.Innvilget,
                             grunnlag = uføregrunnlag,
                             periode = TestBeregning.periode,


### PR DESCRIPTION
* Oversetter avslag til null-verdier for grunnlag
* Kan plassere vurderingsperioder uten grunnlag på tidslinje
* Gjennomfører ny beregning selv om vilkår fører til opphør.
* Vis opphørsdato som fra-dato i simuleringsstub.
* Oppdaterer alle felter i behanlingsinformasjon/uførhet med informasjon fra første vurderingsperiode.