### PR TITLE
Bytt funksjonene i Fradrag's-interfacet til val's

### DIFF
--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/beregning/BeregningMapper.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/beregning/BeregningMapper.kt
@@ -1,6 +1,5 @@
 package no.nav.su.se.bakover.database.beregning
 
-import com.fasterxml.jackson.annotation.JsonAlias
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.beregning.Beregning
@@ -83,18 +82,12 @@ internal data class PersistertMånedsberegning(
 }
 
 internal data class PersistertFradrag(
-    private val fradragstype: Fradragstype,
-    private val månedsbeløp: Double,
-    private val utenlandskInntekt: UtenlandskInntekt?,
+    override val fradragstype: Fradragstype,
+    override val månedsbeløp: Double,
+    override val utenlandskInntekt: UtenlandskInntekt?,
     override val periode: Periode,
-    private val tilhører: FradragTilhører
+    override val tilhører: FradragTilhører,
 ) : Fradrag {
-    override fun getFradragstype(): Fradragstype = fradragstype
-
-    @JsonAlias("totaltFradrag")
-    override fun getMånedsbeløp(): Double = månedsbeløp
-    override fun getUtenlandskInntekt(): UtenlandskInntekt? = utenlandskInntekt
-    override fun getTilhører(): FradragTilhører = tilhører
 
     override fun equals(other: Any?) = (other as? Fradrag)?.let { this.equals(other) } ?: false
 
@@ -133,9 +126,9 @@ internal fun Månedsberegning.toSnapshot() = PersistertMånedsberegning(
 )
 
 internal fun Fradrag.toSnapshot() = PersistertFradrag(
-    fradragstype = getFradragstype(),
-    månedsbeløp = getMånedsbeløp(),
-    utenlandskInntekt = getUtenlandskInntekt(),
+    fradragstype = fradragstype,
+    månedsbeløp = månedsbeløp,
+    utenlandskInntekt = utenlandskInntekt,
     periode = periode,
-    tilhører = getTilhører()
+    tilhører = tilhører,
 )

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/beregning/BeregningMapperTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/beregning/BeregningMapperTest.kt
@@ -1,6 +1,5 @@
 package no.nav.su.se.bakover.database.beregning
 
-import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import no.nav.su.se.bakover.common.Tidspunkt
@@ -99,32 +98,6 @@ internal class BeregningMapperTest {
     }
 
     @Test
-    fun `kan deserialisere fradrag ved hjelp av alias for månedsbeløp`() {
-        //language=json
-        val json = """
-            {
-                  "fradragstype": "ForventetInntekt",
-                  "totaltFradrag": 12000.0,
-                  "utenlandskInntekt": null,
-                  "periode": {
-                    "fraOgMed": "2021-01-01",
-                    "tilOgMed": "2021-01-31"
-                  },
-                  "tilhører": "BRUKER",
-                  "begrunnelse": null
-                }
-        """.trimIndent()
-
-        objectMapper.readValue<PersistertFradrag>(json) shouldBe PersistertFradrag(
-            fradragstype = Fradragstype.ForventetInntekt,
-            månedsbeløp = 12000.0,
-            utenlandskInntekt = null,
-            periode = Periode.create(fraOgMed = 1.januar(2021), tilOgMed = 31.januar(2021)),
-            tilhører = FradragTilhører.BRUKER,
-        )
-    }
-
-    @Test
     fun `should be equal to PersistertBeregning ignoring id, opprettet and begrunnelse`() {
         val a: Beregning = createBeregning(fixedTidspunkt, "a")
         val b: Beregning = createBeregning(fixedTidspunkt.plus(1, ChronoUnit.SECONDS), "b")
@@ -160,8 +133,8 @@ internal class BeregningMapperTest {
 
 internal fun assertFradragMapping(mapped: Fradrag, original: Fradrag) {
     mapped.periode shouldBe original.periode
-    mapped.getUtenlandskInntekt() shouldBe original.getUtenlandskInntekt()
-    mapped.getMånedsbeløp() shouldBe original.getMånedsbeløp()
+    mapped.utenlandskInntekt shouldBe original.utenlandskInntekt
+    mapped.månedsbeløp shouldBe original.månedsbeløp
 }
 
 internal fun assertMånedsberegningMapping(mapped: Månedsberegning, original: Månedsberegning) {

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/beregning/TestBeregning.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/beregning/TestBeregning.kt
@@ -43,10 +43,10 @@ internal object TestMånedsberegning : Månedsberegning {
 }
 
 internal object TestFradrag : Fradrag {
-    override fun getFradragstype(): Fradragstype = Fradragstype.ForventetInntekt
-    override fun getMånedsbeløp(): Double = 12000.0
-    override fun getUtenlandskInntekt(): UtenlandskInntekt? = null
-    override fun getTilhører(): FradragTilhører = FradragTilhører.BRUKER
+    override val fradragstype: Fradragstype = Fradragstype.ForventetInntekt
+    override val månedsbeløp: Double = 12000.0
+    override val utenlandskInntekt: UtenlandskInntekt? = null
+    override val tilhører: FradragTilhører = FradragTilhører.BRUKER
     override val periode: Periode = Periode.create(1.januar(2021), 31.januar(2021))
     override fun equals(other: Any?) = (other as? Fradrag)?.let { this.equals(other) } ?: false
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Beregningsgrunnlag.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Beregningsgrunnlag.kt
@@ -64,7 +64,7 @@ internal data class Beregningsgrunnlag private constructor(
                 return UgyldigBeregningsgrunnlag.IkkeLovMedFradragUtenforPerioden.left()
             }
 
-            fradrag.filter { it.getFradragstype() == Fradragstype.ForventetInntekt && it.getTilhører() == FradragTilhører.BRUKER }.let { forventedeInntekter ->
+            fradrag.filter { it.fradragstype == Fradragstype.ForventetInntekt && it.tilhører == FradragTilhører.BRUKER }.let { forventedeInntekter ->
                 if (forventedeInntekter.count() < 1) {
                     // TODO jah: Denne kan ikke slå til så lenge vi har ifEmpty-blokka
                     return UgyldigBeregningsgrunnlag.BrukerMåHaMinst1ForventetInntekt.left()

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Månedsberegning.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Månedsberegning.kt
@@ -14,10 +14,10 @@ interface Månedsberegning : PeriodisertInformasjon {
     fun getFribeløpForEps(): Double
 
     fun erFradragForEpsBenyttetIBeregning() =
-        getFradrag().any { it.getFradragstype() == Fradragstype.BeregnetFradragEPS }
+        getFradrag().any { it.fradragstype == Fradragstype.BeregnetFradragEPS }
 
     fun erSumYtelseUnderMinstebeløp() =
-        getSumYtelse() == 0 && getFradrag().any { it.getFradragstype() == Fradragstype.UnderMinstenivå }
+        getSumYtelse() == 0 && getFradrag().any { it.fradragstype == Fradragstype.UnderMinstenivå }
 
     /**
      * Sammenligner alle metodene.

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/PeriodisertBeregning.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/PeriodisertBeregning.kt
@@ -23,7 +23,7 @@ internal data class PeriodisertBeregning(
         .roundToInt()
 
     override fun getSumFradrag() = fradrag
-        .sumOf { it.getMånedsbeløp() }
+        .sumOf { it.månedsbeløp }
         .limitedUpwardsTo(getSatsbeløp())
 
     override fun getBenyttetGrunnbeløp(): Int = Grunnbeløp.`1G`.fraDato(periode.fraOgMed).toInt()

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/RevurdertBeregning.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/RevurdertBeregning.kt
@@ -66,8 +66,8 @@ private fun beregnMedVirkningFraOgMedMånedenEtter(
             }
             .map {
                 FradragFactory.ny(
-                    type = it.getFradragstype(),
-                    månedsbeløp = it.getMånedsbeløp(),
+                    type = it.fradragstype,
+                    månedsbeløp = it.månedsbeløp,
                     periode = Periode.create(
                         fraOgMed = it.periode.fraOgMed.let { fraOgMed ->
                             if (fraOgMed == revurdertBeregning.periode.fraOgMed) {
@@ -78,8 +78,8 @@ private fun beregnMedVirkningFraOgMedMånedenEtter(
                         },
                         tilOgMed = it.periode.tilOgMed
                     ),
-                    utenlandskInntekt = it.getUtenlandskInntekt(),
-                    tilhører = it.getTilhører(),
+                    utenlandskInntekt = it.utenlandskInntekt,
+                    tilhører = it.tilhører,
                 )
             },
         fradragStrategy = FradragStrategy.fromName(revurdertBeregning.getFradragStrategyName()),

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/SlåSammenEkvivalenteMånedsberegningerTilBeregningsperioder.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/SlåSammenEkvivalenteMånedsberegningerTilBeregningsperioder.kt
@@ -56,10 +56,10 @@ internal data class SlåSammenEkvivalenteMånedsberegningerTilBeregningsperioder
             this.getFradrag().likeFradrag(other.getFradrag())
 
     private infix fun Fradrag.likhetUtenDato(other: Fradrag): Boolean =
-        this.getFradragstype() == other.getFradragstype() &&
-            this.getMånedsbeløp() == other.getMånedsbeløp() &&
-            this.getUtenlandskInntekt() == other.getUtenlandskInntekt() &&
-            this.getTilhører() == other.getTilhører()
+        this.fradragstype == other.fradragstype &&
+            this.månedsbeløp == other.månedsbeløp &&
+            this.utenlandskInntekt == other.utenlandskInntekt &&
+            this.tilhører == other.tilhører
 
     private infix fun List<Fradrag>.likeFradrag(other: List<Fradrag>): Boolean {
         if (this.size != other.size) return false
@@ -72,9 +72,9 @@ internal data class SlåSammenEkvivalenteMånedsberegningerTilBeregningsperioder
         .sortedBy { it.periode.fraOgMed }
 
     private fun List<Fradrag>.sorterFradrag() = this
-        .sortedBy { it.getMånedsbeløp() }
-        .sortedBy { it.getFradragstype() }
-        .sortedBy { it.getTilhører() }
+        .sortedBy { it.månedsbeløp }
+        .sortedBy { it.fradragstype }
+        .sortedBy { it.tilhører }
 }
 
 /**

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/Fradrag.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/Fradrag.kt
@@ -6,10 +6,10 @@ import arrow.core.right
 import no.nav.su.se.bakover.common.periode.PeriodisertInformasjon
 
 interface Fradrag : PeriodisertInformasjon {
-    fun getFradragstype(): Fradragstype
-    fun getMånedsbeløp(): Double
-    fun getUtenlandskInntekt(): UtenlandskInntekt? // TODO can we pls do something about this one?
-    fun getTilhører(): FradragTilhører
+    val fradragstype: Fradragstype
+    val månedsbeløp: Double
+    val utenlandskInntekt: UtenlandskInntekt? // TODO can we pls do something about this one?
+    val tilhører: FradragTilhører
 
     /**
      * Sammenligner alle metodene.
@@ -19,10 +19,10 @@ interface Fradrag : PeriodisertInformasjon {
         if (this === other) return true
         if (other == null) return false
 
-        if (getFradragstype() != other.getFradragstype()) return false
-        if (getMånedsbeløp() != other.getMånedsbeløp()) return false
-        if (getUtenlandskInntekt() != other.getUtenlandskInntekt()) return false
-        if (getTilhører() != other.getTilhører()) return false
+        if (fradragstype != other.fradragstype) return false
+        if (månedsbeløp != other.månedsbeløp) return false
+        if (utenlandskInntekt != other.utenlandskInntekt) return false
+        if (tilhører != other.tilhører) return false
         return true
     }
 

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/FradragFactory.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/FradragFactory.kt
@@ -22,11 +22,11 @@ object FradragFactory {
     fun periodiser(fradrag: Fradrag): List<Fradrag> =
         fradrag.periode.tilMånedsperioder().map {
             PeriodisertFradrag(
-                type = fradrag.getFradragstype(),
-                månedsbeløp = fradrag.getMånedsbeløp(),
+                type = fradrag.fradragstype,
+                månedsbeløp = fradrag.månedsbeløp,
                 periode = it,
-                utenlandskInntekt = fradrag.getUtenlandskInntekt(),
-                tilhører = fradrag.getTilhører()
+                utenlandskInntekt = fradrag.utenlandskInntekt,
+                tilhører = fradrag.tilhører
             )
         }
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/IkkePeriodisertFradrag.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/IkkePeriodisertFradrag.kt
@@ -4,19 +4,16 @@ import no.nav.su.se.bakover.common.periode.Periode
 
 internal data class IkkePeriodisertFradrag(
     private val type: Fradragstype,
-    private val månedsbeløp: Double,
+    override val månedsbeløp: Double,
     override val periode: Periode,
-    private val utenlandskInntekt: UtenlandskInntekt? = null,
-    private val tilhører: FradragTilhører
+    override val utenlandskInntekt: UtenlandskInntekt? = null,
+    override val tilhører: FradragTilhører,
 ) : Fradrag {
     init {
         require(månedsbeløp >= 0) { "Fradrag kan ikke være negative" }
     }
 
-    override fun getTilhører(): FradragTilhører = tilhører
-    override fun getFradragstype(): Fradragstype = type
-    override fun getMånedsbeløp(): Double = månedsbeløp
-    override fun getUtenlandskInntekt(): UtenlandskInntekt? = utenlandskInntekt
+    override val fradragstype: Fradragstype = type
 
     override fun equals(other: Any?) = (other as? Fradrag)?.let { this.equals(other) } ?: false
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/PeriodisertFradrag.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/PeriodisertFradrag.kt
@@ -4,20 +4,17 @@ import no.nav.su.se.bakover.common.periode.Periode
 
 internal data class PeriodisertFradrag(
     private val type: Fradragstype,
-    private val månedsbeløp: Double,
+    override val månedsbeløp: Double,
     override val periode: Periode,
-    private val utenlandskInntekt: UtenlandskInntekt? = null,
-    private val tilhører: FradragTilhører
+    override val utenlandskInntekt: UtenlandskInntekt? = null,
+    override val tilhører: FradragTilhører
 ) : Fradrag {
     init {
         require(månedsbeløp >= 0) { "Fradrag kan ikke være negative" }
         require(periode.getAntallMåneder() == 1) { "Periodiserte fradrag kan bare gjelde for en enkelt måned" }
     }
 
-    override fun getTilhører(): FradragTilhører = tilhører
-    override fun getFradragstype(): Fradragstype = type
-    override fun getMånedsbeløp(): Double = månedsbeløp
-    override fun getUtenlandskInntekt(): UtenlandskInntekt? = utenlandskInntekt
+    override val fradragstype: Fradragstype = type
 
     override fun equals(other: Any?) = (other as? Fradrag)?.let { this.equals(other) } ?: false
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/beregning/FradragsMapper.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/beregning/FradragsMapper.kt
@@ -10,8 +10,8 @@ internal data class BrukerFradragBenyttetIBeregningsperiode(
     private val fradragForBeregningsperiode: List<Fradrag>
 ) {
     val fradrag: List<Månedsfradrag> = fradragForBeregningsperiode
-        .filter { it.getTilhører() == FradragTilhører.BRUKER }
-        .filter { it.getMånedsbeløp() > 0 }
+        .filter { it.tilhører == FradragTilhører.BRUKER }
+        .filter { it.månedsbeløp > 0 }
         .toMånedsfradragPerType()
 }
 
@@ -20,20 +20,20 @@ internal data class EpsFradragFraSaksbehandlerIBeregningsperiode(
     private val beregningsperiode: Periode
 ) {
     val fradrag: List<Månedsfradrag> = fradragFraSaksbehandler
-        .filter { it.getTilhører() == FradragTilhører.EPS }
+        .filter { it.tilhører == FradragTilhører.EPS }
         .fradragStørreEnn0IPeriode(beregningsperiode)
 }
 
 internal fun List<Fradrag>.fradragStørreEnn0IPeriode(periode: Periode) =
     this.filter { it.periode inneholder periode }
-        .filter { it.getMånedsbeløp() > 0 }
+        .filter { it.månedsbeløp > 0 }
         .toMånedsfradragPerType()
 
 internal fun List<Fradrag>.toMånedsfradragPerType(): List<Månedsfradrag> =
     this
         .groupBy {
-            "${it.getFradragstype()}${
-            it.getUtenlandskInntekt()
+            "${it.fradragstype}${
+            it.utenlandskInntekt
                 ?.let { u ->
                     "${u.valuta}${u.beløpIUtenlandskValuta}"
                 }
@@ -42,14 +42,14 @@ internal fun List<Fradrag>.toMånedsfradragPerType(): List<Månedsfradrag> =
         .map { (_, fradrag) ->
             Månedsfradrag(
                 type = fradrag[0]
-                    .getFradragstype()
+                    .fradragstype
                     .toReadableTypeName(
-                        utenlandsk = fradrag[0].getUtenlandskInntekt() != null
+                        utenlandsk = fradrag[0].utenlandskInntekt != null
                     ),
                 beløp = fradrag
-                    .sumOf { it.getMånedsbeløp() }
+                    .sumOf { it.månedsbeløp }
                     .roundToInt(),
-                utenlandskInntekt = fradrag[0].getUtenlandskInntekt()
+                utenlandskInntekt = fradrag[0].utenlandskInntekt
             )
         }
         .sortedBy { it.type }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/VurderOmBeregningHarEndringerIYtelseTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/VurderOmBeregningHarEndringerIYtelseTest.kt
@@ -83,7 +83,7 @@ internal class VurderOmBeregningHarEndringerIYtelseTest {
     fun `skal bli true for en nyBeregning som ikke er ett subset av en tidlegereBeregning`() {
         val nyOgEndretBeregning = nyBeregning.copy(
             fradrag = nyBeregning.getFradrag()
-                .map { (it as IkkePeriodisertFradrag).copy(månedsbeløp = it.getMånedsbeløp() + 1) },
+                .map { (it as IkkePeriodisertFradrag).copy(månedsbeløp = it.månedsbeløp + 1) },
         )
 
         VurderOmBeregningHarEndringerIYtelse(tidligereBeregning, nyOgEndretBeregning).resultat shouldBe true

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/beregning/BeregningMedFradragBeregnetMånedsvisTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/beregning/BeregningMedFradragBeregnetMånedsvisTest.kt
@@ -168,7 +168,7 @@ internal class BeregningMedFradragBeregnetMånedsvisTest {
         val (janAprUnderMinstenivå, janAprAndre) = beregning.getMånedsberegninger()
             .flatMap { it.getFradrag() }
             .filter { Periode.create(1.januar(2020), 30.april(2020)) inneholder it.periode }
-            .partition { it.getFradragstype() == Fradragstype.UnderMinstenivå }
+            .partition { it.fradragstype == Fradragstype.UnderMinstenivå }
 
         janAprUnderMinstenivå shouldHaveSize 4
         janAprUnderMinstenivå.forEach {
@@ -194,7 +194,7 @@ internal class BeregningMedFradragBeregnetMånedsvisTest {
         val (maiDesUnderMinstenivå, maiDesAndre) = beregning.getMånedsberegninger()
             .flatMap { it.getFradrag() }
             .filter { Periode.create(1.mai(2020), 31.desember(2020)) inneholder it.periode }
-            .partition { it.getFradragstype() == Fradragstype.UnderMinstenivå }
+            .partition { it.fradragstype == Fradragstype.UnderMinstenivå }
 
         maiDesUnderMinstenivå shouldHaveSize 0
         maiDesAndre shouldHaveSize 8

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/EnsligStrategyTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/EnsligStrategyTest.kt
@@ -34,7 +34,7 @@ internal class EnsligStrategyTest {
                 expectedArbeidsinntekt,
                 expectedKontantstøtte
             )
-            it.values.forEach { it.none { it.getFradragstype() == ForventetInntekt } }
+            it.values.forEach { it.none { it.fradragstype == ForventetInntekt } }
         }
     }
 
@@ -59,7 +59,7 @@ internal class EnsligStrategyTest {
                 expectedForventetInntekt,
                 expectedKontantstøtte
             )
-            it.values.forEach { it.none { it.getFradragstype() == Arbeidsinntekt } }
+            it.values.forEach { it.none { it.fradragstype == Arbeidsinntekt } }
         }
     }
 
@@ -74,7 +74,7 @@ internal class EnsligStrategyTest {
             fradrag = listOf(arbeidsinntekt, kontantstøtte, forventetInntekt),
             beregningsperiode = periode
         ).let {
-            it.values.forEach { it.none { it.getTilhører() == FradragTilhører.EPS } }
+            it.values.forEach { it.none { it.tilhører == FradragTilhører.EPS } }
         }
     }
 

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/EpsOver67StrategyTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/EpsOver67StrategyTest.kt
@@ -123,7 +123,7 @@ internal class EpsOver67StrategyTest {
         ).let {
             it shouldHaveSize 4
             it.values.forEach {
-                it.filter { it.getTilhører() == EPS }.all { it.getFradragstype() == BeregnetFradragEPS }
+                it.filter { it.tilhører == EPS }.all { it.fradragstype == BeregnetFradragEPS }
             }
         }
     }
@@ -139,8 +139,8 @@ internal class EpsOver67StrategyTest {
             beregningsperiode = periode
         ).let {
             it shouldHaveSize 12
-            it.values.forEach { it.sumOf { it.getMånedsbeløp() } shouldBe arbeidsinntekt.getMånedsbeløp() }
-            it.values.forEach { it.none { it.getTilhører() == EPS } shouldBe true }
+            it.values.forEach { it.sumOf { it.månedsbeløp } shouldBe arbeidsinntekt.månedsbeløp }
+            it.values.forEach { it.none { it.tilhører == EPS } shouldBe true }
         }
     }
 }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/EpsUnder67OgUførFlyktningStrategyTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/EpsUnder67OgUførFlyktningStrategyTest.kt
@@ -120,8 +120,8 @@ internal class EpsUnder67OgUførFlyktningStrategyTest {
         ).let {
             it shouldHaveSize 4
             it.values.forEach {
-                it.filter { it.getTilhører() == EPS }
-                    .all { it.getFradragstype() == BeregnetFradragEPS }
+                it.filter { it.tilhører == EPS }
+                    .all { it.fradragstype == BeregnetFradragEPS }
             }
         }
     }
@@ -135,7 +135,7 @@ internal class EpsUnder67OgUførFlyktningStrategyTest {
 
         val expectedBeregnetEpsFradrag = lagPeriodisertFradrag(
             type = BeregnetFradragEPS,
-            beløp = (epsKapitalinntekt.getMånedsbeløp() + epsPrivatPensjon.getMånedsbeløp() - 18973.02),
+            beløp = (epsKapitalinntekt.månedsbeløp + epsPrivatPensjon.månedsbeløp - 18973.02),
             periode,
             tilhører = EPS
         )
@@ -162,8 +162,8 @@ internal class EpsUnder67OgUførFlyktningStrategyTest {
             beregningsperiode = periode
         ).let {
             it shouldHaveSize 12
-            it.values.forEach { it.sumOf { it.getMånedsbeløp() } shouldBe arbeidsinntekt.getMånedsbeløp() }
-            it.values.forEach { it.none { it.getTilhører() == EPS } shouldBe true }
+            it.values.forEach { it.sumOf { it.månedsbeløp } shouldBe arbeidsinntekt.månedsbeløp }
+            it.values.forEach { it.none { it.tilhører == EPS } shouldBe true }
         }
     }
 }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/EpsUnder67Test.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/EpsUnder67Test.kt
@@ -39,7 +39,7 @@ internal class EpsUnder67Test {
                 expectedArbeidsinntekt,
                 expectedKontantstøtte
             )
-            it.values.forEach { it.none { it.getFradragstype() == ForventetInntekt } }
+            it.values.forEach { it.none { it.fradragstype == ForventetInntekt } }
         }
     }
 
@@ -64,7 +64,7 @@ internal class EpsUnder67Test {
                 expectedForventetInntekt,
                 expectedKontantstøtte
             )
-            it.values.forEach { it.none { it.getFradragstype() == Arbeidsinntekt } }
+            it.values.forEach { it.none { it.fradragstype == Arbeidsinntekt } }
         }
     }
 
@@ -89,8 +89,8 @@ internal class EpsUnder67Test {
                 expectedBrukerInntekt,
                 expectedEpsInntekt
             )
-            it.values.forEach { it.any { it.getTilhører() == BRUKER } shouldBe true }
-            it.values.forEach { it.any { it.getTilhører() == EPS } shouldBe true }
+            it.values.forEach { it.any { it.tilhører == BRUKER } shouldBe true }
+            it.values.forEach { it.any { it.tilhører == EPS } shouldBe true }
         }
     }
 
@@ -117,9 +117,9 @@ internal class EpsUnder67Test {
         ).let { fradrag ->
             fradrag.size shouldBe 12
             fradrag.values.forEach { alleFradrag ->
-                alleFradrag.filter { it.getTilhører() == EPS }.let { epsFradrag ->
+                alleFradrag.filter { it.tilhører == EPS }.let { epsFradrag ->
                     epsFradrag shouldHaveSize 1
-                    epsFradrag.all { it.getFradragstype() == BeregnetFradragEPS } shouldBe true
+                    epsFradrag.all { it.fradragstype == BeregnetFradragEPS } shouldBe true
                 }
             }
         }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/IkkePeriodisertFradragTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/fradrag/IkkePeriodisertFradragTest.kt
@@ -29,7 +29,7 @@ internal class IkkePeriodisertFradragTest {
             periode = Periode.create(1.januar(2020), 31.januar(2020)),
             tilhører = FradragTilhører.BRUKER
         )
-        f1.getMånedsbeløp() shouldBe 12000.0
+        f1.månedsbeløp shouldBe 12000.0
 
         val f2 = FradragFactory.ny(
             type = Fradragstype.Arbeidsinntekt,
@@ -37,7 +37,7 @@ internal class IkkePeriodisertFradragTest {
             periode = Periode.create(1.januar(2020), 31.desember(2020)),
             tilhører = FradragTilhører.BRUKER
         )
-        f2.getMånedsbeløp() shouldBe 12000.0
+        f2.månedsbeløp shouldBe 12000.0
     }
 
     @Test

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/beregning/TestBeregning.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/beregning/TestBeregning.kt
@@ -70,10 +70,10 @@ internal object TestMånedsberegningSomGirOpphør : Månedsberegning {
 }
 
 internal object TestFradrag : Fradrag {
-    override fun getFradragstype(): Fradragstype = Fradragstype.ForventetInntekt
-    override fun getMånedsbeløp(): Double = 12000.0
-    override fun getUtenlandskInntekt(): UtenlandskInntekt? = null
-    override fun getTilhører(): FradragTilhører = FradragTilhører.BRUKER
+    override val fradragstype: Fradragstype = Fradragstype.ForventetInntekt
+    override val månedsbeløp: Double = 12000.0
+    override val utenlandskInntekt: UtenlandskInntekt? = null
+    override val tilhører: FradragTilhører = FradragTilhører.BRUKER
     override val periode: Periode = Periode.create(1.januar(2020), 31.januar(2020))
     override fun equals(other: Any?) = (other as? Fradrag)?.let { this.equals(other) } ?: false
 }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RegulerGrunnbeløpServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RegulerGrunnbeløpServiceImplTest.kt
@@ -206,10 +206,10 @@ internal class RegulerGrunnbeløpServiceImplTest {
             ),
         )
         val fradrag = object : Fradrag {
-            override fun getFradragstype() = Fradragstype.ForventetInntekt
-            override fun getMånedsbeløp() = 1000.0
-            override fun getUtenlandskInntekt(): UtenlandskInntekt? = null
-            override fun getTilhører() = FradragTilhører.BRUKER
+            override val fradragstype = Fradragstype.ForventetInntekt
+            override val månedsbeløp = 1000.0
+            override val utenlandskInntekt: UtenlandskInntekt? = null
+            override val tilhører = FradragTilhører.BRUKER
             override val periode = Periode.create(1.januar(2020), 31.januar(2020))
             override fun equals(other: Any?) =
                 throw IllegalStateException("Skal ikke kalles fra testen")

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/beregning/BeregningJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/beregning/BeregningJson.kt
@@ -19,7 +19,7 @@ internal data class BeregningJson(
 
 internal fun Beregning.toJson(): BeregningJson {
     val epsInputFradragMap = getFradrag()
-        .filter { it.getTilhører() == FradragTilhører.EPS }
+        .filter { it.tilhører == FradragTilhører.EPS }
         .flatMap { FradragFactory.periodiser(it) }
         .groupBy { it.periode }
 

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/beregning/FradragJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/beregning/FradragJson.kt
@@ -53,11 +53,11 @@ internal data class FradragJson(
         fun List<Fradrag>.toJson(): List<FradragJson> {
             return this.map {
                 FradragJson(
-                    type = it.getFradragstype().toString(),
-                    beløp = it.getMånedsbeløp(),
-                    utenlandskInntekt = it.getUtenlandskInntekt()?.toJson(),
+                    type = it.fradragstype.toString(),
+                    beløp = it.månedsbeløp,
+                    utenlandskInntekt = it.utenlandskInntekt?.toJson(),
                     periode = it.periode.toJson(),
-                    tilhører = it.getTilhører().toString()
+                    tilhører = it.tilhører.toString()
                 )
             }
         }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/beregning/BeregningTestUtils.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/beregning/BeregningTestUtils.kt
@@ -45,19 +45,19 @@ internal object TestMånedsberegning : Månedsberegning {
 }
 
 internal object TestFradrag : Fradrag {
-    override fun getFradragstype(): Fradragstype = Fradragstype.Arbeidsinntekt
-    override fun getMånedsbeløp(): Double = 1000.0
-    override fun getUtenlandskInntekt(): UtenlandskInntekt? = null
-    override fun getTilhører(): FradragTilhører = FradragTilhører.BRUKER
+    override val fradragstype: Fradragstype = Fradragstype.Arbeidsinntekt
+    override val månedsbeløp: Double = 1000.0
+    override val utenlandskInntekt: UtenlandskInntekt? = null
+    override val tilhører: FradragTilhører = FradragTilhører.BRUKER
     override val periode: Periode = Periode.create(1.august(2020), 31.august(2020))
     override fun equals(other: Any?) = (other as? Fradrag)?.let { this.equals(other) } ?: false
 }
 
 internal object TestFradragEps : Fradrag {
-    override fun getFradragstype(): Fradragstype = Fradragstype.Arbeidsinntekt
-    override fun getMånedsbeløp(): Double = 20000.0
-    override fun getUtenlandskInntekt(): UtenlandskInntekt? = null
-    override fun getTilhører(): FradragTilhører = FradragTilhører.EPS
+    override val fradragstype: Fradragstype = Fradragstype.Arbeidsinntekt
+    override val månedsbeløp: Double = 20000.0
+    override val utenlandskInntekt: UtenlandskInntekt? = null
+    override val tilhører: FradragTilhører = FradragTilhører.EPS
     override val periode: Periode = Periode.create(1.august(2020), 31.august(2020))
     override fun equals(other: Any?) = (other as? Fradrag)?.let { this.equals(other) } ?: false
 }


### PR DESCRIPTION
Har tatt en titt i produksjonsdatabasen med spørringen: `select beregning-> ‘fradrag’ from behandling where beregning is not null and beregning::text like ‘%total%’;` som ga 0 rows