### PR TITLE
Bare vis beregning i opphørsbrev hvor det er relevant

### DIFF
--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/LagBrevRequest.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/LagBrevRequest.kt
@@ -92,7 +92,10 @@ interface LagBrevRequest {
                 satsBeløp = beregning.getSats().månedsbeløpSomHeltall(beregning.periode.tilOgMed),
                 satsGjeldendeFraDato = beregning.getSats().datoForSisteEndringAvSats(beregning.periode.tilOgMed).ddMMyyyy(),
                 harEktefelle = behandlingsinformasjon.harEktefelle(),
-                beregningsperioder = LagBrevinnholdForBeregning(beregning).brevInnhold,
+                beregningsperioder = if (
+                    opphørsgrunner.contains(Opphørsgrunn.FOR_HØY_INNTEKT) ||
+                    opphørsgrunner.contains(Opphørsgrunn.SU_UNDER_MINSTEGRENSE)
+                ) LagBrevinnholdForBeregning(beregning).brevInnhold else emptyList(),
                 saksbehandlerNavn = saksbehandlerNavn,
                 attestantNavn = attestantNavn,
                 fritekst = fritekst,


### PR DESCRIPTION
Quickwin som ikke gjør noe med at vi burde omstrukturere hvordan vi bygger brev-DTOene våre.