### PR TITLE
Ny logikk for opphør ved revurdering

### DIFF
--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Beregning.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/beregning/Beregning.kt
@@ -39,4 +39,7 @@ interface Beregning : PeriodisertInformasjon {
      * Denne vil tvinge sub-klassene til å override.
      */
     override fun equals(other: Any?): Boolean
+
+    fun alleMånederErUnderMinstebeløp(): Boolean = getMånedsberegninger().all { it.erSumYtelseUnderMinstebeløp() }
+    fun alleMånederHarBeløpLik0(): Boolean = getMånedsberegninger().all { it.getSumYtelse() == 0 }
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/Simulering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/Simulering.kt
@@ -15,6 +15,8 @@ data class Simulering(
     fun bruttoYtelse() = periodeList
         .sumOf { it.bruttoYtelse() }
 
+    fun harFeilutbetalinger() = TolketSimulering(this).simulertePerioder.any { it.harFeilutbetalinger() }
+
     override fun equals(other: Any?) = other is Simulering &&
         other.gjelderId == this.gjelderId &&
         other.gjelderNavn == this.gjelderNavn &&

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/IdentifiserSaksbehandlingsutfallSomIkkeStøttes.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/IdentifiserSaksbehandlingsutfallSomIkkeStøttes.kt
@@ -13,34 +13,34 @@ data class IdentifiserSaksbehandlingsutfallSomIkkeStøttes(
     val tidligereBeregning: Beregning,
     val nyBeregning: Beregning,
 ) {
-    val resultat: Either<Set<SaksbehandlingsutfallSomIkkeStøttes>, Unit> = VurderOpphørVedRevurdering(vilkårsvurderinger, nyBeregning).resultat.let { opphørVedRevurdering ->
-        val utfall = mutableSetOf<SaksbehandlingsutfallSomIkkeStøttes>()
+    val resultat: Either<Set<RevurderingsutfallSomIkkeStøttes>, Unit> = VurderOpphørVedRevurdering(vilkårsvurderinger, nyBeregning).resultat.let { opphørVedRevurdering ->
+        val utfall = mutableSetOf<RevurderingsutfallSomIkkeStøttes>()
         when (opphørVedRevurdering) {
             is OpphørVedRevurdering.Ja -> {
                 if (opphørVedRevurdering.grunn.count() > 1) {
-                    utfall.add(SaksbehandlingsutfallSomIkkeStøttes.OpphørAvFlereVilkår)
+                    utfall.add(RevurderingsutfallSomIkkeStøttes.OpphørAvFlereVilkår)
                 }
                 if (!opphørVedRevurdering.opphørsdatoErTidligesteDatoIRevurdering()) {
-                    utfall.add(SaksbehandlingsutfallSomIkkeStøttes.OpphørErIkkeFraFørsteMåned)
+                    utfall.add(RevurderingsutfallSomIkkeStøttes.OpphørErIkkeFraFørsteMåned)
                 }
                 if (setOf(Opphørsgrunn.SU_UNDER_MINSTEGRENSE).containsAll(opphørVedRevurdering.grunn)) {
                     if (harAndreBeløpsendringerEnnMånederUnderMinstegrense()) {
-                        utfall.add(SaksbehandlingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon)
+                        utfall.add(RevurderingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon)
                     }
                     if (!fullstendigOpphør()) {
-                        utfall.add(SaksbehandlingsutfallSomIkkeStøttes.DelvisOpphør)
+                        utfall.add(RevurderingsutfallSomIkkeStøttes.DelvisOpphør)
                     }
                 }
                 if (setOf(Opphørsgrunn.FOR_HØY_INNTEKT).containsAll(opphørVedRevurdering.grunn)) {
                     if (harAndreBeløpsendringerEnnMånederMedBeløp0()) {
-                        utfall.add(SaksbehandlingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon)
+                        utfall.add(RevurderingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon)
                     }
                     if (!fullstendigOpphør()) {
-                        utfall.add(SaksbehandlingsutfallSomIkkeStøttes.DelvisOpphør)
+                        utfall.add(RevurderingsutfallSomIkkeStøttes.DelvisOpphør)
                     }
                 }
                 if (setOf(Opphørsgrunn.UFØRHET).containsAll(opphørVedRevurdering.grunn) && harBeløpsendringer(nyBeregning.getMånedsberegninger())) {
-                    utfall.add(SaksbehandlingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon)
+                    utfall.add(RevurderingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon)
                 }
                 if (utfall.isEmpty()) Unit.right() else utfall.left()
             }
@@ -71,9 +71,9 @@ data class IdentifiserSaksbehandlingsutfallSomIkkeStøttes(
     }
 }
 
-sealed class SaksbehandlingsutfallSomIkkeStøttes {
-    object OpphørOgAndreEndringerIKombinasjon : SaksbehandlingsutfallSomIkkeStøttes()
-    object OpphørErIkkeFraFørsteMåned : SaksbehandlingsutfallSomIkkeStøttes()
-    object DelvisOpphør : SaksbehandlingsutfallSomIkkeStøttes()
-    object OpphørAvFlereVilkår : SaksbehandlingsutfallSomIkkeStøttes()
+sealed class RevurderingsutfallSomIkkeStøttes {
+    object OpphørOgAndreEndringerIKombinasjon : RevurderingsutfallSomIkkeStøttes()
+    object OpphørErIkkeFraFørsteMåned : RevurderingsutfallSomIkkeStøttes()
+    object DelvisOpphør : RevurderingsutfallSomIkkeStøttes()
+    object OpphørAvFlereVilkår : RevurderingsutfallSomIkkeStøttes()
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/IdentifiserSaksbehandlingsutfallSomIkkeStøttes.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/IdentifiserSaksbehandlingsutfallSomIkkeStøttes.kt
@@ -1,0 +1,79 @@
+package no.nav.su.se.bakover.domain.revurdering
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import no.nav.su.se.bakover.domain.behandling.avslag.Opphørsgrunn
+import no.nav.su.se.bakover.domain.beregning.Beregning
+import no.nav.su.se.bakover.domain.beregning.Månedsberegning
+import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
+
+data class IdentifiserSaksbehandlingsutfallSomIkkeStøttes(
+    val vilkårsvurderinger: Vilkårsvurderinger,
+    val tidligereBeregning: Beregning,
+    val nyBeregning: Beregning,
+) {
+    val resultat: Either<Set<SaksbehandlingsutfallSomIkkeStøttes>, Unit> = VurderOpphørVedRevurdering(vilkårsvurderinger, nyBeregning).resultat.let { opphørVedRevurdering ->
+        val utfall = mutableSetOf<SaksbehandlingsutfallSomIkkeStøttes>()
+        when (opphørVedRevurdering) {
+            is OpphørVedRevurdering.Ja -> {
+                if (opphørVedRevurdering.grunn.count() > 1) {
+                    utfall.add(SaksbehandlingsutfallSomIkkeStøttes.OpphørAvFlereVilkår)
+                }
+                if (!opphørVedRevurdering.opphørsdatoErTidligesteDatoIRevurdering()) {
+                    utfall.add(SaksbehandlingsutfallSomIkkeStøttes.OpphørErIkkeFraFørsteMåned)
+                }
+                if (setOf(Opphørsgrunn.SU_UNDER_MINSTEGRENSE).containsAll(opphørVedRevurdering.grunn)) {
+                    if (harAndreBeløpsendringerEnnMånederUnderMinstegrense()) {
+                        utfall.add(SaksbehandlingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon)
+                    }
+                    if (!fullstendigOpphør()) {
+                        utfall.add(SaksbehandlingsutfallSomIkkeStøttes.DelvisOpphør)
+                    }
+                }
+                if (setOf(Opphørsgrunn.FOR_HØY_INNTEKT).containsAll(opphørVedRevurdering.grunn)) {
+                    if (harAndreBeløpsendringerEnnMånederMedBeløp0()) {
+                        utfall.add(SaksbehandlingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon)
+                    }
+                    if (!fullstendigOpphør()) {
+                        utfall.add(SaksbehandlingsutfallSomIkkeStøttes.DelvisOpphør)
+                    }
+                }
+                if (setOf(Opphørsgrunn.UFØRHET).containsAll(opphørVedRevurdering.grunn) && harBeløpsendringer(nyBeregning.getMånedsberegninger())) {
+                    utfall.add(SaksbehandlingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon)
+                }
+                if (utfall.isEmpty()) Unit.right() else utfall.left()
+            }
+            OpphørVedRevurdering.Nei -> Unit.right()
+        }
+    }
+
+    private fun fullstendigOpphør(): Boolean {
+        return nyBeregning.getMånedsberegninger().all { it.erSumYtelseUnderMinstebeløp() } || nyBeregning.getMånedsberegninger().all { it.getSumYtelse() == 0 }
+    }
+
+    private fun harAndreBeløpsendringerEnnMånederUnderMinstegrense(): Boolean {
+        return harBeløpsendringer(nyBeregning.getMånedsberegninger().filterNot { it.erSumYtelseUnderMinstebeløp() })
+    }
+
+    private fun harAndreBeløpsendringerEnnMånederMedBeløp0(): Boolean {
+        return harBeløpsendringer(nyBeregning.getMånedsberegninger().filterNot { !it.erSumYtelseUnderMinstebeløp() && it.getSumYtelse() == 0 })
+    }
+
+    private fun harBeløpsendringer(nyeMånedsberegninger: List<Månedsberegning>): Boolean {
+        return tidligereBeregning.getMånedsberegninger().associate { it.periode to it.getSumYtelse() }.let { tidligereMånederOgBeløp ->
+            nyeMånedsberegninger.any { tidligereMånederOgBeløp[it.periode] != it.getSumYtelse() }
+        }
+    }
+
+    private fun OpphørVedRevurdering.Ja.opphørsdatoErTidligesteDatoIRevurdering(): Boolean {
+        return this.opphørsdato == nyBeregning.getMånedsberegninger().minByOrNull { it.periode.fraOgMed }!!.periode.fraOgMed
+    }
+}
+
+sealed class SaksbehandlingsutfallSomIkkeStøttes {
+    object OpphørOgAndreEndringerIKombinasjon : SaksbehandlingsutfallSomIkkeStøttes()
+    object OpphørErIkkeFraFørsteMåned : SaksbehandlingsutfallSomIkkeStøttes()
+    object DelvisOpphør : SaksbehandlingsutfallSomIkkeStøttes()
+    object OpphørAvFlereVilkår : SaksbehandlingsutfallSomIkkeStøttes()
+}

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurdering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurdering.kt
@@ -28,7 +28,6 @@ import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.journal.JournalpostId
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
-import no.nav.su.se.bakover.domain.oppdrag.simulering.TolketSimulering
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.vedtak.Vedtak
 import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
@@ -948,7 +947,7 @@ sealed class UnderkjentRevurdering : Revurdering() {
             visitor.visit(this)
         }
 
-        fun harSimuleringFeilutbetaling() = TolketSimulering(simulering).simulertePerioder.any { it.harFeilutbetalinger() }
+        fun harSimuleringFeilutbetaling() = simulering.harFeilutbetalinger()
 
         fun tilAttestering(
             oppgaveId: OppgaveId,
@@ -998,7 +997,7 @@ sealed class UnderkjentRevurdering : Revurdering() {
         fun utledOpphørsgrunner(): List<Opphørsgrunn> = vilkårsvurderinger.utledOpphørsgrunner() +
             listOfNotNull(VurderAvslagGrunnetBeregning.hentAvslagsgrunnForBeregning(beregning).toOpphørsgrunn())
 
-        fun harSimuleringFeilutbetaling() = TolketSimulering(simulering).simulertePerioder.any { it.harFeilutbetalinger() }
+        fun harSimuleringFeilutbetaling() = simulering.harFeilutbetalinger()
 
         fun tilAttestering(
             oppgaveId: OppgaveId,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurdering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurdering.kt
@@ -456,7 +456,7 @@ sealed class SimulertRevurdering : Revurdering() {
     abstract override val grunnlagsdata: Grunnlagsdata
 
     abstract override fun accept(visitor: RevurderingVisitor)
-    fun harSimuleringFeilutbetaling() = TolketSimulering(simulering).simulertePerioder.any { it.harFeilutbetalinger() }
+    fun harSimuleringFeilutbetaling() = simulering.harFeilutbetalinger()
 
     data class Innvilget(
         override val id: UUID,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/VurderOpphørVedRevurdering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/VurderOpphørVedRevurdering.kt
@@ -1,0 +1,72 @@
+package no.nav.su.se.bakover.domain.revurdering
+
+import no.nav.su.se.bakover.common.periode.Periode
+import no.nav.su.se.bakover.common.startOfMonth
+import no.nav.su.se.bakover.domain.behandling.avslag.Opphørsgrunn
+import no.nav.su.se.bakover.domain.beregning.Beregning
+import no.nav.su.se.bakover.domain.beregning.Månedsberegning
+import no.nav.su.se.bakover.domain.vilkår.Resultat
+import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
+import java.time.Clock
+import java.time.LocalDate
+
+data class VurderOpphørVedRevurdering(
+    val vilkårsvurderinger: Vilkårsvurderinger,
+    val beregning: Beregning,
+    val clock: Clock = Clock.systemUTC(),
+) {
+    val resultat = when {
+        vilkårGirOpphør() is OpphørVedRevurdering.Ja -> vilkårGirOpphør()
+        beregningGirOpphør() is OpphørVedRevurdering.Ja -> beregningGirOpphør()
+        else -> OpphørVedRevurdering.Nei
+    }
+
+    private fun vilkårGirOpphør(): OpphørVedRevurdering {
+        return if (vilkårsvurderinger.resultat == Resultat.Avslag) {
+            OpphørVedRevurdering.Ja(vilkårsvurderinger.utledOpphørsgrunner(), vilkårsvurderinger.tidligsteDatoFrorAvslag()!!)
+        } else {
+            OpphørVedRevurdering.Nei
+        }
+    }
+
+    private fun beregningGirOpphør(): OpphørVedRevurdering {
+        fun fullstendigOpphør(): Boolean {
+            return beregning.getMånedsberegninger().all { it.erSumYtelseUnderMinstebeløp() } || beregning.getMånedsberegninger().all { it.getSumYtelse() == 0 }
+        }
+
+        if (fullstendigOpphør()) {
+            when {
+                beregning.getMånedsberegninger().all { it.erSumYtelseUnderMinstebeløp() } -> return OpphørVedRevurdering.Ja(listOf(Opphørsgrunn.SU_UNDER_MINSTEGRENSE), beregning.getMånedsberegninger().first().periode.fraOgMed)
+                beregning.getMånedsberegninger().all { !it.erSumYtelseUnderMinstebeløp() && it.getSumYtelse() == 0 } -> return OpphørVedRevurdering.Ja(listOf(Opphørsgrunn.FOR_HØY_INNTEKT), beregning.getMånedsberegninger().first().periode.fraOgMed)
+            }
+        }
+
+        førsteFremtidigeMånedUnderMinstebeløp()?.let {
+            return OpphørVedRevurdering.Ja(listOf(Opphørsgrunn.SU_UNDER_MINSTEGRENSE), it.periode.fraOgMed)
+        }
+        førsteFremtidigeMånedBeløpLik0()?.let {
+            return OpphørVedRevurdering.Ja(listOf(Opphørsgrunn.FOR_HØY_INNTEKT), it.periode.fraOgMed)
+        }
+        return OpphørVedRevurdering.Nei
+    }
+
+    private fun førsteFremtidigeMånedUnderMinstebeløp(): Månedsberegning? {
+        val førsteDagInneværendeMåned = LocalDate.now(clock).startOfMonth()
+        return beregning.getMånedsberegninger().sortedBy { it.periode.fraOgMed }
+            .firstOrNull() { it.periode.starterSamtidigEllerSenere(førsteDagInneværendeMåned) && it.erSumYtelseUnderMinstebeløp() }
+    }
+
+    private fun førsteFremtidigeMånedBeløpLik0(): Månedsberegning? {
+        val førsteDagInneværendeMåned = LocalDate.now(clock).startOfMonth()
+        return beregning.getMånedsberegninger().sortedBy { it.periode.fraOgMed }
+            .firstOrNull() { it.periode.starterSamtidigEllerSenere(førsteDagInneværendeMåned) && !it.erSumYtelseUnderMinstebeløp() && it.getSumYtelse() == 0 }
+    }
+
+    private fun Periode.starterSamtidigEllerSenere(other: LocalDate) =
+        this.fraOgMed.isEqual(other) || this.fraOgMed.isAfter(other)
+}
+
+sealed class OpphørVedRevurdering {
+    data class Ja(val grunn: List<Opphørsgrunn>, val opphørsdato: LocalDate) : OpphørVedRevurdering()
+    object Nei : OpphørVedRevurdering()
+}

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/VurderOpphørVedRevurdering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/VurderOpphørVedRevurdering.kt
@@ -22,10 +22,10 @@ data class VurderOpphørVedRevurdering(
     }
 
     private fun vilkårGirOpphør(): OpphørVedRevurdering {
-        return if (vilkårsvurderinger.resultat == Resultat.Avslag) {
-            OpphørVedRevurdering.Ja(vilkårsvurderinger.utledOpphørsgrunner(), vilkårsvurderinger.tidligsteDatoFrorAvslag()!!)
-        } else {
-            OpphørVedRevurdering.Nei
+        return when (vilkårsvurderinger.resultat) {
+            Resultat.Avslag -> OpphørVedRevurdering.Ja(vilkårsvurderinger.utledOpphørsgrunner(), vilkårsvurderinger.tidligsteDatoFrorAvslag()!!)
+            Resultat.Innvilget -> OpphørVedRevurdering.Nei
+            Resultat.Uavklart -> throw IllegalStateException("Alle vilkår må vurders før opphør kan vurderes.")
         }
     }
 

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vilkår/Vilkår.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vilkår/Vilkår.kt
@@ -63,7 +63,7 @@ data class Vilkårsvurderinger(
         }
     }
 
-    fun tidligsteDatoFrorAvslag(): LocalDate? {
+    fun tidligsteDatoForAvslag(): LocalDate? {
         return vilkår.filterIsInstance<Vilkår.Vurdert<*>>()
             .flatMap { it.vurderingsperioder }
             .filter { it.resultat == Resultat.Avslag }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vilkår/Vilkår.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vilkår/Vilkår.kt
@@ -71,7 +71,6 @@ data class Vilkårsvurderinger(
             .minByOrNull { it.periode.fraOgMed }?.periode?.fraOgMed
     }
 
-
     fun utledOpphørsgrunner(): List<Opphørsgrunn> {
         return vilkår.mapNotNull {
             when (it) {
@@ -152,8 +151,8 @@ sealed class Vilkår<T : Grunnlag?> {
                     vurderingsperioder: Nel<Vurderingsperiode<Grunnlag.Uføregrunnlag?>>,
                 ): Either<UgyldigUførevilkår, Uførhet> {
                     if (vurderingsperioder.forAll { v1 ->
-                            vurderingsperioder.minus(v1).any { v2 -> v1.periode overlapper v2.periode }
-                        }
+                        vurderingsperioder.minus(v1).any { v2 -> v1.periode overlapper v2.periode }
+                    }
                     ) {
                         return UgyldigUførevilkår.OverlappendeVurderingsperioder.left()
                     }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/beregning/BeregningMedFradragBeregnetMånedsvisTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/beregning/BeregningMedFradragBeregnetMånedsvisTest.kt
@@ -62,14 +62,59 @@ internal class BeregningMedFradragBeregnetMånedsvisTest {
                 IkkePeriodisertFradrag(
                     type = Fradragstype.ForventetInntekt, månedsbeløp = 1000.0,
                     periode = periode,
-                    tilhører = FradragTilhører.BRUKER
-                )
+                    tilhører = FradragTilhører.BRUKER,
+                ),
             ),
-            fradragStrategy = FradragStrategy.Enslig
+            fradragStrategy = FradragStrategy.Enslig,
         )
 
         beregning.getSumYtelse() shouldBe 238116
         beregning.getSumFradrag() shouldBe 12000
+    }
+
+    @Test
+    fun `fradrag som gjør at alle perioder får beløp under minstenivå`() {
+        val periode = Periode.create(1.januar(2020), 31.desember(2020))
+        val beregning = BeregningFactory.ny(
+            periode = periode,
+            sats = Sats.HØY,
+            fradrag = listOf(
+                IkkePeriodisertFradrag(
+                    type = Fradragstype.ForventetInntekt, månedsbeløp = 20500.0,
+                    periode = Periode.create(1.januar(2020), 30.april(2020)),
+                    tilhører = FradragTilhører.BRUKER,
+                ),
+                IkkePeriodisertFradrag(
+                    type = Fradragstype.ForventetInntekt, månedsbeløp = 20800.0,
+                    periode = Periode.create(1.mai(2020), 31.desember(2020)),
+                    tilhører = FradragTilhører.BRUKER,
+                ),
+            ),
+            fradragStrategy = FradragStrategy.Enslig,
+        )
+
+        beregning.alleMånederErUnderMinstebeløp() shouldBe true
+        beregning.alleMånederHarBeløpLik0() shouldBe true
+    }
+
+    @Test
+    fun `fradrag som gjør at alle perioder får beløp lik 0`() {
+        val periode = Periode.create(1.januar(2020), 31.desember(2020))
+        val beregning = BeregningFactory.ny(
+            periode = periode,
+            sats = Sats.HØY,
+            fradrag = listOf(
+                IkkePeriodisertFradrag(
+                    type = Fradragstype.ForventetInntekt, månedsbeløp = 150000.0,
+                    periode = periode,
+                    tilhører = FradragTilhører.BRUKER,
+                ),
+            ),
+            fradragStrategy = FradragStrategy.Enslig,
+        )
+
+        beregning.alleMånederErUnderMinstebeløp() shouldBe false
+        beregning.alleMånederHarBeløpLik0() shouldBe true
     }
 
     @Test
@@ -83,16 +128,16 @@ internal class BeregningMedFradragBeregnetMånedsvisTest {
                     type = Fradragstype.ForventetInntekt,
                     månedsbeløp = 500.0,
                     periode = periode,
-                    tilhører = FradragTilhører.BRUKER
+                    tilhører = FradragTilhører.BRUKER,
                 ),
                 IkkePeriodisertFradrag(
                     type = Fradragstype.Arbeidsinntekt,
                     månedsbeløp = 6000.0,
                     periode = Periode.create(1.juni(2020), 30.juni(2020)),
-                    tilhører = FradragTilhører.BRUKER
+                    tilhører = FradragTilhører.BRUKER,
                 ),
             ),
-            fradragStrategy = FradragStrategy.Enslig
+            fradragStrategy = FradragStrategy.Enslig,
         )
 
         beregning.getSumYtelse() shouldBe 238616
@@ -110,16 +155,16 @@ internal class BeregningMedFradragBeregnetMånedsvisTest {
                     type = Fradragstype.ForventetInntekt,
                     månedsbeløp = 500.0,
                     periode = periode,
-                    tilhører = FradragTilhører.BRUKER
+                    tilhører = FradragTilhører.BRUKER,
                 ),
                 IkkePeriodisertFradrag(
                     type = Fradragstype.Kontantstøtte,
                     månedsbeløp = 6000.0,
                     periode = Periode.create(1.januar(2020), 31.januar(2020)),
-                    tilhører = FradragTilhører.BRUKER
-                )
+                    tilhører = FradragTilhører.BRUKER,
+                ),
             ),
-            fradragStrategy = FradragStrategy.Enslig
+            fradragStrategy = FradragStrategy.Enslig,
         )
 
         beregning.getSumYtelse() shouldBe 238116
@@ -159,10 +204,10 @@ internal class BeregningMedFradragBeregnetMånedsvisTest {
                     type = Fradragstype.ForventetInntekt,
                     månedsbeløp = 20426.42,
                     periode = periode,
-                    tilhører = FradragTilhører.BRUKER
-                )
+                    tilhører = FradragTilhører.BRUKER,
+                ),
             ),
-            fradragStrategy = FradragStrategy.Enslig
+            fradragStrategy = FradragStrategy.Enslig,
         )
 
         val (janAprUnderMinstenivå, janAprAndre) = beregning.getMånedsberegninger()
@@ -177,7 +222,7 @@ internal class BeregningMedFradragBeregnetMånedsvisTest {
                 månedsbeløp = 211.0,
                 periode = it.periode,
                 utenlandskInntekt = null,
-                tilhører = FradragTilhører.BRUKER
+                tilhører = FradragTilhører.BRUKER,
             )
         }
         janAprAndre shouldHaveSize 4
@@ -187,7 +232,7 @@ internal class BeregningMedFradragBeregnetMånedsvisTest {
                 månedsbeløp = 20426.42,
                 periode = it.periode,
                 utenlandskInntekt = null,
-                tilhører = FradragTilhører.BRUKER
+                tilhører = FradragTilhører.BRUKER,
             )
         }
 
@@ -204,7 +249,7 @@ internal class BeregningMedFradragBeregnetMånedsvisTest {
                 månedsbeløp = 20426.42,
                 periode = it.periode,
                 utenlandskInntekt = null,
-                tilhører = FradragTilhører.BRUKER
+                tilhører = FradragTilhører.BRUKER,
             )
         }
 
@@ -223,10 +268,10 @@ internal class BeregningMedFradragBeregnetMånedsvisTest {
                     månedsbeløp = 0.0,
                     periode = Periode.create(1.januar(2020), 31.mars(2020)),
                     utenlandskInntekt = null,
-                    tilhører = FradragTilhører.BRUKER
-                )
+                    tilhører = FradragTilhører.BRUKER,
+                ),
             ),
-            fradragStrategy = FradragStrategy.Enslig
+            fradragStrategy = FradragStrategy.Enslig,
         )
         beregning.getId() shouldBe beregning.getId()
         beregning.getOpprettet() shouldBe beregning.getOpprettet()
@@ -246,16 +291,16 @@ internal class BeregningMedFradragBeregnetMånedsvisTest {
                     type = Fradragstype.ForventetInntekt,
                     månedsbeløp = 0.0,
                     periode = periode,
-                    tilhører = FradragTilhører.BRUKER
+                    tilhører = FradragTilhører.BRUKER,
                 ),
                 IkkePeriodisertFradrag(
                     type = Fradragstype.Arbeidsinntekt,
                     månedsbeløp = totaltFradrag,
                     periode = Periode.create(1.januar(2020), 31.januar(2020)),
-                    tilhører = FradragTilhører.BRUKER
-                )
+                    tilhører = FradragTilhører.BRUKER,
+                ),
             ),
-            fradragStrategy = FradragStrategy.Enslig
+            fradragStrategy = FradragStrategy.Enslig,
         )
 
         beregning.getSumYtelse() shouldBe 41274
@@ -283,16 +328,16 @@ internal class BeregningMedFradragBeregnetMånedsvisTest {
                     type = Fradragstype.ForventetInntekt,
                     månedsbeløp = 0.0,
                     periode = periode,
-                    tilhører = FradragTilhører.BRUKER
+                    tilhører = FradragTilhører.BRUKER,
                 ),
                 IkkePeriodisertFradrag(
                     type = Fradragstype.Arbeidsinntekt,
                     månedsbeløp = totaltFradrag,
                     periode = Periode.create(1.januar(2020), 31.januar(2020)),
-                    tilhører = FradragTilhører.BRUKER
-                )
+                    tilhører = FradragTilhører.BRUKER,
+                ),
             ),
-            fradragStrategy = FradragStrategy.Enslig
+            fradragStrategy = FradragStrategy.Enslig,
         )
 
         val beregning2 = BeregningFactory.ny(
@@ -303,16 +348,16 @@ internal class BeregningMedFradragBeregnetMånedsvisTest {
                     type = Fradragstype.ForventetInntekt,
                     månedsbeløp = 0.0,
                     periode = periode,
-                    tilhører = FradragTilhører.BRUKER
+                    tilhører = FradragTilhører.BRUKER,
                 ),
                 IkkePeriodisertFradrag(
                     type = Fradragstype.Arbeidsinntekt,
                     månedsbeløp = totaltFradrag,
                     periode = periode,
-                    tilhører = FradragTilhører.BRUKER
-                )
+                    tilhører = FradragTilhører.BRUKER,
+                ),
             ),
-            fradragStrategy = FradragStrategy.Enslig
+            fradragStrategy = FradragStrategy.Enslig,
         )
 
         beregning.getMånedsberegninger() shouldNotBe beregning2.getMånedsberegninger()
@@ -333,10 +378,10 @@ internal class BeregningMedFradragBeregnetMånedsvisTest {
                         månedsbeløp = 12000.0,
                         periode = Periode.create(fraOgMed = 1.februar(2020), tilOgMed = 31.januar(2022)),
                         utenlandskInntekt = null,
-                        tilhører = FradragTilhører.BRUKER
-                    )
+                        tilhører = FradragTilhører.BRUKER,
+                    ),
                 ),
-                fradragStrategy = FradragStrategy.Enslig
+                fradragStrategy = FradragStrategy.Enslig,
             )
         }
 

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/IdentifiserRevurderingsutfallSomIkkeStøttesTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/IdentifiserRevurderingsutfallSomIkkeStøttesTest.kt
@@ -15,7 +15,7 @@ import no.nav.su.se.bakover.domain.vilkår.Resultat
 import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
 import org.junit.jupiter.api.Test
 
-internal class IdentifiserSaksbehandlingsutfallSomIkkeStøttesTest {
+internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
 
     @Test
     fun `identifiserer at opphør ikke skjer fra samme dato som den første i beregningen`() {
@@ -41,7 +41,7 @@ internal class IdentifiserSaksbehandlingsutfallSomIkkeStøttesTest {
             tidligereBeregning = tidligereBeregningMock,
             nyBeregning = nyBeregningMock,
         ).resultat shouldBeLeft setOf(
-            SaksbehandlingsutfallSomIkkeStøttes.OpphørErIkkeFraFørsteMåned,
+            RevurderingsutfallSomIkkeStøttes.OpphørErIkkeFraFørsteMåned,
         )
     }
 
@@ -69,7 +69,7 @@ internal class IdentifiserSaksbehandlingsutfallSomIkkeStøttesTest {
             tidligereBeregning = tidligereBeregningMock,
             nyBeregning = nyBeregningMock,
         ).resultat shouldBeLeft setOf(
-            SaksbehandlingsutfallSomIkkeStøttes.OpphørAvFlereVilkår,
+            RevurderingsutfallSomIkkeStøttes.OpphørAvFlereVilkår,
         )
     }
 
@@ -102,8 +102,8 @@ internal class IdentifiserSaksbehandlingsutfallSomIkkeStøttesTest {
             tidligereBeregning = tidligereBeregningMock,
             nyBeregning = nyBeregningMock,
         ).resultat shouldBeLeft setOf(
-            SaksbehandlingsutfallSomIkkeStøttes.OpphørErIkkeFraFørsteMåned,
-            SaksbehandlingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon,
+            RevurderingsutfallSomIkkeStøttes.OpphørErIkkeFraFørsteMåned,
+            RevurderingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon,
         )
     }
 
@@ -146,8 +146,8 @@ internal class IdentifiserSaksbehandlingsutfallSomIkkeStøttesTest {
             tidligereBeregning = tidligereBeregningMock,
             nyBeregning = nyBeregningMock,
         ).resultat shouldBeLeft setOf(
-            SaksbehandlingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon,
-            SaksbehandlingsutfallSomIkkeStøttes.DelvisOpphør,
+            RevurderingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon,
+            RevurderingsutfallSomIkkeStøttes.DelvisOpphør,
         )
     }
 
@@ -190,8 +190,8 @@ internal class IdentifiserSaksbehandlingsutfallSomIkkeStøttesTest {
             tidligereBeregning = tidligereBeregningMock,
             nyBeregning = nyBeregningMock,
         ).resultat shouldBeLeft setOf(
-            SaksbehandlingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon,
-            SaksbehandlingsutfallSomIkkeStøttes.DelvisOpphør,
+            RevurderingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon,
+            RevurderingsutfallSomIkkeStøttes.DelvisOpphør,
         )
     }
 
@@ -275,7 +275,7 @@ internal class IdentifiserSaksbehandlingsutfallSomIkkeStøttesTest {
             tidligereBeregning = tidligereBeregningMock,
             nyBeregning = nyBeregningMock,
         ).resultat shouldBeLeft setOf(
-            SaksbehandlingsutfallSomIkkeStøttes.DelvisOpphør,
+            RevurderingsutfallSomIkkeStøttes.DelvisOpphør,
         )
     }
 
@@ -318,7 +318,7 @@ internal class IdentifiserSaksbehandlingsutfallSomIkkeStøttesTest {
             tidligereBeregning = tidligereBeregningMock,
             nyBeregning = nyBeregningMock,
         ).resultat shouldBeLeft setOf(
-            SaksbehandlingsutfallSomIkkeStøttes.DelvisOpphør,
+            RevurderingsutfallSomIkkeStøttes.DelvisOpphør,
         )
     }
 

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/IdentifiserRevurderingsutfallSomIkkeStøttesTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/IdentifiserRevurderingsutfallSomIkkeStøttesTest.kt
@@ -22,7 +22,7 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
         val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
             on { resultat } doReturn Resultat.Avslag
             on { utledOpphørsgrunner() } doReturn listOf(Opphørsgrunn.UFØRHET)
-            on { tidligsteDatoFrorAvslag() } doReturn 1.juni(2021)
+            on { tidligsteDatoForAvslag() } doReturn 1.juni(2021)
         }
         val månedsberegningMock = mock<Månedsberegning> {
             on { periode } doReturn Periode.create(1.desember(2021), 31.desember(2021))
@@ -50,7 +50,7 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
         val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
             on { resultat } doReturn Resultat.Avslag
             on { utledOpphørsgrunner() } doReturn listOf(mock(), mock())
-            on { tidligsteDatoFrorAvslag() } doReturn 1.desember(2021)
+            on { tidligsteDatoForAvslag() } doReturn 1.desember(2021)
         }
         val månedsberegningMock = mock<Månedsberegning> {
             on { periode } doReturn Periode.create(1.desember(2021), 31.desember(2021))
@@ -78,7 +78,7 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
         val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
             on { resultat } doReturn Resultat.Avslag
             on { utledOpphørsgrunner() } doReturn listOf(Opphørsgrunn.UFØRHET)
-            on { tidligsteDatoFrorAvslag() } doReturn 1.juni(2021)
+            on { tidligsteDatoForAvslag() } doReturn 1.juni(2021)
         }
         val tidligereMånedsberegningMock = mock<Månedsberegning> {
             on { periode } doReturn Periode.create(1.desember(2021), 31.desember(2021))
@@ -112,7 +112,7 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
         val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
             on { resultat } doReturn Resultat.Innvilget
             on { utledOpphørsgrunner() } doReturn listOf(Opphørsgrunn.SU_UNDER_MINSTEGRENSE)
-            on { tidligsteDatoFrorAvslag() } doReturn null
+            on { tidligsteDatoForAvslag() } doReturn null
         }
         val tidligereMånedsberegningMock1 = mock<Månedsberegning> {
             on { periode } doReturn Periode.create(1.november(2021), 30.november(2021))
@@ -156,7 +156,7 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
         val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
             on { resultat } doReturn Resultat.Innvilget
             on { utledOpphørsgrunner() } doReturn listOf(Opphørsgrunn.FOR_HØY_INNTEKT)
-            on { tidligsteDatoFrorAvslag() } doReturn null
+            on { tidligsteDatoForAvslag() } doReturn null
         }
         val tidligereMånedsberegningMock1 = mock<Månedsberegning> {
             on { periode } doReturn Periode.create(1.november(2021), 30.november(2021))
@@ -200,7 +200,7 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
         val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
             on { resultat } doReturn Resultat.Innvilget
             on { utledOpphørsgrunner() } doReturn listOf(Opphørsgrunn.FOR_HØY_INNTEKT)
-            on { tidligsteDatoFrorAvslag() } doReturn null
+            on { tidligsteDatoForAvslag() } doReturn null
         }
         val tidligereMånedsberegningMock1 = mock<Månedsberegning> {
             on { periode } doReturn Periode.create(1.november(2021), 30.november(2021))
@@ -227,6 +227,8 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
         }
         val nyBeregningMock = mock<Beregning> {
             on { getMånedsberegninger() } doReturn listOf(nyMånedsberegningMock1, nyMånedsberegningMock2)
+            on { alleMånederErUnderMinstebeløp() } doReturn false
+            on { alleMånederHarBeløpLik0() } doReturn true
         }
 
         IdentifiserSaksbehandlingsutfallSomIkkeStøttes(
@@ -241,7 +243,7 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
         val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
             on { resultat } doReturn Resultat.Innvilget
             on { utledOpphørsgrunner() } doReturn listOf(Opphørsgrunn.SU_UNDER_MINSTEGRENSE)
-            on { tidligsteDatoFrorAvslag() } doReturn null
+            on { tidligsteDatoForAvslag() } doReturn null
         }
         val tidligereMånedsberegningMock1 = mock<Månedsberegning> {
             on { periode } doReturn Periode.create(1.november(2021), 30.november(2021))
@@ -284,7 +286,7 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
         val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
             on { resultat } doReturn Resultat.Innvilget
             on { utledOpphørsgrunner() } doReturn listOf(Opphørsgrunn.FOR_HØY_INNTEKT)
-            on { tidligsteDatoFrorAvslag() } doReturn null
+            on { tidligsteDatoForAvslag() } doReturn null
         }
         val tidligereMånedsberegningMock1 = mock<Månedsberegning> {
             on { periode } doReturn Periode.create(1.november(2021), 30.november(2021))

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/IdentifiserSaksbehandlingsutfallSomIkkeStøttesTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/IdentifiserSaksbehandlingsutfallSomIkkeStøttesTest.kt
@@ -1,0 +1,344 @@
+package no.nav.su.se.bakover.domain.revurdering
+
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import io.kotest.assertions.arrow.either.shouldBeLeft
+import io.kotest.assertions.arrow.either.shouldBeRight
+import no.nav.su.se.bakover.common.desember
+import no.nav.su.se.bakover.common.juni
+import no.nav.su.se.bakover.common.november
+import no.nav.su.se.bakover.common.periode.Periode
+import no.nav.su.se.bakover.domain.behandling.avslag.Opphørsgrunn
+import no.nav.su.se.bakover.domain.beregning.Beregning
+import no.nav.su.se.bakover.domain.beregning.Månedsberegning
+import no.nav.su.se.bakover.domain.vilkår.Resultat
+import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
+import org.junit.jupiter.api.Test
+
+internal class IdentifiserSaksbehandlingsutfallSomIkkeStøttesTest {
+
+    @Test
+    fun `identifiserer at opphør ikke skjer fra samme dato som den første i beregningen`() {
+        val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
+            on { resultat } doReturn Resultat.Avslag
+            on { utledOpphørsgrunner() } doReturn listOf(Opphørsgrunn.UFØRHET)
+            on { tidligsteDatoFrorAvslag() } doReturn 1.juni(2021)
+        }
+        val månedsberegningMock = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.desember(2021), 31.desember(2021))
+            on { getSumYtelse() } doReturn 5000
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val tidligereBeregningMock = mock<Beregning>() {
+            on { getMånedsberegninger() } doReturn listOf(månedsberegningMock)
+        }
+        val nyBeregningMock = mock<Beregning> {
+            on { getMånedsberegninger() } doReturn listOf(månedsberegningMock)
+        }
+
+        IdentifiserSaksbehandlingsutfallSomIkkeStøttes(
+            vilkårsvurderinger = vilkårsvurderingerMock,
+            tidligereBeregning = tidligereBeregningMock,
+            nyBeregning = nyBeregningMock,
+        ).resultat shouldBeLeft setOf(
+            SaksbehandlingsutfallSomIkkeStøttes.OpphørErIkkeFraFørsteMåned,
+        )
+    }
+
+    @Test
+    fun `identifiserer at flere vilkår har opphørt`() {
+        val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
+            on { resultat } doReturn Resultat.Avslag
+            on { utledOpphørsgrunner() } doReturn listOf(mock(), mock())
+            on { tidligsteDatoFrorAvslag() } doReturn 1.desember(2021)
+        }
+        val månedsberegningMock = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.desember(2021), 31.desember(2021))
+            on { getSumYtelse() } doReturn 5000
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val tidligereBeregningMock = mock<Beregning>() {
+            on { getMånedsberegninger() } doReturn listOf(månedsberegningMock)
+        }
+        val nyBeregningMock = mock<Beregning> {
+            on { getMånedsberegninger() } doReturn listOf(månedsberegningMock)
+        }
+
+        IdentifiserSaksbehandlingsutfallSomIkkeStøttes(
+            vilkårsvurderinger = vilkårsvurderingerMock,
+            tidligereBeregning = tidligereBeregningMock,
+            nyBeregning = nyBeregningMock,
+        ).resultat shouldBeLeft setOf(
+            SaksbehandlingsutfallSomIkkeStøttes.OpphørAvFlereVilkår,
+        )
+    }
+
+    @Test
+    fun `identifiserer at opphør av vilkår skjer i kombinasjon med beløpsendringer`() {
+        val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
+            on { resultat } doReturn Resultat.Avslag
+            on { utledOpphørsgrunner() } doReturn listOf(Opphørsgrunn.UFØRHET)
+            on { tidligsteDatoFrorAvslag() } doReturn 1.juni(2021)
+        }
+        val tidligereMånedsberegningMock = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.desember(2021), 31.desember(2021))
+            on { getSumYtelse() } doReturn 2500
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val tidligereBeregningMock = mock<Beregning>() {
+            on { getMånedsberegninger() } doReturn listOf(tidligereMånedsberegningMock)
+        }
+        val nyMånedsberegningMock = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.desember(2021), 31.desember(2021))
+            on { getSumYtelse() } doReturn 5000
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val nyBeregningMock = mock<Beregning> {
+            on { getMånedsberegninger() } doReturn listOf(nyMånedsberegningMock)
+        }
+
+        IdentifiserSaksbehandlingsutfallSomIkkeStøttes(
+            vilkårsvurderinger = vilkårsvurderingerMock,
+            tidligereBeregning = tidligereBeregningMock,
+            nyBeregning = nyBeregningMock,
+        ).resultat shouldBeLeft setOf(
+            SaksbehandlingsutfallSomIkkeStøttes.OpphørErIkkeFraFørsteMåned,
+            SaksbehandlingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon,
+        )
+    }
+
+    @Test
+    fun `identifiserer at opphør grunnet lavt beløp gjøres i kombinasjon med andre beløpsendringer - under minstegrense`() {
+        val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
+            on { resultat } doReturn Resultat.Innvilget
+            on { utledOpphørsgrunner() } doReturn listOf(Opphørsgrunn.SU_UNDER_MINSTEGRENSE)
+            on { tidligsteDatoFrorAvslag() } doReturn null
+        }
+        val tidligereMånedsberegningMock1 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.november(2021), 30.november(2021))
+            on { getSumYtelse() } doReturn 2500
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val tidligereMånedsberegningMock2 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.desember(2021), 31.desember(2021))
+            on { getSumYtelse() } doReturn 5000
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val tidligereBeregningMock = mock<Beregning>() {
+            on { getMånedsberegninger() } doReturn listOf(tidligereMånedsberegningMock1, tidligereMånedsberegningMock2)
+        }
+        val nyMånedsberegningMock1 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.november(2021), 30.november(2021))
+            on { getSumYtelse() } doReturn 200
+            on { erSumYtelseUnderMinstebeløp() } doReturn true
+        }
+        val nyMånedsberegningMock2 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.desember(2021), 31.desember(2021))
+            on { getSumYtelse() } doReturn 3333
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val nyBeregningMock = mock<Beregning> {
+            on { getMånedsberegninger() } doReturn listOf(nyMånedsberegningMock1, nyMånedsberegningMock2)
+        }
+
+        IdentifiserSaksbehandlingsutfallSomIkkeStøttes(
+            vilkårsvurderinger = vilkårsvurderingerMock,
+            tidligereBeregning = tidligereBeregningMock,
+            nyBeregning = nyBeregningMock,
+        ).resultat shouldBeLeft setOf(
+            SaksbehandlingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon,
+            SaksbehandlingsutfallSomIkkeStøttes.DelvisOpphør,
+        )
+    }
+
+    @Test
+    fun `identifiserer at opphør grunnet lavt beløp gjøres i kombinasjon med andre beløpsendringer - for høy inntekt`() {
+        val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
+            on { resultat } doReturn Resultat.Innvilget
+            on { utledOpphørsgrunner() } doReturn listOf(Opphørsgrunn.FOR_HØY_INNTEKT)
+            on { tidligsteDatoFrorAvslag() } doReturn null
+        }
+        val tidligereMånedsberegningMock1 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.november(2021), 30.november(2021))
+            on { getSumYtelse() } doReturn 2500
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val tidligereMånedsberegningMock2 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.desember(2021), 31.desember(2021))
+            on { getSumYtelse() } doReturn 5000
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val tidligereBeregningMock = mock<Beregning>() {
+            on { getMånedsberegninger() } doReturn listOf(tidligereMånedsberegningMock1, tidligereMånedsberegningMock2)
+        }
+        val nyMånedsberegningMock1 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.november(2021), 30.november(2021))
+            on { getSumYtelse() } doReturn 0
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val nyMånedsberegningMock2 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.desember(2021), 31.desember(2021))
+            on { getSumYtelse() } doReturn 3333
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val nyBeregningMock = mock<Beregning> {
+            on { getMånedsberegninger() } doReturn listOf(nyMånedsberegningMock1, nyMånedsberegningMock2)
+        }
+
+        IdentifiserSaksbehandlingsutfallSomIkkeStøttes(
+            vilkårsvurderinger = vilkårsvurderingerMock,
+            tidligereBeregning = tidligereBeregningMock,
+            nyBeregning = nyBeregningMock,
+        ).resultat shouldBeLeft setOf(
+            SaksbehandlingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon,
+            SaksbehandlingsutfallSomIkkeStøttes.DelvisOpphør,
+        )
+    }
+
+    @Test
+    fun `identifiserer ingen problemer hvis alle nye måneder har for lavt beløp - for høy inntekt`() {
+        val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
+            on { resultat } doReturn Resultat.Innvilget
+            on { utledOpphørsgrunner() } doReturn listOf(Opphørsgrunn.FOR_HØY_INNTEKT)
+            on { tidligsteDatoFrorAvslag() } doReturn null
+        }
+        val tidligereMånedsberegningMock1 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.november(2021), 30.november(2021))
+            on { getSumYtelse() } doReturn 2500
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val tidligereMånedsberegningMock2 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.desember(2021), 31.desember(2021))
+            on { getSumYtelse() } doReturn 5000
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val tidligereBeregningMock = mock<Beregning>() {
+            on { getMånedsberegninger() } doReturn listOf(tidligereMånedsberegningMock1, tidligereMånedsberegningMock2)
+        }
+        val nyMånedsberegningMock1 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.november(2021), 30.november(2021))
+            on { getSumYtelse() } doReturn 0
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val nyMånedsberegningMock2 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.desember(2021), 31.desember(2021))
+            on { getSumYtelse() } doReturn 0
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val nyBeregningMock = mock<Beregning> {
+            on { getMånedsberegninger() } doReturn listOf(nyMånedsberegningMock1, nyMånedsberegningMock2)
+        }
+
+        IdentifiserSaksbehandlingsutfallSomIkkeStøttes(
+            vilkårsvurderinger = vilkårsvurderingerMock,
+            tidligereBeregning = tidligereBeregningMock,
+            nyBeregning = nyBeregningMock,
+        ).resultat shouldBeRight Unit
+    }
+
+    @Test
+    fun `identifiserer delvis opphør hvis første måned gir opphør og andre måneder er uendret - under minstebeløp`() {
+        val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
+            on { resultat } doReturn Resultat.Innvilget
+            on { utledOpphørsgrunner() } doReturn listOf(Opphørsgrunn.SU_UNDER_MINSTEGRENSE)
+            on { tidligsteDatoFrorAvslag() } doReturn null
+        }
+        val tidligereMånedsberegningMock1 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.november(2021), 30.november(2021))
+            on { getSumYtelse() } doReturn 200
+            on { erSumYtelseUnderMinstebeløp() } doReturn true
+        }
+        val tidligereMånedsberegningMock2 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.desember(2021), 31.desember(2021))
+            on { getSumYtelse() } doReturn 5000
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val tidligereBeregningMock = mock<Beregning>() {
+            on { getMånedsberegninger() } doReturn listOf(tidligereMånedsberegningMock1, tidligereMånedsberegningMock2)
+        }
+        val nyMånedsberegningMock1 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.november(2021), 30.november(2021))
+            on { getSumYtelse() } doReturn 200
+            on { erSumYtelseUnderMinstebeløp() } doReturn true
+        }
+        val nyMånedsberegningMock2 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.desember(2021), 31.desember(2021))
+            on { getSumYtelse() } doReturn 5000
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val nyBeregningMock = mock<Beregning> {
+            on { getMånedsberegninger() } doReturn listOf(nyMånedsberegningMock1, nyMånedsberegningMock2)
+        }
+
+        IdentifiserSaksbehandlingsutfallSomIkkeStøttes(
+            vilkårsvurderinger = vilkårsvurderingerMock,
+            tidligereBeregning = tidligereBeregningMock,
+            nyBeregning = nyBeregningMock,
+        ).resultat shouldBeLeft setOf(
+            SaksbehandlingsutfallSomIkkeStøttes.DelvisOpphør,
+        )
+    }
+
+    @Test
+    fun `identifiserer delvis opphør hvis første måned gir opphør og andre måneder er uendret - for høy inntekt`() {
+        val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
+            on { resultat } doReturn Resultat.Innvilget
+            on { utledOpphørsgrunner() } doReturn listOf(Opphørsgrunn.FOR_HØY_INNTEKT)
+            on { tidligsteDatoFrorAvslag() } doReturn null
+        }
+        val tidligereMånedsberegningMock1 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.november(2021), 30.november(2021))
+            on { getSumYtelse() } doReturn 2500
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val tidligereMånedsberegningMock2 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.desember(2021), 31.desember(2021))
+            on { getSumYtelse() } doReturn 5000
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val tidligereBeregningMock = mock<Beregning>() {
+            on { getMånedsberegninger() } doReturn listOf(tidligereMånedsberegningMock1, tidligereMånedsberegningMock2)
+        }
+        val nyMånedsberegningMock1 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.november(2021), 30.november(2021))
+            on { getSumYtelse() } doReturn 0
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val nyMånedsberegningMock2 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.desember(2021), 31.desember(2021))
+            on { getSumYtelse() } doReturn 5000
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val nyBeregningMock = mock<Beregning> {
+            on { getMånedsberegninger() } doReturn listOf(nyMånedsberegningMock1, nyMånedsberegningMock2)
+        }
+
+        IdentifiserSaksbehandlingsutfallSomIkkeStøttes(
+            vilkårsvurderinger = vilkårsvurderingerMock,
+            tidligereBeregning = tidligereBeregningMock,
+            nyBeregning = nyBeregningMock,
+        ).resultat shouldBeLeft setOf(
+            SaksbehandlingsutfallSomIkkeStøttes.DelvisOpphør,
+        )
+    }
+
+    @Test
+    fun `identifiserer ingen problemer hvis det ikke er opphør`() {
+        val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
+            on { resultat } doReturn Resultat.Innvilget
+        }
+        val nyMånedsberegningMock1 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.november(2021), 30.november(2021))
+            on { getSumYtelse() } doReturn 5000
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+        }
+        val nyBeregningMock = mock<Beregning> {
+            on { getMånedsberegninger() } doReturn listOf(nyMånedsberegningMock1)
+        }
+        IdentifiserSaksbehandlingsutfallSomIkkeStøttes(
+            vilkårsvurderinger = vilkårsvurderingerMock,
+            tidligereBeregning = mock(),
+            nyBeregning = nyBeregningMock,
+        ).resultat shouldBeRight Unit
+    }
+}

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/RevurderingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/RevurderingTest.kt
@@ -5,13 +5,14 @@ import arrow.core.getOrElse
 import arrow.core.right
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
-import io.kotest.assertions.arrow.either.shouldBeLeft
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.beOfType
 import no.nav.su.se.bakover.common.Tidspunkt
+import no.nav.su.se.bakover.common.april
 import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.januar
+import no.nav.su.se.bakover.common.mai
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.FnrGenerator
 import no.nav.su.se.bakover.domain.NavIdentBruker
@@ -37,14 +38,6 @@ import java.time.LocalDate
 import java.util.UUID
 
 internal class RevurderingTest {
-    @Test
-    fun `beregning gir feilmelding hvis vilkår er uavklart`() {
-        lagRevurdering(
-            vilkårsvurderinger = Vilkårsvurderinger(
-                uføre = Vilkår.IkkeVurdert.Uførhet,
-            ),
-        ).beregn() shouldBeLeft Revurdering.KunneIkkeBeregneRevurdering.UfullstendigVilkårsvurdering
-    }
 
     @Test
     fun `beregning gir opphør hvis vilkår ikke er oppfylt`() {
@@ -196,7 +189,15 @@ internal class RevurderingTest {
                     fradrag = FradragFactory.ny(
                         type = Fradragstype.Arbeidsinntekt,
                         månedsbeløp = 20900.0,
-                        periode = Periode.create(1.januar(2021), 31.desember(2021)),
+                        periode = Periode.create(1.januar(2021), 30.april(2021)),
+                        tilhører = FradragTilhører.BRUKER,
+                    ),
+                ),
+                Grunnlag.Fradragsgrunnlag(
+                    fradrag = FradragFactory.ny(
+                        type = Fradragstype.Arbeidsinntekt,
+                        månedsbeløp = 21900.0,
+                        periode = Periode.create(1.mai(2021), 31.desember(2021)),
                         tilhører = FradragTilhører.BRUKER,
                     ),
                 ),

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/VurderOpphørVedRevurderingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/VurderOpphørVedRevurderingTest.kt
@@ -18,6 +18,7 @@ import no.nav.su.se.bakover.domain.beregning.Månedsberegning
 import no.nav.su.se.bakover.domain.vilkår.Resultat
 import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.Clock
 import java.time.LocalDate
 import java.time.ZoneOffset
@@ -228,5 +229,19 @@ internal class VurderOpphørVedRevurderingTest {
             beregning = beregningMock,
             clock = fixedClock,
         ).resultat shouldBe OpphørVedRevurdering.Ja(listOf(Opphørsgrunn.SU_UNDER_MINSTEGRENSE), 1.januar(2021))
+    }
+
+    @Test
+    fun `kaster exception hvis vilkårsvurderinger svarer med uavklart`() {
+        val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
+            on { resultat } doReturn Resultat.Uavklart
+        }
+        assertThrows<IllegalStateException> {
+            VurderOpphørVedRevurdering(
+                vilkårsvurderinger = vilkårsvurderingerMock,
+                beregning = mock(),
+                clock = fixedClock,
+            )
+        }
     }
 }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/VurderOpphørVedRevurderingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/VurderOpphørVedRevurderingTest.kt
@@ -1,0 +1,232 @@
+package no.nav.su.se.bakover.domain.revurdering
+
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.common.desember
+import no.nav.su.se.bakover.common.endOfMonth
+import no.nav.su.se.bakover.common.februar
+import no.nav.su.se.bakover.common.januar
+import no.nav.su.se.bakover.common.juni
+import no.nav.su.se.bakover.common.november
+import no.nav.su.se.bakover.common.periode.Periode
+import no.nav.su.se.bakover.common.startOfDay
+import no.nav.su.se.bakover.common.startOfMonth
+import no.nav.su.se.bakover.domain.behandling.avslag.Opphørsgrunn
+import no.nav.su.se.bakover.domain.beregning.Beregning
+import no.nav.su.se.bakover.domain.beregning.Månedsberegning
+import no.nav.su.se.bakover.domain.vilkår.Resultat
+import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+internal class VurderOpphørVedRevurderingTest {
+
+    private val fixedClock: Clock = Clock.fixed(1.juni(2021).startOfDay().instant, ZoneOffset.UTC)
+
+    @Test
+    fun `vilkår ikke er oppfylt gir opphør`() {
+        val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
+            on { resultat } doReturn Resultat.Avslag
+            on { utledOpphørsgrunner() } doReturn listOf(Opphørsgrunn.UFØRHET)
+            on { tidligsteDatoFrorAvslag() } doReturn 1.juni(2021)
+        }
+        val beregningMock = mock<Beregning>()
+
+        VurderOpphørVedRevurdering(
+            vilkårsvurderinger = vilkårsvurderingerMock,
+            beregning = beregningMock,
+            clock = fixedClock,
+        ).resultat shouldBe OpphørVedRevurdering.Ja(listOf(Opphørsgrunn.UFØRHET), 1.juni(2021))
+    }
+
+    @Test
+    fun `en fremtidig måned under minstebeløp gir opphør`() {
+        val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
+            on { resultat } doReturn Resultat.Innvilget
+        }
+        val månedsberegningMock = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.desember(2021), 31.desember(2021))
+            on { erSumYtelseUnderMinstebeløp() } doReturn true
+        }
+        val beregningMock = mock<Beregning> {
+            on { getMånedsberegninger() } doReturn listOf(månedsberegningMock)
+        }
+
+        VurderOpphørVedRevurdering(
+            vilkårsvurderinger = vilkårsvurderingerMock,
+            beregning = beregningMock,
+            clock = fixedClock,
+        ).resultat shouldBe OpphørVedRevurdering.Ja(listOf(Opphørsgrunn.SU_UNDER_MINSTEGRENSE), 1.desember(2021))
+    }
+
+    @Test
+    fun `alle fremtidige måneder under minstebeløp gir opphør`() {
+        val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
+            on { resultat } doReturn Resultat.Innvilget
+        }
+        val månedsberegningMock1 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.november(2021), 30.november(2021))
+            on { erSumYtelseUnderMinstebeløp() } doReturn true
+        }
+        val månedsberegningMock2 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.desember(2021), 31.desember(2021))
+            on { erSumYtelseUnderMinstebeløp() } doReturn true
+        }
+        val beregningMock = mock<Beregning> {
+            on { getMånedsberegninger() } doReturn listOf(månedsberegningMock1, månedsberegningMock2)
+        }
+
+        VurderOpphørVedRevurdering(
+            vilkårsvurderinger = vilkårsvurderingerMock,
+            beregning = beregningMock,
+            clock = fixedClock,
+        ).resultat shouldBe OpphørVedRevurdering.Ja(listOf(Opphørsgrunn.SU_UNDER_MINSTEGRENSE), 1.november(2021))
+    }
+
+    @Test
+    fun `inneværende måned under minstebeløp gir opphør`() {
+        val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
+            on { resultat } doReturn Resultat.Innvilget
+        }
+        val månedsberegningMock = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(LocalDate.now(fixedClock).startOfMonth(), LocalDate.now(fixedClock).endOfMonth())
+            on { erSumYtelseUnderMinstebeløp() } doReturn true
+        }
+        val beregningMock = mock<Beregning> {
+            on { getMånedsberegninger() } doReturn listOf(månedsberegningMock)
+        }
+
+        VurderOpphørVedRevurdering(
+            vilkårsvurderinger = vilkårsvurderingerMock,
+            beregning = beregningMock,
+            clock = fixedClock,
+        ).resultat shouldBe OpphørVedRevurdering.Ja(listOf(Opphørsgrunn.SU_UNDER_MINSTEGRENSE), LocalDate.now(fixedClock).startOfMonth())
+    }
+
+    @Test
+    fun `en fremtidig måned med beløp lik 0 gir opphør`() {
+        val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
+            on { resultat } doReturn Resultat.Innvilget
+        }
+        val månedsberegningMock = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.desember(2021), 31.desember(2021))
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+            on { getSumYtelse() } doReturn 0
+        }
+        val beregningMock = mock<Beregning> {
+            on { getMånedsberegninger() } doReturn listOf(månedsberegningMock)
+        }
+
+        VurderOpphørVedRevurdering(
+            vilkårsvurderinger = vilkårsvurderingerMock,
+            beregning = beregningMock,
+            clock = fixedClock,
+        ).resultat shouldBe OpphørVedRevurdering.Ja(listOf(Opphørsgrunn.FOR_HØY_INNTEKT), 1.desember(2021))
+    }
+
+    @Test
+    fun `en måned i fortiden under minstebeløp gir ikke opphør`() {
+        val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
+            on { resultat } doReturn Resultat.Innvilget
+        }
+        val månedsberegningMock1 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.januar(2021), 31.januar(2021))
+            on { erSumYtelseUnderMinstebeløp() } doReturn true
+        }
+        val månedsberegningMock2 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.februar(2021), 28.februar(2021))
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+            on { getSumYtelse() } doReturn 5000
+        }
+        val beregningMock = mock<Beregning> {
+            on { getMånedsberegninger() } doReturn listOf(månedsberegningMock1, månedsberegningMock2)
+        }
+
+        VurderOpphørVedRevurdering(
+            vilkårsvurderinger = vilkårsvurderingerMock,
+            beregning = beregningMock,
+            clock = fixedClock,
+        ).resultat shouldBe OpphørVedRevurdering.Nei
+    }
+
+    @Test
+    fun `en måned i fortiden med beløp lik 0 gir ikke opphør`() {
+        val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
+            on { resultat } doReturn Resultat.Innvilget
+        }
+        val månedsberegningMock1 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.januar(2021), 31.januar(2021))
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+            on { getSumYtelse() } doReturn 0
+        }
+        val månedsberegningMock2 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.februar(2021), 28.februar(2021))
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+            on { getSumYtelse() } doReturn 5000
+        }
+        val beregningMock = mock<Beregning> {
+            on { getMånedsberegninger() } doReturn listOf(månedsberegningMock1, månedsberegningMock2)
+        }
+
+        VurderOpphørVedRevurdering(
+            vilkårsvurderinger = vilkårsvurderingerMock,
+            beregning = beregningMock,
+            clock = fixedClock,
+        ).resultat shouldBe OpphørVedRevurdering.Nei
+    }
+
+    @Test
+    fun `alle måneder i fortiden med beløp lik 0 gir opphør`() {
+        val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
+            on { resultat } doReturn Resultat.Innvilget
+        }
+        val månedsberegningMock1 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.januar(2021), 31.januar(2021))
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+            on { getSumYtelse() } doReturn 0
+        }
+        val månedsberegningMock2 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.februar(2021), 28.februar(2021))
+            on { erSumYtelseUnderMinstebeløp() } doReturn false
+            on { getSumYtelse() } doReturn 0
+        }
+        val beregningMock = mock<Beregning> {
+            on { getMånedsberegninger() } doReturn listOf(månedsberegningMock1, månedsberegningMock2)
+        }
+
+        VurderOpphørVedRevurdering(
+            vilkårsvurderinger = vilkårsvurderingerMock,
+            beregning = beregningMock,
+            clock = fixedClock,
+        ).resultat shouldBe OpphørVedRevurdering.Ja(listOf(Opphørsgrunn.FOR_HØY_INNTEKT), 1.januar(2021))
+    }
+
+    @Test
+    fun `alle måneder i fortiden med beløp under minstegrense gir opphør`() {
+        val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
+            on { resultat } doReturn Resultat.Innvilget
+        }
+        val månedsberegningMock1 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.januar(2021), 31.januar(2021))
+            on { erSumYtelseUnderMinstebeløp() } doReturn true
+            on { getSumYtelse() } doReturn 0
+        }
+        val månedsberegningMock2 = mock<Månedsberegning> {
+            on { periode } doReturn Periode.create(1.februar(2021), 28.februar(2021))
+            on { erSumYtelseUnderMinstebeløp() } doReturn true
+            on { getSumYtelse() } doReturn 0
+        }
+        val beregningMock = mock<Beregning> {
+            on { getMånedsberegninger() } doReturn listOf(månedsberegningMock1, månedsberegningMock2)
+        }
+
+        VurderOpphørVedRevurdering(
+            vilkårsvurderinger = vilkårsvurderingerMock,
+            beregning = beregningMock,
+            clock = fixedClock,
+        ).resultat shouldBe OpphørVedRevurdering.Ja(listOf(Opphørsgrunn.SU_UNDER_MINSTEGRENSE), 1.januar(2021))
+    }
+}

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vilkår/VilkårsvurderingerTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vilkår/VilkårsvurderingerTest.kt
@@ -59,7 +59,10 @@ internal class VilkårsvurderingerTest {
     fun `ingen vurderingsperioder gir uavklart vilkår`() {
         Vilkårsvurderinger(
             uføre = Vilkår.IkkeVurdert.Uførhet,
-        ).resultat shouldBe Resultat.Uavklart
+        ).let {
+            it.resultat shouldBe Resultat.Uavklart
+            it.tidligsteDatoFrorAvslag() shouldBe null
+        }
     }
 
     @Test
@@ -89,7 +92,10 @@ internal class VilkårsvurderingerTest {
                     ),
                 ),
             ),
-        ).resultat shouldBe Resultat.Avslag
+        ).let {
+            it.resultat shouldBe Resultat.Avslag
+            it.tidligsteDatoFrorAvslag() shouldBe 1.mai(2021)
+        }
     }
 
     @Test
@@ -124,6 +130,7 @@ internal class VilkårsvurderingerTest {
 
         val actual = vilkårsvurdering.oppdaterStønadsperiode(Stønadsperiode.create(nyPeriode, "test"))
         actual.grunnlagsdata.uføregrunnlag.first().periode shouldBe nyPeriode
+        actual.tidligsteDatoFrorAvslag() shouldBe 1.februar(2021)
     }
 
     @Test
@@ -145,12 +152,13 @@ internal class VilkårsvurderingerTest {
             ),
         )
         vilkårsvurdering.utledOpphørsgrunner() shouldBe listOf(Opphørsgrunn.UFØRHET)
+        vilkårsvurdering.tidligsteDatoFrorAvslag() shouldBe 1.januar(2021)
     }
 
     @Test
     fun `ikke vurderte vilkår gir ikke opphørtsgrunn`() {
         val vilkårsvurdering = Vilkårsvurderinger(
-            uføre = Vilkår.IkkeVurdert.Uførhet
+            uføre = Vilkår.IkkeVurdert.Uførhet,
         )
         vilkårsvurdering.utledOpphørsgrunner() shouldBe emptyList()
     }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vilkår/VilkårsvurderingerTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vilkår/VilkårsvurderingerTest.kt
@@ -61,7 +61,7 @@ internal class VilkårsvurderingerTest {
             uføre = Vilkår.IkkeVurdert.Uførhet,
         ).let {
             it.resultat shouldBe Resultat.Uavklart
-            it.tidligsteDatoFrorAvslag() shouldBe null
+            it.tidligsteDatoForAvslag() shouldBe null
         }
     }
 
@@ -94,7 +94,7 @@ internal class VilkårsvurderingerTest {
             ),
         ).let {
             it.resultat shouldBe Resultat.Avslag
-            it.tidligsteDatoFrorAvslag() shouldBe 1.mai(2021)
+            it.tidligsteDatoForAvslag() shouldBe 1.mai(2021)
         }
     }
 
@@ -130,7 +130,7 @@ internal class VilkårsvurderingerTest {
 
         val actual = vilkårsvurdering.oppdaterStønadsperiode(Stønadsperiode.create(nyPeriode, "test"))
         actual.grunnlagsdata.uføregrunnlag.first().periode shouldBe nyPeriode
-        actual.tidligsteDatoFrorAvslag() shouldBe 1.februar(2021)
+        actual.tidligsteDatoForAvslag() shouldBe 1.februar(2021)
     }
 
     @Test
@@ -152,7 +152,7 @@ internal class VilkårsvurderingerTest {
             ),
         )
         vilkårsvurdering.utledOpphørsgrunner() shouldBe listOf(Opphørsgrunn.UFØRHET)
-        vilkårsvurdering.tidligsteDatoFrorAvslag() shouldBe 1.januar(2021)
+        vilkårsvurdering.tidligsteDatoForAvslag() shouldBe 1.januar(2021)
     }
 
     @Test

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
@@ -42,6 +42,7 @@ import no.nav.su.se.bakover.service.brev.BrevService
 import no.nav.su.se.bakover.service.grunnlag.GrunnlagService
 import no.nav.su.se.bakover.service.oppgave.OppgaveService
 import no.nav.su.se.bakover.service.person.PersonService
+import no.nav.su.se.bakover.service.revurdering.BeregnOgSimulerResponse
 import no.nav.su.se.bakover.service.revurdering.FortsettEtterForhåndsvarselFeil
 import no.nav.su.se.bakover.service.revurdering.FortsettEtterForhåndsvarslingRequest
 import no.nav.su.se.bakover.service.revurdering.HentGjeldendeGrunnlagsdataOgVilkårsvurderingerResponse
@@ -393,7 +394,7 @@ open class AccessCheckProxy(
                 override fun beregnOgSimuler(
                     revurderingId: UUID,
                     saksbehandler: NavIdentBruker.Saksbehandler,
-                ): Either<KunneIkkeBeregneOgSimulereRevurdering, Revurdering> {
+                ): Either<KunneIkkeBeregneOgSimulereRevurdering, BeregnOgSimulerResponse> {
                     assertHarTilgangTilRevurdering(revurderingId)
                     return services.revurdering.beregnOgSimuler(
                         revurderingId = revurderingId,

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
@@ -9,6 +9,7 @@ import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.revurdering.IverksattRevurdering
 import no.nav.su.se.bakover.domain.revurdering.OpprettetRevurdering
 import no.nav.su.se.bakover.domain.revurdering.Revurdering
+import no.nav.su.se.bakover.domain.revurdering.SaksbehandlingsutfallSomIkkeStøttes
 import no.nav.su.se.bakover.domain.revurdering.UnderkjentRevurdering
 import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
 import no.nav.su.se.bakover.service.vilkår.LeggTilUførevurderingerRequest
@@ -94,6 +95,7 @@ data class LeggTilFradragsgrunnlagResponse(
 
 data class BeregnOgSimulerResponse(
     val revurdering: Revurdering,
+    val feilmeldinger: List<SaksbehandlingsutfallSomIkkeStøttes> = emptyList()
 )
 
 sealed class FortsettEtterForhåndsvarslingRequest {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
@@ -9,7 +9,7 @@ import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.revurdering.IverksattRevurdering
 import no.nav.su.se.bakover.domain.revurdering.OpprettetRevurdering
 import no.nav.su.se.bakover.domain.revurdering.Revurdering
-import no.nav.su.se.bakover.domain.revurdering.SaksbehandlingsutfallSomIkkeStøttes
+import no.nav.su.se.bakover.domain.revurdering.RevurderingsutfallSomIkkeStøttes
 import no.nav.su.se.bakover.domain.revurdering.UnderkjentRevurdering
 import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
 import no.nav.su.se.bakover.service.vilkår.LeggTilUførevurderingerRequest
@@ -95,7 +95,7 @@ data class LeggTilFradragsgrunnlagResponse(
 
 data class BeregnOgSimulerResponse(
     val revurdering: Revurdering,
-    val feilmeldinger: List<SaksbehandlingsutfallSomIkkeStøttes> = emptyList()
+    val feilmeldinger: List<RevurderingsutfallSomIkkeStøttes> = emptyList()
 )
 
 sealed class FortsettEtterForhåndsvarslingRequest {
@@ -213,6 +213,7 @@ sealed class KunneIkkeSendeRevurderingTilAttestering {
 
     object ManglerBeslutningPåForhåndsvarsel : KunneIkkeSendeRevurderingTilAttestering()
     object FeilutbetalingStøttesIkke : KunneIkkeSendeRevurderingTilAttestering()
+    data class RevurderingsutfallStøttesIkke(val feilmeldinger: List<RevurderingsutfallSomIkkeStøttes>) : KunneIkkeSendeRevurderingTilAttestering()
 }
 
 sealed class KunneIkkeIverksetteRevurdering {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
@@ -29,7 +29,7 @@ interface RevurderingService {
     fun beregnOgSimuler(
         revurderingId: UUID,
         saksbehandler: NavIdentBruker.Saksbehandler,
-    ): Either<KunneIkkeBeregneOgSimulereRevurdering, Revurdering>
+    ): Either<KunneIkkeBeregneOgSimulereRevurdering, BeregnOgSimulerResponse>
 
     fun forhåndsvarsleEllerSendTilAttestering(
         revurderingId: UUID,
@@ -90,6 +90,10 @@ data class LeggTilFradragsgrunnlagRequest(
 
 data class LeggTilFradragsgrunnlagResponse(
     val revurdering: Revurdering
+)
+
+data class BeregnOgSimulerResponse(
+    val revurdering: Revurdering,
 )
 
 sealed class FortsettEtterForhåndsvarslingRequest {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -361,7 +361,7 @@ internal class RevurderingServiceImpl(
     override fun beregnOgSimuler(
         revurderingId: UUID,
         saksbehandler: NavIdentBruker.Saksbehandler,
-    ): Either<KunneIkkeBeregneOgSimulereRevurdering, Revurdering> {
+    ): Either<KunneIkkeBeregneOgSimulereRevurdering, BeregnOgSimulerResponse> {
         return when (val originalRevurdering = revurderingRepo.hent(revurderingId)) {
             is BeregnetRevurdering, is OpprettetRevurdering, is SimulertRevurdering, is UnderkjentRevurdering -> {
                 when (
@@ -378,7 +378,7 @@ internal class RevurderingServiceImpl(
                 ) {
                     is BeregnetRevurdering.IngenEndring -> {
                         revurderingRepo.lagre(beregnetRevurdering)
-                        beregnetRevurdering.right()
+                        BeregnOgSimulerResponse(beregnetRevurdering).right()
                     }
                     is BeregnetRevurdering.Innvilget -> {
                         utbetalingService.simulerUtbetaling(
@@ -390,7 +390,7 @@ internal class RevurderingServiceImpl(
                         }.map {
                             val simulert = beregnetRevurdering.toSimulert(it.simulering)
                             revurderingRepo.lagre(simulert)
-                            simulert
+                            BeregnOgSimulerResponse(simulert)
                         }
                     }
 
@@ -404,7 +404,7 @@ internal class RevurderingServiceImpl(
                         }.map {
                             val simulert = beregnetRevurdering.toSimulert(it.simulering)
                             revurderingRepo.lagre(simulert)
-                            simulert
+                            BeregnOgSimulerResponse(simulert)
                         }
                     }
                 }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -373,7 +373,6 @@ internal class RevurderingServiceImpl(
                                 is Revurdering.KunneIkkeBeregneRevurdering.UgyldigBeregningsgrunnlag -> KunneIkkeBeregneOgSimulereRevurdering.UgyldigBeregningsgrunnlag(
                                     it.reason,
                                 )
-                                is Revurdering.KunneIkkeBeregneRevurdering.UfullstendigVilkårsvurdering -> KunneIkkeBeregneOgSimulereRevurdering.UfullstendigVilkårsvurdering
                             }.left()
                         }
                 ) {

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RegulerGrunnbeløpServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RegulerGrunnbeløpServiceImplTest.kt
@@ -332,7 +332,7 @@ internal class RegulerGrunnbeløpServiceImplTest {
         ).beregnOgSimuler(
             revurderingId = revurderingId,
             saksbehandler = BehandlingTestUtils.saksbehandler,
-        ).orNull()!! as BeregnetRevurdering.IngenEndring
+        ).orNull()!!.revurdering as BeregnetRevurdering.IngenEndring
 
         // TODO jah: BeregningMedFradragBeregnetMånedsvis er internal, skal vi heller gjøre den public? Dette ble løst av å ha en felles equal funksjon for alle Fradrag
         actual.shouldBeEqualToIgnoringFields(expectedBeregnetRevurdering, BeregnetRevurdering.IngenEndring::beregning)

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RegulerGrunnbeløpServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RegulerGrunnbeløpServiceImplTest.kt
@@ -360,11 +360,13 @@ internal class RegulerGrunnbeløpServiceImplTest {
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsakRegulerGrunnbeløp,
             behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
-            beregning = mock(),
+            beregning = TestBeregning,
             simulering = mock(),
             forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
             grunnlagsdata = Grunnlagsdata.EMPTY,
-            vilkårsvurderinger = Vilkårsvurderinger.EMPTY,
+            vilkårsvurderinger = mock {
+                on { resultat } doReturn Resultat.Innvilget
+            },
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
         )
 
@@ -417,12 +419,14 @@ internal class RegulerGrunnbeløpServiceImplTest {
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsakRegulerGrunnbeløp,
             behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
-            beregning = mock(),
+            beregning = TestBeregning,
             simulering = mock(),
             attestering = mock(),
             forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
             grunnlagsdata = Grunnlagsdata.EMPTY,
-            vilkårsvurderinger = Vilkårsvurderinger.EMPTY,
+            vilkårsvurderinger = mock {
+                on { resultat } doReturn Resultat.Innvilget
+            },
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
         )
 
@@ -475,10 +479,12 @@ internal class RegulerGrunnbeløpServiceImplTest {
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsakRegulerGrunnbeløp,
             behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
-            beregning = mock(),
+            beregning = TestBeregning,
             forhåndsvarsel = null,
             grunnlagsdata = Grunnlagsdata.EMPTY,
-            vilkårsvurderinger = Vilkårsvurderinger.EMPTY,
+            vilkårsvurderinger = mock {
+                on { resultat } doReturn Resultat.Innvilget
+            },
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
         )
 
@@ -521,7 +527,7 @@ internal class RegulerGrunnbeløpServiceImplTest {
             skalFøreTilBrevutsending = false,
             forhåndsvarsel = null,
             grunnlagsdata = Grunnlagsdata.EMPTY,
-            vilkårsvurderinger = Vilkårsvurderinger.EMPTY,
+            vilkårsvurderinger = actual.vilkårsvurderinger,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
         )
 
@@ -551,12 +557,14 @@ internal class RegulerGrunnbeløpServiceImplTest {
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsakRegulerGrunnbeløp,
             behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
-            beregning = mock(),
+            beregning = TestBeregning,
             attestering = mock(),
             skalFøreTilBrevutsending = true,
             forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
             grunnlagsdata = Grunnlagsdata.EMPTY,
-            vilkårsvurderinger = Vilkårsvurderinger.EMPTY,
+            vilkårsvurderinger = mock {
+                on { resultat } doReturn Resultat.Innvilget
+            },
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
         )
 
@@ -599,7 +607,7 @@ internal class RegulerGrunnbeløpServiceImplTest {
             skalFøreTilBrevutsending = false,
             forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
             grunnlagsdata = Grunnlagsdata.EMPTY,
-            vilkårsvurderinger = Vilkårsvurderinger.EMPTY,
+            vilkårsvurderinger = actual.vilkårsvurderinger,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
         )
 

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingBeregnOgSimulerTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingBeregnOgSimulerTest.kt
@@ -20,7 +20,7 @@ import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.revurdering.InformasjonSomRevurderes
 import no.nav.su.se.bakover.domain.revurdering.OpprettetRevurdering
 import no.nav.su.se.bakover.domain.revurdering.Revurderingsteg
-import no.nav.su.se.bakover.domain.revurdering.SaksbehandlingsutfallSomIkkeStøttes
+import no.nav.su.se.bakover.domain.revurdering.RevurderingsutfallSomIkkeStøttes
 import no.nav.su.se.bakover.domain.vilkår.Resultat
 import no.nav.su.se.bakover.domain.vilkår.Vilkår
 import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
@@ -100,7 +100,7 @@ class RevurderingBeregnOgSimulerTest {
         ).getOrHandle { throw RuntimeException() }
 
         response.feilmeldinger shouldBe listOf(
-            SaksbehandlingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon,
+            RevurderingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon,
         )
     }
 }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingBeregnOgSimulerTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingBeregnOgSimulerTest.kt
@@ -1,0 +1,106 @@
+package no.nav.su.se.bakover.service.revurdering
+
+import arrow.core.Nel
+import arrow.core.getOrHandle
+import arrow.core.right
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.common.Tidspunkt
+import no.nav.su.se.bakover.database.revurdering.RevurderingRepo
+import no.nav.su.se.bakover.domain.beregning.fradrag.FradragFactory
+import no.nav.su.se.bakover.domain.beregning.fradrag.FradragTilhører
+import no.nav.su.se.bakover.domain.beregning.fradrag.Fradragstype
+import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
+import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
+import no.nav.su.se.bakover.domain.grunnlag.Uføregrad
+import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
+import no.nav.su.se.bakover.domain.oppgave.OppgaveId
+import no.nav.su.se.bakover.domain.revurdering.InformasjonSomRevurderes
+import no.nav.su.se.bakover.domain.revurdering.OpprettetRevurdering
+import no.nav.su.se.bakover.domain.revurdering.Revurderingsteg
+import no.nav.su.se.bakover.domain.revurdering.SaksbehandlingsutfallSomIkkeStøttes
+import no.nav.su.se.bakover.domain.vilkår.Resultat
+import no.nav.su.se.bakover.domain.vilkår.Vilkår
+import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
+import no.nav.su.se.bakover.domain.vilkår.Vurderingsperiode
+import no.nav.su.se.bakover.service.fixedTidspunkt
+import no.nav.su.se.bakover.service.utbetaling.UtbetalingService
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class RevurderingBeregnOgSimulerTest {
+
+    @Test
+    fun `legger ved feilmeldinger for tilfeller som ikke støttes`() {
+        val uføregrunnlag = Grunnlag.Uføregrunnlag(
+            periode = RevurderingTestUtils.periode,
+            uføregrad = Uføregrad.parse(20),
+            forventetInntekt = 10,
+        )
+        val opprettetRevurdering = OpprettetRevurdering(
+            id = RevurderingTestUtils.revurderingId,
+            periode = RevurderingTestUtils.periode,
+            opprettet = Tidspunkt.EPOCH,
+            tilRevurdering = RevurderingTestUtils.søknadsbehandlingVedtak,
+            saksbehandler = RevurderingTestUtils.saksbehandler,
+            oppgaveId = OppgaveId("oppgaveid"),
+            fritekstTilBrev = "",
+            revurderingsårsak = RevurderingTestUtils.revurderingsårsak,
+            forhåndsvarsel = null,
+            behandlingsinformasjon = RevurderingTestUtils.søknadsbehandlingVedtak.behandlingsinformasjon,
+            grunnlagsdata = Grunnlagsdata(
+                uføregrunnlag = listOf(uføregrunnlag),
+                fradragsgrunnlag = listOf(
+                    Grunnlag.Fradragsgrunnlag(
+                        fradrag = FradragFactory.ny(
+                            type = Fradragstype.Arbeidsinntekt,
+                            månedsbeløp = 150500.0,
+                            periode = RevurderingTestUtils.søknadsbehandlingVedtak.periode,
+                            utenlandskInntekt = null,
+                            tilhører = FradragTilhører.BRUKER,
+                        ),
+                    ),
+                ),
+            ),
+            vilkårsvurderinger = Vilkårsvurderinger(
+                uføre = Vilkår.Vurdert.Uførhet.create(
+                    vurderingsperioder = Nel.of(
+                        Vurderingsperiode.Uføre.create(
+                            id = UUID.randomUUID(),
+                            opprettet = fixedTidspunkt,
+                            resultat = Resultat.Avslag,
+                            grunnlag = uføregrunnlag,
+                            periode = RevurderingTestUtils.periode,
+                            begrunnelse = "ok2k",
+                        ),
+                    ),
+                ),
+            ),
+            informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+        )
+
+        val revurderingRepoMock = mock<RevurderingRepo> {
+            on { hent(RevurderingTestUtils.revurderingId) } doReturn opprettetRevurdering
+        }
+        val simulertUtbetaling = mock<Utbetaling.SimulertUtbetaling> {
+            on { simulering } doReturn mock()
+        }
+        val utbetalingServiceMock = mock<UtbetalingService> {
+            on { simulerOpphør(any(), any(), any()) } doReturn simulertUtbetaling.right()
+        }
+
+        val response = RevurderingTestUtils.createRevurderingService(
+            revurderingRepo = revurderingRepoMock,
+            utbetalingService = utbetalingServiceMock,
+        ).beregnOgSimuler(
+            revurderingId = RevurderingTestUtils.revurderingId,
+            saksbehandler = RevurderingTestUtils.saksbehandler,
+        ).getOrHandle { throw RuntimeException() }
+
+        response.feilmeldinger shouldBe listOf(
+            SaksbehandlingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon,
+        )
+    }
+}

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingBeregnOgSimulerTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingBeregnOgSimulerTest.kt
@@ -6,6 +6,7 @@ import arrow.core.right
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
+import io.kotest.assertions.fail
 import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.database.revurdering.RevurderingRepo
@@ -97,7 +98,7 @@ class RevurderingBeregnOgSimulerTest {
         ).beregnOgSimuler(
             revurderingId = RevurderingTestUtils.revurderingId,
             saksbehandler = RevurderingTestUtils.saksbehandler,
-        ).getOrHandle { throw RuntimeException() }
+        ).getOrHandle { fail("Skulle returnert en instans av ${BeregnOgSimulerResponse::class}") }
 
         response.feilmeldinger shouldBe listOf(
             RevurderingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
@@ -109,7 +109,7 @@ class RevurderingIngenEndringTest {
         ).beregnOgSimuler(
             revurderingId = revurderingId,
             saksbehandler = saksbehandler,
-        ).orNull()!! as BeregnetRevurdering.IngenEndring
+        ).orNull()!!.revurdering as BeregnetRevurdering.IngenEndring
         actual.shouldBeEqualToIgnoringFields(
             BeregnetRevurdering.IngenEndring(
                 id = revurderingId,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
@@ -95,8 +95,8 @@ class RevurderingIngenEndringTest {
             ),
             informasjonSomRevurderes = InformasjonSomRevurderes.create(
                 mapOf(
-                    Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert
-                )
+                    Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert,
+                ),
             ),
         )
 
@@ -127,8 +127,8 @@ class RevurderingIngenEndringTest {
                 vilkårsvurderinger = opprettetRevurdering.vilkårsvurderinger,
                 informasjonSomRevurderes = InformasjonSomRevurderes.create(
                     mapOf(
-                        Revurderingsteg.Inntekt to Vurderingstatus.Vurdert
-                    )
+                        Revurderingsteg.Inntekt to Vurderingstatus.Vurdert,
+                    ),
                 ),
             ),
             // beregningstypen er internal i domene modulen
@@ -149,6 +149,9 @@ class RevurderingIngenEndringTest {
 
     @Test
     fun `attesterer revurdering som ikke fører til endring i ytelse`() {
+        val vilkårsvurderingerMock = mock<Vilkårsvurderinger> {
+            on { resultat } doReturn Resultat.Innvilget
+        }
         val beregnetRevurdering = BeregnetRevurdering.IngenEndring(
             id = revurderingId,
             periode = periode,
@@ -162,7 +165,7 @@ class RevurderingIngenEndringTest {
             forhåndsvarsel = null,
             behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
             grunnlagsdata = Grunnlagsdata.EMPTY,
-            vilkårsvurderinger = Vilkårsvurderinger.EMPTY,
+            vilkårsvurderinger = vilkårsvurderingerMock,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
         )
         val endretSaksbehandler = NavIdentBruker.Saksbehandler("endretSaksbehandler")
@@ -180,7 +183,7 @@ class RevurderingIngenEndringTest {
             skalFøreTilBrevutsending = true,
             behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
             grunnlagsdata = Grunnlagsdata.EMPTY,
-            vilkårsvurderinger = Vilkårsvurderinger.EMPTY,
+            vilkårsvurderinger = vilkårsvurderingerMock,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
         )
         val revurderingRepoMock = mock<RevurderingRepo> {

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingSendTilAttesteringTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingSendTilAttesteringTest.kt
@@ -237,4 +237,31 @@ class RevurderingSendTilAttesteringTest {
 
         verify(revurderingRepoMock, never()).lagre(any())
     }
+
+    @Test
+    fun `kan ikke sende revurdering med utfall som ikke støttes til attestering - simulering har feilubtbetaling`() {
+        val simuleringMock = mock<Simulering> {
+            on { harFeilutbetalinger() } doReturn true
+        }
+        val revurderingRepoMock = mock<RevurderingRepo> {
+            on { hent(RevurderingTestUtils.revurderingId) } doReturn RevurderingTestUtils.simulertRevurderingInnvilget.copy(
+                simulering = simuleringMock,
+            )
+        }
+
+        val actual = RevurderingTestUtils.createRevurderingService(
+            revurderingRepo = revurderingRepoMock,
+        ).sendTilAttestering(
+            SendTilAttesteringRequest(
+                revurderingId = RevurderingTestUtils.revurderingId,
+                saksbehandler = RevurderingTestUtils.saksbehandler,
+                fritekstTilBrev = "Fritekst",
+                skalFøreTilBrevutsending = true,
+            ),
+        )
+
+        actual shouldBe KunneIkkeSendeRevurderingTilAttestering.FeilutbetalingStøttesIkke.left()
+
+        verify(revurderingRepoMock, never()).lagre(any())
+    }
 }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
@@ -1448,7 +1448,9 @@ internal class RevurderingServiceImplTest {
             ),
             behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
             grunnlagsdata = Grunnlagsdata.EMPTY,
-            vilkårsvurderinger = Vilkårsvurderinger.EMPTY,
+            vilkårsvurderinger = mock {
+                on { resultat } doReturn Resultat.Innvilget
+            },
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
         )
 

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
@@ -332,7 +332,7 @@ internal class RevurderingServiceImplTest {
         ).beregnOgSimuler(
             revurderingId = revurderingId,
             saksbehandler = saksbehandler,
-        ).getOrHandle { throw Exception("Vi skal få tilbake en revurdering") }
+        ).getOrHandle { throw Exception("Vi skal få tilbake en revurdering") }.revurdering
         if (actual !is SimulertRevurdering) throw RuntimeException("Skal returnere en simulert revurdering")
 
         inOrder(revurderingRepoMock, utbetalingServiceMock) {
@@ -789,7 +789,7 @@ internal class RevurderingServiceImplTest {
         val actual = revurderingService.beregnOgSimuler(
             underkjentRevurdering.id,
             saksbehandler,
-        ).getOrElse { throw RuntimeException("Noe gikk galt") }
+        ).getOrElse { throw RuntimeException("Noe gikk galt") }.revurdering
         if (actual !is SimulertRevurdering.Innvilget) throw RuntimeException("Skal returnere en simulert revurdering")
 
         inOrder(revurderingRepoMock, utbetalingServiceMock) {
@@ -1660,7 +1660,7 @@ internal class RevurderingServiceImplTest {
         ).beregnOgSimuler(
             revurderingId = revurderingId,
             saksbehandler = NavIdentBruker.Saksbehandler("s1"),
-        ).orNull()!!
+        ).orNull()!!.revurdering
 
         actual shouldBe beOfType<SimulertRevurdering.Opphørt>()
 

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
@@ -50,7 +50,6 @@ import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimuleringFeilet
 import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
 import no.nav.su.se.bakover.domain.oppgave.OppgaveFeil
-import no.nav.su.se.bakover.domain.oppgave.OppgaveFeil.KunneIkkeOppretteOppgave
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.person.KunneIkkeHentePerson
 import no.nav.su.se.bakover.domain.revurdering.BeregnetRevurdering
@@ -1681,7 +1680,7 @@ internal class RevurderingServiceImplTest {
     }
 
     @Test
-    fun `uavklarte vilkår gir feilmelding`() {
+    fun `uavklarte vilkår kaster exception`() {
         val uavklarteVilkår = vilkårsvurderinger.copy(
             uføre = Vilkår.IkkeVurdert.Uførhet,
         )
@@ -1692,19 +1691,13 @@ internal class RevurderingServiceImplTest {
             on { hent(revurderingId) } doReturn revurdering
         }
 
-        val actual = createRevurderingService(
-            revurderingRepo = revurderingRepoMock,
-        ).beregnOgSimuler(
-            revurderingId = revurderingId,
-            saksbehandler = NavIdentBruker.Saksbehandler("s1"),
-        )
-
-        actual shouldBe KunneIkkeBeregneOgSimulereRevurdering.UfullstendigVilkårsvurdering.left()
-
-        inOrder(
-            revurderingRepoMock,
-        ) {
-            verify(revurderingRepoMock).hent(revurderingId)
+        assertThrows<IllegalStateException> {
+            createRevurderingService(
+                revurderingRepo = revurderingRepoMock,
+            ).beregnOgSimuler(
+                revurderingId = revurderingId,
+                saksbehandler = NavIdentBruker.Saksbehandler("s1"),
+            )
         }
     }
 

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/Resultat.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/Resultat.kt
@@ -11,7 +11,7 @@ import no.nav.su.se.bakover.web.Resultat.Companion.json
 internal data class Resultat private constructor(
     val httpCode: HttpStatusCode,
     private val json: String,
-    private val contentType: ContentType
+    private val contentType: ContentType,
 ) {
     init {
         require(httpCode in HttpStatusCode.allStatusCodes) { "Unknown http status code:$httpCode" }
@@ -31,6 +31,10 @@ internal data class Resultat private constructor(
 internal fun HttpStatusCode.message(nonJsonMessage: String): Resultat = Resultat.message(this, nonJsonMessage)
 internal fun HttpStatusCode.errorJson(message: String, code: String): Resultat {
     return json(this, serialize(ErrorJson(message, code)))
+}
+
+internal fun HttpStatusCode.errorJson(errors: List<ErrorJson>): Resultat {
+    return json(this, serialize(errors))
 }
 
 internal suspend fun ApplicationCall.svar(resultat: Resultat) = resultat.svar(this)

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BeregnOgSimulerRevurderingRoute.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BeregnOgSimulerRevurderingRoute.kt
@@ -10,6 +10,7 @@ import io.ktor.util.KtorExperimentalAPI
 import no.nav.su.se.bakover.common.serialize
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.NavIdentBruker
+import no.nav.su.se.bakover.service.revurdering.BeregnOgSimulerResponse
 import no.nav.su.se.bakover.service.revurdering.KunneIkkeBeregneOgSimulereRevurdering
 import no.nav.su.se.bakover.service.revurdering.KunneIkkeBeregneOgSimulereRevurdering.FantIkkeRevurdering
 import no.nav.su.se.bakover.service.revurdering.KunneIkkeBeregneOgSimulereRevurdering.KanIkkeVelgeSisteMånedVedNedgangIStønaden
@@ -42,20 +43,24 @@ internal fun Route.beregnOgSimulerRevurdering(
                         saksbehandler = NavIdentBruker.Saksbehandler(call.suUserContext.navIdent),
                     ).mapLeft {
                         call.svar(it.tilResultat())
-                    }.map { revurdering ->
-                        call.sikkerlogg("Beregnet og simulert revurdering ${revurdering.id} på sak med id $sakId")
-                        call.audit(revurdering.fnr, AuditLogEvent.Action.UPDATE, revurdering.id)
+                    }.map { response ->
+                        call.sikkerlogg("Beregnet og simulert revurdering ${response.revurdering.id} på sak med id $sakId")
+                        call.audit(response.revurdering.fnr, AuditLogEvent.Action.UPDATE, response.revurdering.id)
                         call.svar(
                             Resultat.json(
                                 HttpStatusCode.Created,
-                                serialize(revurdering.toJson()),
-                            )
+                                serialize(response.toJson()),
+                            ),
                         )
                     }
                 }
             }
         }
     }
+}
+
+internal fun BeregnOgSimulerResponse.toJson(): RevurderingJson {
+    return this.revurdering.toJson()
 }
 
 private fun KunneIkkeBeregneOgSimulereRevurdering.tilResultat(): Resultat {

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BeregnOgSimulerRevurderingRoute.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BeregnOgSimulerRevurderingRoute.kt
@@ -10,7 +10,7 @@ import io.ktor.util.KtorExperimentalAPI
 import no.nav.su.se.bakover.common.serialize
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.NavIdentBruker
-import no.nav.su.se.bakover.domain.revurdering.SaksbehandlingsutfallSomIkkeStøttes
+import no.nav.su.se.bakover.domain.revurdering.RevurderingsutfallSomIkkeStøttes
 import no.nav.su.se.bakover.service.revurdering.BeregnOgSimulerResponse
 import no.nav.su.se.bakover.service.revurdering.KunneIkkeBeregneOgSimulereRevurdering
 import no.nav.su.se.bakover.service.revurdering.KunneIkkeBeregneOgSimulereRevurdering.FantIkkeRevurdering
@@ -71,20 +71,20 @@ internal fun BeregnOgSimulerResponse.toJson() = BeregnOgSimulerResponseJson(
     feilmeldinger = feilmeldinger.map { it.toJson() },
 )
 
-internal fun SaksbehandlingsutfallSomIkkeStøttes.toJson(): ErrorJson = when (this) {
-    SaksbehandlingsutfallSomIkkeStøttes.DelvisOpphør -> ErrorJson(
+internal fun RevurderingsutfallSomIkkeStøttes.toJson(): ErrorJson = when (this) {
+    RevurderingsutfallSomIkkeStøttes.DelvisOpphør -> ErrorJson(
         message = "Delvis opphør støttes ikke. Revurderingen må gjennomføres i flere steg.",
         code = "delvis_opphør",
     )
-    SaksbehandlingsutfallSomIkkeStøttes.OpphørAvFlereVilkår -> ErrorJson(
+    RevurderingsutfallSomIkkeStøttes.OpphørAvFlereVilkår -> ErrorJson(
         message = "Opphør av flere vilkår i kombinasjon støttes ikke",
         code = "opphør_av_flere_vilkår",
     )
-    SaksbehandlingsutfallSomIkkeStøttes.OpphørErIkkeFraFørsteMåned -> ErrorJson(
+    RevurderingsutfallSomIkkeStøttes.OpphørErIkkeFraFørsteMåned -> ErrorJson(
         message = "Opphørsdato er ikke lik fra-dato for revurderingsperioden. Revurdering må gjennomføres i flere steg.",
         code = "opphør_ikke_tidligste_dato",
     )
-    SaksbehandlingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon -> ErrorJson(
+    RevurderingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon -> ErrorJson(
         message = "Opphør i kombinasjon med andre endringer støttes ikke. Revurdering må gjennomføres i flere steg.",
         code = "opphør_og_andre_endringer_i_kombinasjon",
     )

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/SendRevurderingTilAttestering.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/SendRevurderingTilAttestering.kt
@@ -76,5 +76,6 @@ internal fun KunneIkkeSendeRevurderingTilAttestering.tilResultat(): Resultat {
         )
         is KunneIkkeSendeRevurderingTilAttestering.ManglerBeslutningPåForhåndsvarsel -> manglerBeslutningPåForhåndsvarsel
         KunneIkkeSendeRevurderingTilAttestering.FeilutbetalingStøttesIkke -> feilutbetalingStøttesIkke
+        is KunneIkkeSendeRevurderingTilAttestering.RevurderingsutfallStøttesIkke -> BadRequest.errorJson(feilmeldinger.map { it.toJson() })
     }
 }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BeregnOgSimulerRevurderingRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BeregnOgSimulerRevurderingRouteKtTest.kt
@@ -35,6 +35,7 @@ import no.nav.su.se.bakover.domain.vilkår.Resultat
 import no.nav.su.se.bakover.domain.vilkår.Vilkår
 import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
 import no.nav.su.se.bakover.domain.vilkår.Vurderingsperiode
+import no.nav.su.se.bakover.service.revurdering.BeregnOgSimulerResponse
 import no.nav.su.se.bakover.service.revurdering.KunneIkkeBeregneOgSimulereRevurdering
 import no.nav.su.se.bakover.service.revurdering.RevurderingService
 import no.nav.su.se.bakover.web.argThat
@@ -165,7 +166,7 @@ internal class BeregnOgSimulerRevurderingRouteKtTest {
         }
 
         val revurderingServiceMock = mock<RevurderingService> {
-            on { beregnOgSimuler(any(), any()) } doReturn simulertRevurdering.right()
+            on { beregnOgSimuler(any(), any()) } doReturn BeregnOgSimulerResponse(simulertRevurdering).right()
         }
 
         withTestApplication(

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BeregnOgSimulerRevurderingRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BeregnOgSimulerRevurderingRouteKtTest.kt
@@ -142,11 +142,11 @@ internal class BeregnOgSimulerRevurderingRouteKtTest {
                             periode = TestBeregning.periode,
                             begrunnelse = null,
 
-                        )
-                    )
-                )
+                        ),
+                    ),
+                ),
             ),
-            informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt))
+            informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
         ).beregn().orNull()!!
 
         val simulertRevurdering = when (beregnetRevurdering) {
@@ -182,14 +182,15 @@ internal class BeregnOgSimulerRevurderingRouteKtTest {
                 setBody(validBody)
             }.apply {
                 response.status() shouldBe HttpStatusCode.Created
-                val actualResponse = objectMapper.readValue<SimulertRevurderingJson>(response.content!!)
+                val actualResponse = objectMapper.readValue<Map<String, Any>>(response.content!!)
+                val revurdering = objectMapper.readValue<SimulertRevurderingJson>(objectMapper.writeValueAsString(actualResponse["revurdering"]))
                 verify(revurderingServiceMock).beregnOgSimuler(
                     argThat { it shouldBe simulertRevurdering.id },
                     argThat { it shouldBe NavIdentBruker.Saksbehandler("Z990Lokal") },
                 )
                 verifyNoMoreInteractions(revurderingServiceMock)
-                actualResponse.id shouldBe simulertRevurdering.id.toString()
-                actualResponse.status shouldBe RevurderingsStatus.SIMULERT_INNVILGET
+                revurdering.id shouldBe simulertRevurdering.id.toString()
+                revurdering.status shouldBe RevurderingsStatus.SIMULERT_INNVILGET
             }
         }
     }


### PR DESCRIPTION
Endret logikk for opphør til å være i tråd med mål satt for MVP:

Generelt:
- Alle opphør må gjøres fra dato lik revurderingsperiode-start
- Opphør for deler av perioden støttes ikke.
- Kombinasjon av opphør og endringer i ytelse støttes ikke
- 0-beløp for alle måneder i revurderingsperioden fører til opphør (uavhengig av framtid/fortid)

Vilkår:
- Opphør for hele revurderingsperioden dersom minst 1 vilkår er avslått.
- Opphør av flere vilkår støttes ikke (må utvides og lages logikk for etterhvert)

Inntekt:
Framover i tid:
- Minst 1 måned med 0-beløp gir opphør

Bakover i tid:
- 0-beløp bakover i tid (før dagens dato) gir ikke opphør, men håndteres som en normal endring (tilbakereving/etterbetaling)
