### PR TITLE
Åpne for å kunne revurdere tilbake i tid.

### DIFF
--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/Utbetalingsstrategi.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/Utbetalingsstrategi.kt
@@ -117,7 +117,6 @@ sealed class Utbetalingsstrategi {
             val sisteUtbetalingslinje = sisteOversendteUtbetaling()?.sisteUtbetalingslinje().let {
                 validate(it is Utbetalingslinje) { "Sak: $sakId har ingen utbetalinger som kan opphøres" }
                 it!!.let { sisteUtbetalingslinje ->
-                    validate(opphørsDato.isAfter(LocalDate.now(clock))) { "Støtter kun opphør framover i tid" }
                     validate(opphørsDato.isBefore(sisteUtbetalingslinje.tilOgMed)) { "Dato for opphør må være tidligere enn tilOgMed for siste utbetalingslinje" }
                     validate(opphørsDato.erFørsteDagIMåned() || opphørsDato.erSisteDagIMåned()) { "Ytelse kan kun opphøres fra første eller siste dag i en måned." }
                 }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/oppdrag/utbetaling/UtbetalingsstrategiOpphørTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/oppdrag/utbetaling/UtbetalingsstrategiOpphørTest.kt
@@ -76,23 +76,6 @@ internal class UtbetalingsstrategiOpphørTest {
     }
 
     @Test
-    fun `kaster exception dersom man forsøker å opphøre utbetalinger bakover i tid`() {
-        assertThrows<Utbetalingsstrategi.UtbetalingStrategyException> {
-            Utbetalingsstrategi.Opphør(
-                sakId = sakId,
-                saksnummer = saksnummer,
-                fnr = fnr,
-                utbetalinger = listOf(enUtbetaling),
-                behandler = NavIdentBruker.Saksbehandler("Z123"),
-                clock = fixedClock,
-                opphørsDato = 1.januar(2020),
-            ).generate()
-        }.also {
-            it.message shouldBe "Støtter kun opphør framover i tid"
-        }
-    }
-
-    @Test
     fun `kaster exception dersom man forsøker å opphøre utbetalinger senere enn siste utbetalingslinje sin sluttdato`() {
         assertThrows<Utbetalingsstrategi.UtbetalingStrategyException> {
             Utbetalingsstrategi.Opphør(

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
@@ -148,7 +148,6 @@ sealed class KunneIkkeOppretteRevurdering {
     data class UgyldigPeriode(val subError: Periode.UgyldigPeriode) : KunneIkkeOppretteRevurdering()
     object UgyldigÅrsak : KunneIkkeOppretteRevurdering()
     object UgyldigBegrunnelse : KunneIkkeOppretteRevurdering()
-    object PeriodeOgÅrsakKombinasjonErUgyldig : KunneIkkeOppretteRevurdering()
     object MåVelgeInformasjonSomSkalRevurderes : KunneIkkeOppretteRevurdering()
 }
 
@@ -161,7 +160,6 @@ sealed class KunneIkkeOppdatereRevurdering {
         KunneIkkeOppdatereRevurdering()
 
     object KanIkkeOppdatereRevurderingSomErForhåndsvarslet : KunneIkkeOppdatereRevurdering()
-    object PeriodeOgÅrsakKombinasjonErUgyldig : KunneIkkeOppdatereRevurdering()
     object MåVelgeInformasjonSomSkalRevurderes : KunneIkkeOppdatereRevurdering()
     object FantIkkeSak : KunneIkkeOppdatereRevurdering()
 }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -9,10 +9,8 @@ import arrow.core.right
 import no.nav.su.se.bakover.client.person.MicrosoftGraphApiOppslag
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.between
-import no.nav.su.se.bakover.common.endOfMonth
 import no.nav.su.se.bakover.common.log
 import no.nav.su.se.bakover.common.periode.Periode
-import no.nav.su.se.bakover.common.startOfMonth
 import no.nav.su.se.bakover.database.revurdering.RevurderingRepo
 import no.nav.su.se.bakover.database.vedtak.VedtakRepo
 import no.nav.su.se.bakover.domain.NavIdentBruker
@@ -55,7 +53,6 @@ import no.nav.su.se.bakover.service.utbetaling.UtbetalingService
 import no.nav.su.se.bakover.service.vedtak.FerdigstillVedtakService
 import no.nav.su.se.bakover.service.vilkår.LeggTilUførevurderingerRequest
 import java.time.Clock
-import java.time.LocalDate
 import java.util.UUID
 
 internal class RevurderingServiceImpl(
@@ -94,13 +91,6 @@ internal class RevurderingServiceImpl(
             }.left()
         }
 
-        if (!kanOppretteEllerOppdatereRevurderingsPeriodeOgEllerÅrsak(
-                revurderingsårsak,
-                opprettRevurderingRequest.fraOgMed,
-            )
-        ) {
-            return KunneIkkeOppretteRevurdering.PeriodeOgÅrsakKombinasjonErUgyldig.left()
-        }
         val sak = sakService.hentSak(opprettRevurderingRequest.sakId).getOrElse {
             return KunneIkkeOppretteRevurdering.FantIkkeSak.left()
         }
@@ -288,14 +278,6 @@ internal class RevurderingServiceImpl(
 
         if (revurdering.forhåndsvarsel is Forhåndsvarsel.SkalForhåndsvarsles) {
             return KunneIkkeOppdatereRevurdering.KanIkkeOppdatereRevurderingSomErForhåndsvarslet.left()
-        }
-
-        if (!kanOppretteEllerOppdatereRevurderingsPeriodeOgEllerÅrsak(
-                revurderingsårsak,
-                oppdaterRevurderingRequest.fraOgMed,
-            )
-        ) {
-            return KunneIkkeOppdatereRevurdering.PeriodeOgÅrsakKombinasjonErUgyldig.left()
         }
 
         val stønadsperiode = revurdering.tilRevurdering.periode
@@ -886,24 +868,6 @@ internal class RevurderingServiceImpl(
         }
 
         return revurdering.right()
-    }
-
-    private fun kanOppretteEllerOppdatereRevurderingsPeriodeOgEllerÅrsak(
-        revurderingsårsak: Revurderingsårsak,
-        fraOgMed: LocalDate,
-    ): Boolean {
-        val dagensDato = LocalDate.now(clock)
-        val startenAvForrigeKalenderMåned = dagensDato.minusMonths(1).startOfMonth()
-
-        val regulererGVerdiTilbakeITid =
-            revurderingsårsak.årsak == REGULER_GRUNNBELØP && !fraOgMed.isBefore(
-                startenAvForrigeKalenderMåned,
-            )
-
-        if (regulererGVerdiTilbakeITid || fraOgMed.isAfter(dagensDato.endOfMonth())) {
-            return true
-        }
-        return false
     }
 
     private fun lagreForhåndsvarsling(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OppdaterRevurderingServiceTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OppdaterRevurderingServiceTest.kt
@@ -216,27 +216,6 @@ internal class OppdaterRevurderingServiceTest {
     }
 
     @Test
-    fun `oppdatert periode må være fra neste kalendermåned`() {
-        val revurderingRepoMock = mock<RevurderingRepo> {
-            on { hent(any()) } doReturn opprettetRevurdering
-        }
-        val mocks = RevurderingServiceMocks(revurderingRepo = revurderingRepoMock)
-        val actual = mocks.revurderingService.oppdaterRevurdering(
-            OppdaterRevurderingRequest(
-                revurderingId = revurderingId,
-                fraOgMed = periode.fraOgMed.minus(1, ChronoUnit.MONTHS),
-                årsak = "MELDING_FRA_BRUKER",
-                begrunnelse = "gyldig begrunnelse",
-                saksbehandler = saksbehandler,
-                informasjonSomRevurderes = informasjonSomRevurderes,
-            ),
-        )
-        actual shouldBe KunneIkkeOppdatereRevurdering.PeriodeOgÅrsakKombinasjonErUgyldig.left()
-        verify(revurderingRepoMock).hent(argThat { it shouldBe revurderingId })
-        mocks.verifyNoMoreInteractions()
-    }
-
-    @Test
     fun `Ugyldig periode - fra og med dato må være første dag i måneden`() {
         val revurderingRepoMock = mock<RevurderingRepo> {
             on { hent(any()) } doReturn opprettetRevurdering

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OpprettRevurderingServiceTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OpprettRevurderingServiceTest.kt
@@ -278,24 +278,6 @@ internal class OpprettRevurderingServiceTest {
     }
 
     @Test
-    fun `oppretter ikke en revurdering hvis perioden er i samme måned for årsaker som ikke er g-regulering`() {
-        val mocks = RevurderingServiceMocks()
-        val actual = mocks.revurderingService.opprettRevurdering(
-            OpprettRevurderingRequest(
-                sakId = sakId,
-                fraOgMed = 1.januar(2021),
-                årsak = "MELDING_FRA_BRUKER",
-                begrunnelse = "Ny informasjon",
-                saksbehandler = saksbehandler,
-                informasjonSomRevurderes = emptyList(),
-            ),
-        )
-
-        actual shouldBe KunneIkkeOppretteRevurdering.PeriodeOgÅrsakKombinasjonErUgyldig.left()
-        mocks.verifyNoMoreInteractions()
-    }
-
-    @Test
     fun `kan opprette revurdering med årsak g-regulering i samme måned`() {
         val sak = createSak()
         val sakServiceMock = mock<SakService> {

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
@@ -252,22 +252,6 @@ internal class RevurderingServiceImplTest {
     }
 
     @Test
-    fun `oppretter ikke en revurdering hvis perioden er i samme måned`() {
-        val actual = createRevurderingService().opprettRevurdering(
-            OpprettRevurderingRequest(
-                sakId = sakId,
-                fraOgMed = 1.januar(2021),
-                årsak = "MELDING_FRA_BRUKER",
-                begrunnelse = "Ny informasjon",
-                saksbehandler = saksbehandler,
-                informasjonSomRevurderes = emptyList(),
-            ),
-        )
-
-        actual shouldBe KunneIkkeOppretteRevurdering.PeriodeOgÅrsakKombinasjonErUgyldig.left()
-    }
-
-    @Test
     fun `kan beregne og simulere`() {
         val uføregrunnlag = Grunnlag.Uføregrunnlag(
             periode = periode,

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OppdaterRevurderingsperiodeRoute.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OppdaterRevurderingsperiodeRoute.kt
@@ -21,7 +21,6 @@ import no.nav.su.se.bakover.web.features.suUserContext
 import no.nav.su.se.bakover.web.routes.revurdering.Revurderingsfeilresponser.fantIkkeRevurdering
 import no.nav.su.se.bakover.web.routes.revurdering.Revurderingsfeilresponser.fantIkkeSak
 import no.nav.su.se.bakover.web.routes.revurdering.Revurderingsfeilresponser.måVelgeInformasjonSomRevurderes
-import no.nav.su.se.bakover.web.routes.revurdering.Revurderingsfeilresponser.periodeOgÅrsakKombinasjonErUgyldig
 import no.nav.su.se.bakover.web.routes.revurdering.Revurderingsfeilresponser.ugyldigTilstand
 import no.nav.su.se.bakover.web.sikkerlogg
 import no.nav.su.se.bakover.web.svar
@@ -87,7 +86,6 @@ private fun KunneIkkeOppdatereRevurdering.tilResultat(): Resultat {
             "Kan ikke oppdatere revurdering som er forhåndsvarslet",
             "kan_ikke_oppdatere_revurdering_som_er_forhåndsvarslet",
         )
-        KunneIkkeOppdatereRevurdering.PeriodeOgÅrsakKombinasjonErUgyldig -> periodeOgÅrsakKombinasjonErUgyldig
         KunneIkkeOppdatereRevurdering.MåVelgeInformasjonSomSkalRevurderes -> måVelgeInformasjonSomRevurderes
         KunneIkkeOppdatereRevurdering.FantIkkeSak -> fantIkkeSak
     }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OpprettRevurderingRoute.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OpprettRevurderingRoute.kt
@@ -31,7 +31,6 @@ import no.nav.su.se.bakover.web.routes.revurdering.Revurderingsfeilresponser.fan
 import no.nav.su.se.bakover.web.routes.revurdering.Revurderingsfeilresponser.fantIkkeSak
 import no.nav.su.se.bakover.web.routes.revurdering.Revurderingsfeilresponser.kunneIkkeOppretteOppgave
 import no.nav.su.se.bakover.web.routes.revurdering.Revurderingsfeilresponser.måVelgeInformasjonSomRevurderes
-import no.nav.su.se.bakover.web.routes.revurdering.Revurderingsfeilresponser.periodeOgÅrsakKombinasjonErUgyldig
 import no.nav.su.se.bakover.web.routes.revurdering.Revurderingsfeilresponser.ugyldigPeriode
 import no.nav.su.se.bakover.web.sikkerlogg
 import no.nav.su.se.bakover.web.svar
@@ -95,7 +94,6 @@ private fun KunneIkkeOppretteRevurdering.tilResultat(): Resultat {
             "Ugyldig årsak, må være en av: ${Revurderingsårsak.Årsak.values()}",
             "ugyldig_årsak",
         )
-        KunneIkkeOppretteRevurdering.PeriodeOgÅrsakKombinasjonErUgyldig -> periodeOgÅrsakKombinasjonErUgyldig
         KunneIkkeOppretteRevurdering.MåVelgeInformasjonSomSkalRevurderes -> måVelgeInformasjonSomRevurderes
     }
 }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/Revurderingsfeilresponser.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/Revurderingsfeilresponser.kt
@@ -36,10 +36,6 @@ internal object Revurderingsfeilresponser {
         "Mangler beslutning på forhåndsvarsel",
         "mangler_beslutning_på_forhåndsvarsel",
     )
-    val periodeOgÅrsakKombinasjonErUgyldig = BadRequest.errorJson(
-        "periode og årsak kombinasjon er ugyldig",
-        "periode_og_årsak_kombinasjon_er_ugyldig",
-    )
 
     val måVelgeInformasjonSomRevurderes = BadRequest.errorJson(
         "Må velge minst en ting som skal revurderes",

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OppdaterRevurderingsperiodeRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OppdaterRevurderingsperiodeRouteKtTest.kt
@@ -163,21 +163,6 @@ internal class OppdaterRevurderingsperiodeRouteKtTest {
     }
 
     @Test
-    fun `perioden må være innenfor allerede valgt stønadsperiode`() {
-        shouldMapErrorCorrectly(
-            error = KunneIkkeOppdatereRevurdering.PeriodeOgÅrsakKombinasjonErUgyldig,
-            expectedStatusCode = HttpStatusCode.BadRequest,
-            expectedJsonResponse = """
-                {
-                    "message":"periode og årsak kombinasjon er ugyldig",
-                    "code":"periode_og_årsak_kombinasjon_er_ugyldig"
-                }
-            """.trimIndent(),
-
-        )
-    }
-
-    @Test
     fun `ugyldig tilstand`() {
         shouldMapErrorCorrectly(
             error = KunneIkkeOppdatereRevurdering.UgyldigTilstand(

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OpprettRevurderingRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OpprettRevurderingRouteKtTest.kt
@@ -184,21 +184,6 @@ internal class OpprettRevurderingRouteKtTest {
     }
 
     @Test
-    fun `årsak og periode kombinasjon er ugyldig`() {
-        shouldMapErrorCorrectly(
-            error = KunneIkkeOppretteRevurdering.PeriodeOgÅrsakKombinasjonErUgyldig,
-            expectedStatusCode = HttpStatusCode.BadRequest,
-            expectedJsonResponse = """
-                {
-                    "message":"periode og årsak kombinasjon er ugyldig",
-                    "code":"periode_og_årsak_kombinasjon_er_ugyldig"
-                }
-            """.trimIndent(),
-
-        )
-    }
-
-    @Test
     fun `ugyldig fraOgMed dato`() {
         shouldMapErrorCorrectly(
             error = KunneIkkeOppretteRevurdering.UgyldigPeriode(


### PR DESCRIPTION
Fjerner sperrer som forhindrer opprettelse av revurderinger tilbake i tid. 

Åpner for en del tilfeller som ikke støttes, må avventes til nye sperringer lagt til av https://github.com/navikt/su-se-bakover/pull/324 er på plass.