### PR TITLE
Bruk POST i stedet for GET på kall som inkluderer fnr

### DIFF
--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/Application.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/Application.kt
@@ -62,7 +62,6 @@ import no.nav.su.se.bakover.web.routes.installMetrics
 import no.nav.su.se.bakover.web.routes.me.meRoutes
 import no.nav.su.se.bakover.web.routes.naisPaths
 import no.nav.su.se.bakover.web.routes.naisRoutes
-import no.nav.su.se.bakover.web.routes.person.personPath
 import no.nav.su.se.bakover.web.routes.person.personRoutes
 import no.nav.su.se.bakover.web.routes.revurdering.revurderingRoutes
 import no.nav.su.se.bakover.web.routes.sak.sakRoutes
@@ -201,7 +200,6 @@ internal fun Application.susebakover(
             if (call.request.httpMethod.value == "OPTIONS") return@filter false
             if (call.pathShouldBeExcluded(naisPaths)) return@filter false
             if (call.pathShouldBeExcluded(togglePaths)) return@filter false
-            if (call.pathShouldBeExcluded(personPath)) return@filter false
 
             return@filter true
         }
@@ -276,5 +274,3 @@ fun ApplicationCall.pathShouldBeExcluded(paths: List<String>): Boolean {
         this.request.path().startsWith(it)
     }
 }
-
-fun ApplicationCall.pathShouldBeExcluded(path: String) = pathShouldBeExcluded(listOf(path))

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/Extensions.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/Extensions.kt
@@ -18,7 +18,6 @@ import no.nav.su.se.bakover.common.deserialize
 import no.nav.su.se.bakover.common.log
 import no.nav.su.se.bakover.common.sikkerLogg
 import no.nav.su.se.bakover.domain.Fnr
-import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.web.features.suUserContext
 import java.util.UUID
 
@@ -86,11 +85,6 @@ internal fun ApplicationCall.lesUUID(param: String) =
         it.toUUID().mapLeft { "$param er ikke en gyldig UUID" }
     } ?: Either.Left("$param er ikke et parameter")
 
-internal fun ApplicationCall.lesFnr(param: String) =
-    this.parameters[param]?.let {
-        Either.catch { Fnr(it) }.mapLeft { "$param er ikke et gyldig fødselsnummer" }
-    } ?: Either.Left("$param er ikke et parameter")
-
 internal fun ApplicationCall.parameter(parameterName: String) =
     this.parameters[parameterName]?.let { Either.Right(it) } ?: Either.Left("$parameterName er ikke et parameter")
 
@@ -109,21 +103,6 @@ internal suspend fun ApplicationCall.withSakId(ifRight: suspend (UUID) -> Unit) 
     this.lesUUID("sakId").fold(
         ifLeft = { this.svar(HttpStatusCode.BadRequest.message(it)) },
         ifRight = { ifRight(it) },
-    )
-}
-
-internal suspend fun ApplicationCall.withSaksnummer(ifRight: suspend (Saksnummer) -> Unit) {
-    this.parameter("saksnummer").fold(
-        ifLeft = { this.svar(HttpStatusCode.BadRequest.message(it)) },
-        ifRight = {
-            Saksnummer.tryParse(it)
-                .mapLeft {
-                    this.svar(HttpStatusCode.BadRequest.message("Er ikke ett gyldigt tall"))
-                }
-                .map { saksnummer ->
-                    ifRight(saksnummer)
-                }
-        },
     )
 }
 

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/Feilresponser.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/Feilresponser.kt
@@ -32,4 +32,9 @@ internal object Feilresponser {
         "Alle vurderingsperiodene må ha samme vurdering (ja/nei)",
         "vurderingene_må_ha_samme_resultat",
     )
+
+    val ikkeGyldigFødselsnummer = HttpStatusCode.BadRequest.errorJson(
+        "Inneholder ikke et gyldig fødselsnummer",
+        "ikke_gyldig_fødselsnummer",
+    )
 }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/sak/SakRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/sak/SakRoutes.kt
@@ -1,60 +1,72 @@
 package no.nav.su.se.bakover.web.routes.sak
 
+import arrow.core.Either
 import io.ktor.application.call
 import io.ktor.http.HttpStatusCode.Companion.BadRequest
 import io.ktor.http.HttpStatusCode.Companion.NotFound
 import io.ktor.http.HttpStatusCode.Companion.OK
 import io.ktor.routing.Route
 import io.ktor.routing.get
+import io.ktor.routing.post
 import no.nav.su.se.bakover.common.serialize
+import no.nav.su.se.bakover.domain.Fnr
+import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.service.sak.SakService
 import no.nav.su.se.bakover.web.AuditLogEvent
 import no.nav.su.se.bakover.web.Resultat
 import no.nav.su.se.bakover.web.audit
-import no.nav.su.se.bakover.web.lesFnr
 import no.nav.su.se.bakover.web.message
 import no.nav.su.se.bakover.web.routes.sak.SakJson.Companion.toJson
 import no.nav.su.se.bakover.web.svar
+import no.nav.su.se.bakover.web.withBody
 import no.nav.su.se.bakover.web.withSakId
-import no.nav.su.se.bakover.web.withSaksnummer
 
 internal const val sakPath = "/saker"
 
 internal fun Route.sakRoutes(
     sakService: SakService,
 ) {
-    get(sakPath) {
-        when {
-            call.parameters.contains("saksnummer") -> {
-                call.withSaksnummer { saksnummer ->
-                    call.svar(
-                        sakService.hentSak(saksnummer).fold(
-                            { NotFound.message("Fant ikke sak med saksnummer: $saksnummer") },
-                            {
-                                call.audit(it.fnr, AuditLogEvent.Action.ACCESS, null)
-                                Resultat.json(OK, serialize((it.toJson())))
-                            }
-                        )
+    post("$sakPath/søk") {
+        data class Body(
+            val fnr: String?,
+            val saksnummer: String?,
+        )
+        call.withBody<Body> { body ->
+            when {
+                body.fnr != null -> {
+                    Either.catch { Fnr(body.fnr) }.fold(
+                        ifLeft = { call.svar(BadRequest.message("${body.fnr} er ikke et gyldig fødselsnummer")) },
+                        ifRight = { fnr ->
+                            sakService.hentSak(fnr)
+                                .mapLeft {
+                                    call.audit(fnr, AuditLogEvent.Action.SEARCH, null)
+                                    call.svar(NotFound.message("Fant ikke noen sak for person: ${body.fnr}"))
+                                }
+                                .map {
+                                    call.audit(fnr, AuditLogEvent.Action.ACCESS, null)
+                                    call.svar(Resultat.json(OK, serialize(it.toJson())))
+                                }
+                        },
                     )
                 }
+                body.saksnummer != null -> {
+                    Saksnummer.tryParse(body.saksnummer).fold(
+                        ifLeft = { call.svar(BadRequest.message("${body.saksnummer} er ikke et gyldig saksnummer")) },
+                        ifRight = { saksnummer ->
+                            call.svar(
+                                sakService.hentSak(saksnummer).fold(
+                                    { NotFound.message("Fant ikke sak med saksnummer: ${body.saksnummer}") },
+                                    {
+                                        call.audit(it.fnr, AuditLogEvent.Action.ACCESS, null)
+                                        Resultat.json(OK, serialize((it.toJson())))
+                                    },
+                                ),
+                            )
+                        },
+                    )
+                }
+                else -> call.svar(BadRequest.message("Må oppgi enten saksnummer eller fødselsnummer"))
             }
-            call.parameters.contains("fnr") -> {
-                call.lesFnr("fnr").fold(
-                    ifLeft = { call.svar(BadRequest.message(it)) },
-                    ifRight = { fnr ->
-                        sakService.hentSak(fnr)
-                            .mapLeft {
-                                call.audit(fnr, AuditLogEvent.Action.SEARCH, null)
-                                call.svar(NotFound.message("Fant ikke noen sak for person: $fnr"))
-                            }
-                            .map {
-                                call.audit(fnr, AuditLogEvent.Action.ACCESS, null)
-                                call.svar(Resultat.json(OK, serialize((it.toJson()))))
-                            }
-                    }
-                )
-            }
-            else -> call.svar(BadRequest.message("Må oppgi saksnummer eller fødselsnummer"))
         }
     }
 
@@ -66,8 +78,8 @@ internal fun Route.sakRoutes(
                     {
                         call.audit(it.fnr, AuditLogEvent.Action.ACCESS, null)
                         Resultat.json(OK, serialize((it.toJson())))
-                    }
-                )
+                    },
+                ),
             )
         }
     }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/RoutesTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/RoutesTest.kt
@@ -9,10 +9,12 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpHeaders.XCorrelationId
 import io.ktor.http.HttpMethod.Companion.Get
+import io.ktor.http.HttpMethod.Companion.Post
 import io.ktor.http.HttpStatusCode.Companion.InternalServerError
 import io.ktor.http.HttpStatusCode.Companion.OK
 import io.ktor.server.testing.contentType
 import io.ktor.server.testing.handleRequest
+import io.ktor.server.testing.setBody
 import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.Fnr
@@ -101,7 +103,9 @@ class RoutesTest {
                 )
             )
         }) {
-            defaultRequest(Get, "$personPath/${FnrGenerator.random()}", listOf(Brukerrolle.Veileder))
+            defaultRequest(Post, "$personPath/søk", listOf(Brukerrolle.Veileder)) {
+                setBody("""{"fnr":"${FnrGenerator.random()}"}""")
+            }
         }.apply {
             assertEquals(InternalServerError, response.status())
             JSONAssert.assertEquals("""{"message":"Ukjent feil"}""", response.content, true)
@@ -113,7 +117,9 @@ class RoutesTest {
         withTestApplication({
             testSusebakover()
         }) {
-            defaultRequest(Get, "$personPath/${FnrGenerator.random()}", listOf(Brukerrolle.Veileder))
+            defaultRequest(Post, "$personPath/søk", listOf(Brukerrolle.Veileder)) {
+                setBody("""{"fnr":"${FnrGenerator.random()}"}""")
+            }
         }.apply {
             assertEquals(
                 "${ContentType.Application.Json}; charset=${Charsets.UTF_8}",

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/person/PersonRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/person/PersonRoutesKtTest.kt
@@ -6,11 +6,13 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import io.kotest.matchers.shouldBe
+import io.ktor.http.HttpMethod
 import io.ktor.http.HttpMethod.Companion.Get
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.HttpStatusCode.Companion.NotFound
 import io.ktor.http.HttpStatusCode.Companion.OK
 import io.ktor.server.testing.handleRequest
+import io.ktor.server.testing.setBody
 import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.client.stubs.person.PersonOppslagStub
 import no.nav.su.se.bakover.common.endOfDay
@@ -42,7 +44,9 @@ internal class PersonRoutesKtTest {
         withTestApplication({
             testSusebakover()
         }) {
-            handleRequest(Get, "$personPath/$testIdent")
+            handleRequest(HttpMethod.Post, "$personPath/søk") {
+                setBody("""{"fnr":"$testIdent"}""")
+            }
         }.apply {
             assertEquals(HttpStatusCode.Unauthorized, response.status())
         }
@@ -53,7 +57,9 @@ internal class PersonRoutesKtTest {
         withTestApplication({
             testSusebakover()
         }) {
-            defaultRequest(Get, "$personPath/qwertyuiopå", listOf(Brukerrolle.Veileder))
+            defaultRequest(HttpMethod.Post, "$personPath/søk", listOf(Brukerrolle.Veileder)) {
+                setBody("""{"fnr":"qwertyuiopå"}""")
+            }
         }.apply {
             assertEquals(HttpStatusCode.BadRequest, response.status())
         }
@@ -110,7 +116,9 @@ internal class PersonRoutesKtTest {
         withTestApplication({
             testSusebakover(accessCheckProxy = accessCheckProxyMock, clock = fixedClock)
         }) {
-            defaultRequest(Get, "$personPath/$testIdent", listOf(Brukerrolle.Veileder))
+            defaultRequest(HttpMethod.Post, "$personPath/søk", listOf(Brukerrolle.Veileder)) {
+                setBody("""{"fnr":"$testIdent"}""")
+            }
         }.apply {
             assertEquals(OK, response.status())
             JSONAssert.assertEquals(expectedResponseJson, response.content!!, true)
@@ -125,7 +133,9 @@ internal class PersonRoutesKtTest {
         withTestApplication({
             testSusebakover(accessCheckProxy = accessCheckProxyMock)
         }) {
-            defaultRequest(Get, "$personPath/$testIdent", listOf(Brukerrolle.Veileder))
+            defaultRequest(HttpMethod.Post, "$personPath/søk", listOf(Brukerrolle.Veileder)) {
+                setBody("""{"fnr":"$testIdent"}""")
+            }
         }.apply {
             response.status() shouldBe HttpStatusCode.InternalServerError
         }


### PR DESCRIPTION
Har erstattet `GET /person/{fnr}` og `GET /saker?fnr={fnr}` med POSTs til hhv. `/person/søk` og `/saker/søk` med fnr som parameter i body. Tok da også med søket på saker med saksnummer, altså `POST /saker/søk` med saksnummer som parameter i body.

Tas i bruk i klient i https://github.com/navikt/su-se-framover/pull/837