### PR TITLE
Komponent for konsistenssjekk av grunnlag

### DIFF
--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/grunnlag/SjekkOmGrunnlagErKonsistent.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/grunnlag/SjekkOmGrunnlagErKonsistent.kt
@@ -1,0 +1,100 @@
+package no.nav.su.se.bakover.domain.grunnlag
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import arrow.core.separateEither
+
+data class SjekkOmGrunnlagErKonsistent(
+    private val uføregrunnlag: List<Grunnlag.Uføregrunnlag>,
+    private val bosituasjongrunnlag: List<Grunnlag.Bosituasjon>,
+    private val fradragsgrunnlag: List<Grunnlag.Fradragsgrunnlag>,
+) {
+    val resultat: Either<Set<Konsistensproblem>, Unit> = setOf(
+        Uføre(uføregrunnlag).resultat,
+        Bosituasjon(bosituasjongrunnlag).resultat,
+        BosituasjonOgFradrag(bosituasjongrunnlag, fradragsgrunnlag).resultat,
+    ).let {
+        val problemer = it.separateEither().first.flatten().toSet()
+        if (problemer.isEmpty()) Unit.right() else problemer.left()
+    }
+
+    data class Uføre(
+        val uføregrunnlag: List<Grunnlag.Uføregrunnlag>,
+    ) {
+        val resultat: Either<Set<Konsistensproblem.Uføre>, Unit> = uføregrunnlag(uføregrunnlag)
+
+        private fun uføregrunnlag(uføregrunnlag: List<Grunnlag.Uføregrunnlag>): Either<Set<Konsistensproblem.Uføre>, Unit> {
+            mutableSetOf<Konsistensproblem.Uføre>().apply {
+                when {
+                    uføregrunnlag.isEmpty() -> {
+                        add(Konsistensproblem.Uføre.Mangler)
+                    }
+                }
+                return if (this.isEmpty()) Unit.right() else this.left()
+            }
+        }
+    }
+
+    data class Bosituasjon(
+        val bosituasjon: List<Grunnlag.Bosituasjon>,
+    ) {
+        val resultat: Either<Set<Konsistensproblem.Bosituasjon>, Unit> = bosituasjon(bosituasjon)
+
+        private fun bosituasjon(bosituasjon: List<Grunnlag.Bosituasjon>): Either<Set<Konsistensproblem.Bosituasjon>, Unit> {
+            mutableSetOf<Konsistensproblem.Bosituasjon>().apply {
+                when {
+                    bosituasjon.isEmpty() -> {
+                        add(Konsistensproblem.Bosituasjon.Mangler)
+                    }
+                    bosituasjon.any { it is Grunnlag.Bosituasjon.Ufullstendig } -> {
+                        add(Konsistensproblem.Bosituasjon.Ufullstendig)
+                    }
+                    bosituasjon.harFlerEnnEnBosituasjonsperiode() -> {
+                        add(Konsistensproblem.Bosituasjon.Flere)
+                    }
+                }
+                return if (this.isEmpty()) Unit.right() else this.left()
+            }
+        }
+    }
+
+    data class BosituasjonOgFradrag(
+        val bosituasjon: List<Grunnlag.Bosituasjon>,
+        val fradrag: List<Grunnlag.Fradragsgrunnlag>,
+    ) {
+        val resultat: Either<Set<Konsistensproblem.BosituasjonOgFradrag>, Unit> = bosituasjonOgFradrag(bosituasjon, fradrag)
+
+        private fun bosituasjonOgFradrag(bosituasjon: List<Grunnlag.Bosituasjon>, fradrag: List<Grunnlag.Fradragsgrunnlag>): Either<Set<Konsistensproblem.BosituasjonOgFradrag>, Unit> {
+            mutableSetOf<Konsistensproblem.BosituasjonOgFradrag>().apply {
+                when {
+                    bosituasjon.harFlerEnnEnBosituasjonsperiode() && fradrag.harEpsInntekt() -> {
+                        add(Konsistensproblem.BosituasjonOgFradrag.FlereBosituasjonerOgFradragForEPS)
+                    }
+                    !bosituasjon.harFlerEnnEnBosituasjonsperiode() && !bosituasjon.harEktefelle() && fradrag.harEpsInntekt() -> {
+                        add(Konsistensproblem.BosituasjonOgFradrag.IngenEPSMenFradragForEPS)
+                    }
+                }
+                return if (this.isEmpty()) Unit.right() else this.left()
+            }
+        }
+    }
+}
+
+sealed class Konsistensproblem {
+
+    sealed class Uføre : Konsistensproblem() {
+        object Mangler : Uføre()
+    }
+
+    sealed class Bosituasjon : Konsistensproblem() {
+        object Flere : Bosituasjon()
+        object Ufullstendig : Bosituasjon()
+        object Mangler : Bosituasjon()
+    }
+
+    sealed class BosituasjonOgFradrag : Konsistensproblem() {
+        object FlereBosituasjonerOgFradragForEPS : BosituasjonOgFradrag()
+        object IngenEPSMenFradragForEPS : BosituasjonOgFradrag()
+    }
+}

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/grunnlag/SjekkOmGrunnlagErKonsistentTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/grunnlag/SjekkOmGrunnlagErKonsistentTest.kt
@@ -1,0 +1,195 @@
+package no.nav.su.se.bakover.domain.grunnlag
+
+import io.kotest.assertions.arrow.either.shouldBeLeft
+import io.kotest.assertions.arrow.either.shouldBeRight
+import no.nav.su.se.bakover.common.Tidspunkt
+import no.nav.su.se.bakover.common.desember
+import no.nav.su.se.bakover.common.januar
+import no.nav.su.se.bakover.common.periode.Periode
+import no.nav.su.se.bakover.domain.FnrGenerator
+import no.nav.su.se.bakover.domain.beregning.fradrag.FradragFactory
+import no.nav.su.se.bakover.domain.beregning.fradrag.FradragTilhører
+import no.nav.su.se.bakover.domain.beregning.fradrag.Fradragstype
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+internal class SjekkOmGrunnlagErKonsistentTest {
+
+    private val periode = Periode.create(1.januar(2021), 31.desember(2021))
+
+    @Nested
+    inner class Uføre {
+        @Test
+        fun `uføregrunnlag mangler`() {
+            SjekkOmGrunnlagErKonsistent.Uføre(emptyList()).resultat shouldBeLeft setOf(Konsistensproblem.Uføre.Mangler)
+        }
+    }
+
+    @Nested
+    inner class Bosituasjon {
+        @Test
+        fun `bosituasjon er ufullstendig`() {
+            val bosituasjon = Grunnlag.Bosituasjon.Ufullstendig.HarIkkeEps(
+                id = UUID.randomUUID(),
+                opprettet = Tidspunkt.now(),
+                periode = periode,
+            )
+            SjekkOmGrunnlagErKonsistent.Bosituasjon(listOf(bosituasjon)).resultat shouldBeLeft setOf(Konsistensproblem.Bosituasjon.Ufullstendig)
+        }
+
+        @Test
+        fun `bosituasjon har flere innslag`() {
+            val bosituasjon1 = Grunnlag.Bosituasjon.Fullstendig.EktefellePartnerSamboer.Under67.UførFlyktning(
+                id = UUID.randomUUID(),
+                opprettet = Tidspunkt.now(),
+                periode = periode,
+                fnr = FnrGenerator.random(),
+                begrunnelse = "",
+            )
+            val bosituasjon2 = Grunnlag.Bosituasjon.Fullstendig.Enslig(
+                id = UUID.randomUUID(),
+                opprettet = Tidspunkt.now(),
+                periode = periode,
+                begrunnelse = "",
+            )
+            SjekkOmGrunnlagErKonsistent.Bosituasjon(listOf(bosituasjon1, bosituasjon2)).resultat shouldBeLeft setOf(Konsistensproblem.Bosituasjon.Flere)
+        }
+
+        @Test
+        fun `bosituasjon mangler`() {
+            SjekkOmGrunnlagErKonsistent.Bosituasjon(emptyList()).resultat shouldBeLeft setOf(Konsistensproblem.Bosituasjon.Mangler)
+        }
+    }
+
+    @Nested
+    inner class BosituasjonOgFradrag {
+        @Test
+        fun `bosituasjon har flere innslag og fradrag har inntekter for eps`() {
+            val bosituasjon1 = Grunnlag.Bosituasjon.Fullstendig.EktefellePartnerSamboer.Under67.UførFlyktning(
+                id = UUID.randomUUID(),
+                opprettet = Tidspunkt.now(),
+                periode = periode,
+                fnr = FnrGenerator.random(),
+                begrunnelse = "",
+            )
+            val bosituasjon2 = Grunnlag.Bosituasjon.Fullstendig.Enslig(
+                id = UUID.randomUUID(),
+                opprettet = Tidspunkt.now(),
+                periode = periode,
+                begrunnelse = "",
+            )
+            val arbEps = Grunnlag.Fradragsgrunnlag(
+                fradrag = FradragFactory.ny(
+                    type = Fradragstype.Arbeidsinntekt,
+                    månedsbeløp = 5000.0,
+                    periode = periode,
+                    utenlandskInntekt = null,
+                    tilhører = FradragTilhører.EPS,
+                ),
+            )
+            SjekkOmGrunnlagErKonsistent.BosituasjonOgFradrag(
+                listOf(bosituasjon1, bosituasjon2),
+                listOf(arbEps),
+            ).resultat shouldBeLeft setOf(
+                Konsistensproblem.BosituasjonOgFradrag.FlereBosituasjonerOgFradragForEPS,
+            )
+        }
+
+        @Test
+        fun `bosituasjon uten eps men fradrag for eps`() {
+            val bosituasjon = Grunnlag.Bosituasjon.Fullstendig.Enslig(
+                id = UUID.randomUUID(),
+                opprettet = Tidspunkt.now(),
+                periode = periode,
+                begrunnelse = "",
+            )
+            val arbEps = Grunnlag.Fradragsgrunnlag(
+                fradrag = FradragFactory.ny(
+                    type = Fradragstype.Arbeidsinntekt,
+                    månedsbeløp = 5000.0,
+                    periode = periode,
+                    utenlandskInntekt = null,
+                    tilhører = FradragTilhører.EPS,
+                ),
+            )
+            SjekkOmGrunnlagErKonsistent.BosituasjonOgFradrag(
+                listOf(bosituasjon),
+                listOf(arbEps),
+            ).resultat shouldBeLeft setOf(
+                Konsistensproblem.BosituasjonOgFradrag.IngenEPSMenFradragForEPS,
+            )
+        }
+    }
+
+    @Nested
+    inner class Fullstendig {
+        @Test
+        fun `fullstendig konsistenssjekk`() {
+            val bosituasjon1 = Grunnlag.Bosituasjon.Fullstendig.EktefellePartnerSamboer.Under67.UførFlyktning(
+                id = UUID.randomUUID(),
+                opprettet = Tidspunkt.now(),
+                periode = periode,
+                fnr = FnrGenerator.random(),
+                begrunnelse = "",
+            )
+            val bosituasjon2 = Grunnlag.Bosituasjon.Fullstendig.Enslig(
+                id = UUID.randomUUID(),
+                opprettet = Tidspunkt.now(),
+                periode = periode,
+                begrunnelse = "",
+            )
+            val arbEps = Grunnlag.Fradragsgrunnlag(
+                fradrag = FradragFactory.ny(
+                    type = Fradragstype.Arbeidsinntekt,
+                    månedsbeløp = 5000.0,
+                    periode = periode,
+                    utenlandskInntekt = null,
+                    tilhører = FradragTilhører.EPS,
+                ),
+            )
+            SjekkOmGrunnlagErKonsistent(
+                uføregrunnlag = emptyList(),
+                bosituasjongrunnlag = listOf(bosituasjon1, bosituasjon2),
+                fradragsgrunnlag = listOf(arbEps),
+            ).resultat shouldBeLeft setOf(
+                Konsistensproblem.Uføre.Mangler,
+                Konsistensproblem.Bosituasjon.Flere,
+                Konsistensproblem.BosituasjonOgFradrag.FlereBosituasjonerOgFradragForEPS,
+            )
+        }
+    }
+
+    @Nested
+    inner class HappyCase {
+        @Test
+        fun `happy case`() {
+            val uføregrunnlag = Grunnlag.Uføregrunnlag(
+                periode = periode,
+                uføregrad = Uføregrad.parse(100),
+                forventetInntekt = 0,
+            )
+            val bosituasjon = Grunnlag.Bosituasjon.Fullstendig.EktefellePartnerSamboer.Under67.UførFlyktning(
+                id = UUID.randomUUID(),
+                opprettet = Tidspunkt.now(),
+                periode = periode,
+                fnr = FnrGenerator.random(),
+                begrunnelse = "",
+            )
+            val arbEps = Grunnlag.Fradragsgrunnlag(
+                fradrag = FradragFactory.ny(
+                    type = Fradragstype.Arbeidsinntekt,
+                    månedsbeløp = 5000.0,
+                    periode = periode,
+                    utenlandskInntekt = null,
+                    tilhører = FradragTilhører.EPS,
+                ),
+            )
+            SjekkOmGrunnlagErKonsistent(
+                uføregrunnlag = listOf(uføregrunnlag),
+                bosituasjongrunnlag = listOf(bosituasjon),
+                fradragsgrunnlag = listOf(arbEps),
+            ).resultat shouldBeRight Unit
+        }
+    }
+}

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/grunnlag/KonsistensproblemJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/grunnlag/KonsistensproblemJson.kt
@@ -1,0 +1,31 @@
+package no.nav.su.se.bakover.web.routes.grunnlag
+
+import no.nav.su.se.bakover.domain.grunnlag.Konsistensproblem
+import no.nav.su.se.bakover.web.ErrorJson
+
+fun Konsistensproblem.tilResultat() = when (this) {
+    Konsistensproblem.Bosituasjon.Flere -> ErrorJson(
+        message = "Flere bosituasjoner støttes ikke",
+        code = "flere_bosituasjoner_støttes_ikke",
+    )
+    Konsistensproblem.Bosituasjon.Ufullstendig -> ErrorJson(
+        message = "Bosituasjon er ufullstendig",
+        code = "bosituajson_er_ufullstendig",
+    )
+    Konsistensproblem.BosituasjonOgFradrag.FlereBosituasjonerOgFradragForEPS -> ErrorJson(
+        message = "Flere bosituasjoner og fradrag for EPS",
+        code = "flere_bositiasjoner_og_fradrag_for_eps",
+    )
+    Konsistensproblem.BosituasjonOgFradrag.IngenEPSMenFradragForEPS -> ErrorJson(
+        message = "Har fradrag for EPS, men ingen EPS er registrert.",
+        code = "fradrag_for_eps_ingen_eps_registrert",
+    )
+    Konsistensproblem.Bosituasjon.Mangler -> ErrorJson(
+        message = "Bosituasjon mangler",
+        code = "bosituasjon_mangler",
+    )
+    Konsistensproblem.Uføre.Mangler -> ErrorJson(
+        message = "Uføregrunnlag mangler",
+        code = "uføregrunnlag_mangler",
+    )
+}

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/grunnlag/KonsistensproblemJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/grunnlag/KonsistensproblemJson.kt
@@ -10,11 +10,11 @@ fun Konsistensproblem.tilResultat() = when (this) {
     )
     Konsistensproblem.Bosituasjon.Ufullstendig -> ErrorJson(
         message = "Bosituasjon er ufullstendig",
-        code = "bosituajson_er_ufullstendig",
+        code = "bosituasjone_er_ufullstendig",
     )
     Konsistensproblem.BosituasjonOgFradrag.FlereBosituasjonerOgFradragForEPS -> ErrorJson(
         message = "Flere bosituasjoner og fradrag for EPS",
-        code = "flere_bositiasjoner_og_fradrag_for_eps",
+        code = "flere_bosituasjoner_og_fradrag_for_eps",
     )
     Konsistensproblem.BosituasjonOgFradrag.IngenEPSMenFradragForEPS -> ErrorJson(
         message = "Har fradrag for EPS, men ingen EPS er registrert.",


### PR DESCRIPTION
Tanke; en komponent som kan håndtere konsistenssjekk av grunnlag på alle tidspunkter vi måtte ha behov for det (både for revurdering og søknadsbehandling)

"Modulær" for å kunne støtte at man i enkelte tilfeller kun ønsker å sjekke konsistens mellom enkelte typer grunnlag (f.eks når man legger til nytt grunnlag), eller i tilfeller hvor man mangler mye grunnlag (f.eks søknadsbehandling) - i tillegg til at man kan lage kompositter som sjekker mer/mindre (f.eks burde vi sjekke alt før vi beregner). Laget slik at det er konsumenten som må ta stilling til hvordan eventuelle feil håndteres, slik at disse kan brukes på flere måter (f.eks hard stop med feilmelding, eller feedback-meldinger)

Har bare tatt i bruk for opprettelse/oppdatering av revurdering til nå, men på sikt hadde det vært fint om alle sjekker som går på tvers av ulike grunnlag flyttes til komponenten - på denne måten får vi forhåpentligvis en helhetlig ramme for hva som er "konsistent".

Kan vurderes om videre arbeid med flytting av validering/utvidelse kan/bør gjøres som egne oppgaver/i samsvar med andre oppgaver.