### PR TITLE
Bruk tidligste dato av "datoStatusFom" og "datoVedtakFom".

### DIFF
--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/oppdrag/simulering/SimuleringRequestBuilder.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/oppdrag/simulering/SimuleringRequestBuilder.kt
@@ -47,12 +47,16 @@ internal class SimuleringRequestBuilder(
             request = SimulerBeregningRequest().apply {
                 oppdrag = this@SimuleringRequestBuilder.oppdragRequest
                 simuleringsPeriode = SimulerBeregningRequest.SimuleringsPeriode().apply {
-                    datoSimulerFom =
-                        mappedRequest.oppdragslinjer.map { LocalDate.parse(it.datoVedtakFom) }.minByOrNull { it }!!
-                            .toString()
-                    datoSimulerTom =
-                        mappedRequest.oppdragslinjer.map { LocalDate.parse(it.datoVedtakTom) }.maxByOrNull { it }!!
-                            .toString()
+                    datoSimulerFom = mappedRequest.oppdragslinjer.map {
+                        if (it.datoStatusFom != null) {
+                            minOf(LocalDate.parse(it.datoStatusFom), LocalDate.parse(it.datoVedtakFom))
+                        } else {
+                            LocalDate.parse(it.datoVedtakFom)
+                        }
+                    }.minByOrNull { it }!!.toString()
+                    datoSimulerTom = mappedRequest.oppdragslinjer.map {
+                        LocalDate.parse(it.datoVedtakTom)
+                    }.maxByOrNull { it }!!.toString()
                 }
             }
         }

--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/simulering/SimuleringRequestBuilderTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/simulering/SimuleringRequestBuilderTest.kt
@@ -4,11 +4,8 @@ import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.client.oppdrag.utbetaling.UtbetalingRequest
 import no.nav.su.se.bakover.client.oppdrag.utbetaling.UtbetalingRequestTest
 import no.nav.su.se.bakover.client.oppdrag.utbetaling.toUtbetalingRequest
-import no.nav.su.se.bakover.common.Tidspunkt
-import no.nav.su.se.bakover.common.UUID30
-import no.nav.su.se.bakover.common.april
 import no.nav.su.se.bakover.common.februar
-import no.nav.su.se.bakover.common.januar
+import no.nav.su.se.bakover.common.september
 import no.nav.su.se.bakover.common.startOfDay
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppdrag.Utbetalingslinje
@@ -40,25 +37,22 @@ internal class SimuleringRequestBuilderTest {
 
     @Test
     fun `bygger simulering request ved endring av eksisterende oppdragslinjer`() {
-        val endretUtbetalingslinje = Utbetalingslinje.Endring(
-            id = UUID30.randomUUID(),
-            opprettet = Tidspunkt.now(),
-            fraOgMed = 1.januar(2020),
-            tilOgMed = 30.april(2020),
-            beløp = UtbetalingRequestTest.BELØP,
-            forrigeUtbetalingslinjeId = UUID30.randomUUID(),
+        val linjeSomSkalEndres = UtbetalingRequestTest.nyUtbetaling.sisteUtbetalingslinje()!!
+
+        val linjeMedEndring = Utbetalingslinje.Endring(
+            utbetalingslinje = linjeSomSkalEndres,
             statusendring = Utbetalingslinje.Statusendring(
                 status = Utbetalingslinje.LinjeStatus.OPPHØR,
                 fraOgMed = 1.februar(2020),
             ),
         )
-        val endring = UtbetalingRequestTest.nyUtbetaling.copy(
+        val utbetalingMedEndring = UtbetalingRequestTest.nyUtbetaling.copy(
             type = Utbetaling.UtbetalingsType.OPPHØR,
-            avstemmingsnøkkel = Avstemmingsnøkkel(1.januar(2020).startOfDay()),
-            utbetalingslinjer = listOf(endretUtbetalingslinje),
+            avstemmingsnøkkel = Avstemmingsnøkkel(18.september(2020).startOfDay()),
+            utbetalingslinjer = listOf(linjeMedEndring),
         )
 
-        val utbetalingsRequest = toUtbetalingRequest(endring).oppdragRequest
+        val utbetalingsRequest = toUtbetalingRequest(utbetalingMedEndring).oppdragRequest
         SimuleringRequestBuilder(utbetalingsRequest).build().request.let {
             it.oppdrag.let { oppdrag ->
                 oppdrag.assert(utbetalingsRequest)
@@ -70,8 +64,8 @@ internal class SimuleringRequestBuilderTest {
                 }
             }
             it.simuleringsPeriode.assert(
-                fraOgMed = "2020-01-01",
-                tilOgMed = "2020-04-30",
+                fraOgMed = "2020-02-01",
+                tilOgMed = "2020-12-31",
             )
         }
     }


### PR DESCRIPTION
Ved simulering av f.eks opphør sender vi med den siste utbetalingslinjen samt en dato hvor opphøret skal starte å gjelde fra. I tilfeller hvor opphørsdatoen er tidligere enn datoen på siste utbetalingslinje må vi bruke denne for å få med eventuelle utbetalingsperioder forut for siste utbetalingslinje i simuleringen.