### PR TITLE
Refaktorert logikken for valg av forhåndsvarel/attestering.

### DIFF
--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -547,24 +547,6 @@ internal class RevurderingServiceImpl(
         val revurdering = revurderingRepo.hent(revurderingId)
             ?: return KunneIkkeForhåndsvarsle.FantIkkeRevurdering.left()
 
-        fun sendTilAttestering(
-            revurderingId: UUID,
-            saksbehandler: NavIdentBruker.Saksbehandler,
-            fritekst: String,
-            skalFøreTilBrevutsending: Boolean = true,
-        ): Either<KunneIkkeForhåndsvarsle.Attestering, Revurdering> {
-            return sendTilAttestering(
-                SendTilAttesteringRequest(
-                    revurderingId = revurderingId,
-                    saksbehandler = saksbehandler,
-                    fritekstTilBrev = fritekst,
-                    skalFøreTilBrevutsending = skalFøreTilBrevutsending,
-                ),
-            ).mapLeft {
-                KunneIkkeForhåndsvarsle.Attestering(it)
-            }
-        }
-
         when (revurdering) {
             is SimulertRevurdering -> {
                 kanSendesTilAttestering(revurdering).getOrHandle {
@@ -579,10 +561,15 @@ internal class RevurderingServiceImpl(
                         Revurderingshandling.SEND_TIL_ATTESTERING -> {
                             lagreForhåndsvarsling(revurdering, Forhåndsvarsel.IngenForhåndsvarsel)
                             sendTilAttestering(
-                                revurderingId = revurderingId,
-                                saksbehandler = saksbehandler,
-                                fritekst = fritekst,
-                            )
+                                SendTilAttesteringRequest(
+                                    revurderingId = revurderingId,
+                                    saksbehandler = saksbehandler,
+                                    fritekstTilBrev = fritekst,
+                                    skalFøreTilBrevutsending = true,
+                                ),
+                            ).mapLeft {
+                                KunneIkkeForhåndsvarsle.Attestering(it)
+                            }
                         }
                         Revurderingshandling.FORHÅNDSVARSLE -> {
                             sendForhåndsvarsling(revurdering, fritekst)

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
@@ -1026,7 +1026,20 @@ internal class RevurderingServiceImplTest {
             forhåndsvarsel = null,
             behandlingsinformasjon = søknadsbehandlingVedtak.behandlingsinformasjon,
             grunnlagsdata = Grunnlagsdata.EMPTY,
-            vilkårsvurderinger = Vilkårsvurderinger.EMPTY,
+            vilkårsvurderinger = Vilkårsvurderinger(
+                uføre = Vilkår.Vurdert.Uførhet.create(
+                    vurderingsperioder = nonEmptyListOf(
+                        Vurderingsperiode.Uføre.create(
+                            id = UUID.randomUUID(),
+                            opprettet = fixedTidspunkt,
+                            resultat = Resultat.Innvilget,
+                            grunnlag = null,
+                            periode = periode,
+                            begrunnelse = "ok2k",
+                        ),
+                    ),
+                ),
+            ),
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
         )
 
@@ -1106,7 +1119,9 @@ internal class RevurderingServiceImplTest {
 
     @Test
     fun `forhåndsvarsler ikke en allerede forhåndsvarslet revurdering`() {
-        val simulertRevurdering = simulertRevurderingInnvilget
+        val simulertRevurdering = simulertRevurderingInnvilget.copy(
+            forhåndsvarsel = Forhåndsvarsel.SkalForhåndsvarsles.Sendt(JournalpostId(""), BrevbestillingId("")),
+        )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
             on { hent(any()) } doReturn simulertRevurdering
@@ -1120,6 +1135,85 @@ internal class RevurderingServiceImplTest {
             revurderingshandling = Revurderingshandling.FORHÅNDSVARSLE,
             fritekst = "",
         ) shouldBe KunneIkkeForhåndsvarsle.AlleredeForhåndsvarslet.left()
+    }
+
+    @Test
+    fun `kan endre fra ingen forhåndsvarsel til forhåndsvarsel`() {
+        val simulertRevurdering = simulertRevurderingInnvilget.copy(
+            forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
+        )
+
+        val revurderingRepoMock = mock<RevurderingRepo> {
+            on { hent(any()) } doReturn simulertRevurdering
+        }
+
+        val personServiceMock = mock<PersonService> {
+            on { hentPerson(any()) } doReturn person.right()
+        }
+
+        val brevServiceMock = mock<BrevService> {
+            on { journalførBrev(any(), any()) } doReturn JournalpostId("").right()
+            on { distribuerBrev(any()) } doReturn BrevbestillingId("").right()
+        }
+
+        val oppgaveServiceMock = mock<OppgaveService> {
+            on { oppdaterOppgave(any(), any()) } doReturn Unit.right()
+        }
+
+        val microsoftGraphApiClientMock = mock<MicrosoftGraphApiClient> {
+            on { hentNavnForNavIdent(any()) } doReturn saksbehandler.navIdent.right()
+        }
+
+        val response = createRevurderingService(
+            revurderingRepo = revurderingRepoMock,
+            personService = personServiceMock,
+            brevService = brevServiceMock,
+            oppgaveService = oppgaveServiceMock,
+            microsoftGraphApiClient = microsoftGraphApiClientMock,
+        ).forhåndsvarsleEllerSendTilAttestering(
+            revurderingId = revurderingId,
+            saksbehandler = saksbehandler,
+            revurderingshandling = Revurderingshandling.FORHÅNDSVARSLE,
+            fritekst = "",
+        )
+
+        response shouldBeRight simulertRevurdering.copy(
+            forhåndsvarsel = Forhåndsvarsel.SkalForhåndsvarsles.Sendt(
+                JournalpostId(""),
+                BrevbestillingId(""),
+            ),
+        )
+
+        verify(personServiceMock).hentPerson(any())
+        verify(brevServiceMock).journalførBrev(any(), any())
+        verify(revurderingRepoMock).lagre(any())
+        verify(oppgaveServiceMock).oppdaterOppgave(any(), any())
+    }
+
+    @Test
+    fun `får ikke sendt forhåndsvarsel dersom det ikke er mulig å sende behandlingen videre til attestering`() {
+        val simuleringMock = mock<Simulering> {
+            on { harFeilutbetalinger() } doReturn true
+        }
+        val simulertRevurdering = simulertRevurderingInnvilget.copy(
+            simulering = simuleringMock,
+            forhåndsvarsel = null,
+        )
+
+        val revurderingRepoMock = mock<RevurderingRepo> {
+            on { hent(any()) } doReturn simulertRevurdering
+        }
+
+        createRevurderingService(
+            revurderingRepo = revurderingRepoMock,
+        ).forhåndsvarsleEllerSendTilAttestering(
+            revurderingId = revurderingId,
+            saksbehandler = saksbehandler,
+            revurderingshandling = Revurderingshandling.FORHÅNDSVARSLE,
+            fritekst = "",
+        ) shouldBeLeft KunneIkkeForhåndsvarsle.Attestering(
+            KunneIkkeSendeRevurderingTilAttestering.FeilutbetalingStøttesIkke,
+        )
     }
 
     private fun testForhåndsvarslerIkkeGittRevurdering(revurdering: Revurdering) {


### PR DESCRIPTION
-Unngår feilmeldinger om at "forhåndsvarsel allerede er sendt" selv om man har valgt at forhåndsvarsel ikke skal sendes.
-Sjekker om revurderingen lar seg sende til attestering før forhåndsvarsel sendes ut
-Gjort det mulig å endre fra "ingen forhåndsvarsel" til "forhåndsvarsel", noe som sannsynligvis kan være nyttig for tilfeller hvor attestering underkjennes.

Frontend: https://github.com/navikt/su-se-framover/pull/872