### PR TITLE
Migrate behandlingsinformasjon from revurdering to grunnlagsdata

### DIFF
--- a/database/src/main/resources/db/migration/V93__migrer_formue_behandlingsinformasjon_til_grunnlagsdata.sql
+++ b/database/src/main/resources/db/migration/V93__migrer_formue_behandlingsinformasjon_til_grunnlagsdata.sql
@@ -10,14 +10,14 @@ with manglende_grunnlagsdata as (
                             ( periode ->> 'tilOgMed' )::date as tilogmed,
                                case
                                    when (behandlingsinformasjon -> 'formue' -> 'epsVerdier' is not null) then jsonb_build_object(
-                                       'verdiIkkePrimærbolig', coalesce(( behandlingsinformasjon -> 'formue' -> 'epsVerdier' -> 'verdiIkkePrimærbolig' )::int, 0),
-                                       'verdiEiendommer', coalesce(( behandlingsinformasjon -> 'formue' -> 'epsVerdier' -> 'verdiEiendommer')::int, 0),
-                                       'verdiKjøretøy', coalesce(( behandlingsinformasjon -> 'formue' -> 'epsVerdier' -> 'verdiKjøretøy' )::int, 0),
-                                       'innskudd', coalesce(( behandlingsinformasjon -> 'formue' -> 'epsVerdier' -> 'innskudd' )::int, 0),
-                                       'verdipapir', coalesce(( behandlingsinformasjon -> 'formue' -> 'epsVerdier' -> 'verdipapir' )::int, 0),
-                                       'pengerSkyldt', coalesce(( behandlingsinformasjon -> 'formue' -> 'epsVerdier' -> 'pengerSkyldt' )::int, 0),
-                                       'kontanter', coalesce(( behandlingsinformasjon -> 'formue' -> 'epsVerdier' -> 'kontanter' )::int, 0),
-                                       'depositumskonto', coalesce(( behandlingsinformasjon -> 'formue' -> 'epsVerdier' -> 'depositumskonto' )::int, 0)
+                                       'verdiIkkePrimærbolig', coalesce(cast(( behandlingsinformasjon -> 'formue' -> 'epsVerdier' ->> 'verdiIkkePrimærbolig' ) as integer), 0),
+                                       'verdiEiendommer', coalesce(cast(( behandlingsinformasjon -> 'formue' -> 'epsVerdier' ->> 'verdiEiendommer') as integer), 0),
+                                       'verdiKjøretøy', coalesce(cast(( behandlingsinformasjon -> 'formue' -> 'epsVerdier' ->> 'verdiKjøretøy' ) as integer), 0),
+                                       'innskudd', coalesce(cast(( behandlingsinformasjon -> 'formue' -> 'epsVerdier' ->> 'innskudd' ) as integer), 0),
+                                       'verdipapir', coalesce( cast(( behandlingsinformasjon -> 'formue' -> 'epsVerdier' ->> 'verdipapir' ) as integer), 0),
+                                       'pengerSkyldt', coalesce(cast(( behandlingsinformasjon -> 'formue' -> 'epsVerdier' ->> 'pengerSkyldt' ) as integer), 0),
+                                       'kontanter', coalesce(cast(( behandlingsinformasjon -> 'formue' -> 'epsVerdier' ->> 'kontanter' ) as integer), 0),
+                                       'depositumskonto', coalesce(cast(( behandlingsinformasjon -> 'formue' -> 'epsVerdier' ->> 'depositumskonto' ) as integer), 0)
                                        )
                                 end as epsformue,
                                 coalesce( behandlingsinformasjon -> 'formue' -> 'verdier',

--- a/database/src/main/resources/db/migration/V93__migrer_formue_behandlingsinformasjon_til_grunnlagsdata.sql
+++ b/database/src/main/resources/db/migration/V93__migrer_formue_behandlingsinformasjon_til_grunnlagsdata.sql
@@ -1,0 +1,42 @@
+with manglende_grunnlagsdata as (
+    select * from revurdering
+    where not exists
+        (select null from grunnlag_formue where grunnlag_formue.behandlingid = revurdering.id)
+),
+     mapped_verdier as (select
+                            opprettet,
+                            id behandlingid,
+                            ( periode ->> 'fraOgMed' )::date as fraogmed,
+                            ( periode ->> 'tilOgMed' )::date as tilogmed,
+                            behandlingsinformasjon -> 'formue' -> 'epsVerdier' as epsformue,
+                            behandlingsinformasjon -> 'formue' -> 'verdier' as søkerformue,
+                            ( behandlingsinformasjon -> 'formue' ->> 'begrunnelse' )::text as begrunnelse,
+                            behandlingsinformasjon
+                        from manglende_grunnlagsdata),
+     ny_grunnlag as ( insert into grunnlag_formue (id, opprettet, behandlingid, fraogmed, tilogmed, epsformue, søkerformue, begrunnelse)
+         select
+             uuid_generate_v4() as id,
+             opprettet,
+             behandlingid,
+             fraogmed,
+             tilogmed,
+             epsformue,
+             søkerformue,
+             begrunnelse
+         from mapped_verdier
+         returning id, behandlingid
+     )
+insert into vilkårsvurdering_formue (id, opprettet, behandlingid, formue_grunnlag_id, vurdering, resultat, fraogmed, tilogmed)
+select uuid_generate_v4(),
+       opprettet,
+       ny_grunnlag.behandlingid,
+       ny_grunnlag.id,
+       'AUTOMATISK',
+       case
+           when (behandlingsinformasjon -> 'formue' ->> 'status' = 'VilkårOppfylt') then 'INNVILGET'
+           when (behandlingsinformasjon -> 'formue' ->> 'status' = 'VilkårIkkeOppfylt') then 'AVSLAG'
+           else 'UAVKLART'
+       end,
+       fraogmed,
+       tilogmed
+from mapped_verdier left join ny_grunnlag on mapped_verdier.behandlingid = ny_grunnlag.behandlingid;


### PR DESCRIPTION
- Migrerer kun behandlingsinformasjon fra revurderinger som ikke har grunnlagsdata_formue idag
- fraogmed / tilogmed -dato er lik revurderingens periode (så det blir 1-1 mapping mellom revurdering og grunnlag for formue)