### PR TITLE
Attestering historik

### DIFF
--- a/common/src/main/kotlin/no/nav/su/se/bakover/common/Jackson.kt
+++ b/common/src/main/kotlin/no/nav/su/se/bakover/common/Jackson.kt
@@ -33,5 +33,10 @@ inline fun <reified T> List<T>.serialize(): String {
     val listType = objectMapper.typeFactory.constructCollectionLikeType(List::class.java, T::class.java)
     return objectMapper.writerFor(listType).writeValueAsString(this)
 }
+inline fun <reified T> String.deserializeList(): List<T> {
+    val listType = objectMapper.typeFactory.constructCollectionLikeType(List::class.java, T::class.java)
+    // return objectMapper.readerFor(listType).readValue(this)
+    return objectMapper.readerFor(listType).readValue(this)
+}
 
 inline fun <reified T> deserialize(value: String): T = objectMapper.readValue(value)

--- a/common/src/main/kotlin/no/nav/su/se/bakover/common/Jackson.kt
+++ b/common/src/main/kotlin/no/nav/su/se/bakover/common/Jackson.kt
@@ -29,5 +29,9 @@ inline fun <reified K, reified V> ObjectMapper.readMap(value: String): Map<K, V>
 )
 
 fun serialize(value: Any): String = objectMapper.writeValueAsString(value)
+inline fun <reified T> List<T>.serialize(): String {
+    val listType = objectMapper.typeFactory.constructCollectionLikeType(List::class.java, T::class.java)
+    return objectMapper.writerFor(listType).writeValueAsString(this)
+}
 
 inline fun <reified T> deserialize(value: String): T = objectMapper.readValue(value)

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/revurdering/RevurderingPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/revurdering/RevurderingPostgresRepo.kt
@@ -499,7 +499,7 @@ internal class RevurderingPostgresRepo(
                         :saksbehandler,
                         :oppgaveId,
                         '${RevurderingsType.OPPRETTET}',
-                        jsonb_build_array(),
+                        to_jsonb(:attestering::jsonb),
                         :vedtakSomRevurderesId,
                         :fritekstTilBrev,
                         :arsak,

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/revurdering/RevurderingPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/revurdering/RevurderingPostgresRepo.kt
@@ -26,6 +26,7 @@ import no.nav.su.se.bakover.database.vedtak.VedtakPosgresRepo
 import no.nav.su.se.bakover.database.withSession
 import no.nav.su.se.bakover.domain.NavIdentBruker.Saksbehandler
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.brev.BrevbestillingId
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
@@ -171,7 +172,7 @@ internal class RevurderingPostgresRepo(
         val simulering = stringOrNull("simulering")?.let { objectMapper.readValue<Simulering>(it) }
         val saksbehandler = string("saksbehandler")
         val oppgaveId = stringOrNull("oppgaveid")
-        val attestering = stringOrNull("attestering")?.let { objectMapper.readValue<Attestering>(it) }
+        val attesteringer = string("attestering").let { objectMapper.readValue<AttesteringHistorik>(it) }
         val fritekstTilBrev = stringOrNull("fritekstTilBrev")
         val årsak = string("årsak")
         val begrunnelse = string("begrunnelse")
@@ -210,7 +211,7 @@ internal class RevurderingPostgresRepo(
                 beregning = beregning!!,
                 simulering = simulering!!,
                 oppgaveId = OppgaveId(oppgaveId!!),
-                attestering = attestering!! as Attestering.Underkjent,
+                attesteringer = attesteringer,
                 fritekstTilBrev = fritekstTilBrev ?: "",
                 revurderingsårsak = revurderingsårsak,
                 forhåndsvarsel = forhåndsvarsel!!,
@@ -228,7 +229,7 @@ internal class RevurderingPostgresRepo(
                 beregning = beregning!!,
                 simulering = simulering!!,
                 oppgaveId = OppgaveId(oppgaveId!!),
-                attestering = attestering!! as Attestering.Underkjent,
+                attesteringer = attesteringer,
                 fritekstTilBrev = fritekstTilBrev ?: "",
                 revurderingsårsak = revurderingsårsak,
                 forhåndsvarsel = forhåndsvarsel!!,
@@ -246,7 +247,7 @@ internal class RevurderingPostgresRepo(
                 oppgaveId = OppgaveId(oppgaveId!!),
                 beregning = beregning!!,
                 simulering = simulering!!,
-                attestering = attestering!! as Attestering.Iverksatt,
+                attesteringer = attesteringer,
                 fritekstTilBrev = fritekstTilBrev ?: "",
                 revurderingsårsak = revurderingsårsak,
                 forhåndsvarsel = forhåndsvarsel!!,
@@ -264,7 +265,7 @@ internal class RevurderingPostgresRepo(
                 beregning = beregning!!,
                 simulering = simulering!!,
                 oppgaveId = OppgaveId(oppgaveId!!),
-                attestering = attestering!! as Attestering.Iverksatt,
+                attesteringer = attesteringer,
                 grunnlagsdata = grunnlagsdata,
                 fritekstTilBrev = fritekstTilBrev ?: "",
                 revurderingsårsak = revurderingsårsak,
@@ -289,6 +290,7 @@ internal class RevurderingPostgresRepo(
                 behandlingsinformasjon = behandlingsinformasjon,
                 vilkårsvurderinger = vilkårsvurderinger,
                 informasjonSomRevurderes = informasjonSomRevurderes,
+                attesteringer = attesteringer,
             )
             RevurderingsType.TIL_ATTESTERING_OPPHØRT -> RevurderingTilAttestering.Opphørt(
                 id = id,
@@ -306,6 +308,7 @@ internal class RevurderingPostgresRepo(
                 grunnlagsdata = grunnlagsdata,
                 vilkårsvurderinger = vilkårsvurderinger,
                 informasjonSomRevurderes = informasjonSomRevurderes,
+                attesteringer = attesteringer,
             )
             RevurderingsType.SIMULERT_INNVILGET -> SimulertRevurdering.Innvilget(
                 id = id,
@@ -323,6 +326,7 @@ internal class RevurderingPostgresRepo(
                 grunnlagsdata = grunnlagsdata,
                 vilkårsvurderinger = vilkårsvurderinger,
                 informasjonSomRevurderes = informasjonSomRevurderes,
+                attesteringer = attesteringer,
             )
             RevurderingsType.SIMULERT_OPPHØRT -> SimulertRevurdering.Opphørt(
                 id = id,
@@ -340,6 +344,7 @@ internal class RevurderingPostgresRepo(
                 behandlingsinformasjon = behandlingsinformasjon,
                 vilkårsvurderinger = vilkårsvurderinger,
                 informasjonSomRevurderes = informasjonSomRevurderes,
+                attesteringer = attesteringer,
             )
             RevurderingsType.BEREGNET_INNVILGET -> BeregnetRevurdering.Innvilget(
                 id = id,
@@ -356,6 +361,7 @@ internal class RevurderingPostgresRepo(
                 behandlingsinformasjon = behandlingsinformasjon,
                 vilkårsvurderinger = vilkårsvurderinger,
                 informasjonSomRevurderes = informasjonSomRevurderes,
+                attesteringer = attesteringer,
             )
             RevurderingsType.BEREGNET_OPPHØRT -> BeregnetRevurdering.Opphørt(
                 id = id,
@@ -372,6 +378,7 @@ internal class RevurderingPostgresRepo(
                 behandlingsinformasjon = behandlingsinformasjon,
                 vilkårsvurderinger = vilkårsvurderinger,
                 informasjonSomRevurderes = informasjonSomRevurderes,
+                attesteringer = attesteringer,
             )
             RevurderingsType.OPPRETTET -> OpprettetRevurdering(
                 id = id,
@@ -387,6 +394,7 @@ internal class RevurderingPostgresRepo(
                 behandlingsinformasjon = behandlingsinformasjon,
                 vilkårsvurderinger = vilkårsvurderinger,
                 informasjonSomRevurderes = informasjonSomRevurderes,
+                attesteringer = attesteringer,
             )
             RevurderingsType.BEREGNET_INGEN_ENDRING -> BeregnetRevurdering.IngenEndring(
                 id = id,
@@ -403,6 +411,7 @@ internal class RevurderingPostgresRepo(
                 grunnlagsdata = grunnlagsdata,
                 vilkårsvurderinger = vilkårsvurderinger,
                 informasjonSomRevurderes = informasjonSomRevurderes,
+                attesteringer = attesteringer,
             )
             RevurderingsType.TIL_ATTESTERING_INGEN_ENDRING -> RevurderingTilAttestering.IngenEndring(
                 id = id,
@@ -420,6 +429,7 @@ internal class RevurderingPostgresRepo(
                 grunnlagsdata = grunnlagsdata,
                 vilkårsvurderinger = vilkårsvurderinger,
                 informasjonSomRevurderes = informasjonSomRevurderes,
+                attesteringer = attesteringer,
             )
             RevurderingsType.IVERKSATT_INGEN_ENDRING -> IverksattRevurdering.IngenEndring(
                 id = id,
@@ -432,7 +442,7 @@ internal class RevurderingPostgresRepo(
                 fritekstTilBrev = fritekstTilBrev ?: "",
                 revurderingsårsak = revurderingsårsak,
                 forhåndsvarsel = forhåndsvarsel,
-                attestering = attestering!! as Attestering.Iverksatt,
+                attesteringer = attesteringer,
                 skalFøreTilBrevutsending = skalFøreTilBrevutsending,
                 behandlingsinformasjon = behandlingsinformasjon,
                 grunnlagsdata = grunnlagsdata,
@@ -450,7 +460,7 @@ internal class RevurderingPostgresRepo(
                 fritekstTilBrev = fritekstTilBrev ?: "",
                 revurderingsårsak = revurderingsårsak,
                 forhåndsvarsel = forhåndsvarsel,
-                attestering = attestering!! as Attestering.Underkjent,
+                attesteringer = attesteringer,
                 skalFøreTilBrevutsending = skalFøreTilBrevutsending,
                 behandlingsinformasjon = behandlingsinformasjon,
                 grunnlagsdata = grunnlagsdata,

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/revurdering/RevurderingPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/revurdering/RevurderingPostgresRepo.kt
@@ -499,7 +499,7 @@ internal class RevurderingPostgresRepo(
                         :saksbehandler,
                         :oppgaveId,
                         '${RevurderingsType.OPPRETTET}',
-                        jsonb_build_array(),
+                        :attestering,
                         :vedtakSomRevurderesId,
                         :fritekstTilBrev,
                         :arsak,

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/revurdering/RevurderingPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/revurdering/RevurderingPostgresRepo.kt
@@ -107,7 +107,7 @@ internal class RevurderingPostgresRepo(
             "select * from revurdering where id = :id"
                 .hent(mapOf("id" to id), session) { row ->
                     row.string("attestering").let {
-                        val attesteringer = objectMapper.readValue<Attesteringshistorikk>(it)
+                        val attesteringer = Attesteringshistorikk(objectMapper.readValue(it))
                         attesteringer.hentAttesteringer().lastOrNull()
                     }
                 }
@@ -173,7 +173,7 @@ internal class RevurderingPostgresRepo(
         val simulering = stringOrNull("simulering")?.let { objectMapper.readValue<Simulering>(it) }
         val saksbehandler = string("saksbehandler")
         val oppgaveId = stringOrNull("oppgaveid")
-        val attesteringer = string("attestering").let { objectMapper.readValue<Attesteringshistorikk>(it) }
+        val attesteringer = Attesteringshistorikk(objectMapper.readValue(string("attestering")))
         val fritekstTilBrev = stringOrNull("fritekstTilBrev")
         val årsak = string("årsak")
         val begrunnelse = string("begrunnelse")
@@ -499,7 +499,7 @@ internal class RevurderingPostgresRepo(
                         :saksbehandler,
                         :oppgaveId,
                         '${RevurderingsType.OPPRETTET}',
-                        :attestering,
+                        jsonb_build_array(),
                         :vedtakSomRevurderesId,
                         :fritekstTilBrev,
                         :arsak,
@@ -517,7 +517,7 @@ internal class RevurderingPostgresRepo(
                         saksbehandler=:saksbehandler,
                         oppgaveId=:oppgaveId,
                         revurderingsType='${RevurderingsType.OPPRETTET}',
-                        attestering=to_json(:attestering::json),
+                        attestering=to_jsonb(:attestering::jsonb),
                         vedtakSomRevurderesId=:vedtakSomRevurderesId,
                         fritekstTilBrev=:fritekstTilBrev,
                         årsak=:arsak,
@@ -673,7 +673,7 @@ internal class RevurderingPostgresRepo(
                         beregning = to_json(:beregning::json),
                         simulering = to_json(:simulering::json),
                         oppgaveId = :oppgaveId,
-                        attestering = to_json(:attestering::json),
+                        attestering = to_jsonb(:attestering::jsonb),
                         årsak = :arsak,
                         begrunnelse =:begrunnelse,
                         revurderingsType = :revurderingsType,
@@ -711,7 +711,7 @@ internal class RevurderingPostgresRepo(
                         revurdering
                     set
                         oppgaveId = :oppgaveId,
-                        attestering = to_json(:attestering::json),
+                        attestering = to_jsonb(:attestering::jsonb),
                         årsak = :arsak,
                         begrunnelse =:begrunnelse,
                         revurderingsType = :revurderingsType,

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/søknadsbehandling/SøknadsbehandlingPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/søknadsbehandling/SøknadsbehandlingPostgresRepo.kt
@@ -23,6 +23,7 @@ import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
@@ -139,7 +140,7 @@ internal class SøknadsbehandlingPostgresRepo(
         val oppgaveId = OppgaveId(string("oppgaveId"))
         val beregning = stringOrNull("beregning")?.let { objectMapper.readValue<PersistertBeregning>(it) }
         val simulering = stringOrNull("simulering")?.let { objectMapper.readValue<Simulering>(it) }
-        val attestering = stringOrNull("attestering")?.let { objectMapper.readValue<Attestering>(it) }
+        val attesteringer = stringOrNull("attestering")?.let { objectMapper.readValue<AttesteringHistorik>(it) } ?: AttesteringHistorik.empty()
         val saksbehandler = stringOrNull("saksbehandler")?.let { NavIdentBruker.Saksbehandler(it) }
         val saksnummer = Saksnummer(long("saksnummer"))
         val fritekstTilBrev = stringOrNull("fritekstTilBrev") ?: ""
@@ -168,6 +169,7 @@ internal class SøknadsbehandlingPostgresRepo(
                 stønadsperiode = stønadsperiode,
                 grunnlagsdata = grunnlagsdata,
                 vilkårsvurderinger = vilkårsvurderinger,
+                attesteringer = attesteringer
             )
             BehandlingsStatus.VILKÅRSVURDERT_INNVILGET -> Søknadsbehandling.Vilkårsvurdert.Innvilget(
                 id = behandlingId,
@@ -182,6 +184,7 @@ internal class SøknadsbehandlingPostgresRepo(
                 stønadsperiode = stønadsperiode!!,
                 grunnlagsdata = grunnlagsdata,
                 vilkårsvurderinger = vilkårsvurderinger,
+                attesteringer = attesteringer
             )
             BehandlingsStatus.VILKÅRSVURDERT_AVSLAG -> Søknadsbehandling.Vilkårsvurdert.Avslag(
                 id = behandlingId,
@@ -196,6 +199,7 @@ internal class SøknadsbehandlingPostgresRepo(
                 stønadsperiode = stønadsperiode!!,
                 grunnlagsdata = grunnlagsdata,
                 vilkårsvurderinger = vilkårsvurderinger,
+                attesteringer = attesteringer
             )
             BehandlingsStatus.BEREGNET_INNVILGET -> Søknadsbehandling.Beregnet.Innvilget(
                 id = behandlingId,
@@ -211,6 +215,7 @@ internal class SøknadsbehandlingPostgresRepo(
                 stønadsperiode = stønadsperiode!!,
                 grunnlagsdata = grunnlagsdata,
                 vilkårsvurderinger = vilkårsvurderinger,
+                attesteringer = attesteringer
             )
             BehandlingsStatus.BEREGNET_AVSLAG -> Søknadsbehandling.Beregnet.Avslag(
                 id = behandlingId,
@@ -226,6 +231,7 @@ internal class SøknadsbehandlingPostgresRepo(
                 stønadsperiode = stønadsperiode!!,
                 grunnlagsdata = grunnlagsdata,
                 vilkårsvurderinger = vilkårsvurderinger,
+                attesteringer = attesteringer
             )
             BehandlingsStatus.SIMULERT -> Søknadsbehandling.Simulert(
                 id = behandlingId,
@@ -242,6 +248,7 @@ internal class SøknadsbehandlingPostgresRepo(
                 stønadsperiode = stønadsperiode!!,
                 grunnlagsdata = grunnlagsdata,
                 vilkårsvurderinger = vilkårsvurderinger,
+                attesteringer = attesteringer
             )
             BehandlingsStatus.TIL_ATTESTERING_INNVILGET -> Søknadsbehandling.TilAttestering.Innvilget(
                 id = behandlingId,
@@ -259,6 +266,7 @@ internal class SøknadsbehandlingPostgresRepo(
                 stønadsperiode = stønadsperiode!!,
                 grunnlagsdata = grunnlagsdata,
                 vilkårsvurderinger = vilkårsvurderinger,
+                attesteringer = attesteringer
             )
             BehandlingsStatus.TIL_ATTESTERING_AVSLAG -> when (beregning) {
                 null -> Søknadsbehandling.TilAttestering.Avslag.UtenBeregning(
@@ -275,6 +283,7 @@ internal class SøknadsbehandlingPostgresRepo(
                     stønadsperiode = stønadsperiode!!,
                     grunnlagsdata = grunnlagsdata,
                     vilkårsvurderinger = vilkårsvurderinger,
+                    attesteringer = attesteringer
                 )
                 else -> Søknadsbehandling.TilAttestering.Avslag.MedBeregning(
                     id = behandlingId,
@@ -291,6 +300,7 @@ internal class SøknadsbehandlingPostgresRepo(
                     stønadsperiode = stønadsperiode!!,
                     grunnlagsdata = grunnlagsdata,
                     vilkårsvurderinger = vilkårsvurderinger,
+                    attesteringer = attesteringer
                 )
             }
             BehandlingsStatus.UNDERKJENT_INNVILGET -> Søknadsbehandling.Underkjent.Innvilget(
@@ -305,7 +315,7 @@ internal class SøknadsbehandlingPostgresRepo(
                 beregning = beregning!!,
                 simulering = simulering!!,
                 saksbehandler = saksbehandler!!,
-                attestering = attestering!!,
+                attesteringer = attesteringer,
                 fritekstTilBrev = fritekstTilBrev,
                 stønadsperiode = stønadsperiode!!,
                 grunnlagsdata = grunnlagsdata,
@@ -322,7 +332,7 @@ internal class SøknadsbehandlingPostgresRepo(
                     behandlingsinformasjon = behandlingsinformasjon,
                     fnr = fnr,
                     saksbehandler = saksbehandler!!,
-                    attestering = attestering!!,
+                    attesteringer = attesteringer,
                     fritekstTilBrev = fritekstTilBrev,
                     stønadsperiode = stønadsperiode!!,
                     grunnlagsdata = grunnlagsdata,
@@ -339,7 +349,7 @@ internal class SøknadsbehandlingPostgresRepo(
                     fnr = fnr,
                     beregning = beregning,
                     saksbehandler = saksbehandler!!,
-                    attestering = attestering!!,
+                    attesteringer = attesteringer,
                     fritekstTilBrev = fritekstTilBrev,
                     stønadsperiode = stønadsperiode!!,
                     grunnlagsdata = grunnlagsdata,
@@ -359,7 +369,7 @@ internal class SøknadsbehandlingPostgresRepo(
                     beregning = beregning!!,
                     simulering = simulering!!,
                     saksbehandler = saksbehandler!!,
-                    attestering = attestering!!,
+                    attesteringer = attesteringer,
                     fritekstTilBrev = fritekstTilBrev,
                     stønadsperiode = stønadsperiode!!,
                     grunnlagsdata = grunnlagsdata,
@@ -378,7 +388,7 @@ internal class SøknadsbehandlingPostgresRepo(
                         behandlingsinformasjon = behandlingsinformasjon,
                         fnr = fnr,
                         saksbehandler = saksbehandler!!,
-                        attestering = attestering!!,
+                        attesteringer = attesteringer,
                         fritekstTilBrev = fritekstTilBrev,
                         stønadsperiode = stønadsperiode!!,
                         grunnlagsdata = grunnlagsdata,
@@ -395,7 +405,7 @@ internal class SøknadsbehandlingPostgresRepo(
                         fnr = fnr,
                         beregning = beregning,
                         saksbehandler = saksbehandler!!,
-                        attestering = attestering!!,
+                        attesteringer = attesteringer,
                         fritekstTilBrev = fritekstTilBrev,
                         stønadsperiode = stønadsperiode!!,
                         grunnlagsdata = grunnlagsdata,
@@ -474,12 +484,13 @@ internal class SøknadsbehandlingPostgresRepo(
         """.trimIndent()
             .oppdatering(
                 params = defaultParams(søknadsbehandling).plus(
-                    "attestering" to objectMapper.writeValueAsString(søknadsbehandling.attestering),
+                    "attestering" to objectMapper.writeValueAsString(søknadsbehandling.attesteringer),
                 ),
                 session = session,
             )
     }
 
+    // TODO ai: Se over lagring for nye attesteringer (Attestering -> AttesteringHistorik)
     private fun lagre(søknadsbehandling: Søknadsbehandling.Iverksatt, session: Session) {
         when (søknadsbehandling) {
             is Søknadsbehandling.Iverksatt.Innvilget -> {
@@ -489,7 +500,7 @@ internal class SøknadsbehandlingPostgresRepo(
                     .oppdatering(
                         params = defaultParams(søknadsbehandling).plus(
                             listOf(
-                                "attestering" to objectMapper.writeValueAsString(søknadsbehandling.attestering),
+                                "attestering" to objectMapper.writeValueAsString(søknadsbehandling.attesteringer),
                             ),
                         ),
                         session = session,
@@ -502,7 +513,7 @@ internal class SøknadsbehandlingPostgresRepo(
                     .oppdatering(
                         params = defaultParams(søknadsbehandling).plus(
                             listOf(
-                                "attestering" to objectMapper.writeValueAsString(søknadsbehandling.attestering),
+                                "attestering" to objectMapper.writeValueAsString(søknadsbehandling.attesteringer),
                             ),
                         ),
                         session = session,

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/søknadsbehandling/SøknadsbehandlingPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/søknadsbehandling/SøknadsbehandlingPostgresRepo.kt
@@ -102,7 +102,7 @@ internal class SøknadsbehandlingPostgresRepo(
             "select b.attestering from behandling b where b.id=:id"
                 .hent(mapOf("id" to id), session) { row ->
                     row.stringOrNull("attestering")?.let {
-                        val attesteringer = objectMapper.readValue<Attesteringshistorikk>(it)
+                        val attesteringer = Attesteringshistorikk(objectMapper.readValue(it))
                         attesteringer.hentAttesteringer().lastOrNull()
                     }
                 }
@@ -145,7 +145,7 @@ internal class SøknadsbehandlingPostgresRepo(
         val oppgaveId = OppgaveId(string("oppgaveId"))
         val beregning = stringOrNull("beregning")?.let { objectMapper.readValue<PersistertBeregning>(it) }
         val simulering = stringOrNull("simulering")?.let { objectMapper.readValue<Simulering>(it) }
-        val attesteringer = string("attestering").let { objectMapper.readValue<Attesteringshistorikk>(it) }
+        val attesteringer = string("attestering").let { Attesteringshistorikk(objectMapper.readValue(it)) }
         val saksbehandler = stringOrNull("saksbehandler")?.let { NavIdentBruker.Saksbehandler(it) }
         val saksnummer = Saksnummer(long("saksnummer"))
         val fritekstTilBrev = stringOrNull("fritekstTilBrev") ?: ""

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/vedtak/snapshot/VedtakssnapshotJson.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/vedtak/snapshot/VedtakssnapshotJson.kt
@@ -97,7 +97,7 @@ internal sealed class VedtakssnapshotJson {
                     fnr = fnr.toString(),
                     status = status.toString(),
                     saksbehandler = saksbehandler.toString(),
-                    attestering = attestering,
+                    attestering = attesteringer.hentSisteAttestering(),
                     oppgaveId = oppgaveId.toString(),
                     // TODO jah: Denne vil alltid være null for innvilgelse siden vi ikke gjør dette før vi får kvitteringen
                     iverksattJournalpostId = journalføringOgBrevdistribusjon.journalpostId()?.toString(),
@@ -123,7 +123,7 @@ internal sealed class VedtakssnapshotJson {
                     fnr = fnr.toString(),
                     status = status.toString(),
                     saksbehandler = saksbehandler.toString(),
-                    attestering = attestering,
+                    attestering = attesteringer.hentSisteAttestering(),
                     oppgaveId = oppgaveId.toString(),
                     iverksattJournalpostId = journalføringOgBrevdistribusjon.journalpostId()?.toString(),
                     iverksattBrevbestillingId = (journalføringOgBrevdistribusjon as? JournalføringOgBrevdistribusjon.JournalførtOgDistribuertBrev)?.brevbestillingId?.toString(),

--- a/database/src/main/resources/db/migration/V94__legg_til_flere_attesteringer.sql
+++ b/database/src/main/resources/db/migration/V94__legg_til_flere_attesteringer.sql
@@ -9,3 +9,13 @@ set attestering = case
     end
 from ( behandling as b left join behandling_vedtak bv on b.id = bv.søknadsbehandlingid left join vedtak v on bv.vedtakid = v.id )
 where b.id = behandling.id;
+
+update revurdering
+set attestering = case
+                      when ( revurdering.attestering is null ) then jsonb_build_array()
+                      else jsonb_build_array(
+                                  revurdering.attestering || jsonb_build_object('opprettet', coalesce(v.opprettet, revurdering.opprettet))
+                          )
+    end
+from ( revurdering as r left join behandling_vedtak bv on r.id = bv.revurderingid left join vedtak v on bv.vedtakid = v.id )
+where r.id = revurdering.id;

--- a/database/src/main/resources/db/migration/V94__legg_til_flere_attesteringer.sql
+++ b/database/src/main/resources/db/migration/V94__legg_til_flere_attesteringer.sql
@@ -1,0 +1,11 @@
+update behandling
+set attestering = case
+    /* Lag tom array hvis det ikke finnes attestering */
+                      when ( behandling.attestering is null ) then jsonb_build_array()
+    /* Annars, wrap nåværande attestering i en array og legg till opprettet med tidspunkt fra vedtak hvis det finnes. Annars default till opprettet fra behandling */
+                      else jsonb_build_array(
+                                  behandling.attestering || jsonb_build_object('opprettet', coalesce(v.opprettet, behandling.opprettet))
+                          )
+    end
+from ( behandling as b left join behandling_vedtak bv on b.id = bv.søknadsbehandlingid left join vedtak v on bv.vedtakid = v.id )
+where b.id = behandling.id;

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
@@ -34,6 +34,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.behandling.withVilkårAvslått
@@ -114,8 +115,13 @@ internal fun simulering(fnr: Fnr) = Simulering(
 internal val saksbehandler = NavIdentBruker.Saksbehandler("saksbehandler")
 internal val attestant = NavIdentBruker.Attestant("attestant")
 internal val underkjentAttestering =
-    Attestering.Underkjent(attestant, Attestering.Underkjent.Grunn.ANDRE_FORHOLD, "kommentar")
-internal val iverksattAttestering = Attestering.Iverksatt(attestant)
+    Attestering.Underkjent(
+        attestant = attestant,
+        grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
+        kommentar = "kommentar",
+        tidspunkt = fixedTidspunkt
+    )
+internal val iverksattAttestering = Attestering.Iverksatt(attestant, fixedTidspunkt)
 internal val iverksattJournalpostId = JournalpostId("iverksattJournalpostId")
 internal val iverksattBrevbestillingId = BrevbestillingId("iverksattBrevbestillingId")
 internal val avstemmingsnøkkel = Avstemmingsnøkkel()
@@ -373,6 +379,7 @@ internal class TestDataHelper(
             grunnlagsdata = grunnlagsdata,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = AttesteringHistorik.empty()
         ).also {
             revurderingRepo.lagre(it)
             grunnlagRepo.lagreBosituasjongrunnlag(revurderingId, grunnlagsdata.bosituasjon)

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
@@ -34,7 +34,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.behandling.withVilkårAvslått
@@ -119,7 +119,7 @@ internal val underkjentAttestering =
         attestant = attestant,
         grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
         kommentar = "kommentar",
-        tidspunkt = fixedTidspunkt
+        opprettet = fixedTidspunkt
     )
 internal val iverksattAttestering = Attestering.Iverksatt(attestant, fixedTidspunkt)
 internal val iverksattJournalpostId = JournalpostId("iverksattJournalpostId")
@@ -379,7 +379,7 @@ internal class TestDataHelper(
             grunnlagsdata = grunnlagsdata,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         ).also {
             revurderingRepo.lagre(it)
             grunnlagRepo.lagreBosituasjongrunnlag(revurderingId, grunnlagsdata.bosituasjon)

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/person/PersonPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/person/PersonPostgresRepoTest.kt
@@ -8,6 +8,7 @@ import no.nav.su.se.bakover.database.beregning
 import no.nav.su.se.bakover.database.simulering
 import no.nav.su.se.bakover.database.withMigratedDb
 import no.nav.su.se.bakover.domain.Fnr
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.revurdering.Forhåndsvarsel
 import no.nav.su.se.bakover.domain.revurdering.Revurdering
@@ -192,6 +193,7 @@ internal class PersonPostgresRepoTest {
                     grunnlagsdata = revurdering.grunnlagsdata,
                     vilkårsvurderinger = revurdering.vilkårsvurderinger,
                     informasjonSomRevurderes = revurdering.informasjonSomRevurderes,
+                    attesteringer = AttesteringHistorik.empty()
                 ),
             ).first
             val revurderingAvRevurdering = testDataHelper.nyRevurdering(

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/person/PersonPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/person/PersonPostgresRepoTest.kt
@@ -8,7 +8,7 @@ import no.nav.su.se.bakover.database.beregning
 import no.nav.su.se.bakover.database.simulering
 import no.nav.su.se.bakover.database.withMigratedDb
 import no.nav.su.se.bakover.domain.Fnr
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.revurdering.Forhåndsvarsel
 import no.nav.su.se.bakover.domain.revurdering.Revurdering
@@ -193,7 +193,7 @@ internal class PersonPostgresRepoTest {
                     grunnlagsdata = revurdering.grunnlagsdata,
                     vilkårsvurderinger = revurdering.vilkårsvurderinger,
                     informasjonSomRevurderes = revurdering.informasjonSomRevurderes,
-                    attesteringer = AttesteringHistorik.empty()
+                    attesteringer = Attesteringshistorikk.empty()
                 ),
             ).first
             val revurderingAvRevurdering = testDataHelper.nyRevurdering(

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/revurdering/RevurderingPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/revurdering/RevurderingPostgresRepoTest.kt
@@ -21,7 +21,7 @@ import no.nav.su.se.bakover.database.withTransaction
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.NavIdentBruker.Saksbehandler
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragTilhører
 import no.nav.su.se.bakover.domain.beregning.fradrag.Fradragstype
 import no.nav.su.se.bakover.domain.brev.BrevbestillingId
@@ -94,7 +94,7 @@ internal class RevurderingPostgresRepoTest {
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
         informasjonSomRevurderes = informasjonSomRevurderes,
-        attesteringer = AttesteringHistorik.empty()
+        attesteringer = Attesteringshistorikk.empty()
     )
 
     private fun beregnetIngenEndring(
@@ -115,7 +115,7 @@ internal class RevurderingPostgresRepoTest {
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
         informasjonSomRevurderes = informasjonSomRevurderes,
-        attesteringer = AttesteringHistorik.empty()
+        attesteringer = Attesteringshistorikk.empty()
     )
 
     private fun beregnetInnvilget(
@@ -136,7 +136,7 @@ internal class RevurderingPostgresRepoTest {
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
         informasjonSomRevurderes = informasjonSomRevurderes,
-        attesteringer = AttesteringHistorik.empty()
+        attesteringer = Attesteringshistorikk.empty()
     )
 
     private fun beregnetOpphørt(
@@ -157,7 +157,7 @@ internal class RevurderingPostgresRepoTest {
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
         informasjonSomRevurderes = informasjonSomRevurderes,
-        attesteringer = AttesteringHistorik.empty()
+        attesteringer = Attesteringshistorikk.empty()
     )
 
     private fun simulertInnvilget(beregnet: BeregnetRevurdering.Innvilget) = SimulertRevurdering.Innvilget(
@@ -176,7 +176,7 @@ internal class RevurderingPostgresRepoTest {
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
         informasjonSomRevurderes = informasjonSomRevurderes,
-        attesteringer = AttesteringHistorik.empty()
+        attesteringer = Attesteringshistorikk.empty()
     )
 
     private fun simulertOpphørt(beregnet: BeregnetRevurdering.Opphørt) = SimulertRevurdering.Opphørt(
@@ -195,7 +195,7 @@ internal class RevurderingPostgresRepoTest {
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
         informasjonSomRevurderes = informasjonSomRevurderes,
-        attesteringer = AttesteringHistorik.empty()
+        attesteringer = Attesteringshistorikk.empty()
     )
 
     @Test
@@ -420,7 +420,7 @@ internal class RevurderingPostgresRepoTest {
                 ),
                 vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
                 informasjonSomRevurderes = opprettet.informasjonSomRevurderes,
-                attesteringer = AttesteringHistorik.empty()
+                attesteringer = Attesteringshistorikk.empty()
             )
 
             fradragsgrunnlagPostgresRepo.lagreFradragsgrunnlag(
@@ -483,7 +483,7 @@ internal class RevurderingPostgresRepoTest {
                 attestant = attestant,
                 grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
                 kommentar = "feil",
-                tidspunkt = fixedTidspunkt
+                opprettet = fixedTidspunkt
             )
 
             val underkjent = tilAttestering.underkjenn(attestering, OppgaveId("nyOppgaveId"))
@@ -527,12 +527,12 @@ internal class RevurderingPostgresRepoTest {
                 revurderingsårsak = opprettet.revurderingsårsak,
                 beregning = vedtak.beregning,
                 simulering = simulering,
-                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(
+                attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(
                     Attestering.Underkjent(
                         attestant = attestant,
                         grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
                         kommentar = "kommentar",
-                        tidspunkt = fixedTidspunkt
+                        opprettet = fixedTidspunkt
                     )
                 ),
                 forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
@@ -573,7 +573,7 @@ internal class RevurderingPostgresRepoTest {
                 grunnlagsdata = Grunnlagsdata.EMPTY,
                 vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
                 informasjonSomRevurderes = opprettet.informasjonSomRevurderes,
-                attesteringer = AttesteringHistorik.empty()
+                attesteringer = Attesteringshistorikk.empty()
             )
 
             repo.lagre(underkjent)
@@ -612,7 +612,7 @@ internal class RevurderingPostgresRepoTest {
                 revurderingsårsak = opprettet.revurderingsårsak,
                 beregning = vedtak.beregning,
                 simulering = simulering,
-                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(
+                attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(
                     Attestering.Iverksatt(
                         attestant,
                         fixedTidspunkt
@@ -656,7 +656,7 @@ internal class RevurderingPostgresRepoTest {
                 grunnlagsdata = opprettet.grunnlagsdata,
                 vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
                 informasjonSomRevurderes = opprettet.informasjonSomRevurderes,
-                attesteringer = AttesteringHistorik.empty()
+                attesteringer = Attesteringshistorikk.empty()
             )
             repo.lagre(underkjentTilAttestering)
             val underkjent = UnderkjentRevurdering.IngenEndring(
@@ -669,12 +669,12 @@ internal class RevurderingPostgresRepoTest {
                 fritekstTilBrev = opprettet.fritekstTilBrev,
                 revurderingsårsak = opprettet.revurderingsårsak,
                 beregning = vedtak.beregning,
-                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(
+                attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(
                     Attestering.Underkjent(
                         attestant = attestant,
                         grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
                         kommentar = "kommentar",
-                        tidspunkt = fixedTidspunkt
+                        opprettet = fixedTidspunkt
                     )
                 ),
                 skalFøreTilBrevutsending = false,
@@ -715,7 +715,7 @@ internal class RevurderingPostgresRepoTest {
                 grunnlagsdata = Grunnlagsdata.EMPTY,
                 vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
                 informasjonSomRevurderes = opprettet.informasjonSomRevurderes,
-                attesteringer = AttesteringHistorik.empty()
+                attesteringer = Attesteringshistorikk.empty()
             )
 
             repo.lagre(underkjent)
@@ -748,7 +748,7 @@ internal class RevurderingPostgresRepoTest {
                 grunnlagsdata = opprettet.grunnlagsdata,
                 vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
                 informasjonSomRevurderes = opprettet.informasjonSomRevurderes,
-                attesteringer = AttesteringHistorik.empty()
+                attesteringer = Attesteringshistorikk.empty()
             )
             repo.lagre(revurderingTilAttestering)
             val underkjent = IverksattRevurdering.IngenEndring(
@@ -761,7 +761,7 @@ internal class RevurderingPostgresRepoTest {
                 fritekstTilBrev = opprettet.fritekstTilBrev,
                 revurderingsårsak = opprettet.revurderingsårsak,
                 beregning = vedtak.beregning,
-                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(
+                attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(
                     Attestering.Iverksatt(
                         attestant,
                         fixedTidspunkt

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/revurdering/RevurderingPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/revurdering/RevurderingPostgresRepoTest.kt
@@ -21,6 +21,7 @@ import no.nav.su.se.bakover.database.withTransaction
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.NavIdentBruker.Saksbehandler
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragTilhører
 import no.nav.su.se.bakover.domain.beregning.fradrag.Fradragstype
 import no.nav.su.se.bakover.domain.brev.BrevbestillingId
@@ -93,6 +94,7 @@ internal class RevurderingPostgresRepoTest {
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
         informasjonSomRevurderes = informasjonSomRevurderes,
+        attesteringer = AttesteringHistorik.empty()
     )
 
     private fun beregnetIngenEndring(
@@ -113,6 +115,7 @@ internal class RevurderingPostgresRepoTest {
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
         informasjonSomRevurderes = informasjonSomRevurderes,
+        attesteringer = AttesteringHistorik.empty()
     )
 
     private fun beregnetInnvilget(
@@ -133,6 +136,7 @@ internal class RevurderingPostgresRepoTest {
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
         informasjonSomRevurderes = informasjonSomRevurderes,
+        attesteringer = AttesteringHistorik.empty()
     )
 
     private fun beregnetOpphørt(
@@ -153,6 +157,7 @@ internal class RevurderingPostgresRepoTest {
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
         informasjonSomRevurderes = informasjonSomRevurderes,
+        attesteringer = AttesteringHistorik.empty()
     )
 
     private fun simulertInnvilget(beregnet: BeregnetRevurdering.Innvilget) = SimulertRevurdering.Innvilget(
@@ -171,6 +176,7 @@ internal class RevurderingPostgresRepoTest {
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
         informasjonSomRevurderes = informasjonSomRevurderes,
+        attesteringer = AttesteringHistorik.empty()
     )
 
     private fun simulertOpphørt(beregnet: BeregnetRevurdering.Opphørt) = SimulertRevurdering.Opphørt(
@@ -189,6 +195,7 @@ internal class RevurderingPostgresRepoTest {
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
         informasjonSomRevurderes = informasjonSomRevurderes,
+        attesteringer = AttesteringHistorik.empty()
     )
 
     @Test
@@ -413,6 +420,7 @@ internal class RevurderingPostgresRepoTest {
                 ),
                 vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
                 informasjonSomRevurderes = opprettet.informasjonSomRevurderes,
+                attesteringer = AttesteringHistorik.empty()
             )
 
             fradragsgrunnlagPostgresRepo.lagreFradragsgrunnlag(
@@ -475,6 +483,7 @@ internal class RevurderingPostgresRepoTest {
                 attestant = attestant,
                 grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
                 kommentar = "feil",
+                tidspunkt = fixedTidspunkt
             )
 
             val underkjent = tilAttestering.underkjenn(attestering, OppgaveId("nyOppgaveId"))
@@ -518,10 +527,13 @@ internal class RevurderingPostgresRepoTest {
                 revurderingsårsak = opprettet.revurderingsårsak,
                 beregning = vedtak.beregning,
                 simulering = simulering,
-                attestering = Attestering.Underkjent(
-                    attestant,
-                    Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
-                    "kommentar",
+                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(
+                    Attestering.Underkjent(
+                        attestant = attestant,
+                        grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
+                        kommentar = "kommentar",
+                        tidspunkt = fixedTidspunkt
+                    )
                 ),
                 forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
                 behandlingsinformasjon = opprettet.behandlingsinformasjon,
@@ -561,6 +573,7 @@ internal class RevurderingPostgresRepoTest {
                 grunnlagsdata = Grunnlagsdata.EMPTY,
                 vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
                 informasjonSomRevurderes = opprettet.informasjonSomRevurderes,
+                attesteringer = AttesteringHistorik.empty()
             )
 
             repo.lagre(underkjent)
@@ -599,8 +612,11 @@ internal class RevurderingPostgresRepoTest {
                 revurderingsårsak = opprettet.revurderingsårsak,
                 beregning = vedtak.beregning,
                 simulering = simulering,
-                attestering = Attestering.Iverksatt(
-                    attestant,
+                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(
+                    Attestering.Iverksatt(
+                        attestant,
+                        fixedTidspunkt
+                    )
                 ),
                 forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
                 behandlingsinformasjon = opprettet.behandlingsinformasjon,
@@ -640,6 +656,7 @@ internal class RevurderingPostgresRepoTest {
                 grunnlagsdata = opprettet.grunnlagsdata,
                 vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
                 informasjonSomRevurderes = opprettet.informasjonSomRevurderes,
+                attesteringer = AttesteringHistorik.empty()
             )
             repo.lagre(underkjentTilAttestering)
             val underkjent = UnderkjentRevurdering.IngenEndring(
@@ -652,10 +669,13 @@ internal class RevurderingPostgresRepoTest {
                 fritekstTilBrev = opprettet.fritekstTilBrev,
                 revurderingsårsak = opprettet.revurderingsårsak,
                 beregning = vedtak.beregning,
-                attestering = Attestering.Underkjent(
-                    attestant,
-                    Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
-                    "kommentar",
+                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(
+                    Attestering.Underkjent(
+                        attestant = attestant,
+                        grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
+                        kommentar = "kommentar",
+                        tidspunkt = fixedTidspunkt
+                    )
                 ),
                 skalFøreTilBrevutsending = false,
                 forhåndsvarsel = null,
@@ -695,6 +715,7 @@ internal class RevurderingPostgresRepoTest {
                 grunnlagsdata = Grunnlagsdata.EMPTY,
                 vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
                 informasjonSomRevurderes = opprettet.informasjonSomRevurderes,
+                attesteringer = AttesteringHistorik.empty()
             )
 
             repo.lagre(underkjent)
@@ -727,6 +748,7 @@ internal class RevurderingPostgresRepoTest {
                 grunnlagsdata = opprettet.grunnlagsdata,
                 vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
                 informasjonSomRevurderes = opprettet.informasjonSomRevurderes,
+                attesteringer = AttesteringHistorik.empty()
             )
             repo.lagre(revurderingTilAttestering)
             val underkjent = IverksattRevurdering.IngenEndring(
@@ -739,8 +761,11 @@ internal class RevurderingPostgresRepoTest {
                 fritekstTilBrev = opprettet.fritekstTilBrev,
                 revurderingsårsak = opprettet.revurderingsårsak,
                 beregning = vedtak.beregning,
-                attestering = Attestering.Iverksatt(
-                    attestant,
+                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(
+                    Attestering.Iverksatt(
+                        attestant,
+                        fixedTidspunkt
+                    )
                 ),
                 skalFøreTilBrevutsending = false,
                 forhåndsvarsel = null,

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/søknadsbehandling/SøknadsbehandlingPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/søknadsbehandling/SøknadsbehandlingPostgresRepoTest.kt
@@ -27,6 +27,7 @@ import no.nav.su.se.bakover.database.stønadsperiode
 import no.nav.su.se.bakover.database.underkjentAttestering
 import no.nav.su.se.bakover.database.withMigratedDb
 import no.nav.su.se.bakover.database.withSession
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.grunnlag.Uføregrad
@@ -226,6 +227,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                             stønadsperiode = stønadsperiode,
                             grunnlagsdata = tilAttestering.grunnlagsdata,
                             vilkårsvurderinger = tilAttestering.vilkårsvurderinger,
+                            attesteringer = AttesteringHistorik.empty()
                         )
                     }
                 }
@@ -254,6 +256,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                             stønadsperiode = stønadsperiode,
                             grunnlagsdata = Grunnlagsdata.EMPTY,
                             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+                            attesteringer = AttesteringHistorik.empty()
                         )
                     }
                 }
@@ -283,6 +286,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                             stønadsperiode = stønadsperiode,
                             grunnlagsdata = tilAttestering.grunnlagsdata,
                             vilkårsvurderinger = tilAttestering.vilkårsvurderinger,
+                            attesteringer = AttesteringHistorik.empty()
                         )
                     }
                 }
@@ -312,7 +316,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                             beregning = beregning(),
                             simulering = simulering(tilAttestering.fnr),
                             saksbehandler = saksbehandler,
-                            attestering = underkjentAttestering,
+                            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(underkjentAttestering),
                             fritekstTilBrev = "",
                             stønadsperiode = stønadsperiode,
                             grunnlagsdata = tilAttestering.grunnlagsdata,
@@ -341,7 +345,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                             behandlingsinformasjon = tilAttestering.behandlingsinformasjon,
                             fnr = tilAttestering.fnr,
                             saksbehandler = saksbehandler,
-                            attestering = underkjentAttestering,
+                            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(underkjentAttestering),
                             fritekstTilBrev = "",
                             stønadsperiode = stønadsperiode,
                             grunnlagsdata = Grunnlagsdata.EMPTY,
@@ -371,7 +375,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                             fnr = tilAttestering.fnr,
                             beregning = avslåttBeregning,
                             saksbehandler = saksbehandler,
-                            attestering = underkjentAttestering,
+                            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(underkjentAttestering),
                             fritekstTilBrev = "",
                             stønadsperiode = stønadsperiode,
                             grunnlagsdata = tilAttestering.grunnlagsdata,
@@ -412,7 +416,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                 behandlingsinformasjon = iverksatt.behandlingsinformasjon,
                 fnr = iverksatt.fnr,
                 saksbehandler = saksbehandler,
-                attestering = iverksattAttestering,
+                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(iverksattAttestering),
                 fritekstTilBrev = "Dette er fritekst",
                 stønadsperiode = stønadsperiode,
                 grunnlagsdata = Grunnlagsdata.EMPTY,
@@ -440,7 +444,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                     fnr = iverksatt.fnr,
                     beregning = avslåttBeregning,
                     saksbehandler = saksbehandler,
-                    attestering = iverksattAttestering,
+                    attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(iverksattAttestering),
                     fritekstTilBrev = "",
                     stønadsperiode = stønadsperiode,
                     grunnlagsdata = iverksatt.grunnlagsdata,
@@ -490,7 +494,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                     fnr = iverksatt.fnr,
                     beregning = avslåttBeregning,
                     saksbehandler = saksbehandler,
-                    attestering = iverksattAttestering,
+                    attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(iverksattAttestering),
                     fritekstTilBrev = "",
                     stønadsperiode = stønadsperiode,
                     grunnlagsdata = Grunnlagsdata(

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/søknadsbehandling/SøknadsbehandlingPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/søknadsbehandling/SøknadsbehandlingPostgresRepoTest.kt
@@ -27,7 +27,7 @@ import no.nav.su.se.bakover.database.stønadsperiode
 import no.nav.su.se.bakover.database.underkjentAttestering
 import no.nav.su.se.bakover.database.withMigratedDb
 import no.nav.su.se.bakover.database.withSession
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.grunnlag.Uføregrad
@@ -227,7 +227,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                             stønadsperiode = stønadsperiode,
                             grunnlagsdata = tilAttestering.grunnlagsdata,
                             vilkårsvurderinger = tilAttestering.vilkårsvurderinger,
-                            attesteringer = AttesteringHistorik.empty()
+                            attesteringer = Attesteringshistorikk.empty()
                         )
                     }
                 }
@@ -256,7 +256,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                             stønadsperiode = stønadsperiode,
                             grunnlagsdata = Grunnlagsdata.EMPTY,
                             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
-                            attesteringer = AttesteringHistorik.empty()
+                            attesteringer = Attesteringshistorikk.empty()
                         )
                     }
                 }
@@ -286,7 +286,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                             stønadsperiode = stønadsperiode,
                             grunnlagsdata = tilAttestering.grunnlagsdata,
                             vilkårsvurderinger = tilAttestering.vilkårsvurderinger,
-                            attesteringer = AttesteringHistorik.empty()
+                            attesteringer = Attesteringshistorikk.empty()
                         )
                     }
                 }
@@ -316,7 +316,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                             beregning = beregning(),
                             simulering = simulering(tilAttestering.fnr),
                             saksbehandler = saksbehandler,
-                            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(underkjentAttestering),
+                            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(underkjentAttestering),
                             fritekstTilBrev = "",
                             stønadsperiode = stønadsperiode,
                             grunnlagsdata = tilAttestering.grunnlagsdata,
@@ -345,7 +345,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                             behandlingsinformasjon = tilAttestering.behandlingsinformasjon,
                             fnr = tilAttestering.fnr,
                             saksbehandler = saksbehandler,
-                            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(underkjentAttestering),
+                            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(underkjentAttestering),
                             fritekstTilBrev = "",
                             stønadsperiode = stønadsperiode,
                             grunnlagsdata = Grunnlagsdata.EMPTY,
@@ -375,7 +375,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                             fnr = tilAttestering.fnr,
                             beregning = avslåttBeregning,
                             saksbehandler = saksbehandler,
-                            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(underkjentAttestering),
+                            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(underkjentAttestering),
                             fritekstTilBrev = "",
                             stønadsperiode = stønadsperiode,
                             grunnlagsdata = tilAttestering.grunnlagsdata,
@@ -416,7 +416,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                 behandlingsinformasjon = iverksatt.behandlingsinformasjon,
                 fnr = iverksatt.fnr,
                 saksbehandler = saksbehandler,
-                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(iverksattAttestering),
+                attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(iverksattAttestering),
                 fritekstTilBrev = "Dette er fritekst",
                 stønadsperiode = stønadsperiode,
                 grunnlagsdata = Grunnlagsdata.EMPTY,
@@ -444,7 +444,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                     fnr = iverksatt.fnr,
                     beregning = avslåttBeregning,
                     saksbehandler = saksbehandler,
-                    attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(iverksattAttestering),
+                    attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(iverksattAttestering),
                     fritekstTilBrev = "",
                     stønadsperiode = stønadsperiode,
                     grunnlagsdata = iverksatt.grunnlagsdata,
@@ -494,7 +494,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                     fnr = iverksatt.fnr,
                     beregning = avslåttBeregning,
                     saksbehandler = saksbehandler,
-                    attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(iverksattAttestering),
+                    attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(iverksattAttestering),
                     fritekstTilBrev = "",
                     stønadsperiode = stønadsperiode,
                     grunnlagsdata = Grunnlagsdata(

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPosgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPosgresRepoTest.kt
@@ -13,7 +13,7 @@ import no.nav.su.se.bakover.database.hent
 import no.nav.su.se.bakover.database.withMigratedDb
 import no.nav.su.se.bakover.database.withSession
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.brev.BrevbestillingId
 import no.nav.su.se.bakover.domain.eksterneiverksettingssteg.JournalføringOgBrevdistribusjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
@@ -92,7 +92,7 @@ internal class VedtakPosgresRepoTest {
                 beregning = søknadsbehandlingVedtak.beregning,
                 simulering = søknadsbehandlingVedtak.simulering,
                 grunnlagsdata = Grunnlagsdata.EMPTY,
-                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(søknadsbehandlingVedtak.attestant, Tidspunkt.now())),
+                attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(søknadsbehandlingVedtak.attestant, Tidspunkt.now())),
                 fritekstTilBrev = "",
                 revurderingsårsak = Revurderingsårsak(
                     Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
@@ -254,7 +254,7 @@ internal class VedtakPosgresRepoTest {
                 grunnlagsdata = søknadsbehandlingVedtak.behandling.grunnlagsdata,
                 vilkårsvurderinger = søknadsbehandlingVedtak.behandling.vilkårsvurderinger,
                 informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-                attesteringer = AttesteringHistorik.empty()
+                attesteringer = Attesteringshistorikk.empty()
             )
             testDataHelper.revurderingRepo.lagre(attestertRevurdering)
             val iverksattRevurdering = IverksattRevurdering.IngenEndring(
@@ -265,7 +265,7 @@ internal class VedtakPosgresRepoTest {
                 saksbehandler = søknadsbehandlingVedtak.saksbehandler,
                 oppgaveId = OppgaveId(""),
                 beregning = søknadsbehandlingVedtak.beregning,
-                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(søknadsbehandlingVedtak.attestant, Tidspunkt.now())),
+                attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(søknadsbehandlingVedtak.attestant, Tidspunkt.now())),
                 fritekstTilBrev = "",
                 revurderingsårsak = Revurderingsårsak(
                     Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPosgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPosgresRepoTest.kt
@@ -1,6 +1,7 @@
 package no.nav.su.se.bakover.database.vedtak
 
 import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.februar
 import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.mars
@@ -12,6 +13,7 @@ import no.nav.su.se.bakover.database.hent
 import no.nav.su.se.bakover.database.withMigratedDb
 import no.nav.su.se.bakover.database.withSession
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.brev.BrevbestillingId
 import no.nav.su.se.bakover.domain.eksterneiverksettingssteg.JournalføringOgBrevdistribusjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
@@ -90,7 +92,7 @@ internal class VedtakPosgresRepoTest {
                 beregning = søknadsbehandlingVedtak.beregning,
                 simulering = søknadsbehandlingVedtak.simulering,
                 grunnlagsdata = Grunnlagsdata.EMPTY,
-                attestering = Attestering.Iverksatt(søknadsbehandlingVedtak.attestant),
+                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(søknadsbehandlingVedtak.attestant, Tidspunkt.now())),
                 fritekstTilBrev = "",
                 revurderingsårsak = Revurderingsårsak(
                     Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
@@ -252,6 +254,7 @@ internal class VedtakPosgresRepoTest {
                 grunnlagsdata = søknadsbehandlingVedtak.behandling.grunnlagsdata,
                 vilkårsvurderinger = søknadsbehandlingVedtak.behandling.vilkårsvurderinger,
                 informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+                attesteringer = AttesteringHistorik.empty()
             )
             testDataHelper.revurderingRepo.lagre(attestertRevurdering)
             val iverksattRevurdering = IverksattRevurdering.IngenEndring(
@@ -262,7 +265,7 @@ internal class VedtakPosgresRepoTest {
                 saksbehandler = søknadsbehandlingVedtak.saksbehandler,
                 oppgaveId = OppgaveId(""),
                 beregning = søknadsbehandlingVedtak.beregning,
-                attestering = Attestering.Iverksatt(søknadsbehandlingVedtak.attestant),
+                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(søknadsbehandlingVedtak.attestant, Tidspunkt.now())),
                 fritekstTilBrev = "",
                 revurderingsårsak = Revurderingsårsak(
                     Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/vedtak/snapshot/VedtakssnapshotJsonTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/vedtak/snapshot/VedtakssnapshotJsonTest.kt
@@ -17,7 +17,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.avslag.Avslagsgrunn
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
@@ -80,7 +80,7 @@ internal class VedtakssnapshotJsonTest {
                 .withVilkårAvslått(),
             fnr = fnr,
             saksbehandler = NavIdentBruker.Saksbehandler("saksbehandler"),
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), fixedTidspunkt)),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), fixedTidspunkt)),
             fritekstTilBrev = "",
             stønadsperiode = stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
@@ -112,7 +112,8 @@ internal class VedtakssnapshotJsonTest {
                   "saksbehandler":"saksbehandler",
                   "attestering":{
                      "type": "Iverksatt",
-                     "attestant": "attestant"
+                     "attestant": "attestant",
+                     "opprettet": "2021-01-01T01:02:03.456789Z"
                   },
                   "oppgaveId":"oppgaveId",
                   "iverksattJournalpostId":"iverksattJournalpostId",
@@ -426,7 +427,7 @@ internal class VedtakssnapshotJsonTest {
                 ),
             ),
             saksbehandler = NavIdentBruker.Saksbehandler("saksbehandler"),
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), fixedTidspunkt)),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), fixedTidspunkt)),
             fritekstTilBrev = "",
             stønadsperiode = stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
@@ -457,7 +458,8 @@ internal class VedtakssnapshotJsonTest {
                   "saksbehandler":"saksbehandler",
                   "attestering":{
                      "type": "Iverksatt",
-                     "attestant": "attestant"
+                     "attestant": "attestant",
+                     "opprettet": "2021-01-01T01:02:03.456789Z"
                   },
                   "oppgaveId":"oppgaveId",
                   "iverksattJournalpostId":"iverksattJournalpostId",

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/vedtak/snapshot/VedtakssnapshotJsonTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/vedtak/snapshot/VedtakssnapshotJsonTest.kt
@@ -17,6 +17,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.avslag.Avslagsgrunn
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
@@ -79,7 +80,7 @@ internal class VedtakssnapshotJsonTest {
                 .withVilkårAvslått(),
             fnr = fnr,
             saksbehandler = NavIdentBruker.Saksbehandler("saksbehandler"),
-            attestering = Attestering.Iverksatt(NavIdentBruker.Attestant("attestant")),
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), fixedTidspunkt)),
             fritekstTilBrev = "",
             stønadsperiode = stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
@@ -425,7 +426,7 @@ internal class VedtakssnapshotJsonTest {
                 ),
             ),
             saksbehandler = NavIdentBruker.Saksbehandler("saksbehandler"),
-            attestering = Attestering.Iverksatt(NavIdentBruker.Attestant("attestant")),
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), fixedTidspunkt)),
             fritekstTilBrev = "",
             stønadsperiode = stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Attestering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Attestering.kt
@@ -2,25 +2,44 @@ package no.nav.su.se.bakover.domain.behandling
 
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.domain.NavIdentBruker
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.PROPERTY,
-    property = "type"
+    property = "type",
 )
 @JsonSubTypes(
     JsonSubTypes.Type(value = Attestering.Iverksatt::class, name = "Iverksatt"),
     JsonSubTypes.Type(value = Attestering.Underkjent::class, name = "Underkjent"),
 )
+data class AttesteringHistorik(private val attesteringer: MutableList<Attestering>) {
+    companion object {
+        fun empty(): AttesteringHistorik {
+            return AttesteringHistorik(mutableListOf())
+        }
+    }
+    fun leggTilNyAttestering(attestering: Attestering): AttesteringHistorik {
+        attesteringer.add(attestering)
+
+        return this
+    }
+
+    fun hentSisteAttestering() = attesteringer.last()
+    fun hentAttesteringer() = attesteringer.toList()
+}
+
 sealed class Attestering {
     abstract val attestant: NavIdentBruker.Attestant
+    abstract val tidspunkt: Tidspunkt
 
-    data class Iverksatt(override val attestant: NavIdentBruker.Attestant) : Attestering()
+    data class Iverksatt(override val attestant: NavIdentBruker.Attestant, override val tidspunkt: Tidspunkt) : Attestering()
     data class Underkjent(
         override val attestant: NavIdentBruker.Attestant,
+        override val tidspunkt: Tidspunkt,
         val grunn: Grunn,
-        val kommentar: String
+        val kommentar: String,
     ) : Attestering() {
         enum class Grunn {
             INNGANGSVILKÅRENE_ER_FEILVURDERT,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Attestering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Attestering.kt
@@ -5,6 +5,28 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.domain.NavIdentBruker
 
+data class Attesteringshistorikk(private val attesteringer: MutableList<Attestering>) {
+    init {
+        attesteringer.sortBy {
+            it.opprettet.instant
+        }
+    }
+
+    companion object {
+        fun empty(): Attesteringshistorikk {
+            return Attesteringshistorikk(mutableListOf())
+        }
+    }
+    fun leggTilNyAttestering(attestering: Attestering): Attesteringshistorikk {
+        this.attesteringer.add(attestering)
+
+        return this.copy()
+    }
+
+    fun hentSisteAttestering() = attesteringer.last()
+    fun hentAttesteringer(): List<Attestering> = attesteringer.toList()
+}
+
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.PROPERTY,
@@ -14,30 +36,14 @@ import no.nav.su.se.bakover.domain.NavIdentBruker
     JsonSubTypes.Type(value = Attestering.Iverksatt::class, name = "Iverksatt"),
     JsonSubTypes.Type(value = Attestering.Underkjent::class, name = "Underkjent"),
 )
-data class AttesteringHistorik(private val attesteringer: MutableList<Attestering>) {
-    companion object {
-        fun empty(): AttesteringHistorik {
-            return AttesteringHistorik(mutableListOf())
-        }
-    }
-    fun leggTilNyAttestering(attestering: Attestering): AttesteringHistorik {
-        attesteringer.add(attestering)
-
-        return this
-    }
-
-    fun hentSisteAttestering() = attesteringer.last()
-    fun hentAttesteringer() = attesteringer.toList()
-}
-
 sealed class Attestering {
     abstract val attestant: NavIdentBruker.Attestant
-    abstract val tidspunkt: Tidspunkt
+    abstract val opprettet: Tidspunkt
 
-    data class Iverksatt(override val attestant: NavIdentBruker.Attestant, override val tidspunkt: Tidspunkt) : Attestering()
+    data class Iverksatt(override val attestant: NavIdentBruker.Attestant, override val opprettet: Tidspunkt) : Attestering()
     data class Underkjent(
         override val attestant: NavIdentBruker.Attestant,
-        override val tidspunkt: Tidspunkt,
+        override val opprettet: Tidspunkt,
         val grunn: Grunn,
         val kommentar: String,
     ) : Attestering() {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Attestering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Attestering.kt
@@ -5,26 +5,20 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.domain.NavIdentBruker
 
-data class Attesteringshistorikk(private val attesteringer: MutableList<Attestering>) {
-    init {
-        attesteringer.sortBy {
-            it.opprettet.instant
-        }
-    }
+data class Attesteringshistorikk(val attesteringer: List<Attestering>) {
+    private val sortedAttesteringer = attesteringer.sortedBy { it.opprettet.instant }
 
     companion object {
         fun empty(): Attesteringshistorikk {
-            return Attesteringshistorikk(mutableListOf())
+            return Attesteringshistorikk(listOf())
         }
     }
     fun leggTilNyAttestering(attestering: Attestering): Attesteringshistorikk {
-        this.attesteringer.add(attestering)
-
-        return this.copy()
+        return this.copy(attesteringer = sortedAttesteringer + attestering)
     }
 
-    fun hentSisteAttestering() = attesteringer.last()
-    fun hentAttesteringer(): List<Attestering> = attesteringer.toList()
+    fun hentSisteAttestering() = sortedAttesteringer.last()
+    fun hentAttesteringer(): List<Attestering> = sortedAttesteringer
 }
 
 @JsonTypeInfo(

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Behandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Behandling.kt
@@ -19,4 +19,5 @@ interface Behandling {
     val periode: Periode
     val grunnlagsdata: Grunnlagsdata
     val vilkårsvurderinger: Vilkårsvurderinger
+    val attesteringer: AttesteringHistorik
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Behandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Behandling.kt
@@ -19,5 +19,5 @@ interface Behandling {
     val periode: Periode
     val grunnlagsdata: Grunnlagsdata
     val vilkårsvurderinger: Vilkårsvurderinger
-    val attesteringer: AttesteringHistorik
+    val attesteringer: Attesteringshistorikk
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurdering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurdering.kt
@@ -12,6 +12,7 @@ import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.NavIdentBruker.Saksbehandler
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandling
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.avslag.Opphørsgrunn
@@ -100,6 +101,7 @@ sealed class Revurdering : Behandling, Visitable<RevurderingVisitor> {
         grunnlagsdata = grunnlagsdata,
         vilkårsvurderinger = vilkårsvurderinger,
         informasjonSomRevurderes = informasjonSomRevurderes.markerSomVurdert(revurderingsteg),
+        attesteringer = attesteringer,
     )
 
     open fun oppdaterBehandlingsinformasjon(behandlingsinformasjon: Behandlingsinformasjon) = OpprettetRevurdering(
@@ -116,6 +118,7 @@ sealed class Revurdering : Behandling, Visitable<RevurderingVisitor> {
         grunnlagsdata = grunnlagsdata,
         vilkårsvurderinger = vilkårsvurderinger,
         informasjonSomRevurderes = informasjonSomRevurderes,
+        attesteringer = attesteringer,
     )
 
     open fun beregn(eksisterendeUtbetalinger: List<Utbetaling>): Either<KunneIkkeBeregneRevurdering, BeregnetRevurdering> {
@@ -141,6 +144,7 @@ sealed class Revurdering : Behandling, Visitable<RevurderingVisitor> {
             grunnlagsdata = grunnlagsdata,
             vilkårsvurderinger = vilkårsvurderinger,
             informasjonSomRevurderes = informasjonSomRevurderes,
+            attesteringer = attesteringer
         )
 
         fun innvilget(revurdertBeregning: Beregning): BeregnetRevurdering.Innvilget = BeregnetRevurdering.Innvilget(
@@ -158,6 +162,7 @@ sealed class Revurdering : Behandling, Visitable<RevurderingVisitor> {
             grunnlagsdata = grunnlagsdata,
             vilkårsvurderinger = vilkårsvurderinger,
             informasjonSomRevurderes = informasjonSomRevurderes,
+            attesteringer = attesteringer
         )
 
         fun ingenEndring(revurdertBeregning: Beregning): BeregnetRevurdering.IngenEndring =
@@ -176,6 +181,7 @@ sealed class Revurdering : Behandling, Visitable<RevurderingVisitor> {
                 grunnlagsdata = grunnlagsdata,
                 vilkårsvurderinger = vilkårsvurderinger,
                 informasjonSomRevurderes = informasjonSomRevurderes,
+                attesteringer = attesteringer
             )
 
         // TODO jm: sjekk av vilkår og verifisering av dette bør sannsynligvis legges til et tidspunkt før selve beregningen finner sted. Snarvei inntil videre, da vi mangeler "infrastruktur" for dette pt.  Bør være en tydeligere del av modellen for revurdering.
@@ -288,6 +294,7 @@ data class OpprettetRevurdering(
     override val grunnlagsdata: Grunnlagsdata,
     override val vilkårsvurderinger: Vilkårsvurderinger,
     override val informasjonSomRevurderes: InformasjonSomRevurderes,
+    override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
 ) : Revurdering() {
 
     override fun accept(visitor: RevurderingVisitor) {
@@ -339,6 +346,7 @@ sealed class BeregnetRevurdering : Revurdering() {
         grunnlagsdata = grunnlagsdata,
         vilkårsvurderinger = vilkårsvurderinger,
         informasjonSomRevurderes = informasjonSomRevurderes,
+        attesteringer = attesteringer
     )
 
     data class Innvilget(
@@ -356,6 +364,7 @@ sealed class BeregnetRevurdering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
+        override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
     ) : BeregnetRevurdering() {
         override fun accept(visitor: RevurderingVisitor) {
             visitor.visit(this)
@@ -377,6 +386,7 @@ sealed class BeregnetRevurdering : Revurdering() {
             grunnlagsdata = grunnlagsdata,
             vilkårsvurderinger = vilkårsvurderinger,
             informasjonSomRevurderes = informasjonSomRevurderes,
+            attesteringer = attesteringer
         )
     }
 
@@ -395,6 +405,7 @@ sealed class BeregnetRevurdering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
+        override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
     ) : BeregnetRevurdering() {
 
         fun tilAttestering(
@@ -418,6 +429,7 @@ sealed class BeregnetRevurdering : Revurdering() {
             grunnlagsdata = grunnlagsdata,
             vilkårsvurderinger = vilkårsvurderinger,
             informasjonSomRevurderes = informasjonSomRevurderes,
+            attesteringer = attesteringer
         )
 
         override fun toSimulert(simulering: Simulering): SimulertRevurdering {
@@ -444,6 +456,7 @@ sealed class BeregnetRevurdering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
+        override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
     ) : BeregnetRevurdering() {
         override fun toSimulert(simulering: Simulering) = SimulertRevurdering.Opphørt(
             id = id,
@@ -461,6 +474,7 @@ sealed class BeregnetRevurdering : Revurdering() {
             grunnlagsdata = grunnlagsdata,
             vilkårsvurderinger = vilkårsvurderinger,
             informasjonSomRevurderes = informasjonSomRevurderes,
+            attesteringer = attesteringer
         )
 
         fun utledOpphørsgrunner(): List<Opphørsgrunn> {
@@ -503,6 +517,7 @@ sealed class SimulertRevurdering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
+        override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
     ) : SimulertRevurdering() {
         override fun accept(visitor: RevurderingVisitor) {
             visitor.visit(this)
@@ -529,6 +544,7 @@ sealed class SimulertRevurdering : Revurdering() {
             grunnlagsdata = grunnlagsdata,
             vilkårsvurderinger = vilkårsvurderinger,
             informasjonSomRevurderes = informasjonSomRevurderes,
+            attesteringer = attesteringer
         )
     }
 
@@ -548,6 +564,7 @@ sealed class SimulertRevurdering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
+        override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
     ) : SimulertRevurdering() {
         override fun accept(visitor: RevurderingVisitor) {
             visitor.visit(this)
@@ -585,6 +602,7 @@ sealed class SimulertRevurdering : Revurdering() {
                     grunnlagsdata = grunnlagsdata,
                     vilkårsvurderinger = vilkårsvurderinger,
                     informasjonSomRevurderes = informasjonSomRevurderes,
+                    attesteringer = attesteringer
                 ).right()
             }
         }
@@ -611,6 +629,7 @@ sealed class SimulertRevurdering : Revurdering() {
         grunnlagsdata = grunnlagsdata,
         vilkårsvurderinger = vilkårsvurderinger,
         informasjonSomRevurderes = informasjonSomRevurderes,
+        attesteringer = attesteringer
     )
 }
 
@@ -642,6 +661,7 @@ sealed class RevurderingTilAttestering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
+        override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
     ) : RevurderingTilAttestering() {
 
         override fun accept(visitor: RevurderingVisitor) {
@@ -668,12 +688,12 @@ sealed class RevurderingTilAttestering : Revurdering() {
                     oppgaveId = oppgaveId,
                     fritekstTilBrev = fritekstTilBrev,
                     revurderingsårsak = revurderingsårsak,
-                    attestering = Attestering.Iverksatt(attestant),
                     forhåndsvarsel = forhåndsvarsel,
                     behandlingsinformasjon = behandlingsinformasjon,
                     grunnlagsdata = grunnlagsdata,
                     vilkårsvurderinger = vilkårsvurderinger,
                     informasjonSomRevurderes = informasjonSomRevurderes,
+                    attesteringer = attesteringer.leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now()))
                 )
             }
         }
@@ -695,6 +715,7 @@ sealed class RevurderingTilAttestering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
+        override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty()
     ) : RevurderingTilAttestering() {
         override fun accept(visitor: RevurderingVisitor) {
             visitor.visit(this)
@@ -728,12 +749,12 @@ sealed class RevurderingTilAttestering : Revurdering() {
                     oppgaveId = oppgaveId,
                     fritekstTilBrev = fritekstTilBrev,
                     revurderingsårsak = revurderingsårsak,
-                    attestering = Attestering.Iverksatt(attestant),
                     forhåndsvarsel = forhåndsvarsel,
                     behandlingsinformasjon = behandlingsinformasjon,
                     grunnlagsdata = grunnlagsdata,
                     vilkårsvurderinger = vilkårsvurderinger,
                     informasjonSomRevurderes = informasjonSomRevurderes,
+                    attesteringer = attesteringer.leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now()))
                 )
             }
         }
@@ -755,6 +776,7 @@ sealed class RevurderingTilAttestering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
+        override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty()
     ) : RevurderingTilAttestering() {
 
         override fun accept(visitor: RevurderingVisitor) {
@@ -778,13 +800,13 @@ sealed class RevurderingTilAttestering : Revurdering() {
                 oppgaveId = oppgaveId,
                 fritekstTilBrev = fritekstTilBrev,
                 revurderingsårsak = revurderingsårsak,
-                attestering = Attestering.Iverksatt(attestant),
                 skalFøreTilBrevutsending = skalFøreTilBrevutsending,
                 forhåndsvarsel = forhåndsvarsel,
                 behandlingsinformasjon = behandlingsinformasjon,
                 grunnlagsdata = grunnlagsdata,
                 vilkårsvurderinger = vilkårsvurderinger,
                 informasjonSomRevurderes = informasjonSomRevurderes,
+                attesteringer = attesteringer.leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now())),
             ).right()
         }
     }
@@ -816,7 +838,7 @@ sealed class RevurderingTilAttestering : Revurdering() {
                 beregning = beregning,
                 simulering = simulering,
                 oppgaveId = oppgaveId,
-                attestering = attestering,
+                attesteringer = attesteringer.leggTilNyAttestering(attestering),
                 fritekstTilBrev = fritekstTilBrev,
                 revurderingsårsak = revurderingsårsak,
                 forhåndsvarsel = forhåndsvarsel,
@@ -834,7 +856,7 @@ sealed class RevurderingTilAttestering : Revurdering() {
                 beregning = beregning,
                 simulering = simulering,
                 oppgaveId = oppgaveId,
-                attestering = attestering,
+                attesteringer = attesteringer.leggTilNyAttestering(attestering),
                 fritekstTilBrev = fritekstTilBrev,
                 revurderingsårsak = revurderingsårsak,
                 forhåndsvarsel = forhåndsvarsel,
@@ -851,7 +873,7 @@ sealed class RevurderingTilAttestering : Revurdering() {
                 saksbehandler = saksbehandler,
                 beregning = beregning,
                 oppgaveId = oppgaveId,
-                attestering = attestering,
+                attesteringer = attesteringer.leggTilNyAttestering(attestering),
                 fritekstTilBrev = fritekstTilBrev,
                 revurderingsårsak = revurderingsårsak,
                 skalFøreTilBrevutsending = skalFøreTilBrevutsending,
@@ -875,7 +897,8 @@ sealed class IverksattRevurdering : Revurdering() {
     abstract override val fritekstTilBrev: String
     abstract override val revurderingsårsak: Revurderingsårsak
     abstract val beregning: Beregning
-    abstract val attestering: Attestering.Iverksatt
+    val attestering: Attestering
+        get() = attesteringer.hentSisteAttestering()
 
     abstract override fun accept(visitor: RevurderingVisitor)
 
@@ -895,13 +918,13 @@ sealed class IverksattRevurdering : Revurdering() {
         override val fritekstTilBrev: String,
         override val revurderingsårsak: Revurderingsårsak,
         override val beregning: Beregning,
-        override val attestering: Attestering.Iverksatt,
         override val forhåndsvarsel: Forhåndsvarsel,
         override val behandlingsinformasjon: Behandlingsinformasjon,
         val simulering: Simulering,
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
+        override val attesteringer: AttesteringHistorik
     ) : IverksattRevurdering() {
 
         override fun accept(visitor: RevurderingVisitor) {
@@ -919,13 +942,13 @@ sealed class IverksattRevurdering : Revurdering() {
         override val fritekstTilBrev: String,
         override val revurderingsårsak: Revurderingsårsak,
         override val beregning: Beregning,
-        override val attestering: Attestering.Iverksatt,
         override val behandlingsinformasjon: Behandlingsinformasjon,
         val simulering: Simulering,
         override val forhåndsvarsel: Forhåndsvarsel,
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
+        override val attesteringer: AttesteringHistorik
     ) : IverksattRevurdering() {
 
         override fun accept(visitor: RevurderingVisitor) {
@@ -950,13 +973,13 @@ sealed class IverksattRevurdering : Revurdering() {
         override val oppgaveId: OppgaveId,
         override val fritekstTilBrev: String,
         override val revurderingsårsak: Revurderingsårsak,
-        override val attestering: Attestering.Iverksatt,
         override val behandlingsinformasjon: Behandlingsinformasjon,
         val skalFøreTilBrevutsending: Boolean,
         override val forhåndsvarsel: Forhåndsvarsel?,
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
+        override val attesteringer: AttesteringHistorik
     ) : IverksattRevurdering() {
 
         override fun accept(visitor: RevurderingVisitor) {
@@ -970,8 +993,10 @@ sealed class IverksattRevurdering : Revurdering() {
 
 sealed class UnderkjentRevurdering : Revurdering() {
     abstract val beregning: Beregning
-    abstract val attestering: Attestering.Underkjent
+    abstract override val attesteringer: AttesteringHistorik
     abstract override val grunnlagsdata: Grunnlagsdata
+    val attestering: Attestering.Underkjent
+        get() = attesteringer.hentSisteAttestering() as Attestering.Underkjent
 
     abstract override fun accept(visitor: RevurderingVisitor)
 
@@ -985,7 +1010,7 @@ sealed class UnderkjentRevurdering : Revurdering() {
         override val fritekstTilBrev: String,
         override val revurderingsårsak: Revurderingsårsak,
         override val beregning: Beregning,
-        override val attestering: Attestering.Underkjent,
+        override val attesteringer: AttesteringHistorik,
         override val forhåndsvarsel: Forhåndsvarsel,
         override val behandlingsinformasjon: Behandlingsinformasjon,
         val simulering: Simulering,
@@ -1019,6 +1044,7 @@ sealed class UnderkjentRevurdering : Revurdering() {
             grunnlagsdata = grunnlagsdata,
             vilkårsvurderinger = vilkårsvurderinger,
             informasjonSomRevurderes = informasjonSomRevurderes,
+            attesteringer = attesteringer
         )
     }
 
@@ -1032,13 +1058,13 @@ sealed class UnderkjentRevurdering : Revurdering() {
         override val fritekstTilBrev: String,
         override val revurderingsårsak: Revurderingsårsak,
         override val beregning: Beregning,
-        override val attestering: Attestering.Underkjent,
         override val forhåndsvarsel: Forhåndsvarsel,
         override val behandlingsinformasjon: Behandlingsinformasjon,
         val simulering: Simulering,
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
+        override val attesteringer: AttesteringHistorik
     ) : UnderkjentRevurdering() {
         override fun accept(visitor: RevurderingVisitor) {
             visitor.visit(this)
@@ -1077,6 +1103,7 @@ sealed class UnderkjentRevurdering : Revurdering() {
                     grunnlagsdata = grunnlagsdata,
                     vilkårsvurderinger = vilkårsvurderinger,
                     informasjonSomRevurderes = informasjonSomRevurderes,
+                    attesteringer = attesteringer
                 ).right()
             }
         }
@@ -1092,13 +1119,13 @@ sealed class UnderkjentRevurdering : Revurdering() {
         override val oppgaveId: OppgaveId,
         override val fritekstTilBrev: String,
         override val revurderingsårsak: Revurderingsårsak,
-        override val attestering: Attestering.Underkjent,
         override val behandlingsinformasjon: Behandlingsinformasjon,
         val skalFøreTilBrevutsending: Boolean,
         override val forhåndsvarsel: Forhåndsvarsel?,
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
+        override val attesteringer: AttesteringHistorik
     ) : UnderkjentRevurdering() {
 
         override fun accept(visitor: RevurderingVisitor) {
@@ -1126,6 +1153,7 @@ sealed class UnderkjentRevurdering : Revurdering() {
             grunnlagsdata = grunnlagsdata,
             vilkårsvurderinger = vilkårsvurderinger,
             informasjonSomRevurderes = informasjonSomRevurderes,
+            attesteringer = attesteringer
         )
     }
 
@@ -1150,6 +1178,7 @@ sealed class UnderkjentRevurdering : Revurdering() {
         grunnlagsdata = grunnlagsdata,
         vilkårsvurderinger = vilkårsvurderinger,
         informasjonSomRevurderes = informasjonSomRevurderes,
+        attesteringer = attesteringer
     )
 }
 

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurdering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurdering.kt
@@ -364,7 +364,7 @@ sealed class BeregnetRevurdering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
-        override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
+        override val attesteringer: Attesteringshistorikk,
     ) : BeregnetRevurdering() {
         override fun accept(visitor: RevurderingVisitor) {
             visitor.visit(this)
@@ -405,7 +405,7 @@ sealed class BeregnetRevurdering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
-        override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
+        override val attesteringer: Attesteringshistorikk,
     ) : BeregnetRevurdering() {
 
         fun tilAttestering(
@@ -456,7 +456,7 @@ sealed class BeregnetRevurdering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
-        override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
+        override val attesteringer: Attesteringshistorikk,
     ) : BeregnetRevurdering() {
         override fun toSimulert(simulering: Simulering) = SimulertRevurdering.Opphørt(
             id = id,
@@ -517,7 +517,7 @@ sealed class SimulertRevurdering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
-        override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
+        override val attesteringer: Attesteringshistorikk,
     ) : SimulertRevurdering() {
         override fun accept(visitor: RevurderingVisitor) {
             visitor.visit(this)
@@ -564,7 +564,7 @@ sealed class SimulertRevurdering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
-        override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
+        override val attesteringer: Attesteringshistorikk,
     ) : SimulertRevurdering() {
         override fun accept(visitor: RevurderingVisitor) {
             visitor.visit(this)
@@ -661,7 +661,7 @@ sealed class RevurderingTilAttestering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
-        override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
+        override val attesteringer: Attesteringshistorikk,
     ) : RevurderingTilAttestering() {
 
         override fun accept(visitor: RevurderingVisitor) {
@@ -716,7 +716,7 @@ sealed class RevurderingTilAttestering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
-        override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty()
+        override val attesteringer: Attesteringshistorikk
     ) : RevurderingTilAttestering() {
         override fun accept(visitor: RevurderingVisitor) {
             visitor.visit(this)
@@ -778,7 +778,7 @@ sealed class RevurderingTilAttestering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
-        override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty()
+        override val attesteringer: Attesteringshistorikk
     ) : RevurderingTilAttestering() {
 
         override fun accept(visitor: RevurderingVisitor) {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurdering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurdering.kt
@@ -12,7 +12,7 @@ import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.NavIdentBruker.Saksbehandler
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandling
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.avslag.Opphørsgrunn
@@ -294,7 +294,7 @@ data class OpprettetRevurdering(
     override val grunnlagsdata: Grunnlagsdata,
     override val vilkårsvurderinger: Vilkårsvurderinger,
     override val informasjonSomRevurderes: InformasjonSomRevurderes,
-    override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
+    override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
 ) : Revurdering() {
 
     override fun accept(visitor: RevurderingVisitor) {
@@ -364,7 +364,7 @@ sealed class BeregnetRevurdering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
-        override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
+        override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
     ) : BeregnetRevurdering() {
         override fun accept(visitor: RevurderingVisitor) {
             visitor.visit(this)
@@ -405,7 +405,7 @@ sealed class BeregnetRevurdering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
-        override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
+        override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
     ) : BeregnetRevurdering() {
 
         fun tilAttestering(
@@ -456,7 +456,7 @@ sealed class BeregnetRevurdering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
-        override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
+        override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
     ) : BeregnetRevurdering() {
         override fun toSimulert(simulering: Simulering) = SimulertRevurdering.Opphørt(
             id = id,
@@ -517,7 +517,7 @@ sealed class SimulertRevurdering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
-        override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
+        override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
     ) : SimulertRevurdering() {
         override fun accept(visitor: RevurderingVisitor) {
             visitor.visit(this)
@@ -564,7 +564,7 @@ sealed class SimulertRevurdering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
-        override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
+        override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
     ) : SimulertRevurdering() {
         override fun accept(visitor: RevurderingVisitor) {
             visitor.visit(this)
@@ -661,7 +661,7 @@ sealed class RevurderingTilAttestering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
-        override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
+        override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
     ) : RevurderingTilAttestering() {
 
         override fun accept(visitor: RevurderingVisitor) {
@@ -670,6 +670,7 @@ sealed class RevurderingTilAttestering : Revurdering() {
 
         fun tilIverksatt(
             attestant: NavIdentBruker.Attestant,
+            clock: Clock = Clock.systemUTC(),
             utbetal: () -> Either<KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale, UUID30>,
         ): Either<KunneIkkeIverksetteRevurdering, IverksattRevurdering.Innvilget> {
 
@@ -693,7 +694,7 @@ sealed class RevurderingTilAttestering : Revurdering() {
                     grunnlagsdata = grunnlagsdata,
                     vilkårsvurderinger = vilkårsvurderinger,
                     informasjonSomRevurderes = informasjonSomRevurderes,
-                    attesteringer = attesteringer.leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now()))
+                    attesteringer = attesteringer.leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now(clock)))
                 )
             }
         }
@@ -715,7 +716,7 @@ sealed class RevurderingTilAttestering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
-        override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty()
+        override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty()
     ) : RevurderingTilAttestering() {
         override fun accept(visitor: RevurderingVisitor) {
             visitor.visit(this)
@@ -731,6 +732,7 @@ sealed class RevurderingTilAttestering : Revurdering() {
         // TODO: sjekk om vi skal utbetale 0 utbetalinger, eller ny status
         fun tilIverksatt(
             attestant: NavIdentBruker.Attestant,
+            clock: Clock = Clock.systemUTC(),
             utbetal: () -> Either<KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale, UUID30>,
         ): Either<KunneIkkeIverksetteRevurdering, IverksattRevurdering.Opphørt> {
 
@@ -754,7 +756,7 @@ sealed class RevurderingTilAttestering : Revurdering() {
                     grunnlagsdata = grunnlagsdata,
                     vilkårsvurderinger = vilkårsvurderinger,
                     informasjonSomRevurderes = informasjonSomRevurderes,
-                    attesteringer = attesteringer.leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now()))
+                    attesteringer = attesteringer.leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now(clock)))
                 )
             }
         }
@@ -776,7 +778,7 @@ sealed class RevurderingTilAttestering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
-        override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty()
+        override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty()
     ) : RevurderingTilAttestering() {
 
         override fun accept(visitor: RevurderingVisitor) {
@@ -785,6 +787,7 @@ sealed class RevurderingTilAttestering : Revurdering() {
 
         fun tilIverksatt(
             attestant: NavIdentBruker.Attestant,
+            clock: Clock = Clock.systemUTC()
         ): Either<KunneIkkeIverksetteRevurdering, IverksattRevurdering.IngenEndring> {
 
             if (saksbehandler.navIdent == attestant.navIdent) {
@@ -806,7 +809,7 @@ sealed class RevurderingTilAttestering : Revurdering() {
                 grunnlagsdata = grunnlagsdata,
                 vilkårsvurderinger = vilkårsvurderinger,
                 informasjonSomRevurderes = informasjonSomRevurderes,
-                attesteringer = attesteringer.leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now())),
+                attesteringer = attesteringer.leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now(clock))),
             ).right()
         }
     }
@@ -924,7 +927,7 @@ sealed class IverksattRevurdering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
-        override val attesteringer: AttesteringHistorik
+        override val attesteringer: Attesteringshistorikk
     ) : IverksattRevurdering() {
 
         override fun accept(visitor: RevurderingVisitor) {
@@ -948,7 +951,7 @@ sealed class IverksattRevurdering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
-        override val attesteringer: AttesteringHistorik
+        override val attesteringer: Attesteringshistorikk
     ) : IverksattRevurdering() {
 
         override fun accept(visitor: RevurderingVisitor) {
@@ -979,7 +982,7 @@ sealed class IverksattRevurdering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
-        override val attesteringer: AttesteringHistorik
+        override val attesteringer: Attesteringshistorikk
     ) : IverksattRevurdering() {
 
         override fun accept(visitor: RevurderingVisitor) {
@@ -993,7 +996,7 @@ sealed class IverksattRevurdering : Revurdering() {
 
 sealed class UnderkjentRevurdering : Revurdering() {
     abstract val beregning: Beregning
-    abstract override val attesteringer: AttesteringHistorik
+    abstract override val attesteringer: Attesteringshistorikk
     abstract override val grunnlagsdata: Grunnlagsdata
     val attestering: Attestering.Underkjent
         get() = attesteringer.hentSisteAttestering() as Attestering.Underkjent
@@ -1010,7 +1013,7 @@ sealed class UnderkjentRevurdering : Revurdering() {
         override val fritekstTilBrev: String,
         override val revurderingsårsak: Revurderingsårsak,
         override val beregning: Beregning,
-        override val attesteringer: AttesteringHistorik,
+        override val attesteringer: Attesteringshistorikk,
         override val forhåndsvarsel: Forhåndsvarsel,
         override val behandlingsinformasjon: Behandlingsinformasjon,
         val simulering: Simulering,
@@ -1064,7 +1067,7 @@ sealed class UnderkjentRevurdering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
-        override val attesteringer: AttesteringHistorik
+        override val attesteringer: Attesteringshistorikk
     ) : UnderkjentRevurdering() {
         override fun accept(visitor: RevurderingVisitor) {
             visitor.visit(this)
@@ -1125,7 +1128,7 @@ sealed class UnderkjentRevurdering : Revurdering() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
         override val informasjonSomRevurderes: InformasjonSomRevurderes,
-        override val attesteringer: AttesteringHistorik
+        override val attesteringer: Attesteringshistorikk
     ) : UnderkjentRevurdering() {
 
         override fun accept(visitor: RevurderingVisitor) {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Statusovergang.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Statusovergang.kt
@@ -112,7 +112,7 @@ abstract class Statusovergang<L, T> : StatusovergangVisitor {
 
     class TilAttestering(
         private val saksbehandler: NavIdentBruker.Saksbehandler,
-        private val fritekstTilBrev: String
+        private val fritekstTilBrev: String,
     ) : Statusovergang<Nothing, Søknadsbehandling.TilAttestering>() {
 
         override fun visit(søknadsbehandling: Søknadsbehandling.Vilkårsvurdert.Avslag) {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Søknadsbehandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Søknadsbehandling.kt
@@ -7,7 +7,7 @@ import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.AvslagGrunnetBeregning
 import no.nav.su.se.bakover.domain.behandling.Behandling
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
@@ -29,7 +29,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
     abstract val stønadsperiode: Stønadsperiode?
     abstract override val grunnlagsdata: Grunnlagsdata
     abstract override val vilkårsvurderinger: Vilkårsvurderinger
-    abstract override val attesteringer: AttesteringHistorik
+    abstract override val attesteringer: Attesteringshistorikk
 
     // TODO ia: fritekst bør flyttes ut av denne klassen og til et eget konsept (som også omfatter fritekst på revurderinger)
     abstract val fritekstTilBrev: String
@@ -84,7 +84,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 stønadsperiode: Stønadsperiode?,
                 grunnlagsdata: Grunnlagsdata,
                 vilkårsvurderinger: Vilkårsvurderinger,
-                attesteringer: AttesteringHistorik,
+                attesteringer: Attesteringshistorikk,
             ): Vilkårsvurdert {
                 return when {
                     // TODO jah: Burde vi ikke sjekke Vilkår.Grunnlag også?
@@ -157,7 +157,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             override val stønadsperiode: Stønadsperiode,
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger,
-            override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
+            override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
         ) : Vilkårsvurdert() {
 
             override val status: BehandlingsStatus = BehandlingsStatus.VILKÅRSVURDERT_INNVILGET
@@ -181,7 +181,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             override val stønadsperiode: Stønadsperiode,
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger,
-            override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
+            override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
         ) : Vilkårsvurdert(), ErAvslag {
 
             override val status: BehandlingsStatus = BehandlingsStatus.VILKÅRSVURDERT_AVSLAG
@@ -225,7 +225,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             override val stønadsperiode: Stønadsperiode?,
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger,
-            override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
+            override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
         ) : Vilkårsvurdert() {
 
             override val status: BehandlingsStatus = BehandlingsStatus.OPPRETTET
@@ -316,7 +316,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 stønadsperiode: Stønadsperiode,
                 grunnlagsdata: Grunnlagsdata,
                 vilkårsvurderinger: Vilkårsvurderinger,
-                attesteringer: AttesteringHistorik,
+                attesteringer: Attesteringshistorikk,
             ): Beregnet =
                 when (VurderAvslagGrunnetBeregning.vurderAvslagGrunnetBeregning(beregning)) {
                     is AvslagGrunnetBeregning.Ja -> Avslag(
@@ -368,7 +368,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             override val stønadsperiode: Stønadsperiode,
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger,
-            override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
+            override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
         ) : Beregnet() {
             override val status: BehandlingsStatus = BehandlingsStatus.BEREGNET_INNVILGET
             override val periode: Periode = stønadsperiode.periode
@@ -392,7 +392,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             override val stønadsperiode: Stønadsperiode,
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger,
-            override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
+            override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
         ) : Beregnet(), ErAvslag {
             override val status: BehandlingsStatus = BehandlingsStatus.BEREGNET_AVSLAG
             override val periode: Periode = stønadsperiode.periode
@@ -446,7 +446,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
         override val stønadsperiode: Stønadsperiode,
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
-        override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
+        override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
     ) : Søknadsbehandling() {
         override val status: BehandlingsStatus = BehandlingsStatus.SIMULERT
         override val periode: Periode = stønadsperiode.periode
@@ -535,7 +535,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
         abstract fun nyOppgaveId(nyOppgaveId: OppgaveId): TilAttestering
         abstract fun tilUnderkjent(attestering: Attestering): Underkjent
         abstract override val stønadsperiode: Stønadsperiode
-        abstract override val attesteringer: AttesteringHistorik
+        abstract override val attesteringer: Attesteringshistorikk
 
         data class Innvilget(
             override val id: UUID,
@@ -553,7 +553,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             override val stønadsperiode: Stønadsperiode,
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger,
-            override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
+            override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
         ) : TilAttestering() {
             override val status: BehandlingsStatus = BehandlingsStatus.TIL_ATTESTERING_INNVILGET
             override val periode: Periode = stønadsperiode.periode
@@ -627,7 +627,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 override val stønadsperiode: Stønadsperiode,
                 override val grunnlagsdata: Grunnlagsdata,
                 override val vilkårsvurderinger: Vilkårsvurderinger,
-                override val attesteringer: AttesteringHistorik,
+                override val attesteringer: Attesteringshistorikk,
             ) : Avslag() {
 
                 override val avslagsgrunner = behandlingsinformasjon.utledAvslagsgrunner()
@@ -697,7 +697,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 override val stønadsperiode: Stønadsperiode,
                 override val grunnlagsdata: Grunnlagsdata,
                 override val vilkårsvurderinger: Vilkårsvurderinger,
-                override val attesteringer: AttesteringHistorik,
+                override val attesteringer: Attesteringshistorikk,
             ) : Avslag() {
 
                 private val avslagsgrunnForBeregning: List<Avslagsgrunn> =
@@ -772,7 +772,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
         abstract override val behandlingsinformasjon: Behandlingsinformasjon
         abstract override val fnr: Fnr
         abstract val saksbehandler: NavIdentBruker.Saksbehandler
-        abstract override val attesteringer: AttesteringHistorik
+        abstract override val attesteringer: Attesteringshistorikk
         abstract override val stønadsperiode: Stønadsperiode
 
         abstract fun nyOppgaveId(nyOppgaveId: OppgaveId): Underkjent
@@ -806,7 +806,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             val beregning: Beregning,
             val simulering: Simulering,
             override val saksbehandler: NavIdentBruker.Saksbehandler,
-            override val attesteringer: AttesteringHistorik,
+            override val attesteringer: Attesteringshistorikk,
             override val fritekstTilBrev: String,
             override val stønadsperiode: Stønadsperiode,
             override val grunnlagsdata: Grunnlagsdata,
@@ -894,7 +894,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 override val fnr: Fnr,
                 val beregning: Beregning,
                 override val saksbehandler: NavIdentBruker.Saksbehandler,
-                override val attesteringer: AttesteringHistorik,
+                override val attesteringer: Attesteringshistorikk,
                 override val fritekstTilBrev: String,
                 override val stønadsperiode: Stønadsperiode,
                 override val grunnlagsdata: Grunnlagsdata,
@@ -968,7 +968,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 override val behandlingsinformasjon: Behandlingsinformasjon,
                 override val fnr: Fnr,
                 override val saksbehandler: NavIdentBruker.Saksbehandler,
-                override val attesteringer: AttesteringHistorik,
+                override val attesteringer: Attesteringshistorikk,
                 override val fritekstTilBrev: String,
                 override val stønadsperiode: Stønadsperiode,
                 override val grunnlagsdata: Grunnlagsdata,
@@ -1018,7 +1018,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
         abstract override val behandlingsinformasjon: Behandlingsinformasjon
         abstract override val fnr: Fnr
         abstract val saksbehandler: NavIdentBruker.Saksbehandler
-        abstract override val attesteringer: AttesteringHistorik
+        abstract override val attesteringer: Attesteringshistorikk
         abstract override val stønadsperiode: Stønadsperiode
 
         data class Innvilget(
@@ -1033,7 +1033,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             val beregning: Beregning,
             val simulering: Simulering,
             override val saksbehandler: NavIdentBruker.Saksbehandler,
-            override val attesteringer: AttesteringHistorik,
+            override val attesteringer: Attesteringshistorikk,
             override val fritekstTilBrev: String,
             override val stønadsperiode: Stønadsperiode,
             override val grunnlagsdata: Grunnlagsdata,
@@ -1059,7 +1059,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 override val fnr: Fnr,
                 val beregning: Beregning,
                 override val saksbehandler: NavIdentBruker.Saksbehandler,
-                override val attesteringer: AttesteringHistorik,
+                override val attesteringer: Attesteringshistorikk,
                 override val fritekstTilBrev: String,
                 override val stønadsperiode: Stønadsperiode,
                 override val grunnlagsdata: Grunnlagsdata,
@@ -1092,7 +1092,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 override val behandlingsinformasjon: Behandlingsinformasjon,
                 override val fnr: Fnr,
                 override val saksbehandler: NavIdentBruker.Saksbehandler,
-                override val attesteringer: AttesteringHistorik,
+                override val attesteringer: Attesteringshistorikk,
                 override val fritekstTilBrev: String,
                 override val stønadsperiode: Stønadsperiode,
                 override val grunnlagsdata: Grunnlagsdata,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Søknadsbehandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Søknadsbehandling.kt
@@ -157,7 +157,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             override val stønadsperiode: Stønadsperiode,
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger,
-            override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
+            override val attesteringer: Attesteringshistorikk,
         ) : Vilkårsvurdert() {
 
             override val status: BehandlingsStatus = BehandlingsStatus.VILKÅRSVURDERT_INNVILGET
@@ -181,7 +181,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             override val stønadsperiode: Stønadsperiode,
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger,
-            override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
+            override val attesteringer: Attesteringshistorikk,
         ) : Vilkårsvurdert(), ErAvslag {
 
             override val status: BehandlingsStatus = BehandlingsStatus.VILKÅRSVURDERT_AVSLAG
@@ -225,7 +225,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             override val stønadsperiode: Stønadsperiode?,
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger,
-            override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
+            override val attesteringer: Attesteringshistorikk,
         ) : Vilkårsvurdert() {
 
             override val status: BehandlingsStatus = BehandlingsStatus.OPPRETTET
@@ -368,7 +368,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             override val stønadsperiode: Stønadsperiode,
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger,
-            override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
+            override val attesteringer: Attesteringshistorikk,
         ) : Beregnet() {
             override val status: BehandlingsStatus = BehandlingsStatus.BEREGNET_INNVILGET
             override val periode: Periode = stønadsperiode.periode
@@ -392,7 +392,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             override val stønadsperiode: Stønadsperiode,
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger,
-            override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
+            override val attesteringer: Attesteringshistorikk,
         ) : Beregnet(), ErAvslag {
             override val status: BehandlingsStatus = BehandlingsStatus.BEREGNET_AVSLAG
             override val periode: Periode = stønadsperiode.periode
@@ -446,7 +446,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
         override val stønadsperiode: Stønadsperiode,
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
-        override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
+        override val attesteringer: Attesteringshistorikk,
     ) : Søknadsbehandling() {
         override val status: BehandlingsStatus = BehandlingsStatus.SIMULERT
         override val periode: Periode = stønadsperiode.periode
@@ -553,7 +553,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             override val stønadsperiode: Stønadsperiode,
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger,
-            override val attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
+            override val attesteringer: Attesteringshistorikk,
         ) : TilAttestering() {
             override val status: BehandlingsStatus = BehandlingsStatus.TIL_ATTESTERING_INNVILGET
             override val periode: Periode = stønadsperiode.periode

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Søknadsbehandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Søknadsbehandling.kt
@@ -7,6 +7,7 @@ import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.AvslagGrunnetBeregning
 import no.nav.su.se.bakover.domain.behandling.Behandling
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
@@ -28,6 +29,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
     abstract val stønadsperiode: Stønadsperiode?
     abstract override val grunnlagsdata: Grunnlagsdata
     abstract override val vilkårsvurderinger: Vilkårsvurderinger
+    abstract override val attesteringer: AttesteringHistorik
 
     // TODO ia: fritekst bør flyttes ut av denne klassen og til et eget konsept (som også omfatter fritekst på revurderinger)
     abstract val fritekstTilBrev: String
@@ -47,6 +49,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 stønadsperiode,
                 grunnlagsdata,
                 vilkårsvurderinger,
+                attesteringer
             )
 
         fun tilBeregnet(beregning: Beregning): Beregnet =
@@ -64,6 +67,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 stønadsperiode!!,
                 grunnlagsdata,
                 vilkårsvurderinger,
+                attesteringer
             )
 
         companion object {
@@ -80,6 +84,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 stønadsperiode: Stønadsperiode?,
                 grunnlagsdata: Grunnlagsdata,
                 vilkårsvurderinger: Vilkårsvurderinger,
+                attesteringer: AttesteringHistorik,
             ): Vilkårsvurdert {
                 return when {
                     // TODO jah: Burde vi ikke sjekke Vilkår.Grunnlag også?
@@ -97,6 +102,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                             stønadsperiode!!,
                             grunnlagsdata,
                             vilkårsvurderinger,
+                            attesteringer
                         )
                     }
                     // TODO jah: Burde vi ikke sjekke Vilkår.Grunnlag også?
@@ -114,6 +120,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                             stønadsperiode!!,
                             grunnlagsdata,
                             vilkårsvurderinger,
+                            attesteringer
                         )
                     }
                     else -> {
@@ -130,6 +137,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                             stønadsperiode,
                             grunnlagsdata,
                             vilkårsvurderinger,
+                            attesteringer
                         )
                     }
                 }
@@ -149,6 +157,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             override val stønadsperiode: Stønadsperiode,
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger,
+            override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
         ) : Vilkårsvurdert() {
 
             override val status: BehandlingsStatus = BehandlingsStatus.VILKÅRSVURDERT_INNVILGET
@@ -172,6 +181,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             override val stønadsperiode: Stønadsperiode,
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger,
+            override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
         ) : Vilkårsvurdert(), ErAvslag {
 
             override val status: BehandlingsStatus = BehandlingsStatus.VILKÅRSVURDERT_AVSLAG
@@ -196,6 +206,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                     stønadsperiode,
                     grunnlagsdata,
                     vilkårsvurderinger,
+                    attesteringer
                 )
 
             override val avslagsgrunner: List<Avslagsgrunn> = behandlingsinformasjon.utledAvslagsgrunner()
@@ -214,6 +225,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             override val stønadsperiode: Stønadsperiode?,
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger,
+            override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
         ) : Vilkårsvurdert() {
 
             override val status: BehandlingsStatus = BehandlingsStatus.OPPRETTET
@@ -249,6 +261,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 stønadsperiode,
                 grunnlagsdata,
                 vilkårsvurderinger,
+                attesteringer
             )
 
         fun tilBeregnet(beregning: Beregning): Beregnet =
@@ -266,6 +279,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 stønadsperiode,
                 grunnlagsdata,
                 vilkårsvurderinger,
+                attesteringer
             )
 
         fun tilSimulert(simulering: Simulering): Simulert =
@@ -284,6 +298,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 stønadsperiode,
                 grunnlagsdata,
                 vilkårsvurderinger,
+                attesteringer
             )
 
         companion object {
@@ -301,6 +316,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 stønadsperiode: Stønadsperiode,
                 grunnlagsdata: Grunnlagsdata,
                 vilkårsvurderinger: Vilkårsvurderinger,
+                attesteringer: AttesteringHistorik,
             ): Beregnet =
                 when (VurderAvslagGrunnetBeregning.vurderAvslagGrunnetBeregning(beregning)) {
                     is AvslagGrunnetBeregning.Ja -> Avslag(
@@ -317,6 +333,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                         stønadsperiode,
                         grunnlagsdata,
                         vilkårsvurderinger,
+                        attesteringer,
                     )
                     AvslagGrunnetBeregning.Nei -> Innvilget(
                         id,
@@ -332,6 +349,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                         stønadsperiode,
                         grunnlagsdata,
                         vilkårsvurderinger,
+                        attesteringer
                     )
                 }
         }
@@ -350,6 +368,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             override val stønadsperiode: Stønadsperiode,
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger,
+            override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
         ) : Beregnet() {
             override val status: BehandlingsStatus = BehandlingsStatus.BEREGNET_INNVILGET
             override val periode: Periode = stønadsperiode.periode
@@ -373,6 +392,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             override val stønadsperiode: Stønadsperiode,
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger,
+            override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
         ) : Beregnet(), ErAvslag {
             override val status: BehandlingsStatus = BehandlingsStatus.BEREGNET_AVSLAG
             override val periode: Periode = stønadsperiode.periode
@@ -403,6 +423,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                     stønadsperiode,
                     grunnlagsdata,
                     vilkårsvurderinger,
+                    attesteringer
                 )
 
             override val avslagsgrunner: List<Avslagsgrunn> =
@@ -425,6 +446,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
         override val stønadsperiode: Stønadsperiode,
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger,
+        override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
     ) : Søknadsbehandling() {
         override val status: BehandlingsStatus = BehandlingsStatus.SIMULERT
         override val periode: Periode = stønadsperiode.periode
@@ -447,6 +469,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 stønadsperiode,
                 grunnlagsdata,
                 vilkårsvurderinger,
+                attesteringer
             )
 
         fun tilBeregnet(beregning: Beregning): Beregnet =
@@ -464,6 +487,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 stønadsperiode,
                 grunnlagsdata,
                 vilkårsvurderinger,
+                attesteringer
             )
 
         fun tilSimulert(simulering: Simulering): Simulert =
@@ -482,6 +506,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 stønadsperiode,
                 grunnlagsdata,
                 vilkårsvurderinger,
+                attesteringer
             )
 
         fun tilAttestering(saksbehandler: NavIdentBruker.Saksbehandler, fritekstTilBrev: String): TilAttestering.Innvilget =
@@ -501,6 +526,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 stønadsperiode,
                 grunnlagsdata,
                 vilkårsvurderinger,
+                attesteringer
             )
     }
 
@@ -509,6 +535,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
         abstract fun nyOppgaveId(nyOppgaveId: OppgaveId): TilAttestering
         abstract fun tilUnderkjent(attestering: Attestering): Underkjent
         abstract override val stønadsperiode: Stønadsperiode
+        abstract override val attesteringer: AttesteringHistorik
 
         data class Innvilget(
             override val id: UUID,
@@ -526,6 +553,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             override val stønadsperiode: Stønadsperiode,
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger,
+            override val attesteringer: AttesteringHistorik = AttesteringHistorik.empty(),
         ) : TilAttestering() {
             override val status: BehandlingsStatus = BehandlingsStatus.TIL_ATTESTERING_INNVILGET
             override val periode: Periode = stønadsperiode.periode
@@ -551,7 +579,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                     beregning,
                     simulering,
                     saksbehandler,
-                    attestering,
+                    attesteringer.leggTilNyAttestering(attestering),
                     fritekstTilBrev,
                     stønadsperiode,
                     grunnlagsdata,
@@ -572,7 +600,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                     beregning,
                     simulering,
                     saksbehandler,
-                    attestering,
+                    attesteringer.leggTilNyAttestering(attestering),
                     fritekstTilBrev,
                     stønadsperiode,
                     grunnlagsdata,
@@ -599,6 +627,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 override val stønadsperiode: Stønadsperiode,
                 override val grunnlagsdata: Grunnlagsdata,
                 override val vilkårsvurderinger: Vilkårsvurderinger,
+                override val attesteringer: AttesteringHistorik,
             ) : Avslag() {
 
                 override val avslagsgrunner = behandlingsinformasjon.utledAvslagsgrunner()
@@ -623,7 +652,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                         behandlingsinformasjon,
                         fnr,
                         saksbehandler,
-                        attestering,
+                        attesteringer.leggTilNyAttestering(attestering),
                         fritekstTilBrev,
                         stønadsperiode,
                         grunnlagsdata,
@@ -644,7 +673,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                         behandlingsinformasjon,
                         fnr,
                         saksbehandler,
-                        attestering,
+                        attesteringer.leggTilNyAttestering(attestering),
                         fritekstTilBrev,
                         stønadsperiode,
                         grunnlagsdata,
@@ -668,6 +697,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 override val stønadsperiode: Stønadsperiode,
                 override val grunnlagsdata: Grunnlagsdata,
                 override val vilkårsvurderinger: Vilkårsvurderinger,
+                override val attesteringer: AttesteringHistorik,
             ) : Avslag() {
 
                 private val avslagsgrunnForBeregning: List<Avslagsgrunn> =
@@ -699,7 +729,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                         fnr,
                         beregning,
                         saksbehandler,
-                        attestering,
+                        attesteringer.leggTilNyAttestering(attestering),
                         fritekstTilBrev,
                         stønadsperiode,
                         grunnlagsdata,
@@ -721,7 +751,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                         fnr,
                         beregning,
                         saksbehandler,
-                        attestering,
+                        attesteringer.leggTilNyAttestering(attestering),
                         fritekstTilBrev,
                         stønadsperiode,
                         grunnlagsdata,
@@ -742,7 +772,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
         abstract override val behandlingsinformasjon: Behandlingsinformasjon
         abstract override val fnr: Fnr
         abstract val saksbehandler: NavIdentBruker.Saksbehandler
-        abstract val attestering: Attestering
+        abstract override val attesteringer: AttesteringHistorik
         abstract override val stønadsperiode: Stønadsperiode
 
         abstract fun nyOppgaveId(nyOppgaveId: OppgaveId): Underkjent
@@ -761,6 +791,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 stønadsperiode,
                 grunnlagsdata,
                 vilkårsvurderinger,
+                attesteringer
             )
 
         data class Innvilget(
@@ -775,7 +806,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             val beregning: Beregning,
             val simulering: Simulering,
             override val saksbehandler: NavIdentBruker.Saksbehandler,
-            override val attestering: Attestering,
+            override val attesteringer: AttesteringHistorik,
             override val fritekstTilBrev: String,
             override val stønadsperiode: Stønadsperiode,
             override val grunnlagsdata: Grunnlagsdata,
@@ -808,6 +839,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                     stønadsperiode,
                     grunnlagsdata,
                     vilkårsvurderinger,
+                    attesteringer
                 )
 
             fun tilSimulert(simulering: Simulering): Simulert =
@@ -826,6 +858,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                     stønadsperiode,
                     grunnlagsdata,
                     vilkårsvurderinger,
+                    attesteringer
                 )
 
             fun tilAttestering(saksbehandler: NavIdentBruker.Saksbehandler): TilAttestering.Innvilget =
@@ -845,6 +878,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                     stønadsperiode,
                     grunnlagsdata,
                     vilkårsvurderinger,
+                    attesteringer
                 )
         }
 
@@ -860,7 +894,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 override val fnr: Fnr,
                 val beregning: Beregning,
                 override val saksbehandler: NavIdentBruker.Saksbehandler,
-                override val attestering: Attestering,
+                override val attesteringer: AttesteringHistorik,
                 override val fritekstTilBrev: String,
                 override val stønadsperiode: Stønadsperiode,
                 override val grunnlagsdata: Grunnlagsdata,
@@ -898,6 +932,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                         stønadsperiode,
                         grunnlagsdata,
                         vilkårsvurderinger,
+                        attesteringer
                     )
 
                 fun tilAttestering(saksbehandler: NavIdentBruker.Saksbehandler): TilAttestering.Avslag.MedBeregning =
@@ -916,6 +951,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                         stønadsperiode,
                         grunnlagsdata,
                         vilkårsvurderinger,
+                        attesteringer
                     )
 
                 override val avslagsgrunner: List<Avslagsgrunn> =
@@ -932,7 +968,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 override val behandlingsinformasjon: Behandlingsinformasjon,
                 override val fnr: Fnr,
                 override val saksbehandler: NavIdentBruker.Saksbehandler,
-                override val attestering: Attestering,
+                override val attesteringer: AttesteringHistorik,
                 override val fritekstTilBrev: String,
                 override val stønadsperiode: Stønadsperiode,
                 override val grunnlagsdata: Grunnlagsdata,
@@ -964,6 +1000,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                         stønadsperiode,
                         grunnlagsdata,
                         vilkårsvurderinger,
+                        attesteringer
                     )
 
                 override val avslagsgrunner: List<Avslagsgrunn> = behandlingsinformasjon.utledAvslagsgrunner()
@@ -981,7 +1018,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
         abstract override val behandlingsinformasjon: Behandlingsinformasjon
         abstract override val fnr: Fnr
         abstract val saksbehandler: NavIdentBruker.Saksbehandler
-        abstract val attestering: Attestering
+        abstract override val attesteringer: AttesteringHistorik
         abstract override val stønadsperiode: Stønadsperiode
 
         data class Innvilget(
@@ -996,7 +1033,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
             val beregning: Beregning,
             val simulering: Simulering,
             override val saksbehandler: NavIdentBruker.Saksbehandler,
-            override val attestering: Attestering,
+            override val attesteringer: AttesteringHistorik,
             override val fritekstTilBrev: String,
             override val stønadsperiode: Stønadsperiode,
             override val grunnlagsdata: Grunnlagsdata,
@@ -1022,7 +1059,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 override val fnr: Fnr,
                 val beregning: Beregning,
                 override val saksbehandler: NavIdentBruker.Saksbehandler,
-                override val attestering: Attestering,
+                override val attesteringer: AttesteringHistorik,
                 override val fritekstTilBrev: String,
                 override val stønadsperiode: Stønadsperiode,
                 override val grunnlagsdata: Grunnlagsdata,
@@ -1055,7 +1092,7 @@ sealed class Søknadsbehandling : Behandling, Visitable<SøknadsbehandlingVisito
                 override val behandlingsinformasjon: Behandlingsinformasjon,
                 override val fnr: Fnr,
                 override val saksbehandler: NavIdentBruker.Saksbehandler,
-                override val attestering: Attestering,
+                override val attesteringer: AttesteringHistorik,
                 override val fritekstTilBrev: String,
                 override val stønadsperiode: Stønadsperiode,
                 override val grunnlagsdata: Grunnlagsdata,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/Vedtak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/Vedtak.kt
@@ -80,7 +80,7 @@ sealed class Vedtak : VedtakFelles, Visitable<VedtakVisitor> {
                 beregning = søknadsbehandling.beregning,
                 simulering = søknadsbehandling.simulering,
                 saksbehandler = søknadsbehandling.saksbehandler,
-                attestant = søknadsbehandling.attestering.attestant,
+                attestant = søknadsbehandling.attesteringer.hentSisteAttestering().attestant,
                 utbetalingId = utbetalingId,
                 journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.IkkeJournalførtEllerDistribuert,
                 vedtakType = VedtakType.SØKNAD,
@@ -215,7 +215,7 @@ sealed class Vedtak : VedtakFelles, Visitable<VedtakVisitor> {
                     behandlingsinformasjon = avslag.behandlingsinformasjon,
                     beregning = avslag.beregning,
                     saksbehandler = avslag.saksbehandler,
-                    attestant = avslag.attestering.attestant,
+                    attestant = avslag.attesteringer.hentSisteAttestering().attestant,
                     journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.IkkeJournalførtEllerDistribuert,
                     periode = avslag.periode,
                 )
@@ -227,7 +227,7 @@ sealed class Vedtak : VedtakFelles, Visitable<VedtakVisitor> {
                     behandling = avslag,
                     behandlingsinformasjon = avslag.behandlingsinformasjon,
                     saksbehandler = avslag.saksbehandler,
-                    attestant = avslag.attestering.attestant,
+                    attestant = avslag.attesteringer.hentSisteAttestering().attestant,
                     journalføringOgBrevdistribusjon = JournalføringOgBrevdistribusjon.IkkeJournalførtEllerDistribuert,
                     periode = avslag.periode,
                 )

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/visitor/FinnAttestantVisitor.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/visitor/FinnAttestantVisitor.kt
@@ -21,15 +21,15 @@ class FinnAttestantVisitor : SøknadsbehandlingVisitor, RevurderingVisitor {
     override fun visit(søknadsbehandling: Søknadsbehandling.Beregnet.Avslag) {}
     override fun visit(søknadsbehandling: Søknadsbehandling.Simulert) {}
     override fun visit(søknadsbehandling: Søknadsbehandling.Underkjent.Innvilget) {
-        attestant = søknadsbehandling.attestering.attestant
+        attestant = søknadsbehandling.attesteringer.hentSisteAttestering().attestant
     }
 
     override fun visit(søknadsbehandling: Søknadsbehandling.Underkjent.Avslag.MedBeregning) {
-        attestant = søknadsbehandling.attestering.attestant
+        attestant = søknadsbehandling.attesteringer.hentSisteAttestering().attestant
     }
 
     override fun visit(søknadsbehandling: Søknadsbehandling.Underkjent.Avslag.UtenBeregning) {
-        attestant = søknadsbehandling.attestering.attestant
+        attestant = søknadsbehandling.attesteringer.hentSisteAttestering().attestant
     }
 
     override fun visit(søknadsbehandling: Søknadsbehandling.TilAttestering.Avslag.UtenBeregning) {}
@@ -37,15 +37,15 @@ class FinnAttestantVisitor : SøknadsbehandlingVisitor, RevurderingVisitor {
     override fun visit(søknadsbehandling: Søknadsbehandling.TilAttestering.Innvilget) {}
 
     override fun visit(søknadsbehandling: Søknadsbehandling.Iverksatt.Avslag.UtenBeregning) {
-        attestant = søknadsbehandling.attestering.attestant
+        attestant = søknadsbehandling.attesteringer.hentSisteAttestering().attestant
     }
 
     override fun visit(søknadsbehandling: Søknadsbehandling.Iverksatt.Avslag.MedBeregning) {
-        attestant = søknadsbehandling.attestering.attestant
+        attestant = søknadsbehandling.attesteringer.hentSisteAttestering().attestant
     }
 
     override fun visit(søknadsbehandling: Søknadsbehandling.Iverksatt.Innvilget) {
-        attestant = søknadsbehandling.attestering.attestant
+        attestant = søknadsbehandling.attesteringer.hentSisteAttestering().attestant
     }
 
     override fun visit(revurdering: OpprettetRevurdering) {}

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/behandling/AttesteringTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/behandling/AttesteringTest.kt
@@ -2,6 +2,7 @@ package no.nav.su.se.bakover.domain.behandling
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import org.junit.jupiter.api.Test
@@ -9,6 +10,7 @@ import org.skyscreamer.jsonassert.JSONAssert
 
 internal class AttesteringTest {
     val attestant = NavIdentBruker.Attestant("I1337")
+    val tidspunkt = Tidspunkt.now()
 
     @Test
     fun `should serialize iverksatt`() {
@@ -17,9 +19,10 @@ internal class AttesteringTest {
            {
            "type": "Iverksatt",
            "attestant": "I1337"
+           "tidspunkt": $tidspunkt
            }
         """.trimIndent()
-        val actual = objectMapper.writeValueAsString(Attestering.Iverksatt(attestant))
+        val actual = objectMapper.writeValueAsString(Attestering.Iverksatt(attestant, tidspunkt))
 
         JSONAssert.assertEquals(expected, actual, true)
     }
@@ -30,11 +33,12 @@ internal class AttesteringTest {
         val json = """
            {
            "type": "Iverksatt",
-           "attestant": "I1337"
+           "attestant": "I1337",
+           "tidspunkt": $tidspunkt
            }
         """.trimIndent()
         val deserialized: Attestering = objectMapper.readValue(json)
-        val expected = Attestering.Iverksatt(NavIdentBruker.Attestant("I1337"))
+        val expected = Attestering.Iverksatt(NavIdentBruker.Attestant("I1337"), tidspunkt)
 
         deserialized shouldBe expected
     }
@@ -47,14 +51,16 @@ internal class AttesteringTest {
            "type": "Underkjent",
            "attestant": "I1337", 
            "grunn": "BEREGNINGEN_ER_FEIL", 
-           "kommentar": "Kan ikke dele på 0"
+           "kommentar": "Kan ikke dele på 0",
+           "tidspunkt": $tidspunkt
            }
         """.trimIndent()
         val actual = objectMapper.writeValueAsString(
             Attestering.Underkjent(
                 attestant = NavIdentBruker.Attestant("I1337"),
                 grunn = Attestering.Underkjent.Grunn.BEREGNINGEN_ER_FEIL,
-                kommentar = "Kan ikke dele på 0"
+                kommentar = "Kan ikke dele på 0",
+                tidspunkt = tidspunkt
             )
         )
 
@@ -69,7 +75,8 @@ internal class AttesteringTest {
            "type": "Underkjent",
            "attestant": "I1337", 
            "grunn": "BEREGNINGEN_ER_FEIL", 
-           "kommentar": "Kan ikke dele på 0"
+           "kommentar": "Kan ikke dele på 0",
+           "tidspunkt": $tidspunkt
              }
         
         """.trimIndent()
@@ -77,7 +84,8 @@ internal class AttesteringTest {
         val expected = Attestering.Underkjent(
             attestant = NavIdentBruker.Attestant("I1337"),
             grunn = Attestering.Underkjent.Grunn.BEREGNINGEN_ER_FEIL,
-            kommentar = "Kan ikke dele på 0"
+            kommentar = "Kan ikke dele på 0",
+            tidspunkt = tidspunkt
         )
 
         actual shouldBe expected

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/behandling/AttesteringTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/behandling/AttesteringTest.kt
@@ -18,8 +18,8 @@ internal class AttesteringTest {
         val expected = """
            {
            "type": "Iverksatt",
-           "attestant": "I1337"
-           "tidspunkt": $tidspunkt
+           "attestant": "I1337",
+           "opprettet": "$tidspunkt"
            }
         """.trimIndent()
         val actual = objectMapper.writeValueAsString(Attestering.Iverksatt(attestant, tidspunkt))
@@ -34,7 +34,7 @@ internal class AttesteringTest {
            {
            "type": "Iverksatt",
            "attestant": "I1337",
-           "tidspunkt": $tidspunkt
+           "opprettet": "$tidspunkt"
            }
         """.trimIndent()
         val deserialized: Attestering = objectMapper.readValue(json)
@@ -52,7 +52,7 @@ internal class AttesteringTest {
            "attestant": "I1337", 
            "grunn": "BEREGNINGEN_ER_FEIL", 
            "kommentar": "Kan ikke dele på 0",
-           "tidspunkt": $tidspunkt
+           "opprettet": "$tidspunkt"
            }
         """.trimIndent()
         val actual = objectMapper.writeValueAsString(
@@ -60,7 +60,7 @@ internal class AttesteringTest {
                 attestant = NavIdentBruker.Attestant("I1337"),
                 grunn = Attestering.Underkjent.Grunn.BEREGNINGEN_ER_FEIL,
                 kommentar = "Kan ikke dele på 0",
-                tidspunkt = tidspunkt
+                opprettet = tidspunkt
             )
         )
 
@@ -76,7 +76,7 @@ internal class AttesteringTest {
            "attestant": "I1337", 
            "grunn": "BEREGNINGEN_ER_FEIL", 
            "kommentar": "Kan ikke dele på 0",
-           "tidspunkt": $tidspunkt
+           "opprettet": "$tidspunkt"
              }
         
         """.trimIndent()
@@ -85,7 +85,7 @@ internal class AttesteringTest {
             attestant = NavIdentBruker.Attestant("I1337"),
             grunn = Attestering.Underkjent.Grunn.BEREGNINGEN_ER_FEIL,
             kommentar = "Kan ikke dele på 0",
-            tidspunkt = tidspunkt
+            opprettet = tidspunkt
         )
 
         actual shouldBe expected

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/behandling/AttesteringshistorikkTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/behandling/AttesteringshistorikkTest.kt
@@ -101,4 +101,25 @@ internal class AttesteringshistorikkTest {
 
         Attesteringshistorikk(deserialized) shouldBe expected
     }
+
+    @Test
+    fun `legger till attestering i sluttet av listen`() {
+        val opprettet = Tidspunkt.now(fixedClock)
+        val attestering1 = Attestering.Underkjent(
+            NavIdentBruker.Attestant("Attestant2"),
+            opprettet.plus(1, ChronoUnit.DAYS), Attestering.Underkjent.Grunn.BEREGNINGEN_ER_FEIL, "kommentar"
+        )
+        val attestering2 = Attestering.Underkjent(
+            NavIdentBruker.Attestant("Attestant2"),
+            opprettet.plus(2, ChronoUnit.DAYS), Attestering.Underkjent.Grunn.BEREGNINGEN_ER_FEIL, "kommentar"
+        )
+        val attestering3 = Attestering.Iverksatt(NavIdentBruker.Attestant("Attestant1"), opprettet.plus(3, ChronoUnit.DAYS))
+
+        val actual = Attesteringshistorikk.empty()
+            .leggTilNyAttestering(attestering1)
+            .leggTilNyAttestering(attestering2)
+            .leggTilNyAttestering(attestering3)
+
+        actual.hentAttesteringer() shouldBe listOf(attestering1, attestering2, attestering3)
+    }
 }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/behandling/AttesteringshistorikkTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/behandling/AttesteringshistorikkTest.kt
@@ -1,10 +1,9 @@
 package no.nav.su.se.bakover.domain.behandling
 
-import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.Tidspunkt
+import no.nav.su.se.bakover.common.deserializeList
 import no.nav.su.se.bakover.common.januar
-import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.common.serialize
 import no.nav.su.se.bakover.common.startOfDay
 import no.nav.su.se.bakover.domain.NavIdentBruker
@@ -62,6 +61,16 @@ internal class AttesteringshistorikkTest {
     }
 
     @Test
+    fun `serializerer tom liste riktig`() {
+        val actual = Attesteringshistorikk(listOf()).hentAttesteringer().serialize()
+        val expected = """
+                []
+        """.trimIndent()
+
+        JSONAssert.assertEquals(expected, actual, true)
+    }
+
+    @Test
     fun `deserializerer riktig`() {
         val opprettet = Tidspunkt.now(fixedClock)
         val attestering1 = Attestering.Iverksatt(NavIdentBruker.Attestant("Attestant1"), opprettet)
@@ -87,9 +96,9 @@ internal class AttesteringshistorikkTest {
                 ]
         """.trimIndent()
 
-        val deserialized: Attesteringshistorikk = objectMapper.readValue(json)
+        val deserialized: List<Attestering> = json.deserializeList()
         val expected = Attesteringshistorikk(mutableListOf(attestering1, attestering2))
 
-        deserialized shouldBe expected
+        Attesteringshistorikk(deserialized) shouldBe expected
     }
 }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/behandling/AttesteringshistorikkTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/behandling/AttesteringshistorikkTest.kt
@@ -1,0 +1,95 @@
+package no.nav.su.se.bakover.domain.behandling
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.common.Tidspunkt
+import no.nav.su.se.bakover.common.januar
+import no.nav.su.se.bakover.common.objectMapper
+import no.nav.su.se.bakover.common.serialize
+import no.nav.su.se.bakover.common.startOfDay
+import no.nav.su.se.bakover.domain.NavIdentBruker
+import org.junit.jupiter.api.Test
+import org.skyscreamer.jsonassert.JSONAssert
+import java.time.Clock
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+
+internal class AttesteringshistorikkTest {
+    private val fixedClock = Clock.fixed(1.januar(2021).startOfDay(ZoneOffset.UTC).instant, ZoneOffset.UTC)
+
+    @Test
+    fun `attesteringer er sortert etter tidspunkt`() {
+        val attestering1 = Attestering.Iverksatt(
+            NavIdentBruker.Attestant("Attestant1"),
+            Tidspunkt.now(fixedClock).plus(1, ChronoUnit.DAYS)
+        )
+        val attestering2 = Attestering.Iverksatt(
+            NavIdentBruker.Attestant("Attestant2"),
+            Tidspunkt.now(fixedClock).plus(2, ChronoUnit.DAYS)
+        )
+
+        Attesteringshistorikk(mutableListOf(attestering2, attestering1)).hentAttesteringer() shouldBe listOf(attestering1, attestering2)
+    }
+
+    @Test
+    fun `serializerer riktig`() {
+        val opprettet = Tidspunkt.now(fixedClock)
+        val attestering1 = Attestering.Iverksatt(NavIdentBruker.Attestant("Attestant1"), opprettet)
+        val attestering2 = Attestering.Underkjent(
+            NavIdentBruker.Attestant("Attestant2"),
+            opprettet.plus(1, ChronoUnit.DAYS), Attestering.Underkjent.Grunn.BEREGNINGEN_ER_FEIL, "kommentar"
+        )
+
+        val actual = Attesteringshistorikk(mutableListOf(attestering1, attestering2)).hentAttesteringer().serialize()
+        val expected = """
+                [
+                  {
+                    "type" : "Iverksatt",
+                    "attestant": "Attestant1",
+                    "opprettet": "$opprettet"
+                  },
+                  {
+                    "type" : "Underkjent",
+                    "attestant": "Attestant2",
+                    "opprettet": "${ opprettet.plus(1, ChronoUnit.DAYS) }",
+                    "grunn" : "BEREGNINGEN_ER_FEIL",
+                    "kommentar": "kommentar"
+                  }
+                ]
+        """.trimIndent()
+
+        JSONAssert.assertEquals(expected, actual, true)
+    }
+
+    @Test
+    fun `deserializerer riktig`() {
+        val opprettet = Tidspunkt.now(fixedClock)
+        val attestering1 = Attestering.Iverksatt(NavIdentBruker.Attestant("Attestant1"), opprettet)
+        val attestering2 = Attestering.Underkjent(
+            NavIdentBruker.Attestant("Attestant2"),
+            opprettet.plus(1, ChronoUnit.DAYS), Attestering.Underkjent.Grunn.BEREGNINGEN_ER_FEIL, "kommentar"
+        )
+
+        val json = """
+                [
+                  {
+                    "type" : "Iverksatt",
+                    "attestant": "Attestant1",
+                    "opprettet": "$opprettet"
+                  },
+                  {
+                    "type" : "Underkjent",
+                    "attestant": "Attestant2",
+                    "opprettet": "${ opprettet.plus(1, ChronoUnit.DAYS) }",
+                    "grunn" : "BEREGNINGEN_ER_FEIL",
+                    "kommentar": "kommentar"
+                  }
+                ]
+        """.trimIndent()
+
+        val deserialized: Attesteringshistorikk = objectMapper.readValue(json)
+        val expected = Attesteringshistorikk(mutableListOf(attestering1, attestering2))
+
+        deserialized shouldBe expected
+    }
+}

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/RevurderingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/RevurderingTest.kt
@@ -13,6 +13,7 @@ import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.FnrGenerator
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Saksnummer
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.avslag.Opphørsgrunn
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragFactory
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragTilhører
@@ -501,6 +502,7 @@ internal class RevurderingTest {
             fradragsgrunnlag = fradrag,
         ),
         informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+        attesteringer = AttesteringHistorik.empty()
     )
 
     private fun lagUtbetaling(

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/RevurderingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/RevurderingTest.kt
@@ -13,7 +13,7 @@ import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.FnrGenerator
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Saksnummer
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.avslag.Opphørsgrunn
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragFactory
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragTilhører
@@ -502,7 +502,7 @@ internal class RevurderingTest {
             fradragsgrunnlag = fradrag,
         ),
         informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-        attesteringer = AttesteringHistorik.empty()
+        attesteringer = Attesteringshistorikk.empty()
     )
 
     private fun lagUtbetaling(

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/StatusovergangTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/StatusovergangTest.kt
@@ -600,7 +600,7 @@ internal class StatusovergangTest {
                         attestant = NavIdentBruker.Attestant("sneaky"),
                         grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
                         kommentar = "",
-                        tidspunkt = fixedTidspunkt
+                        opprettet = fixedTidspunkt
                     ),
                 ),
             ) shouldBe Statusovergang.SaksbehandlerOgAttestantKanIkkeVæreSammePerson.left()
@@ -615,7 +615,7 @@ internal class StatusovergangTest {
                         attestant = NavIdentBruker.Attestant("sneaky"),
                         grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
                         kommentar = "",
-                        tidspunkt = fixedTidspunkt
+                        opprettet = fixedTidspunkt
                     ),
                 ),
             ) shouldBe Statusovergang.SaksbehandlerOgAttestantKanIkkeVæreSammePerson.left()
@@ -630,7 +630,7 @@ internal class StatusovergangTest {
                         attestant = NavIdentBruker.Attestant("sneaky"),
                         grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
                         kommentar = "",
-                        tidspunkt = fixedTidspunkt
+                        opprettet = fixedTidspunkt
                     ),
                 ),
             ) shouldBe Statusovergang.SaksbehandlerOgAttestantKanIkkeVæreSammePerson.left()

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/StatusovergangTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/StatusovergangTest.kt
@@ -60,7 +60,7 @@ internal class StatusovergangTest {
 
     private val simulering = no.nav.su.se.bakover.test.simuleringNy()
 
-    private val attestering = Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"))
+    private val attestering = Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), fixedTidspunkt)
     private val utbetalingId = UUID30.randomUUID()
 
     private val fritekstTilBrev: String = "Fritekst til brev"
@@ -597,9 +597,10 @@ internal class StatusovergangTest {
                 tilAttesteringAvslagVilkår.copy(saksbehandler = NavIdentBruker.Saksbehandler("sneaky")),
                 Statusovergang.TilUnderkjent(
                     Attestering.Underkjent(
-                        NavIdentBruker.Attestant("sneaky"),
-                        Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
-                        "",
+                        attestant = NavIdentBruker.Attestant("sneaky"),
+                        grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
+                        kommentar = "",
+                        tidspunkt = fixedTidspunkt
                     ),
                 ),
             ) shouldBe Statusovergang.SaksbehandlerOgAttestantKanIkkeVæreSammePerson.left()
@@ -611,9 +612,10 @@ internal class StatusovergangTest {
                 tilAttesteringAvslagBeregning.copy(saksbehandler = NavIdentBruker.Saksbehandler("sneaky")),
                 Statusovergang.TilUnderkjent(
                     Attestering.Underkjent(
-                        NavIdentBruker.Attestant("sneaky"),
-                        Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
-                        "",
+                        attestant = NavIdentBruker.Attestant("sneaky"),
+                        grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
+                        kommentar = "",
+                        tidspunkt = fixedTidspunkt
                     ),
                 ),
             ) shouldBe Statusovergang.SaksbehandlerOgAttestantKanIkkeVæreSammePerson.left()
@@ -625,9 +627,10 @@ internal class StatusovergangTest {
                 tilAttesteringInnvilget.copy(saksbehandler = NavIdentBruker.Saksbehandler("sneaky")),
                 Statusovergang.TilUnderkjent(
                     Attestering.Underkjent(
-                        NavIdentBruker.Attestant("sneaky"),
-                        Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
-                        "",
+                        attestant = NavIdentBruker.Attestant("sneaky"),
+                        grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
+                        kommentar = "",
+                        tidspunkt = fixedTidspunkt
                     ),
                 ),
             ) shouldBe Statusovergang.SaksbehandlerOgAttestantKanIkkeVæreSammePerson.left()

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/StatusovergangTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/StatusovergangTest.kt
@@ -10,6 +10,7 @@ import no.nav.su.se.bakover.common.mars
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.behandling.withVilkårAvslått
@@ -208,7 +209,7 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentInnvilget,
                 Statusovergang.TilVilkårsvurdert(Behandlingsinformasjon().withAlleVilkårOppfylt()),
-            ) shouldBe vilkårsvurdertInnvilget.medFritekstTilBrev(underkjentInnvilget.fritekstTilBrev)
+            ) shouldBe vilkårsvurdertInnvilget.medFritekstTilBrev(underkjentInnvilget.fritekstTilBrev).copy(attesteringer = Attesteringshistorikk(listOf(underkjentInnvilget.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -216,7 +217,7 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentInnvilget,
                 Statusovergang.TilVilkårsvurdert(Behandlingsinformasjon().withVilkårAvslått()),
-            ) shouldBe vilkårsvurdertAvslag.medFritekstTilBrev(underkjentInnvilget.fritekstTilBrev)
+            ) shouldBe vilkårsvurdertAvslag.medFritekstTilBrev(underkjentInnvilget.fritekstTilBrev).copy(attesteringer = Attesteringshistorikk(listOf(underkjentInnvilget.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -224,7 +225,7 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentAvslagVilkår,
                 Statusovergang.TilVilkårsvurdert(Behandlingsinformasjon().withAlleVilkårOppfylt()),
-            ) shouldBe vilkårsvurdertInnvilget.medFritekstTilBrev(underkjentAvslagVilkår.fritekstTilBrev)
+            ) shouldBe vilkårsvurdertInnvilget.medFritekstTilBrev(underkjentAvslagVilkår.fritekstTilBrev).copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagVilkår.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -232,7 +233,7 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentAvslagVilkår,
                 Statusovergang.TilVilkårsvurdert(Behandlingsinformasjon().withVilkårAvslått()),
-            ) shouldBe vilkårsvurdertAvslag.medFritekstTilBrev(underkjentAvslagVilkår.fritekstTilBrev)
+            ) shouldBe vilkårsvurdertAvslag.medFritekstTilBrev(underkjentAvslagVilkår.fritekstTilBrev).copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagVilkår.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -240,7 +241,7 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentAvslagBeregning,
                 Statusovergang.TilVilkårsvurdert(Behandlingsinformasjon().withAlleVilkårOppfylt()),
-            ) shouldBe vilkårsvurdertInnvilget.medFritekstTilBrev(underkjentAvslagBeregning.fritekstTilBrev)
+            ) shouldBe vilkårsvurdertInnvilget.medFritekstTilBrev(underkjentAvslagBeregning.fritekstTilBrev).copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagBeregning.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -248,7 +249,7 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentAvslagBeregning,
                 Statusovergang.TilVilkårsvurdert(Behandlingsinformasjon().withVilkårAvslått()),
-            ) shouldBe vilkårsvurdertAvslag.medFritekstTilBrev(underkjentAvslagBeregning.fritekstTilBrev)
+            ) shouldBe vilkårsvurdertAvslag.medFritekstTilBrev(underkjentAvslagBeregning.fritekstTilBrev).copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagBeregning.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -348,7 +349,7 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentAvslagBeregning,
                 Statusovergang.TilBeregnet { innvilgetBeregning },
-            ) shouldBe beregnetInnvilget.medFritekstTilBrev(underkjentAvslagBeregning.fritekstTilBrev)
+            ) shouldBe beregnetInnvilget.medFritekstTilBrev(underkjentAvslagBeregning.fritekstTilBrev).copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagBeregning.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -356,7 +357,7 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentAvslagBeregning,
                 Statusovergang.TilBeregnet { avslagBeregning },
-            ) shouldBe beregnetAvslag.medFritekstTilBrev(underkjentAvslagBeregning.fritekstTilBrev)
+            ) shouldBe beregnetAvslag.medFritekstTilBrev(underkjentAvslagBeregning.fritekstTilBrev).copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagBeregning.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -364,7 +365,7 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentInnvilget,
                 Statusovergang.TilBeregnet { innvilgetBeregning },
-            ) shouldBe beregnetInnvilget.medFritekstTilBrev(underkjentInnvilget.fritekstTilBrev)
+            ) shouldBe beregnetInnvilget.medFritekstTilBrev(underkjentInnvilget.fritekstTilBrev).copy(attesteringer = Attesteringshistorikk(listOf(underkjentInnvilget.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -372,7 +373,7 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentInnvilget,
                 Statusovergang.TilBeregnet { avslagBeregning },
-            ) shouldBe beregnetAvslag.medFritekstTilBrev(underkjentInnvilget.fritekstTilBrev)
+            ) shouldBe beregnetAvslag.medFritekstTilBrev(underkjentInnvilget.fritekstTilBrev).copy(attesteringer = Attesteringshistorikk(listOf(underkjentInnvilget.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -463,7 +464,7 @@ internal class StatusovergangTest {
                 Statusovergang.TilSimulert {
                     simulering.right()
                 },
-            ) shouldBe simulert.copy(fritekstTilBrev = "Fritekst til brev").right()
+            ) shouldBe simulert.copy(fritekstTilBrev = "Fritekst til brev", attesteringer = Attesteringshistorikk(listOf(underkjentInnvilget.attesteringer.hentSisteAttestering()))).right()
         }
 
         @Test
@@ -523,7 +524,7 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentAvslagVilkår,
                 Statusovergang.TilAttestering(saksbehandler, fritekstTilBrev),
-            ) shouldBe tilAttesteringAvslagVilkår
+            ) shouldBe tilAttesteringAvslagVilkår.copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagVilkår.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -531,7 +532,7 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentAvslagBeregning,
                 Statusovergang.TilAttestering(saksbehandler, fritekstTilBrev),
-            ) shouldBe tilAttesteringAvslagBeregning
+            ) shouldBe tilAttesteringAvslagBeregning.copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagBeregning.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -539,7 +540,7 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentInnvilget,
                 Statusovergang.TilAttestering(saksbehandler, fritekstTilBrev),
-            ) shouldBe tilAttesteringInnvilget
+            ) shouldBe tilAttesteringInnvilget.copy(attesteringer = Attesteringshistorikk(listOf(underkjentInnvilget.attesteringer.hentSisteAttestering())))
         }
 
         @Test

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vedtak/GjeldendeVedtaksdataTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vedtak/GjeldendeVedtaksdataTest.kt
@@ -17,6 +17,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.beregning.BeregningFactory
@@ -146,7 +147,7 @@ internal class GjeldendeVedtaksdataTest {
             ),
             simulering = mock(),
             saksbehandler = NavIdentBruker.Saksbehandler("saks"),
-            attestering = Attestering.Iverksatt(NavIdentBruker.Attestant("attestant")),
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), Tidspunkt.now(fixedClock))),
             fritekstTilBrev = "",
             stønadsperiode = Stønadsperiode.create(
                 periode = periode,
@@ -220,7 +221,7 @@ internal class GjeldendeVedtaksdataTest {
                 fradragStrategy = FradragStrategy.Enslig,
                 begrunnelse = "just becausre",
             ),
-            attestering = Attestering.Iverksatt(attestant = NavIdentBruker.Attestant(navIdent = "")),
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant = NavIdentBruker.Attestant(navIdent = ""), Tidspunkt.now(fixedClock))),
             forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
             behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon(),
             simulering = Simulering(

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vedtak/GjeldendeVedtaksdataTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vedtak/GjeldendeVedtaksdataTest.kt
@@ -17,7 +17,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.beregning.BeregningFactory
@@ -147,7 +147,7 @@ internal class GjeldendeVedtaksdataTest {
             ),
             simulering = mock(),
             saksbehandler = NavIdentBruker.Saksbehandler("saks"),
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), Tidspunkt.now(fixedClock))),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), Tidspunkt.now(fixedClock))),
             fritekstTilBrev = "",
             stønadsperiode = Stønadsperiode.create(
                 periode = periode,
@@ -221,7 +221,7 @@ internal class GjeldendeVedtaksdataTest {
                 fradragStrategy = FradragStrategy.Enslig,
                 begrunnelse = "just becausre",
             ),
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant = NavIdentBruker.Attestant(navIdent = ""), Tidspunkt.now(fixedClock))),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant = NavIdentBruker.Attestant(navIdent = ""), Tidspunkt.now(fixedClock))),
             forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
             behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon(),
             simulering = Simulering(

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakTest.kt
@@ -15,7 +15,7 @@ import no.nav.su.se.bakover.domain.FnrGenerator
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.fixedClock
@@ -424,7 +424,7 @@ internal class VedtakTest {
                 beregning = mock(),
                 simulering = mock(),
                 saksbehandler = NavIdentBruker.Saksbehandler("saksbehandler"),
-                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("Attes T. Ant"), Tidspunkt.now(clock))),
+                attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("Attes T. Ant"), Tidspunkt.now(clock))),
                 fritekstTilBrev = "",
                 stønadsperiode = Stønadsperiode.create(
                     periode = Periode.create(fraDato, tilDato),

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakTest.kt
@@ -15,6 +15,7 @@ import no.nav.su.se.bakover.domain.FnrGenerator
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.fixedClock
@@ -423,7 +424,7 @@ internal class VedtakTest {
                 beregning = mock(),
                 simulering = mock(),
                 saksbehandler = NavIdentBruker.Saksbehandler("saksbehandler"),
-                attestering = Attestering.Iverksatt(NavIdentBruker.Attestant("Attes T. Ant")),
+                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("Attes T. Ant"), Tidspunkt.now(clock))),
                 fritekstTilBrev = "",
                 stønadsperiode = Stønadsperiode.create(
                     periode = Periode.create(fraDato, tilDato),

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/FinnAttestantVisitorTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/FinnAttestantVisitorTest.kt
@@ -15,6 +15,7 @@ import no.nav.su.se.bakover.domain.FnrGenerator
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.beregning.Beregning
@@ -156,6 +157,7 @@ internal class FinnAttestantVisitorTest {
         stønadsperiode = Stønadsperiode.create(Periode.create(1.januar(2021), 31.desember(2021))),
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+        attesteringer = AttesteringHistorik.empty()
     )
 
     private val behandlingsinformasjonMedAlleVilkårOppfylt = Behandlingsinformasjon.lagTomBehandlingsinformasjon()
@@ -191,22 +193,24 @@ internal class FinnAttestantVisitorTest {
             .tilAttestering(saksbehandler, "")
     private val underkjentInnvilgetSøknadsbehandling = tilAttesteringInnvilgetSøknadsbehandlng.tilUnderkjent(
         Attestering.Underkjent(
-            attestant,
-            Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
-            "",
+            attestant = attestant,
+            grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
+            kommentar = "",
+            tidspunkt = Tidspunkt.now()
         ),
     )
     private val underkjentAvslagSøknadsbehandling = tilAttesteringAvslagSøknadsbehandlng.tilUnderkjent(
         Attestering.Underkjent(
-            attestant,
-            Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
-            "",
+            attestant = attestant,
+            grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
+            kommentar = "",
+            tidspunkt = Tidspunkt.now()
         ),
     )
     private val iverksattInnvilgetSøknadsbehandling =
-        tilAttesteringInnvilgetSøknadsbehandlng.tilIverksatt(Attestering.Iverksatt(attestant))
+        tilAttesteringInnvilgetSøknadsbehandlng.tilIverksatt(Attestering.Iverksatt(attestant, Tidspunkt.now()))
     private val iverksattAvslagSøknadsbehandling =
-        tilAttesteringAvslagSøknadsbehandlng.tilIverksatt(Attestering.Iverksatt(attestant))
+        tilAttesteringAvslagSøknadsbehandlng.tilIverksatt(Attestering.Iverksatt(attestant, Tidspunkt.now()))
 
     private val beregningMock = mock<Beregning> {
         on { getMånedsberegninger() } doReturn listOf(
@@ -274,6 +278,7 @@ internal class FinnAttestantVisitorTest {
             formue = innvilgetFormueVilkår(periode),
         ),
         informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+        attesteringer = AttesteringHistorik.empty()
     )
 
     private val beregnetRevurdering =

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/FinnAttestantVisitorTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/FinnAttestantVisitorTest.kt
@@ -15,7 +15,7 @@ import no.nav.su.se.bakover.domain.FnrGenerator
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.beregning.Beregning
@@ -157,7 +157,7 @@ internal class FinnAttestantVisitorTest {
         stønadsperiode = Stønadsperiode.create(Periode.create(1.januar(2021), 31.desember(2021))),
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
-        attesteringer = AttesteringHistorik.empty()
+        attesteringer = Attesteringshistorikk.empty()
     )
 
     private val behandlingsinformasjonMedAlleVilkårOppfylt = Behandlingsinformasjon.lagTomBehandlingsinformasjon()
@@ -196,7 +196,7 @@ internal class FinnAttestantVisitorTest {
             attestant = attestant,
             grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
             kommentar = "",
-            tidspunkt = Tidspunkt.now()
+            opprettet = Tidspunkt.now()
         ),
     )
     private val underkjentAvslagSøknadsbehandling = tilAttesteringAvslagSøknadsbehandlng.tilUnderkjent(
@@ -204,7 +204,7 @@ internal class FinnAttestantVisitorTest {
             attestant = attestant,
             grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
             kommentar = "",
-            tidspunkt = Tidspunkt.now()
+            opprettet = Tidspunkt.now()
         ),
     )
     private val iverksattInnvilgetSøknadsbehandling =
@@ -278,7 +278,7 @@ internal class FinnAttestantVisitorTest {
             formue = innvilgetFormueVilkår(periode),
         ),
         informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-        attesteringer = AttesteringHistorik.empty()
+        attesteringer = Attesteringshistorikk.empty()
     )
 
     private val beregnetRevurdering =

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitorTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitorTest.kt
@@ -24,6 +24,7 @@ import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Person
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.avslag.Avslag
 import no.nav.su.se.bakover.domain.behandling.avslag.Avslagsgrunn
@@ -92,7 +93,7 @@ internal class LagBrevRequestVisitorTest {
             .tilBeregnet(innvilgetBeregning)
             .tilSimulert(simulering)
             .tilAttestering(saksbehandler, "Fritekst!")
-            .tilIverksatt(Attestering.Iverksatt(attestant))
+            .tilIverksatt(Attestering.Iverksatt(attestant, Tidspunkt.now(clock)))
             .let { søknadsbehandling ->
                 LagBrevRequestVisitor(
                     hentPerson = { person.right() },
@@ -337,9 +338,10 @@ internal class LagBrevRequestVisitorTest {
             .tilAttestering(saksbehandler, "Fritekst!")
             .tilUnderkjent(
                 Attestering.Underkjent(
-                    attestant,
-                    Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
-                    "kommentar",
+                    attestant = attestant,
+                    grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
+                    kommentar = "kommentar",
+                    tidspunkt = Tidspunkt.now(clock)
                 ),
             )
             .let { søknadsbehandling ->
@@ -375,9 +377,11 @@ internal class LagBrevRequestVisitorTest {
             .tilAttestering(saksbehandler, "Fritekst!")
             .tilUnderkjent(
                 Attestering.Underkjent(
-                    attestant,
-                    Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
-                    "kommentar",
+                    attestant = attestant,
+                    grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
+                    kommentar = "kommentar",
+                    tidspunkt = Tidspunkt.now(clock)
+
                 ),
             )
             .let { søknadsbehandling ->
@@ -412,9 +416,10 @@ internal class LagBrevRequestVisitorTest {
             .tilAttestering(saksbehandler, "Fritekst!")
             .tilUnderkjent(
                 Attestering.Underkjent(
-                    attestant,
-                    Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
-                    "kommentar",
+                    attestant = attestant,
+                    grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
+                    kommentar = "kommentar",
+                    tidspunkt = Tidspunkt.now(clock)
                 ),
             )
             .let { søknadsbehandling ->
@@ -447,7 +452,7 @@ internal class LagBrevRequestVisitorTest {
             )
             .tilAttestering(saksbehandler, "Fritekst!")
             .tilIverksatt(
-                Attestering.Iverksatt(attestant),
+                Attestering.Iverksatt(attestant, Tidspunkt.now(clock)),
             )
             .let { søknadsbehandling ->
                 LagBrevRequestVisitor(
@@ -481,7 +486,7 @@ internal class LagBrevRequestVisitorTest {
             )
             .tilAttestering(saksbehandler, "Fritekst!")
             .tilIverksatt(
-                Attestering.Iverksatt(attestant),
+                Attestering.Iverksatt(attestant, Tidspunkt.now(clock)),
             )
             .let { søknadsbehandling ->
                 LagBrevRequestVisitor(
@@ -513,7 +518,7 @@ internal class LagBrevRequestVisitorTest {
             .tilBeregnet(innvilgetBeregning)
             .tilSimulert(simulering)
             .tilAttestering(saksbehandler, "Fritekst!")
-            .tilIverksatt(Attestering.Iverksatt(attestant))
+            .tilIverksatt(Attestering.Iverksatt(attestant, Tidspunkt.now(clock)))
             .let { søknadsbehandling ->
                 LagBrevRequestVisitor(
                     hentPerson = { person.right() },
@@ -543,7 +548,7 @@ internal class LagBrevRequestVisitorTest {
                 .tilBeregnet(innvilgetBeregning)
                 .tilSimulert(simulering)
                 .tilAttestering(saksbehandler, "Fritekst!")
-                .tilIverksatt(Attestering.Iverksatt(attestant))
+                .tilIverksatt(Attestering.Iverksatt(attestant, Tidspunkt.now(clock)))
 
         val innvilgetVedtak = Vedtak.fromSøknadsbehandling(søknadsbehandling, utbetalingId, fixedClock)
 
@@ -581,7 +586,7 @@ internal class LagBrevRequestVisitorTest {
                 .tilBeregnet(avslagBeregning) as Søknadsbehandling.Beregnet.Avslag
             )
             .tilAttestering(saksbehandler, "Fritekst!")
-            .tilIverksatt(Attestering.Iverksatt(attestant))
+            .tilIverksatt(Attestering.Iverksatt(attestant, Tidspunkt.now(clock)))
 
         val avslåttVedtak = Vedtak.Avslag.fromSøknadsbehandlingMedBeregning(søknadsbehandling, fixedClock)
 
@@ -623,7 +628,7 @@ internal class LagBrevRequestVisitorTest {
             ) as Søknadsbehandling.Vilkårsvurdert.Avslag
             )
             .tilAttestering(saksbehandler, "Fritekst!")
-            .tilIverksatt(Attestering.Iverksatt(attestant))
+            .tilIverksatt(Attestering.Iverksatt(attestant, Tidspunkt.now(clock)))
 
         val avslåttVedtak = Vedtak.Avslag.fromSøknadsbehandlingUtenBeregning(søknadsbehandling, fixedClock)
 
@@ -665,7 +670,7 @@ internal class LagBrevRequestVisitorTest {
                 .tilBeregnet(innvilgetBeregning)
                 .tilSimulert(simulering)
                 .tilAttestering(saksbehandler, "Fritekst!")
-                .tilIverksatt(Attestering.Iverksatt(attestant))
+                .tilIverksatt(Attestering.Iverksatt(attestant, Tidspunkt.now(clock)))
 
         val revurderingsperiode = Periode.create(fraOgMed = 1.januar(2021), tilOgMed = 31.desember(2021))
         val revurdering = IverksattRevurdering.Innvilget(
@@ -687,7 +692,7 @@ internal class LagBrevRequestVisitorTest {
             ),
             beregning = innvilgetBeregning,
             simulering = simulering,
-            attestering = Attestering.Iverksatt(attestant),
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now(clock))),
             fritekstTilBrev = "JEPP",
             revurderingsårsak = Revurderingsårsak(
                 Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
@@ -735,7 +740,7 @@ internal class LagBrevRequestVisitorTest {
                 .tilBeregnet(innvilgetBeregning)
                 .tilSimulert(simulering)
                 .tilAttestering(saksbehandler, "Fritekst!")
-                .tilIverksatt(Attestering.Iverksatt(attestant))
+                .tilIverksatt(Attestering.Iverksatt(attestant, Tidspunkt.now(clock)))
 
         val revurderingsperiode = Periode.create(fraOgMed = 1.januar(2021), tilOgMed = 31.desember(2021))
         val revurdering = IverksattRevurdering.Opphørt(
@@ -747,7 +752,7 @@ internal class LagBrevRequestVisitorTest {
             oppgaveId = OppgaveId("15"),
             beregning = innvilgetBeregning,
             simulering = simulering,
-            attestering = Attestering.Iverksatt(attestant),
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now())),
             fritekstTilBrev = "FRITEKST REVURDERING",
             revurderingsårsak = Revurderingsårsak(
                 Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
@@ -819,7 +824,7 @@ internal class LagBrevRequestVisitorTest {
                 .tilBeregnet(innvilgetBeregning)
                 .tilSimulert(simulering)
                 .tilAttestering(saksbehandler, "Fritekst!")
-                .tilIverksatt(Attestering.Iverksatt(attestant))
+                .tilIverksatt(Attestering.Iverksatt(attestant, Tidspunkt.now(clock)))
 
         val opphørsperiode = Periode.create(fraOgMed = 1.januar(2021), tilOgMed = 31.desember(2021))
         val revurdering = IverksattRevurdering.Opphørt(
@@ -831,7 +836,7 @@ internal class LagBrevRequestVisitorTest {
             oppgaveId = OppgaveId("15"),
             beregning = innvilgetBeregning,
             simulering = simulering,
-            attestering = Attestering.Iverksatt(attestant),
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now(clock))),
             fritekstTilBrev = "FRITEKST REVURDERING",
             revurderingsårsak = Revurderingsårsak(
                 Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
@@ -907,7 +912,7 @@ internal class LagBrevRequestVisitorTest {
                 .tilBeregnet(innvilgetBeregning)
                 .tilSimulert(simulering)
                 .tilAttestering(saksbehandler, "Fritekst!")
-                .tilIverksatt(Attestering.Iverksatt(attestant))
+                .tilIverksatt(Attestering.Iverksatt(attestant, Tidspunkt.now(clock)))
 
         val revurderingsperiode = Periode.create(fraOgMed = 1.januar(2021), tilOgMed = 31.desember(2021))
         val revurdering = IverksattRevurdering.IngenEndring(
@@ -918,7 +923,7 @@ internal class LagBrevRequestVisitorTest {
             saksbehandler = saksbehandler,
             oppgaveId = OppgaveId("15"),
             beregning = innvilgetBeregning,
-            attestering = Attestering.Iverksatt(attestant),
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now())),
             fritekstTilBrev = "EN FIN FRITEKST",
             revurderingsårsak = Revurderingsårsak(
                 Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
@@ -1066,5 +1071,6 @@ internal class LagBrevRequestVisitorTest {
             ),
         ),
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+        attesteringer = AttesteringHistorik.empty()
     )
 }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitorTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitorTest.kt
@@ -24,7 +24,7 @@ import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Person
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.avslag.Avslag
 import no.nav.su.se.bakover.domain.behandling.avslag.Avslagsgrunn
@@ -341,7 +341,7 @@ internal class LagBrevRequestVisitorTest {
                     attestant = attestant,
                     grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
                     kommentar = "kommentar",
-                    tidspunkt = Tidspunkt.now(clock)
+                    opprettet = Tidspunkt.now(clock)
                 ),
             )
             .let { søknadsbehandling ->
@@ -380,7 +380,7 @@ internal class LagBrevRequestVisitorTest {
                     attestant = attestant,
                     grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
                     kommentar = "kommentar",
-                    tidspunkt = Tidspunkt.now(clock)
+                    opprettet = Tidspunkt.now(clock)
 
                 ),
             )
@@ -419,7 +419,7 @@ internal class LagBrevRequestVisitorTest {
                     attestant = attestant,
                     grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
                     kommentar = "kommentar",
-                    tidspunkt = Tidspunkt.now(clock)
+                    opprettet = Tidspunkt.now(clock)
                 ),
             )
             .let { søknadsbehandling ->
@@ -692,7 +692,7 @@ internal class LagBrevRequestVisitorTest {
             ),
             beregning = innvilgetBeregning,
             simulering = simulering,
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now(clock))),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now(clock))),
             fritekstTilBrev = "JEPP",
             revurderingsårsak = Revurderingsårsak(
                 Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
@@ -752,7 +752,7 @@ internal class LagBrevRequestVisitorTest {
             oppgaveId = OppgaveId("15"),
             beregning = innvilgetBeregning,
             simulering = simulering,
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now())),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now())),
             fritekstTilBrev = "FRITEKST REVURDERING",
             revurderingsårsak = Revurderingsårsak(
                 Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
@@ -836,7 +836,7 @@ internal class LagBrevRequestVisitorTest {
             oppgaveId = OppgaveId("15"),
             beregning = innvilgetBeregning,
             simulering = simulering,
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now(clock))),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now(clock))),
             fritekstTilBrev = "FRITEKST REVURDERING",
             revurderingsårsak = Revurderingsårsak(
                 Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
@@ -923,7 +923,7 @@ internal class LagBrevRequestVisitorTest {
             saksbehandler = saksbehandler,
             oppgaveId = OppgaveId("15"),
             beregning = innvilgetBeregning,
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now())),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now())),
             fritekstTilBrev = "EN FIN FRITEKST",
             revurderingsårsak = Revurderingsårsak(
                 Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
@@ -1071,6 +1071,6 @@ internal class LagBrevRequestVisitorTest {
             ),
         ),
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
-        attesteringer = AttesteringHistorik.empty()
+        attesteringer = Attesteringshistorikk.empty()
     )
 }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -13,7 +13,7 @@ import no.nav.su.se.bakover.database.revurdering.RevurderingRepo
 import no.nav.su.se.bakover.database.vedtak.VedtakRepo
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.avslag.Opphørsgrunn
 import no.nav.su.se.bakover.domain.beregning.Beregning
@@ -184,7 +184,7 @@ internal class RevurderingServiceImpl(
                 grunnlagsdata = grunnlagsdata,
                 vilkårsvurderinger = vilkårsvurderinger,
                 informasjonSomRevurderes = informasjonSomRevurderes,
-                attesteringer = AttesteringHistorik.empty()
+                attesteringer = Attesteringshistorikk.empty()
             ).also {
                 revurderingRepo.lagre(it)
 
@@ -909,7 +909,7 @@ internal class RevurderingServiceImpl(
                 val iverksattRevurdering = when (revurdering) {
                     is RevurderingTilAttestering.IngenEndring -> {
 
-                        revurdering.tilIverksatt(attestant)
+                        revurdering.tilIverksatt(attestant, clock)
                             .map { iverksattRevurdering ->
                                 if (revurdering.skalFøreTilBrevutsending) {
                                     ferdigstillVedtakService.journalførOgLagre(Vedtak.from(iverksattRevurdering, clock))
@@ -927,7 +927,7 @@ internal class RevurderingServiceImpl(
                             }
                     }
                     is RevurderingTilAttestering.Innvilget -> {
-                        revurdering.tilIverksatt(attestant) {
+                        revurdering.tilIverksatt(attestant, clock) {
                             utbetalingService.utbetal(
                                 sakId = revurdering.sakId,
                                 beregning = revurdering.beregning,
@@ -950,7 +950,7 @@ internal class RevurderingServiceImpl(
                         }
                     }
                     is RevurderingTilAttestering.Opphørt -> {
-                        revurdering.tilIverksatt(attestant) {
+                        revurdering.tilIverksatt(attestant, clock) {
                             utbetalingService.opphør(
                                 sakId = revurdering.sakId,
                                 attestant = attestant,

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -13,6 +13,7 @@ import no.nav.su.se.bakover.database.revurdering.RevurderingRepo
 import no.nav.su.se.bakover.database.vedtak.VedtakRepo
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.avslag.Opphørsgrunn
 import no.nav.su.se.bakover.domain.beregning.Beregning
@@ -183,6 +184,7 @@ internal class RevurderingServiceImpl(
                 grunnlagsdata = grunnlagsdata,
                 vilkårsvurderinger = vilkårsvurderinger,
                 informasjonSomRevurderes = informasjonSomRevurderes,
+                attesteringer = AttesteringHistorik.empty()
             ).also {
                 revurderingRepo.lagre(it)
 

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/statistikk/SøknadsbehandlingStatistikkMapper.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/statistikk/SøknadsbehandlingStatistikkMapper.kt
@@ -34,7 +34,7 @@ internal class SøknadsbehandlingStatistikkMapper(
             is Søknadsbehandling.Iverksatt -> {
                 copy(
                     saksbehandler = søknadsbehandling.saksbehandler.navIdent,
-                    beslutter = søknadsbehandling.attestering.attestant.navIdent,
+                    beslutter = søknadsbehandling.attesteringer.hentSisteAttestering().attestant.navIdent,
                     resultat = ResultatOgBegrunnelseMapper.map(søknadsbehandling).resultat,
                     resultatBegrunnelse = ResultatOgBegrunnelseMapper.map(søknadsbehandling).begrunnelse,
                     avsluttet = true,
@@ -48,7 +48,7 @@ internal class SøknadsbehandlingStatistikkMapper(
             is Søknadsbehandling.Underkjent -> {
                 copy(
                     saksbehandler = søknadsbehandling.saksbehandler.navIdent,
-                    beslutter = søknadsbehandling.attestering.attestant.navIdent,
+                    beslutter = søknadsbehandling.attesteringer.hentSisteAttestering().attestant.navIdent,
                 )
             }
             else -> throw ManglendeStatistikkMappingException(this, søknadsbehandling::class.java)

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OppdaterRevurderingServiceTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OppdaterRevurderingServiceTest.kt
@@ -19,7 +19,7 @@ import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.database.revurdering.RevurderingRepo
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.beregning.Beregning
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragFactory
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragTilhører
@@ -263,10 +263,10 @@ internal class OppdaterRevurderingServiceTest {
                     fritekstTilBrev = it.fritekstTilBrev,
                     revurderingsårsak = it.revurderingsårsak,
                     beregning = mock(),
-                    attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(
+                    attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(
                         Attestering.Iverksatt(
                             attestant = NavIdentBruker.Attestant("navIdent"),
-                            tidspunkt = fixedTidspunkt
+                            opprettet = fixedTidspunkt
                         )
                     ),
                     behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OppdaterRevurderingServiceTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OppdaterRevurderingServiceTest.kt
@@ -19,6 +19,7 @@ import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.database.revurdering.RevurderingRepo
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.beregning.Beregning
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragFactory
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragTilhører
@@ -262,8 +263,11 @@ internal class OppdaterRevurderingServiceTest {
                     fritekstTilBrev = it.fritekstTilBrev,
                     revurderingsårsak = it.revurderingsårsak,
                     beregning = mock(),
-                    attestering = Attestering.Iverksatt(
-                        attestant = NavIdentBruker.Attestant("navIdent"),
+                    attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(
+                        Attestering.Iverksatt(
+                            attestant = NavIdentBruker.Attestant("navIdent"),
+                            tidspunkt = fixedTidspunkt
+                        )
                     ),
                     behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,
                     simulering = mock(),
@@ -588,7 +592,7 @@ internal class OppdaterRevurderingServiceTest {
         val revurderingBeregning = lagBeregning(revurderingsperiode)
 
         val revurdering = mock<IverksattRevurdering.Innvilget> {
-            on { attestering } doReturn Attestering.Iverksatt(NavIdentBruker.Attestant("attestantSomIverksatte"))
+            on { attestering } doReturn Attestering.Iverksatt(NavIdentBruker.Attestant("attestantSomIverksatte"), fixedTidspunkt)
             on { behandlingsinformasjon } doReturn mock()
 
             on { periode } doReturn revurderingsperiode
@@ -671,7 +675,7 @@ internal class OppdaterRevurderingServiceTest {
         val revurderingBeregning = lagBeregning(revurderingsperiode)
 
         val revurdering = mock<IverksattRevurdering.Innvilget> {
-            on { attestering } doReturn Attestering.Iverksatt(NavIdentBruker.Attestant("attestantSomIverksatte"))
+            on { attestering } doReturn Attestering.Iverksatt(NavIdentBruker.Attestant("attestantSomIverksatte"), fixedTidspunkt)
             on { behandlingsinformasjon } doReturn mock()
 
             on { periode } doReturn revurderingsperiode

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OpprettRevurderingServiceTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OpprettRevurderingServiceTest.kt
@@ -25,7 +25,7 @@ import no.nav.su.se.bakover.domain.CopyArgs
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandling
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
@@ -579,7 +579,7 @@ internal class OpprettRevurderingServiceTest {
                 oppgaveId = OppgaveId("null"),
                 beregning = opprinneligVedtak.beregning,
                 simulering = opprinneligVedtak.simulering,
-                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(opprinneligVedtak.attestant, fixedTidspunkt)),
+                attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(opprinneligVedtak.attestant, fixedTidspunkt)),
                 fritekstTilBrev = "",
                 revurderingsårsak = revurderingsårsak,
                 forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OpprettRevurderingServiceTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OpprettRevurderingServiceTest.kt
@@ -25,6 +25,7 @@ import no.nav.su.se.bakover.domain.CopyArgs
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandling
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
@@ -578,7 +579,7 @@ internal class OpprettRevurderingServiceTest {
                 oppgaveId = OppgaveId("null"),
                 beregning = opprinneligVedtak.beregning,
                 simulering = opprinneligVedtak.simulering,
-                attestering = Attestering.Iverksatt(opprinneligVedtak.attestant),
+                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(opprinneligVedtak.attestant, fixedTidspunkt)),
                 fritekstTilBrev = "",
                 revurderingsårsak = revurderingsårsak,
                 forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
@@ -893,7 +894,7 @@ internal class OpprettRevurderingServiceTest {
             tilOgMed = periodeNesteMånedOgTreMånederFram.tilOgMed,
         )
         val revurdering = mock<IverksattRevurdering.Innvilget> {
-            on { attestering } doReturn Attestering.Iverksatt(NavIdentBruker.Attestant("attestantSomIverksatte"))
+            on { attestering } doReturn Attestering.Iverksatt(NavIdentBruker.Attestant("attestantSomIverksatte"), fixedTidspunkt)
             on { behandlingsinformasjon } doReturn mock()
             on { periode } doReturn revurderingsperiode
             on { beregning } doReturn mock()
@@ -966,7 +967,7 @@ internal class OpprettRevurderingServiceTest {
         val revurderingBeregning = lagBeregning(revurderingsperiode)
 
         val revurdering = mock<IverksattRevurdering.Innvilget> {
-            on { attestering } doReturn Attestering.Iverksatt(NavIdentBruker.Attestant("attestantSomIverksatte"))
+            on { attestering } doReturn Attestering.Iverksatt(NavIdentBruker.Attestant("attestantSomIverksatte"), fixedTidspunkt)
             on { behandlingsinformasjon } doReturn mock()
 
             on { periode } doReturn revurderingsperiode

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RegulerGrunnbeløpServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RegulerGrunnbeløpServiceImplTest.kt
@@ -331,6 +331,7 @@ internal class RegulerGrunnbeløpServiceImplTest {
                     Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert,
                 ),
             ),
+            attesteringer = Attesteringshistorikk.empty()
         )
         val revurderingRepoMock = mock<RevurderingRepo> {
             on { hent(revurderingId) } doReturn opprettetRevurdering
@@ -393,6 +394,7 @@ internal class RegulerGrunnbeløpServiceImplTest {
                 on { resultat } doReturn Resultat.Innvilget
             },
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -511,6 +513,7 @@ internal class RegulerGrunnbeløpServiceImplTest {
                 on { resultat } doReturn Resultat.Innvilget
             },
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = Attesteringshistorikk.empty(),
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RegulerGrunnbeløpServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RegulerGrunnbeløpServiceImplTest.kt
@@ -21,6 +21,7 @@ import no.nav.su.se.bakover.database.vedtak.VedtakRepo
 import no.nav.su.se.bakover.domain.CopyArgs
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.beregning.Beregning
@@ -122,6 +123,7 @@ internal class RegulerGrunnbeløpServiceImplTest {
                     Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert,
                 ),
             ),
+            attesteringer = AttesteringHistorik.empty()
         )
 
         val nyttUføregrunnlag = Grunnlag.Uføregrunnlag(
@@ -158,6 +160,7 @@ internal class RegulerGrunnbeløpServiceImplTest {
                     Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert,
                 ),
             ),
+            attesteringer = AttesteringHistorik.empty()
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -439,7 +442,7 @@ internal class RegulerGrunnbeløpServiceImplTest {
             behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
             beregning = TestBeregning,
             simulering = mock(),
-            attestering = mock(),
+            attesteringer = mock(),
             forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = mock {
@@ -547,6 +550,7 @@ internal class RegulerGrunnbeløpServiceImplTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = actual.vilkårsvurderinger,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = AttesteringHistorik.empty(),
         )
 
         inOrder(revurderingRepoMock, personServiceMock, oppgaveServiceMock) {
@@ -576,7 +580,7 @@ internal class RegulerGrunnbeløpServiceImplTest {
             revurderingsårsak = revurderingsårsakRegulerGrunnbeløp,
             behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
             beregning = TestBeregning,
-            attestering = mock(),
+            attesteringer = mock(),
             skalFøreTilBrevutsending = true,
             forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
             grunnlagsdata = Grunnlagsdata.EMPTY,
@@ -627,6 +631,7 @@ internal class RegulerGrunnbeløpServiceImplTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = actual.vilkårsvurderinger,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = AttesteringHistorik.empty(),
         )
 
         inOrder(revurderingRepoMock, personServiceMock, oppgaveServiceMock) {
@@ -655,7 +660,7 @@ internal class RegulerGrunnbeløpServiceImplTest {
             saksbehandler = saksbehandler,
             oppgaveId = OppgaveId(value = "OppgaveId"),
             beregning = TestBeregning,
-            attestering = Attestering.Iverksatt(attestant),
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.EPOCH)),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
             behandlingsinformasjon = søknadsbehandlingsvedtakIverksattInnvilget.behandlingsinformasjon,
@@ -681,6 +686,7 @@ internal class RegulerGrunnbeløpServiceImplTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = AttesteringHistorik.empty(),
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
@@ -14,6 +14,7 @@ import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.database.revurdering.RevurderingRepo
 import no.nav.su.se.bakover.database.vedtak.VedtakRepo
 import no.nav.su.se.bakover.domain.NavIdentBruker
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.brev.BrevbestillingId
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
@@ -307,7 +308,7 @@ class RevurderingIngenEndringTest {
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
             forhåndsvarsel = null,
-            attestering = attesteringUnderkjent,
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(attesteringUnderkjent),
             skalFøreTilBrevutsending = false,
             behandlingsinformasjon = søknadsbehandlingsvedtakIverksattInnvilget.behandlingsinformasjon,
             grunnlagsdata = Grunnlagsdata.EMPTY,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
@@ -160,6 +160,7 @@ class RevurderingIngenEndringTest {
                         Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert,
                     ),
                 ),
+                attesteringer = Attesteringshistorikk.empty()
             ),
             // beregningstypen er internal i domene modulen
             BeregnetRevurdering.IngenEndring::beregning,
@@ -197,6 +198,7 @@ class RevurderingIngenEndringTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = vilkårsvurderingerMock,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = Attesteringshistorikk.empty()
         )
         val endretSaksbehandler = NavIdentBruker.Saksbehandler("endretSaksbehandler")
         val revurderingTilAttestering = RevurderingTilAttestering.IngenEndring(
@@ -215,6 +217,7 @@ class RevurderingIngenEndringTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = vilkårsvurderingerMock,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = Attesteringshistorikk.empty()
         )
         val revurderingRepoMock = mock<RevurderingRepo> {
             on { hent(any()) } doReturn beregnetRevurdering
@@ -296,6 +299,7 @@ class RevurderingIngenEndringTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = Attesteringshistorikk.empty()
         )
         val underkjentRevurdering = UnderkjentRevurdering.IngenEndring(
             id = revurderingId,
@@ -390,6 +394,7 @@ class RevurderingIngenEndringTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = Attesteringshistorikk.empty()
         )
         val attestant = NavIdentBruker.Attestant("ATTT")
         val iverksattRevurdering = revurderingTilAttestering.tilIverksatt(attestant).orNull()!!
@@ -453,6 +458,7 @@ class RevurderingIngenEndringTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = Attesteringshistorikk.empty()
         )
         val attestant = NavIdentBruker.Attestant("ATTT")
         val iverksattRevurdering = revurderingTilAttestering.tilIverksatt(attestant).orNull()!!

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
@@ -397,7 +397,7 @@ class RevurderingIngenEndringTest {
             attesteringer = Attesteringshistorikk.empty()
         )
         val attestant = NavIdentBruker.Attestant("ATTT")
-        val iverksattRevurdering = revurderingTilAttestering.tilIverksatt(attestant).orNull()!!
+        val iverksattRevurdering = revurderingTilAttestering.tilIverksatt(attestant, fixedClock).orNull()!!
         val vedtak = Vedtak.from(iverksattRevurdering, fixedClock)
         val journalførtVedtak = vedtak.journalfør { JournalpostId("journalført").right() }.orNull()!!
         val vedtakMedDistribuertBrev = journalførtVedtak.distribuerBrev { BrevbestillingId("bestiltBrev").right() }.orNull()!!
@@ -461,7 +461,7 @@ class RevurderingIngenEndringTest {
             attesteringer = Attesteringshistorikk.empty()
         )
         val attestant = NavIdentBruker.Attestant("ATTT")
-        val iverksattRevurdering = revurderingTilAttestering.tilIverksatt(attestant).orNull()!!
+        val iverksattRevurdering = revurderingTilAttestering.tilIverksatt(attestant, fixedClock).orNull()!!
         val vedtak = Vedtak.from(iverksattRevurdering, fixedClock)
 
         val revurderingRepoMock = mock<RevurderingRepo> {

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
@@ -14,7 +14,7 @@ import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.database.revurdering.RevurderingRepo
 import no.nav.su.se.bakover.database.vedtak.VedtakRepo
 import no.nav.su.se.bakover.domain.NavIdentBruker
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.brev.BrevbestillingId
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
@@ -308,7 +308,7 @@ class RevurderingIngenEndringTest {
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
             forhåndsvarsel = null,
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(attesteringUnderkjent),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(attesteringUnderkjent),
             skalFøreTilBrevutsending = false,
             behandlingsinformasjon = søknadsbehandlingsvedtakIverksattInnvilget.behandlingsinformasjon,
             grunnlagsdata = Grunnlagsdata.EMPTY,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingLeggTilFormueServiceTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingLeggTilFormueServiceTest.kt
@@ -15,6 +15,7 @@ import no.nav.su.se.bakover.common.mars
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.common.zoneIdOslo
 import no.nav.su.se.bakover.database.revurdering.RevurderingRepo
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragFactory
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragTilhører
@@ -533,5 +534,6 @@ internal class RevurderingLeggTilFormueServiceTest {
         ),
         vilkårsvurderinger = vilkårsvurderinger,
         informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+        attesteringer = Attesteringshistorikk.empty()
     )
 }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
@@ -32,6 +32,7 @@ import no.nav.su.se.bakover.database.vedtak.VedtakRepo
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Person
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragFactory
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragTilhører
 import no.nav.su.se.bakover.domain.beregning.fradrag.Fradragstype
@@ -369,7 +370,7 @@ internal class RevurderingServiceImplTest {
             oppgaveId = OppgaveId(value = "OppgaveId"),
             beregning = TestBeregning,
             simulering = testsimulering,
-            attestering = Attestering.Iverksatt(attestant),
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.EPOCH)),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
             forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
@@ -544,6 +545,7 @@ internal class RevurderingServiceImplTest {
             attestant = NavIdentBruker.Attestant(navIdent = "123"),
             grunn = Attestering.Underkjent.Grunn.BEREGNINGEN_ER_FEIL,
             kommentar = "pls math",
+            tidspunkt = Tidspunkt.EPOCH
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -607,6 +609,7 @@ internal class RevurderingServiceImplTest {
             attestant = NavIdentBruker.Attestant(navIdent = "123"),
             grunn = Attestering.Underkjent.Grunn.BEREGNINGEN_ER_FEIL,
             kommentar = "pls math",
+            tidspunkt = Tidspunkt.EPOCH
         )
         val uføregrunnlag = Grunnlag.Uføregrunnlag(
             periode = periodeNesteMånedOgTreMånederFram,
@@ -626,7 +629,7 @@ internal class RevurderingServiceImplTest {
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
             forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
-            attestering = attestering,
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(attestering),
             behandlingsinformasjon = søknadsbehandlingsvedtakIverksattInnvilget.behandlingsinformasjon,
             grunnlagsdata = Grunnlagsdata(
                 fradragsgrunnlag = listOf(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
@@ -237,6 +237,7 @@ internal class RevurderingServiceImplTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -399,6 +400,7 @@ internal class RevurderingServiceImplTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -476,6 +478,7 @@ internal class RevurderingServiceImplTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = Attesteringshistorikk.empty()
         )
         val attestant = NavIdentBruker.Attestant("ATTT")
 
@@ -544,6 +547,7 @@ internal class RevurderingServiceImplTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val attestering = Attestering.Underkjent(
@@ -765,6 +769,7 @@ internal class RevurderingServiceImplTest {
             ),
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -995,6 +1000,7 @@ internal class RevurderingServiceImplTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = Attesteringshistorikk.empty()
         )
         val revurderingRepoMock = mock<RevurderingRepo> {
             on { hent(any()) } doReturn beregnetRevurdering
@@ -1051,6 +1057,7 @@ internal class RevurderingServiceImplTest {
                 formue = formueVilkår(periodeNesteMånedOgTreMånederFram),
             ),
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -1277,6 +1284,7 @@ internal class RevurderingServiceImplTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = Attesteringshistorikk.empty()
         )
         testForhåndsvarslerIkkeGittRevurdering(beregnet)
     }
@@ -1454,6 +1462,7 @@ internal class RevurderingServiceImplTest {
                 on { resultat } doReturn Resultat.Innvilget
             },
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -1540,6 +1549,7 @@ internal class RevurderingServiceImplTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingTestUtils.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingTestUtils.kt
@@ -75,9 +75,10 @@ object RevurderingTestUtils {
         begrunnelse = "begrunnelsen for perioden",
     )
     internal val attesteringUnderkjent = Attestering.Underkjent(
-        NavIdentBruker.Attestant("Attes T. Ant"),
-        Attestering.Underkjent.Grunn.BEREGNINGEN_ER_FEIL,
-        "kommentar",
+        attestant = NavIdentBruker.Attestant("Attes T. Ant"),
+        grunn = Attestering.Underkjent.Grunn.BEREGNINGEN_ER_FEIL,
+        kommentar = "kommentar",
+        tidspunkt = fixedTidspunkt
     )
 
     internal val beregning = no.nav.su.se.bakover.test.beregning(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingTestUtils.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingTestUtils.kt
@@ -78,7 +78,7 @@ object RevurderingTestUtils {
         attestant = NavIdentBruker.Attestant("Attes T. Ant"),
         grunn = Attestering.Underkjent.Grunn.BEREGNINGEN_ER_FEIL,
         kommentar = "kommentar",
-        tidspunkt = fixedTidspunkt
+        opprettet = fixedTidspunkt
     )
 
     internal val beregning = no.nav.su.se.bakover.test.beregning(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/RevurderingStatistikkMapperTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/RevurderingStatistikkMapperTest.kt
@@ -11,6 +11,7 @@ import no.nav.su.se.bakover.common.zoneIdOslo
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandling
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
@@ -121,7 +122,7 @@ internal class RevurderingStatistikkMapperTest {
             },
             simulering = mock(),
             grunnlagsdata = Grunnlagsdata.EMPTY,
-            attestering = Attestering.Iverksatt(NavIdentBruker.Attestant(navIdent = "2")),
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant(navIdent = "2"), Tidspunkt.now(fixedClock))),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
             forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
@@ -190,7 +191,7 @@ internal class RevurderingStatistikkMapperTest {
             beregning = mock {
                 on { this.periode } doReturn periode
             },
-            attestering = Attestering.Iverksatt(NavIdentBruker.Attestant(navIdent = "2")),
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant(navIdent = "2"), Tidspunkt.now(fixedClock))),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
             forhåndsvarsel = null,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/RevurderingStatistikkMapperTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/RevurderingStatistikkMapperTest.kt
@@ -11,7 +11,7 @@ import no.nav.su.se.bakover.common.zoneIdOslo
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandling
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
@@ -122,7 +122,7 @@ internal class RevurderingStatistikkMapperTest {
             },
             simulering = mock(),
             grunnlagsdata = Grunnlagsdata.EMPTY,
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant(navIdent = "2"), Tidspunkt.now(fixedClock))),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant(navIdent = "2"), Tidspunkt.now(fixedClock))),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
             forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
@@ -191,7 +191,7 @@ internal class RevurderingStatistikkMapperTest {
             beregning = mock {
                 on { this.periode } doReturn periode
             },
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant(navIdent = "2"), Tidspunkt.now(fixedClock))),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant(navIdent = "2"), Tidspunkt.now(fixedClock))),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
             forhåndsvarsel = null,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/StatistikkServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/StatistikkServiceImplTest.kt
@@ -23,7 +23,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandling
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.avslag.Avslagsgrunn
@@ -251,7 +251,7 @@ internal class StatistikkServiceImplTest {
             on { status } doReturn BehandlingsStatus.IVERKSATT_INNVILGET
             on { beregning } doReturn beregningMock
             on { saksbehandler } doReturn NavIdentBruker.Saksbehandler("55")
-            on { attesteringer } doReturn AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("56"), Tidspunkt.now()))
+            on { attesteringer } doReturn Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("56"), Tidspunkt.now()))
             on { periode } doReturn Periode.create(1.januar(2021), 31.desember(2021))
         }
 
@@ -300,7 +300,7 @@ internal class StatistikkServiceImplTest {
             on { saksnummer } doReturn Saksnummer(5959)
             on { status } doReturn BehandlingsStatus.IVERKSATT_AVSLAG
             on { saksbehandler } doReturn NavIdentBruker.Saksbehandler("55")
-            on { attesteringer } doReturn AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("56"), Tidspunkt.now()))
+            on { attesteringer } doReturn Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("56"), Tidspunkt.now()))
             on { avslagsgrunner } doReturn listOf(Avslagsgrunn.UFØRHET, Avslagsgrunn.UTENLANDSOPPHOLD_OVER_90_DAGER)
             on { periode } doReturn Periode.create(1.januar(2021), 31.desember(2021))
         }
@@ -356,12 +356,12 @@ internal class StatistikkServiceImplTest {
             beregning = beregning,
             simulering = mock(),
             saksbehandler = NavIdentBruker.Saksbehandler("saksbehandler"),
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(
                 Attestering.Underkjent(
                     attestant = NavIdentBruker.Attestant("attestant"),
                     grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
                     kommentar = "",
-                    tidspunkt = Tidspunkt.now(clock)
+                    opprettet = Tidspunkt.now(clock)
                 )
             ),
             fritekstTilBrev = "",
@@ -550,7 +550,7 @@ internal class StatistikkServiceImplTest {
                 periodeList = listOf(),
             ),
             grunnlagsdata = Grunnlagsdata.EMPTY,
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), Tidspunkt.now(clock))),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), Tidspunkt.now(clock))),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
             forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/StatistikkServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/StatistikkServiceImplTest.kt
@@ -23,6 +23,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandling
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.avslag.Avslagsgrunn
@@ -250,7 +251,7 @@ internal class StatistikkServiceImplTest {
             on { status } doReturn BehandlingsStatus.IVERKSATT_INNVILGET
             on { beregning } doReturn beregningMock
             on { saksbehandler } doReturn NavIdentBruker.Saksbehandler("55")
-            on { attestering } doReturn Attestering.Iverksatt(NavIdentBruker.Attestant("56"))
+            on { attesteringer } doReturn AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("56"), Tidspunkt.now()))
             on { periode } doReturn Periode.create(1.januar(2021), 31.desember(2021))
         }
 
@@ -299,7 +300,7 @@ internal class StatistikkServiceImplTest {
             on { saksnummer } doReturn Saksnummer(5959)
             on { status } doReturn BehandlingsStatus.IVERKSATT_AVSLAG
             on { saksbehandler } doReturn NavIdentBruker.Saksbehandler("55")
-            on { attestering } doReturn Attestering.Iverksatt(NavIdentBruker.Attestant("56"))
+            on { attesteringer } doReturn AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("56"), Tidspunkt.now()))
             on { avslagsgrunner } doReturn listOf(Avslagsgrunn.UFØRHET, Avslagsgrunn.UTENLANDSOPPHOLD_OVER_90_DAGER)
             on { periode } doReturn Periode.create(1.januar(2021), 31.desember(2021))
         }
@@ -355,10 +356,13 @@ internal class StatistikkServiceImplTest {
             beregning = beregning,
             simulering = mock(),
             saksbehandler = NavIdentBruker.Saksbehandler("saksbehandler"),
-            attestering = Attestering.Underkjent(
-                NavIdentBruker.Attestant("attestant"),
-                Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
-                "",
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(
+                Attestering.Underkjent(
+                    attestant = NavIdentBruker.Attestant("attestant"),
+                    grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
+                    kommentar = "",
+                    tidspunkt = Tidspunkt.now(clock)
+                )
             ),
             fritekstTilBrev = "",
             stønadsperiode = Stønadsperiode.create(Periode.create(1.januar(2021), 31.desember(2021))),
@@ -546,7 +550,7 @@ internal class StatistikkServiceImplTest {
                 periodeList = listOf(),
             ),
             grunnlagsdata = Grunnlagsdata.EMPTY,
-            attestering = Attestering.Iverksatt(NavIdentBruker.Attestant("attestant")),
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), Tidspunkt.now(clock))),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
             forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/StatistikkServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/StatistikkServiceImplTest.kt
@@ -490,6 +490,7 @@ internal class StatistikkServiceImplTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val expected = Statistikk.Behandling(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/SøknadsbehandlingStatistikkMapperTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/SøknadsbehandlingStatistikkMapperTest.kt
@@ -15,6 +15,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
@@ -110,7 +111,7 @@ internal class SøknadsbehandlingStatistikkMapperTest {
             resultatBegrunnelse = null,
             resultatBegrunnelseBeskrivelse = null,
             resultatBeskrivelse = null,
-            beslutter = iverksattSøknadsbehandling.attestering.attestant.navIdent,
+            beslutter = iverksattSøknadsbehandling.attesteringer.hentSisteAttestering().attestant.navIdent,
             saksbehandler = iverksattSøknadsbehandling.saksbehandler.navIdent,
             behandlingOpprettetAv = null,
             behandlingOpprettetType = null,
@@ -296,6 +297,7 @@ internal class SøknadsbehandlingStatistikkMapperTest {
         stønadsperiode = Stønadsperiode.create(Periode.create(1.januar(2021), 31.desember(2021))),
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+        attesteringer = AttesteringHistorik.empty()
     )
 
     private val beregning = TestBeregning
@@ -314,6 +316,7 @@ internal class SøknadsbehandlingStatistikkMapperTest {
     private val iverksattSøknadsbehandling = tilAttesteringSøknadsbehandling.tilIverksatt(
         Attestering.Iverksatt(
             NavIdentBruker.Attestant("att"),
+            Tidspunkt.now(fixedClock)
         ),
     )
 }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/SøknadsbehandlingStatistikkMapperTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/SøknadsbehandlingStatistikkMapperTest.kt
@@ -15,7 +15,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
@@ -297,7 +297,7 @@ internal class SøknadsbehandlingStatistikkMapperTest {
         stønadsperiode = Stønadsperiode.create(Periode.create(1.januar(2021), 31.desember(2021))),
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
-        attesteringer = AttesteringHistorik.empty()
+        attesteringer = Attesteringshistorikk.empty()
     )
 
     private val beregning = TestBeregning

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceAttesteringTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceAttesteringTest.kt
@@ -20,6 +20,7 @@ import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
@@ -82,6 +83,7 @@ class SøknadsbehandlingServiceAttesteringTest {
         stønadsperiode = stønadsperiode,
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+        attesteringer = Attesteringshistorikk.empty()
     )
 
     private val saksbehandler = NavIdentBruker.Saksbehandler("Z12345")
@@ -127,6 +129,7 @@ class SøknadsbehandlingServiceAttesteringTest {
             stønadsperiode = simulertBehandling.stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         actual shouldBe expected.right()
@@ -283,6 +286,7 @@ class SøknadsbehandlingServiceAttesteringTest {
             stønadsperiode = simulertBehandling.stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         actual shouldBe expected.right()

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceBeregningTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceBeregningTest.kt
@@ -17,6 +17,7 @@ import no.nav.su.se.bakover.database.søknadsbehandling.SøknadsbehandlingRepo
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragFactory
@@ -72,6 +73,7 @@ class SøknadsbehandlingServiceBeregningTest {
             ),
         ),
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+        attesteringer = Attesteringshistorikk.empty()
     )
 
     @Test
@@ -128,6 +130,7 @@ class SøknadsbehandlingServiceBeregningTest {
                 ),
             ),
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         response shouldBe expected.right()

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceBrevTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceBrevTest.kt
@@ -18,6 +18,7 @@ import no.nav.su.se.bakover.domain.Ident
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Person
 import no.nav.su.se.bakover.domain.Saksnummer
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
@@ -67,6 +68,7 @@ internal class SøknadsbehandlingServiceBrevTest {
             ),
         ),
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+        attesteringer = Attesteringshistorikk.empty()
     )
 
     private val vilkårsvurdertUavklartSøknadsbehandling = Søknadsbehandling.Vilkårsvurdert.Uavklart(
@@ -82,6 +84,7 @@ internal class SøknadsbehandlingServiceBrevTest {
         stønadsperiode = stønadsperiode,
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+        attesteringer = Attesteringshistorikk.empty()
     )
 
     private val person = Person(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceGrunnlagBosituasjonTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceGrunnlagBosituasjonTest.kt
@@ -18,6 +18,7 @@ import no.nav.su.se.bakover.domain.NavIdentBruker.Saksbehandler
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
@@ -91,6 +92,7 @@ internal class SøknadsbehandlingServiceGrunnlagBosituasjonTest {
             stønadsperiode = stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+            attesteringer = Attesteringshistorikk.empty()
         ).tilAttestering(Saksbehandler("saksa"), "")
 
         val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
@@ -129,6 +131,7 @@ internal class SøknadsbehandlingServiceGrunnlagBosituasjonTest {
             stønadsperiode = stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val bosituasjon = Grunnlag.Bosituasjon.Ufullstendig.HarIkkeEps(
@@ -235,6 +238,7 @@ internal class SøknadsbehandlingServiceGrunnlagBosituasjonTest {
             stønadsperiode = stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+            attesteringer = Attesteringshistorikk.empty()
         ).tilAttestering(Saksbehandler("saksa"), "")
 
         val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
@@ -285,6 +289,7 @@ internal class SøknadsbehandlingServiceGrunnlagBosituasjonTest {
                 ),
             ),
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val bosituasjon = Grunnlag.Bosituasjon.Fullstendig.Enslig(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceIverksettTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceIverksettTest.kt
@@ -25,7 +25,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.BehandlingMetrics
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
@@ -276,7 +276,7 @@ internal class SøknadsbehandlingServiceIverksettTest {
             beregning = behandling.beregning,
             simulering = behandling.simulering,
             saksbehandler = behandling.saksbehandler,
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, attesteringstidspunkt)),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, attesteringstidspunkt)),
             fritekstTilBrev = "",
             stønadsperiode = behandling.stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
@@ -356,7 +356,7 @@ internal class SøknadsbehandlingServiceIverksettTest {
             fnr = behandling.fnr,
             beregning = behandling.beregning,
             saksbehandler = behandling.saksbehandler,
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, attesteringstidspunkt)),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, attesteringstidspunkt)),
             fritekstTilBrev = "",
             stønadsperiode = behandling.stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
@@ -524,7 +524,7 @@ internal class SøknadsbehandlingServiceIverksettTest {
             stønadsperiode = stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
 
     private val beregning = TestBeregning

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceIverksettTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceIverksettTest.kt
@@ -451,6 +451,7 @@ internal class SøknadsbehandlingServiceIverksettTest {
                 stønadsperiode = it.stønadsperiode,
                 grunnlagsdata = Grunnlagsdata.EMPTY,
                 vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+                attesteringer = Attesteringshistorikk.empty()
             )
         }
 
@@ -499,6 +500,7 @@ internal class SøknadsbehandlingServiceIverksettTest {
             stønadsperiode = stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+            attesteringer = Attesteringshistorikk.empty()
         )
 
     private fun avslagTilAttestering() =

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceIverksettTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceIverksettTest.kt
@@ -25,6 +25,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.BehandlingMetrics
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
@@ -74,6 +75,7 @@ internal class SøknadsbehandlingServiceIverksettTest {
     private val utbetalingId = UUID30.randomUUID()
     private val stønadsperiode = Stønadsperiode.create(Periode.create(1.januar(2021), 31.desember(2021)))
     val opprettet = Tidspunkt.now(fixedClock)
+
     private val utbetaling = Utbetaling.OversendtUtbetaling.UtenKvittering(
         id = utbetalingId,
         opprettet = opprettet,
@@ -106,7 +108,7 @@ internal class SøknadsbehandlingServiceIverksettTest {
 
         val response = createSøknadsbehandlingService(
             søknadsbehandlingRepo = søknadsbehandlingRepoMock,
-        ).iverksett(SøknadsbehandlingService.IverksettRequest(behandling.id, Attestering.Iverksatt(attestant)))
+        ).iverksett(SøknadsbehandlingService.IverksettRequest(behandling.id, Attestering.Iverksatt(attestant, Tidspunkt.now())))
 
         response shouldBe SøknadsbehandlingService.KunneIkkeIverksette.FantIkkeBehandling.left()
 
@@ -136,7 +138,7 @@ internal class SøknadsbehandlingServiceIverksettTest {
         val response = createSøknadsbehandlingService(
             søknadsbehandlingRepo = søknadsbehandlingRepoMock,
             utbetalingService = utbetalingServiceMock,
-        ).iverksett(SøknadsbehandlingService.IverksettRequest(behandling.id, Attestering.Iverksatt(attestant)))
+        ).iverksett(SøknadsbehandlingService.IverksettRequest(behandling.id, Attestering.Iverksatt(attestant, Tidspunkt.now())))
 
         response shouldBe SøknadsbehandlingService.KunneIkkeIverksette.KunneIkkeKontrollsimulere.left()
 
@@ -180,7 +182,7 @@ internal class SøknadsbehandlingServiceIverksettTest {
         val response = createSøknadsbehandlingService(
             søknadsbehandlingRepo = søknadsbehandlingRepoMock,
             utbetalingService = utbetalingServiceMock,
-        ).iverksett(SøknadsbehandlingService.IverksettRequest(behandling.id, Attestering.Iverksatt(attestant)))
+        ).iverksett(SøknadsbehandlingService.IverksettRequest(behandling.id, Attestering.Iverksatt(attestant, Tidspunkt.now())))
 
         response shouldBe SøknadsbehandlingService.KunneIkkeIverksette.SimuleringHarBlittEndretSidenSaksbehandlerSimulerte.left()
 
@@ -217,7 +219,7 @@ internal class SøknadsbehandlingServiceIverksettTest {
         val response = createSøknadsbehandlingService(
             søknadsbehandlingRepo = søknadsbehandlingRepoMock,
             utbetalingService = utbetalingServiceMock,
-        ).iverksett(SøknadsbehandlingService.IverksettRequest(behandling.id, Attestering.Iverksatt(attestant)))
+        ).iverksett(SøknadsbehandlingService.IverksettRequest(behandling.id, Attestering.Iverksatt(attestant, Tidspunkt.now())))
 
         response shouldBe SøknadsbehandlingService.KunneIkkeIverksette.KunneIkkeUtbetale.left()
 
@@ -253,13 +255,14 @@ internal class SøknadsbehandlingServiceIverksettTest {
         val vedtakRepoMock = mock<VedtakRepo>()
         val statistikkObserver = mock<EventObserver>()
 
+        val attesteringstidspunkt = Tidspunkt.now()
         val response = createSøknadsbehandlingService(
             søknadsbehandlingRepo = søknadsbehandlingRepoMock,
             utbetalingService = utbetalingServiceMock,
             behandlingMetrics = behandlingMetricsMock,
             vedtakRepo = vedtakRepoMock,
             observer = statistikkObserver,
-        ).iverksett(SøknadsbehandlingService.IverksettRequest(behandling.id, Attestering.Iverksatt(attestant)))
+        ).iverksett(SøknadsbehandlingService.IverksettRequest(behandling.id, Attestering.Iverksatt(attestant, attesteringstidspunkt)))
 
         val expected = Søknadsbehandling.Iverksatt.Innvilget(
             id = behandling.id,
@@ -273,7 +276,7 @@ internal class SøknadsbehandlingServiceIverksettTest {
             beregning = behandling.beregning,
             simulering = behandling.simulering,
             saksbehandler = behandling.saksbehandler,
-            attestering = Attestering.Iverksatt(attestant),
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, attesteringstidspunkt)),
             fritekstTilBrev = "",
             stønadsperiode = behandling.stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
@@ -321,6 +324,7 @@ internal class SøknadsbehandlingServiceIverksettTest {
     @Test
     fun `attesterer og iverksetter avslag hvis alt er ok`() {
         val behandling = avslagTilAttestering()
+        val attesteringstidspunkt = Tidspunkt.now()
 
         val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
             on { hent(any()) } doReturn behandling
@@ -352,7 +356,7 @@ internal class SøknadsbehandlingServiceIverksettTest {
             fnr = behandling.fnr,
             beregning = behandling.beregning,
             saksbehandler = behandling.saksbehandler,
-            attestering = Attestering.Iverksatt(attestant),
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, attesteringstidspunkt)),
             fritekstTilBrev = "",
             stønadsperiode = behandling.stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
@@ -369,7 +373,7 @@ internal class SøknadsbehandlingServiceIverksettTest {
             vedtakRepo = vedtakRepoMock,
             ferdigstillVedtakService = ferdigstillVedtakService,
             opprettVedtakssnapshotService = opprettVedtakssnapshotService,
-        ).iverksett(SøknadsbehandlingService.IverksettRequest(behandling.id, Attestering.Iverksatt(attestant)))
+        ).iverksett(SøknadsbehandlingService.IverksettRequest(behandling.id, Attestering.Iverksatt(attestant, attesteringstidspunkt)))
 
         response shouldBe expectedAvslag.right()
 
@@ -418,7 +422,7 @@ internal class SøknadsbehandlingServiceIverksettTest {
 
         val response = createSøknadsbehandlingService(
             søknadsbehandlingRepo = søknadsbehandlingRepoMock,
-        ).iverksett(SøknadsbehandlingService.IverksettRequest(behandling.id, Attestering.Iverksatt(attestant)))
+        ).iverksett(SøknadsbehandlingService.IverksettRequest(behandling.id, Attestering.Iverksatt(attestant, Tidspunkt.now())))
 
         response shouldBe SøknadsbehandlingService.KunneIkkeIverksette.AttestantOgSaksbehandlerKanIkkeVæreSammePerson.left()
 
@@ -459,7 +463,7 @@ internal class SøknadsbehandlingServiceIverksettTest {
         assertThrows<StatusovergangVisitor.UgyldigStatusovergangException> {
             createSøknadsbehandlingService(
                 søknadsbehandlingRepo = søknadsbehandlingRepoMock,
-            ).iverksett(SøknadsbehandlingService.IverksettRequest(behandling.id, Attestering.Iverksatt(attestant)))
+            ).iverksett(SøknadsbehandlingService.IverksettRequest(behandling.id, Attestering.Iverksatt(attestant, Tidspunkt.now())))
 
             inOrder(søknadsbehandlingRepoMock, ferdigstillVedtakServiceMock) {
                 verify(søknadsbehandlingRepoMock).hent(behandling.id)
@@ -520,6 +524,7 @@ internal class SøknadsbehandlingServiceIverksettTest {
             stønadsperiode = stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+            attesteringer = AttesteringHistorik.empty()
         )
 
     private val beregning = TestBeregning

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceOppdaterStønadsperiodeTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceOppdaterStønadsperiodeTest.kt
@@ -20,6 +20,7 @@ import no.nav.su.se.bakover.domain.NavIdentBruker.Saksbehandler
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
@@ -90,6 +91,7 @@ internal class SøknadsbehandlingServiceOppdaterStønadsperiodeTest {
             stønadsperiode = stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+            attesteringer = Attesteringshistorikk.empty()
         ).tilAttestering(Saksbehandler("saksa"), "")
 
         val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
@@ -127,6 +129,7 @@ internal class SøknadsbehandlingServiceOppdaterStønadsperiodeTest {
             stønadsperiode = null,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+            attesteringer = Attesteringshistorikk.empty()
         )
         val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
             on { hent(any()) } doReturn uavklart
@@ -173,6 +176,7 @@ internal class SøknadsbehandlingServiceOppdaterStønadsperiodeTest {
             stønadsperiode = stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = createVilkårsvurdering(stønadsperiode.periode, vilkårsvurderingId, grunnlagId),
+            attesteringer = Attesteringshistorikk.empty()
         )
         val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
             on { hent(any()) } doReturn uavklart

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceOpprettetTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceOpprettetTest.kt
@@ -20,6 +20,7 @@ import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.journal.JournalpostId
@@ -192,6 +193,7 @@ internal class SøknadsbehandlingServiceOpprettetTest {
             stønadsperiode = stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+            attesteringer = Attesteringshistorikk.empty()
         )
         val søknadService: SøknadService = mock {
             on { hentSøknad(any()) } doReturn søknad.right()

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceSimuleringTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceSimuleringTest.kt
@@ -20,6 +20,7 @@ import no.nav.su.se.bakover.domain.NavIdentBruker.Saksbehandler
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
@@ -70,6 +71,7 @@ internal class SøknadsbehandlingServiceSimuleringTest {
             stønadsperiode = beregnetBehandling.stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         response shouldBe expected.right()
@@ -158,6 +160,7 @@ internal class SøknadsbehandlingServiceSimuleringTest {
         stønadsperiode = stønadsperiode,
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+        attesteringer = Attesteringshistorikk.empty()
     )
 
     private val simulering = Simulering(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceUnderkjennTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceUnderkjennTest.kt
@@ -98,6 +98,7 @@ class SøknadsbehandlingServiceUnderkjennTest {
         stønadsperiode = stønadsperiode,
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+        attesteringer = Attesteringshistorikk.empty()
     )
 
     private val oppgaveConfig = OppgaveConfig.Saksbehandling(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceUnderkjennTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceUnderkjennTest.kt
@@ -24,7 +24,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.BehandlingMetrics
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
@@ -66,7 +66,7 @@ class SøknadsbehandlingServiceUnderkjennTest {
         attestant = NavIdentBruker.Attestant("a"),
         grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
         kommentar = "begrunnelse",
-        tidspunkt = Tidspunkt.now()
+        opprettet = Tidspunkt.now()
     )
 
     private val innvilgetBehandlingTilAttestering = Søknadsbehandling.TilAttestering.Innvilget(
@@ -216,7 +216,7 @@ class SøknadsbehandlingServiceUnderkjennTest {
                     attestant = attestantSomErLikSaksbehandler,
                     grunn = underkjentAttestering.grunn,
                     kommentar = underkjentAttestering.kommentar,
-                    tidspunkt = Tidspunkt.now()
+                    opprettet = Tidspunkt.now()
                 )
             )
         )
@@ -359,7 +359,7 @@ class SøknadsbehandlingServiceUnderkjennTest {
             beregning = innvilgetBehandlingTilAttestering.beregning,
             simulering = innvilgetBehandlingTilAttestering.simulering,
             saksbehandler = innvilgetBehandlingTilAttestering.saksbehandler,
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(underkjentAttestering),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(underkjentAttestering),
             fritekstTilBrev = "",
             stønadsperiode = innvilgetBehandlingTilAttestering.stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
@@ -444,7 +444,7 @@ class SøknadsbehandlingServiceUnderkjennTest {
             beregning = innvilgetBehandlingTilAttestering.beregning,
             simulering = innvilgetBehandlingTilAttestering.simulering,
             saksbehandler = innvilgetBehandlingTilAttestering.saksbehandler,
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(underkjentAttestering),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(underkjentAttestering),
             fritekstTilBrev = "",
             stønadsperiode = innvilgetBehandlingTilAttestering.stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceUnderkjennTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceUnderkjennTest.kt
@@ -24,6 +24,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.BehandlingMetrics
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
@@ -64,7 +65,8 @@ class SøknadsbehandlingServiceUnderkjennTest {
     private val underkjentAttestering = Attestering.Underkjent(
         attestant = NavIdentBruker.Attestant("a"),
         grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
-        kommentar = "begrunnelse"
+        kommentar = "begrunnelse",
+        tidspunkt = Tidspunkt.now()
     )
 
     private val innvilgetBehandlingTilAttestering = Søknadsbehandling.TilAttestering.Innvilget(
@@ -147,7 +149,8 @@ class SøknadsbehandlingServiceUnderkjennTest {
     fun `Feil behandlingsstatus`() {
         val behandling: Søknadsbehandling.Iverksatt.Innvilget = innvilgetBehandlingTilAttestering.tilIverksatt(
             Attestering.Iverksatt(
-                NavIdentBruker.Attestant("attestant")
+                NavIdentBruker.Attestant("attestant"),
+                Tidspunkt.now()
             )
         )
 
@@ -212,7 +215,8 @@ class SøknadsbehandlingServiceUnderkjennTest {
                 attestering = Attestering.Underkjent(
                     attestant = attestantSomErLikSaksbehandler,
                     grunn = underkjentAttestering.grunn,
-                    kommentar = underkjentAttestering.kommentar
+                    kommentar = underkjentAttestering.kommentar,
+                    tidspunkt = Tidspunkt.now()
                 )
             )
         )
@@ -355,7 +359,7 @@ class SøknadsbehandlingServiceUnderkjennTest {
             beregning = innvilgetBehandlingTilAttestering.beregning,
             simulering = innvilgetBehandlingTilAttestering.simulering,
             saksbehandler = innvilgetBehandlingTilAttestering.saksbehandler,
-            attestering = underkjentAttestering,
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(underkjentAttestering),
             fritekstTilBrev = "",
             stønadsperiode = innvilgetBehandlingTilAttestering.stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
@@ -440,7 +444,7 @@ class SøknadsbehandlingServiceUnderkjennTest {
             beregning = innvilgetBehandlingTilAttestering.beregning,
             simulering = innvilgetBehandlingTilAttestering.simulering,
             saksbehandler = innvilgetBehandlingTilAttestering.saksbehandler,
-            attestering = underkjentAttestering,
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(underkjentAttestering),
             fritekstTilBrev = "",
             stønadsperiode = innvilgetBehandlingTilAttestering.stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceVilkårsvurderingTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceVilkårsvurderingTest.kt
@@ -22,7 +22,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.behandling.withVilkårAvslått
@@ -188,7 +188,7 @@ internal class SøknadsbehandlingServiceVilkårsvurderingTest {
             beregning = testBeregning,
             simulering = simulering,
             saksbehandler = saksbehandler,
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now())),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now())),
             fritekstTilBrev = "",
             stønadsperiode = opprettetBehandling.stønadsperiode!!,
             grunnlagsdata = Grunnlagsdata.EMPTY,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceVilkårsvurderingTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceVilkårsvurderingTest.kt
@@ -67,6 +67,7 @@ internal class SøknadsbehandlingServiceVilkårsvurderingTest {
         stønadsperiode = stønadsperiode,
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+        attesteringer = Attesteringshistorikk.empty()
     )
 
     @Test
@@ -107,6 +108,7 @@ internal class SøknadsbehandlingServiceVilkårsvurderingTest {
             stønadsperiode = opprettetBehandling.stønadsperiode!!,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
@@ -148,6 +150,7 @@ internal class SøknadsbehandlingServiceVilkårsvurderingTest {
             stønadsperiode = opprettetBehandling.stønadsperiode!!,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceVilkårsvurderingTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceVilkårsvurderingTest.kt
@@ -22,6 +22,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.behandling.withVilkårAvslått
@@ -187,7 +188,7 @@ internal class SøknadsbehandlingServiceVilkårsvurderingTest {
             beregning = testBeregning,
             simulering = simulering,
             saksbehandler = saksbehandler,
-            attestering = Attestering.Iverksatt(attestant),
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now())),
             fritekstTilBrev = "",
             stønadsperiode = opprettetBehandling.stønadsperiode!!,
             grunnlagsdata = Grunnlagsdata.EMPTY,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/vedtak/FerdigstillVedtakServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/vedtak/FerdigstillVedtakServiceImplTest.kt
@@ -32,6 +32,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.BehandlingMetrics
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.avslag.Avslag
@@ -618,7 +619,7 @@ internal class FerdigstillVedtakServiceImplTest {
                         .withAlleVilkårOppfylt(),
                     beregning = TestBeregning,
                     saksbehandler = saksbehandler,
-                    attestering = Attestering.Iverksatt(attestant),
+                    attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now())),
                     fritekstTilBrev = "",
                     periode = it.periode,
                     tilRevurdering = it,
@@ -1352,7 +1353,7 @@ internal class FerdigstillVedtakServiceImplTest {
                 behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
                 fnr = FnrGenerator.random(),
                 beregning = TestBeregning,
-                attestering = Attestering.Iverksatt(attestant),
+                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.EPOCH)),
                 saksbehandler = saksbehandler,
                 fritekstTilBrev = "",
                 stønadsperiode = Stønadsperiode.create(Periode.create(1.januar(2021), 31.desember(2021))),
@@ -1410,7 +1411,7 @@ internal class FerdigstillVedtakServiceImplTest {
                 beregning = TestBeregning,
                 simulering = mock(),
                 saksbehandler = saksbehandler,
-                attestering = Attestering.Iverksatt(attestant),
+                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now())),
                 fritekstTilBrev = "",
                 stønadsperiode = Stønadsperiode.create(Periode.create(1.januar(2021), 31.desember(2021))),
                 grunnlagsdata = Grunnlagsdata(
@@ -1440,7 +1441,7 @@ internal class FerdigstillVedtakServiceImplTest {
                 beregning = TestBeregning,
                 simulering = mock(),
                 saksbehandler = saksbehandler,
-                attestering = Attestering.Iverksatt(attestant),
+                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now())),
                 fritekstTilBrev = "",
                 periode = Periode.create(1.januar(2021), 31.desember(2021)),
                 tilRevurdering = innvilgetVedtak(),

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/vedtak/FerdigstillVedtakServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/vedtak/FerdigstillVedtakServiceImplTest.kt
@@ -32,7 +32,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.BehandlingMetrics
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.avslag.Avslag
@@ -619,7 +619,7 @@ internal class FerdigstillVedtakServiceImplTest {
                         .withAlleVilkårOppfylt(),
                     beregning = TestBeregning,
                     saksbehandler = saksbehandler,
-                    attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now())),
+                    attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now())),
                     fritekstTilBrev = "",
                     periode = it.periode,
                     tilRevurdering = it,
@@ -1353,7 +1353,7 @@ internal class FerdigstillVedtakServiceImplTest {
                 behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
                 fnr = FnrGenerator.random(),
                 beregning = TestBeregning,
-                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.EPOCH)),
+                attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.EPOCH)),
                 saksbehandler = saksbehandler,
                 fritekstTilBrev = "",
                 stønadsperiode = Stønadsperiode.create(Periode.create(1.januar(2021), 31.desember(2021))),
@@ -1411,7 +1411,7 @@ internal class FerdigstillVedtakServiceImplTest {
                 beregning = TestBeregning,
                 simulering = mock(),
                 saksbehandler = saksbehandler,
-                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now())),
+                attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now())),
                 fritekstTilBrev = "",
                 stønadsperiode = Stønadsperiode.create(Periode.create(1.januar(2021), 31.desember(2021))),
                 grunnlagsdata = Grunnlagsdata(
@@ -1441,7 +1441,7 @@ internal class FerdigstillVedtakServiceImplTest {
                 beregning = TestBeregning,
                 simulering = mock(),
                 saksbehandler = saksbehandler,
-                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now())),
+                attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now())),
                 fritekstTilBrev = "",
                 periode = Periode.create(1.januar(2021), 31.desember(2021)),
                 tilRevurdering = innvilgetVedtak(),

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/vedtak/VedtakServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/vedtak/VedtakServiceImplTest.kt
@@ -27,7 +27,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
@@ -261,7 +261,7 @@ internal class VedtakServiceImplTest {
                 beregning = TestBeregning,
                 simulering = mock(),
                 saksbehandler = saksbehandler,
-                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.EPOCH)),
+                attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.EPOCH)),
                 fritekstTilBrev = "",
                 stønadsperiode = Stønadsperiode.create(Periode.create(1.januar(2021), 31.desember(2021))),
                 grunnlagsdata = Grunnlagsdata.EMPTY,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/vedtak/VedtakServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/vedtak/VedtakServiceImplTest.kt
@@ -27,6 +27,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
@@ -260,7 +261,7 @@ internal class VedtakServiceImplTest {
                 beregning = TestBeregning,
                 simulering = mock(),
                 saksbehandler = saksbehandler,
-                attestering = Attestering.Iverksatt(attestant),
+                attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.EPOCH)),
                 fritekstTilBrev = "",
                 stønadsperiode = Stønadsperiode.create(Periode.create(1.januar(2021), 31.desember(2021))),
                 grunnlagsdata = Grunnlagsdata.EMPTY,

--- a/test-common/src/main/kotlin/GenerelleTestData.kt
+++ b/test-common/src/main/kotlin/GenerelleTestData.kt
@@ -41,11 +41,13 @@ val stønadsperiode2021 = Stønadsperiode.create(periode2021, "stønadsperiode20
 val attestant = NavIdentBruker.Attestant("attestant")
 
 val attesteringIverksatt = Attestering.Iverksatt(
-    attestant = attestant
+    attestant = attestant,
+    tidspunkt = fixedTidspunkt
 )
 
 val attesteringUnderkjent = Attestering.Underkjent(
     attestant = attestant,
     grunn = Attestering.Underkjent.Grunn.DOKUMENTASJON_MANGLER,
-    kommentar = "attesteringUnderkjent"
+    kommentar = "attesteringUnderkjent",
+    tidspunkt = fixedTidspunkt
 )

--- a/test-common/src/main/kotlin/GenerelleTestData.kt
+++ b/test-common/src/main/kotlin/GenerelleTestData.kt
@@ -42,12 +42,12 @@ val attestant = NavIdentBruker.Attestant("attestant")
 
 val attesteringIverksatt = Attestering.Iverksatt(
     attestant = attestant,
-    tidspunkt = fixedTidspunkt
+    opprettet = fixedTidspunkt
 )
 
 val attesteringUnderkjent = Attestering.Underkjent(
     attestant = attestant,
     grunn = Attestering.Underkjent.Grunn.DOKUMENTASJON_MANGLER,
     kommentar = "attesteringUnderkjent",
-    tidspunkt = fixedTidspunkt
+    opprettet = fixedTidspunkt
 )

--- a/test-common/src/main/kotlin/RevurderingTestData.kt
+++ b/test-common/src/main/kotlin/RevurderingTestData.kt
@@ -10,6 +10,7 @@ import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.grunnlag.singleFullstendigOrThrow
@@ -82,7 +83,7 @@ fun opprettetRevurderingFraInnvilgetSøknadsbehandlingsVedtak(
         grunnlagsdata = grunnlagsdata,
         vilkårsvurderinger = vilkårsvurderinger,
         informasjonSomRevurderes = informasjonSomRevurderes,
-        attesteringer = AttesteringHistorik.empty()
+        attesteringer = Attesteringshistorikk.empty()
     )
 }
 
@@ -313,7 +314,8 @@ fun UnderkjentInnvilgetRevurderingFraInnvilgetSøknadsbehandlignsVedtak(
     attestering: Attestering.Underkjent = Attestering.Underkjent(
         attestant = NavIdentBruker.Attestant(navIdent = "attestant"),
         grunn = Attestering.Underkjent.Grunn.INNGANGSVILKÅRENE_ER_FEILVURDERT,
-        kommentar = "feil vilkår man"
+        kommentar = "feil vilkår man",
+        opprettet = fixedTidspunkt
     )
 ): UnderkjentRevurdering {
     return tilAttesteringRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak(

--- a/test-common/src/main/kotlin/RevurderingTestData.kt
+++ b/test-common/src/main/kotlin/RevurderingTestData.kt
@@ -82,6 +82,7 @@ fun opprettetRevurderingFraInnvilgetSøknadsbehandlingsVedtak(
         grunnlagsdata = grunnlagsdata,
         vilkårsvurderinger = vilkårsvurderinger,
         informasjonSomRevurderes = informasjonSomRevurderes,
+        attesteringer = AttesteringHistorik.empty()
     )
 }
 

--- a/test-common/src/main/kotlin/SøknadsbehandlingTestData.kt
+++ b/test-common/src/main/kotlin/SøknadsbehandlingTestData.kt
@@ -2,7 +2,7 @@ package no.nav.su.se.bakover.test
 
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.beregning.Beregning
@@ -42,7 +42,7 @@ fun søknadsbehandlingVilkårsvurdertUavklart(
         stønadsperiode = stønadsperiode,
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
-        attesteringer = AttesteringHistorik.empty()
+        attesteringer = Attesteringshistorikk.empty()
     )
 }
 

--- a/test-common/src/main/kotlin/SøknadsbehandlingTestData.kt
+++ b/test-common/src/main/kotlin/SøknadsbehandlingTestData.kt
@@ -2,6 +2,7 @@ package no.nav.su.se.bakover.test
 
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.beregning.Beregning
@@ -41,6 +42,7 @@ fun søknadsbehandlingVilkårsvurdertUavklart(
         stønadsperiode = stønadsperiode,
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+        attesteringer = AttesteringHistorik.empty()
     )
 }
 

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingJson.kt
@@ -17,9 +17,9 @@ import no.nav.su.se.bakover.domain.revurdering.UnderkjentRevurdering
 import no.nav.su.se.bakover.domain.revurdering.Vurderingstatus
 import no.nav.su.se.bakover.web.routes.grunnlag.GrunnlagsdataOgVilkårsvurderingerJson
 import no.nav.su.se.bakover.web.routes.søknadsbehandling.AttesteringJson
+import no.nav.su.se.bakover.web.routes.søknadsbehandling.AttesteringJson.Companion.toJson
 import no.nav.su.se.bakover.web.routes.søknadsbehandling.SimuleringJson
 import no.nav.su.se.bakover.web.routes.søknadsbehandling.SimuleringJson.Companion.toJson
-import no.nav.su.se.bakover.web.routes.søknadsbehandling.UnderkjennelseJson
 import no.nav.su.se.bakover.web.routes.søknadsbehandling.beregning.BeregningJson
 import no.nav.su.se.bakover.web.routes.søknadsbehandling.beregning.PeriodeJson
 import no.nav.su.se.bakover.web.routes.søknadsbehandling.beregning.PeriodeJson.Companion.toJson
@@ -151,7 +151,7 @@ internal data class UnderkjentRevurderingJson(
     val skalFøreTilBrevutsending: Boolean,
     val årsak: String,
     val begrunnelse: String,
-    val attestering: AttesteringJson,
+    val attesteringer: List<AttesteringJson>,
     val status: RevurderingsStatus,
     val forhåndsvarsel: ForhåndsvarselJson?,
     val simulering: SimuleringJson?,
@@ -293,14 +293,7 @@ internal fun Revurdering.toJson(): RevurderingJson = when (this) {
             revurdert = beregning.toJson(),
         ),
         saksbehandler = saksbehandler.toString(),
-        attestering = AttesteringJson(
-            attestant = attestering.attestant.navIdent,
-            opprettet = attestering.opprettet,
-            underkjennelse = UnderkjennelseJson(
-                grunn = attestering.grunn.toString(),
-                kommentar = attestering.kommentar,
-            ),
-        ),
+        attesteringer = attesteringer.toJson(),
         fritekstTilBrev = fritekstTilBrev,
         skalFøreTilBrevutsending = when (this) {
             is UnderkjentRevurdering.IngenEndring -> skalFøreTilBrevutsending

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingJson.kt
@@ -295,6 +295,7 @@ internal fun Revurdering.toJson(): RevurderingJson = when (this) {
         saksbehandler = saksbehandler.toString(),
         attestering = AttesteringJson(
             attestant = attestering.attestant.navIdent,
+            opprettet = attestering.opprettet,
             underkjennelse = UnderkjennelseJson(
                 grunn = attestering.grunn.toString(),
                 kommentar = attestering.kommentar,

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingJson.kt
@@ -65,6 +65,7 @@ internal data class OpprettetRevurderingJson(
     val forhåndsvarsel: ForhåndsvarselJson?,
     val grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderingerJson,
     val informasjonSomRevurderes: Map<Revurderingsteg, Vurderingstatus>,
+    val attesteringer: List<AttesteringJson>,
 ) : RevurderingJson() {
     @JsonInclude
     val status = RevurderingsStatus.OPPRETTET
@@ -84,6 +85,7 @@ internal data class BeregnetRevurderingJson(
     val forhåndsvarsel: ForhåndsvarselJson?,
     val grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderingerJson,
     val informasjonSomRevurderes: Map<Revurderingsteg, Vurderingstatus>,
+    val attesteringer: List<AttesteringJson>,
 ) : RevurderingJson()
 
 internal data class SimulertRevurderingJson(
@@ -101,6 +103,7 @@ internal data class SimulertRevurderingJson(
     val simulering: SimuleringJson,
     val grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderingerJson,
     val informasjonSomRevurderes: Map<Revurderingsteg, Vurderingstatus>,
+    val attesteringer: List<AttesteringJson>,
 ) : RevurderingJson()
 
 internal data class TilAttesteringJson(
@@ -119,6 +122,7 @@ internal data class TilAttesteringJson(
     val simulering: SimuleringJson?,
     val grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderingerJson,
     val informasjonSomRevurderes: Map<Revurderingsteg, Vurderingstatus>,
+    val attesteringer: List<AttesteringJson>,
 ) : RevurderingJson()
 
 internal data class IverksattRevurderingJson(
@@ -132,12 +136,12 @@ internal data class IverksattRevurderingJson(
     val skalFøreTilBrevutsending: Boolean,
     val årsak: String,
     val begrunnelse: String,
-    val attestant: String,
     val status: RevurderingsStatus,
     val forhåndsvarsel: ForhåndsvarselJson?,
     val simulering: SimuleringJson?,
     val grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderingerJson,
     val informasjonSomRevurderes: Map<Revurderingsteg, Vurderingstatus>,
+    val attesteringer: List<AttesteringJson>,
 ) : RevurderingJson()
 
 internal data class UnderkjentRevurderingJson(
@@ -151,12 +155,12 @@ internal data class UnderkjentRevurderingJson(
     val skalFøreTilBrevutsending: Boolean,
     val årsak: String,
     val begrunnelse: String,
-    val attesteringer: List<AttesteringJson>,
     val status: RevurderingsStatus,
     val forhåndsvarsel: ForhåndsvarselJson?,
     val simulering: SimuleringJson?,
     val grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderingerJson,
     val informasjonSomRevurderes: Map<Revurderingsteg, Vurderingstatus>,
+    val attesteringer: List<AttesteringJson>,
 ) : RevurderingJson()
 
 internal fun Forhåndsvarsel.toJson() = when (this) {
@@ -206,6 +210,7 @@ internal fun Revurdering.toJson(): RevurderingJson = when (this) {
         forhåndsvarsel = forhåndsvarsel?.toJson(),
         grunnlagsdataOgVilkårsvurderinger = GrunnlagsdataOgVilkårsvurderingerJson.create(grunnlagsdata, vilkårsvurderinger),
         informasjonSomRevurderes = informasjonSomRevurderes,
+        attesteringer = attesteringer.toJson()
     )
     is SimulertRevurdering -> SimulertRevurderingJson(
         id = id.toString(),
@@ -225,6 +230,7 @@ internal fun Revurdering.toJson(): RevurderingJson = when (this) {
         simulering = simulering.toJson(),
         grunnlagsdataOgVilkårsvurderinger = GrunnlagsdataOgVilkårsvurderingerJson.create(grunnlagsdata, vilkårsvurderinger),
         informasjonSomRevurderes = informasjonSomRevurderes,
+        attesteringer = attesteringer.toJson()
     )
     is RevurderingTilAttestering -> TilAttesteringJson(
         id = id.toString(),
@@ -253,6 +259,7 @@ internal fun Revurdering.toJson(): RevurderingJson = when (this) {
         },
         grunnlagsdataOgVilkårsvurderinger = GrunnlagsdataOgVilkårsvurderingerJson.create(grunnlagsdata, vilkårsvurderinger),
         informasjonSomRevurderes = informasjonSomRevurderes,
+        attesteringer = attesteringer.toJson()
     )
     is IverksattRevurdering -> IverksattRevurderingJson(
         id = id.toString(),
@@ -272,7 +279,6 @@ internal fun Revurdering.toJson(): RevurderingJson = when (this) {
         },
         årsak = revurderingsårsak.årsak.toString(),
         begrunnelse = revurderingsårsak.begrunnelse.toString(),
-        attestant = attestering.attestant.toString(),
         status = InstansTilStatusMapper(this).status,
         forhåndsvarsel = forhåndsvarsel?.toJson(),
         simulering = when (this) {
@@ -282,6 +288,7 @@ internal fun Revurdering.toJson(): RevurderingJson = when (this) {
         },
         grunnlagsdataOgVilkårsvurderinger = GrunnlagsdataOgVilkårsvurderingerJson.create(grunnlagsdata, vilkårsvurderinger),
         informasjonSomRevurderes = informasjonSomRevurderes,
+        attesteringer = attesteringer.toJson()
     )
     is UnderkjentRevurdering -> UnderkjentRevurderingJson(
         id = id.toString(),
@@ -293,7 +300,6 @@ internal fun Revurdering.toJson(): RevurderingJson = when (this) {
             revurdert = beregning.toJson(),
         ),
         saksbehandler = saksbehandler.toString(),
-        attesteringer = attesteringer.toJson(),
         fritekstTilBrev = fritekstTilBrev,
         skalFøreTilBrevutsending = when (this) {
             is UnderkjentRevurdering.IngenEndring -> skalFøreTilBrevutsending
@@ -311,6 +317,7 @@ internal fun Revurdering.toJson(): RevurderingJson = when (this) {
         },
         grunnlagsdataOgVilkårsvurderinger = GrunnlagsdataOgVilkårsvurderingerJson.create(grunnlagsdata, vilkårsvurderinger),
         informasjonSomRevurderes = informasjonSomRevurderes,
+        attesteringer = attesteringer.toJson(),
     )
     is BeregnetRevurdering -> BeregnetRevurderingJson(
         id = id.toString(),
@@ -332,6 +339,7 @@ internal fun Revurdering.toJson(): RevurderingJson = when (this) {
             vilkårsvurderinger,
         ),
         informasjonSomRevurderes = informasjonSomRevurderes,
+        attesteringer = attesteringer.toJson(),
     )
 }.also {
     // TODO jah: Vi skal ikke pre-utfylle Bosituasjon for revurdering med mer enn ett element.

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/UnderkjennRevurdering.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/UnderkjennRevurdering.kt
@@ -44,7 +44,7 @@ data class UnderkjennBody(
                 attestant = NavIdentBruker.Attestant(navIdent),
                 grunn = Attestering.Underkjent.Grunn.valueOf(this.grunn),
                 kommentar = this.kommentar,
-                tidspunkt = Tidspunkt.now()
+                opprettet = Tidspunkt.now()
             ).right()
         }
         return HttpStatusCode.BadRequest.errorJson(

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/UnderkjennRevurdering.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/UnderkjennRevurdering.kt
@@ -7,6 +7,7 @@ import io.ktor.application.call
 import io.ktor.http.HttpStatusCode
 import io.ktor.routing.Route
 import io.ktor.routing.patch
+import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.log
 import no.nav.su.se.bakover.common.serialize
 import no.nav.su.se.bakover.domain.Brukerrolle
@@ -42,7 +43,8 @@ data class UnderkjennBody(
             return Attestering.Underkjent(
                 attestant = NavIdentBruker.Attestant(navIdent),
                 grunn = Attestering.Underkjent.Grunn.valueOf(this.grunn),
-                kommentar = this.kommentar
+                kommentar = this.kommentar,
+                tidspunkt = Tidspunkt.now()
             ).right()
         }
         return HttpStatusCode.BadRequest.errorJson(

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/AttesteringJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/AttesteringJson.kt
@@ -1,9 +1,31 @@
 package no.nav.su.se.bakover.web.routes.søknadsbehandling
 
+import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+
 internal data class AttesteringJson(
     val attestant: String,
     val underkjennelse: UnderkjennelseJson?
-)
+) {
+    companion object {
+        internal fun AttesteringHistorik.toJson() = this.hentAttesteringer().map { it.toJson() }
+
+        internal fun Attestering.toJson() =
+            when (this) {
+                is Attestering.Iverksatt -> AttesteringJson(
+                    attestant = this.attestant.navIdent,
+                    underkjennelse = null,
+                )
+                is Attestering.Underkjent -> AttesteringJson(
+                    attestant = this.attestant.navIdent,
+                    underkjennelse = UnderkjennelseJson(
+                        grunn = this.grunn.toString(),
+                        kommentar = this.kommentar,
+                    ),
+                )
+            }
+    }
+}
 
 internal data class UnderkjennelseJson(
     val grunn: String,

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/AttesteringJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/AttesteringJson.kt
@@ -1,23 +1,27 @@
 package no.nav.su.se.bakover.web.routes.søknadsbehandling
 
+import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 
 internal data class AttesteringJson(
     val attestant: String,
-    val underkjennelse: UnderkjennelseJson?
+    val underkjennelse: UnderkjennelseJson?,
+    val opprettet: Tidspunkt
 ) {
     companion object {
-        internal fun AttesteringHistorik.toJson() = this.hentAttesteringer().map { it.toJson() }
+        internal fun Attesteringshistorikk.toJson() = this.hentAttesteringer().map { it.toJson() }
 
         internal fun Attestering.toJson() =
             when (this) {
                 is Attestering.Iverksatt -> AttesteringJson(
                     attestant = this.attestant.navIdent,
+                    opprettet = this.opprettet,
                     underkjennelse = null,
                 )
                 is Attestering.Underkjent -> AttesteringJson(
                     attestant = this.attestant.navIdent,
+                    opprettet = this.opprettet,
                     underkjennelse = UnderkjennelseJson(
                         grunn = this.grunn.toString(),
                         kommentar = this.kommentar,

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/BehandlingJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/BehandlingJson.kt
@@ -15,7 +15,7 @@ internal data class BehandlingJson(
     val status: String,
     val simulering: SimuleringJson?,
     val opprettet: String,
-    val attestering: AttesteringJson?,
+    val attesteringer: List<AttesteringJson>,
     val saksbehandler: String?,
     val sakId: UUID,
     val hendelser: List<HendelseJson>? = emptyList(),

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingJson.kt
@@ -8,6 +8,7 @@ import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
 import no.nav.su.se.bakover.web.Resultat
 import no.nav.su.se.bakover.web.routes.grunnlag.GrunnlagsdataOgVilkårsvurderingerJson.Companion.create
 import no.nav.su.se.bakover.web.routes.søknad.toJson
+import no.nav.su.se.bakover.web.routes.søknadsbehandling.AttesteringJson.Companion.toJson
 import no.nav.su.se.bakover.web.routes.søknadsbehandling.BehandlingsinformasjonJson.Companion.toJson
 import no.nav.su.se.bakover.web.routes.søknadsbehandling.SimuleringJson.Companion.toJson
 import no.nav.su.se.bakover.web.routes.søknadsbehandling.beregning.StønadsperiodeJson.Companion.toJson
@@ -23,7 +24,7 @@ internal fun Søknadsbehandling.toJson(): BehandlingJson {
             søknad = søknad.toJson(),
             behandlingsinformasjon = behandlingsinformasjon.toJson(),
             status = status.toString(),
-            attestering = null,
+            attesteringer = attesteringer.toJson(),
             saksbehandler = null,
             beregning = null,
             simulering = null,
@@ -38,7 +39,7 @@ internal fun Søknadsbehandling.toJson(): BehandlingJson {
                 søknad = søknad.toJson(),
                 behandlingsinformasjon = behandlingsinformasjon.toJson(),
                 status = status.toString(),
-                attestering = null,
+                attesteringer = attesteringer.toJson(),
                 saksbehandler = null,
                 beregning = beregning.toJson(),
                 simulering = null,
@@ -54,7 +55,7 @@ internal fun Søknadsbehandling.toJson(): BehandlingJson {
                 søknad = søknad.toJson(),
                 behandlingsinformasjon = behandlingsinformasjon.toJson(),
                 status = status.toString(),
-                attestering = null,
+                attesteringer = attesteringer.toJson(),
                 saksbehandler = null,
                 beregning = beregning.toJson(),
                 simulering = simulering.toJson(),
@@ -70,7 +71,7 @@ internal fun Søknadsbehandling.toJson(): BehandlingJson {
                 søknad = søknad.toJson(),
                 behandlingsinformasjon = behandlingsinformasjon.toJson(),
                 status = status.toString(),
-                attestering = null,
+                attesteringer = attesteringer.toJson(),
                 saksbehandler = saksbehandler.toString(),
                 beregning = beregning.toJson(),
                 simulering = simulering.toJson(),
@@ -86,7 +87,7 @@ internal fun Søknadsbehandling.toJson(): BehandlingJson {
                 søknad = søknad.toJson(),
                 behandlingsinformasjon = behandlingsinformasjon.toJson(),
                 status = status.toString(),
-                attestering = null,
+                attesteringer = attesteringer.toJson(),
                 saksbehandler = saksbehandler.toString(),
                 beregning = beregning.toJson(),
                 simulering = null,
@@ -102,7 +103,7 @@ internal fun Søknadsbehandling.toJson(): BehandlingJson {
                 søknad = søknad.toJson(),
                 behandlingsinformasjon = behandlingsinformasjon.toJson(),
                 status = status.toString(),
-                attestering = null,
+                attesteringer = attesteringer.toJson(),
                 saksbehandler = saksbehandler.toString(),
                 beregning = null,
                 simulering = null,
@@ -118,7 +119,7 @@ internal fun Søknadsbehandling.toJson(): BehandlingJson {
                 søknad = søknad.toJson(),
                 behandlingsinformasjon = behandlingsinformasjon.toJson(),
                 status = status.toString(),
-                attestering = attestering.let {
+                attesteringer = attesteringer.hentAttesteringer().map {
                     when (it) {
                         is Attestering.Iverksatt -> AttesteringJson(
                             attestant = it.attestant.navIdent,
@@ -148,21 +149,7 @@ internal fun Søknadsbehandling.toJson(): BehandlingJson {
                 søknad = søknad.toJson(),
                 behandlingsinformasjon = behandlingsinformasjon.toJson(),
                 status = status.toString(),
-                attestering = attestering.let {
-                    when (it) {
-                        is Attestering.Iverksatt -> AttesteringJson(
-                            attestant = it.attestant.navIdent,
-                            underkjennelse = null,
-                        )
-                        is Attestering.Underkjent -> AttesteringJson(
-                            attestant = it.attestant.navIdent,
-                            underkjennelse = UnderkjennelseJson(
-                                grunn = it.grunn.toString(),
-                                kommentar = it.kommentar,
-                            ),
-                        )
-                    }
-                },
+                attesteringer = attesteringer.toJson(),
                 saksbehandler = saksbehandler.toString(),
                 beregning = null,
                 simulering = null,
@@ -178,21 +165,7 @@ internal fun Søknadsbehandling.toJson(): BehandlingJson {
                 søknad = søknad.toJson(),
                 behandlingsinformasjon = behandlingsinformasjon.toJson(),
                 status = status.toString(),
-                attestering = attestering.let {
-                    when (it) {
-                        is Attestering.Iverksatt -> AttesteringJson(
-                            attestant = it.attestant.navIdent,
-                            underkjennelse = null,
-                        )
-                        is Attestering.Underkjent -> AttesteringJson(
-                            attestant = it.attestant.navIdent,
-                            underkjennelse = UnderkjennelseJson(
-                                grunn = it.grunn.toString(),
-                                kommentar = it.kommentar,
-                            ),
-                        )
-                    }
-                },
+                attesteringer = attesteringer.toJson(),
                 saksbehandler = saksbehandler.toString(),
                 beregning = beregning.toJson(),
                 simulering = null,
@@ -208,21 +181,7 @@ internal fun Søknadsbehandling.toJson(): BehandlingJson {
                 søknad = søknad.toJson(),
                 behandlingsinformasjon = behandlingsinformasjon.toJson(),
                 status = status.toString(),
-                attestering = attestering.let {
-                    when (it) {
-                        is Attestering.Iverksatt -> AttesteringJson(
-                            attestant = it.attestant.navIdent,
-                            underkjennelse = null,
-                        )
-                        is Attestering.Underkjent -> AttesteringJson(
-                            attestant = it.attestant.navIdent,
-                            underkjennelse = UnderkjennelseJson(
-                                grunn = it.grunn.toString(),
-                                kommentar = it.kommentar,
-                            ),
-                        )
-                    }
-                },
+                attesteringer = attesteringer.toJson(),
                 saksbehandler = saksbehandler.toString(),
                 beregning = beregning.toJson(),
                 simulering = null,
@@ -238,21 +197,7 @@ internal fun Søknadsbehandling.toJson(): BehandlingJson {
                 søknad = søknad.toJson(),
                 behandlingsinformasjon = behandlingsinformasjon.toJson(),
                 status = status.toString(),
-                attestering = attestering.let {
-                    when (it) {
-                        is Attestering.Iverksatt -> AttesteringJson(
-                            attestant = it.attestant.navIdent,
-                            underkjennelse = null,
-                        )
-                        is Attestering.Underkjent -> AttesteringJson(
-                            attestant = it.attestant.navIdent,
-                            underkjennelse = UnderkjennelseJson(
-                                grunn = it.grunn.toString(),
-                                kommentar = it.kommentar,
-                            ),
-                        )
-                    }
-                },
+                attesteringer = attesteringer.toJson(),
                 saksbehandler = saksbehandler.toString(),
                 beregning = null,
                 simulering = null,
@@ -268,21 +213,7 @@ internal fun Søknadsbehandling.toJson(): BehandlingJson {
                 søknad = søknad.toJson(),
                 behandlingsinformasjon = behandlingsinformasjon.toJson(),
                 status = status.toString(),
-                attestering = attestering.let {
-                    when (it) {
-                        is Attestering.Iverksatt -> AttesteringJson(
-                            attestant = it.attestant.navIdent,
-                            underkjennelse = null,
-                        )
-                        is Attestering.Underkjent -> AttesteringJson(
-                            attestant = it.attestant.navIdent,
-                            underkjennelse = UnderkjennelseJson(
-                                grunn = it.grunn.toString(),
-                                kommentar = it.kommentar,
-                            ),
-                        )
-                    }
-                },
+                attesteringer = attesteringer.toJson(),
                 saksbehandler = saksbehandler.toString(),
                 beregning = beregning.toJson(),
                 simulering = simulering.toJson(),

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingJson.kt
@@ -123,10 +123,12 @@ internal fun Søknadsbehandling.toJson(): BehandlingJson {
                     when (it) {
                         is Attestering.Iverksatt -> AttesteringJson(
                             attestant = it.attestant.navIdent,
+                            opprettet = it.opprettet,
                             underkjennelse = null,
                         )
                         is Attestering.Underkjent -> AttesteringJson(
                             attestant = it.attestant.navIdent,
+                            opprettet = it.opprettet,
                             underkjennelse = UnderkjennelseJson(
                                 grunn = it.grunn.toString(),
                                 kommentar = it.kommentar,

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutes.kt
@@ -19,6 +19,7 @@ import io.ktor.routing.Route
 import io.ktor.routing.get
 import io.ktor.routing.patch
 import io.ktor.routing.post
+import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.NavIdentBruker.Attestant
 import no.nav.su.se.bakover.domain.NavIdentBruker.Saksbehandler
@@ -439,7 +440,7 @@ internal fun Route.søknadsbehandlingRoutes(
                 søknadsbehandlingService.iverksett(
                     IverksettRequest(
                         behandlingId = behandlingId,
-                        attestering = Attestering.Iverksatt(Attestant(navIdent)),
+                        attestering = Attestering.Iverksatt(Attestant(navIdent), Tidspunkt.now()),
                     ),
                 ).fold(
                     {
@@ -481,6 +482,7 @@ internal fun Route.søknadsbehandlingRoutes(
                                         attestant = Attestant(navIdent),
                                         grunn = Attestering.Underkjent.Grunn.valueOf(body.grunn),
                                         kommentar = body.kommentar,
+                                        tidspunkt = Tidspunkt.now()
                                     ),
                                 ),
                             ).fold(

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutes.kt
@@ -482,7 +482,7 @@ internal fun Route.søknadsbehandlingRoutes(
                                         attestant = Attestant(navIdent),
                                         grunn = Attestering.Underkjent.Grunn.valueOf(body.grunn),
                                         kommentar = body.kommentar,
-                                        tidspunkt = Tidspunkt.now()
+                                        opprettet = Tidspunkt.now()
                                     ),
                                 ),
                             ).fold(

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BeregnOgSimulerRevurderingRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BeregnOgSimulerRevurderingRouteKtTest.kt
@@ -18,6 +18,7 @@ import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.NavIdentBruker
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.beregning.Beregning
 import no.nav.su.se.bakover.domain.beregning.Månedsberegning
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
@@ -159,6 +160,7 @@ internal class BeregnOgSimulerRevurderingRouteKtTest {
                 formue = formueVilkår(periode),
             ),
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = AttesteringHistorik.empty()
         ).beregn(eksisterendeUtbetalinger = emptyList()).orNull()!!
 
         val simulertRevurdering = when (beregnetRevurdering) {

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BeregnOgSimulerRevurderingRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BeregnOgSimulerRevurderingRouteKtTest.kt
@@ -18,7 +18,7 @@ import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.NavIdentBruker
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.beregning.Beregning
 import no.nav.su.se.bakover.domain.beregning.Månedsberegning
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
@@ -160,7 +160,7 @@ internal class BeregnOgSimulerRevurderingRouteKtTest {
                 formue = formueVilkår(periode),
             ),
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         ).beregn(eksisterendeUtbetalinger = emptyList()).orNull()!!
 
         val simulertRevurdering = when (beregnetRevurdering) {

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/ForhåndsvarslingRouteTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/ForhåndsvarslingRouteTest.kt
@@ -15,7 +15,7 @@ import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NavIdentBruker
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.journal.JournalpostId
@@ -96,7 +96,7 @@ internal class ForhåndsvarslingRouteTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingServiceMock = mock<RevurderingService> {
@@ -160,7 +160,7 @@ internal class ForhåndsvarslingRouteTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingServiceMock = mock<RevurderingService> {

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/ForhåndsvarslingRouteTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/ForhåndsvarslingRouteTest.kt
@@ -15,6 +15,7 @@ import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NavIdentBruker
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.journal.JournalpostId
@@ -95,6 +96,7 @@ internal class ForhåndsvarslingRouteTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = AttesteringHistorik.empty()
         )
 
         val revurderingServiceMock = mock<RevurderingService> {
@@ -158,6 +160,7 @@ internal class ForhåndsvarslingRouteTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = AttesteringHistorik.empty()
         )
 
         val revurderingServiceMock = mock<RevurderingService> {

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/FortsettEtterForhåndsvarselRouteTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/FortsettEtterForhåndsvarselRouteTest.kt
@@ -15,6 +15,7 @@ import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NavIdentBruker
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.journal.JournalpostId
@@ -99,6 +100,7 @@ internal class FortsettEtterForhåndsvarselRouteTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = AttesteringHistorik.empty()
         )
 
         val revurderingServiceMock = mock<RevurderingService> {
@@ -171,6 +173,7 @@ internal class FortsettEtterForhåndsvarselRouteTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = AttesteringHistorik.empty()
         )
 
         val revurderingServiceMock = mock<RevurderingService> {
@@ -243,6 +246,7 @@ internal class FortsettEtterForhåndsvarselRouteTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = AttesteringHistorik.empty()
         )
 
         val revurderingServiceMock = mock<RevurderingService> {

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/FortsettEtterForhåndsvarselRouteTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/FortsettEtterForhåndsvarselRouteTest.kt
@@ -15,7 +15,7 @@ import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NavIdentBruker
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.journal.JournalpostId
@@ -100,7 +100,7 @@ internal class FortsettEtterForhåndsvarselRouteTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingServiceMock = mock<RevurderingService> {
@@ -173,7 +173,7 @@ internal class FortsettEtterForhåndsvarselRouteTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingServiceMock = mock<RevurderingService> {
@@ -246,7 +246,7 @@ internal class FortsettEtterForhåndsvarselRouteTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingServiceMock = mock<RevurderingService> {

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/IverksettRevurderingRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/IverksettRevurderingRouteKtTest.kt
@@ -15,7 +15,7 @@ import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
@@ -87,7 +87,7 @@ internal class IverksettRevurderingRouteKtTest {
                 nettoBeløp = 0,
                 periodeList = listOf(),
             ),
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), Tidspunkt.now())),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), Tidspunkt.now())),
             fritekstTilBrev = "",
             revurderingsårsak = Revurderingsårsak(
                 Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/IverksettRevurderingRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/IverksettRevurderingRouteKtTest.kt
@@ -15,6 +15,7 @@ import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
@@ -86,7 +87,7 @@ internal class IverksettRevurderingRouteKtTest {
                 nettoBeløp = 0,
                 periodeList = listOf(),
             ),
-            attestering = Attestering.Iverksatt(NavIdentBruker.Attestant("attestant")),
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), Tidspunkt.now())),
             fritekstTilBrev = "",
             revurderingsårsak = Revurderingsårsak(
                 Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/LeggTilFradragRevurderingRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/LeggTilFradragRevurderingRouteKtTest.kt
@@ -15,6 +15,7 @@ import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.NavIdentBruker
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.revurdering.InformasjonSomRevurderes
@@ -80,6 +81,7 @@ internal class LeggTilFradragRevurderingRouteKtTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = AttesteringHistorik.empty()
         )
 
         val revurderingServiceMock = mock<RevurderingService> {

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/LeggTilFradragRevurderingRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/LeggTilFradragRevurderingRouteKtTest.kt
@@ -15,7 +15,7 @@ import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.NavIdentBruker
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.revurdering.InformasjonSomRevurderes
@@ -81,7 +81,7 @@ internal class LeggTilFradragRevurderingRouteKtTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingServiceMock = mock<RevurderingService> {

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OppdaterRevurderingsperiodeRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OppdaterRevurderingsperiodeRouteKtTest.kt
@@ -16,7 +16,7 @@ import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.NavIdentBruker
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.revurdering.InformasjonSomRevurderes
@@ -96,7 +96,7 @@ internal class OppdaterRevurderingsperiodeRouteKtTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
         val revurderingServiceMock = mock<RevurderingService> {
             on { oppdaterRevurdering(any()) } doReturn opprettetRevurdering.right()

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OppdaterRevurderingsperiodeRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OppdaterRevurderingsperiodeRouteKtTest.kt
@@ -16,6 +16,7 @@ import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.NavIdentBruker
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.revurdering.InformasjonSomRevurderes
@@ -95,6 +96,7 @@ internal class OppdaterRevurderingsperiodeRouteKtTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = AttesteringHistorik.empty()
         )
         val revurderingServiceMock = mock<RevurderingService> {
             on { oppdaterRevurdering(any()) } doReturn opprettetRevurdering.right()

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OpprettRevurderingRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OpprettRevurderingRouteKtTest.kt
@@ -16,6 +16,7 @@ import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.NavIdentBruker
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.revurdering.InformasjonSomRevurderes
@@ -93,6 +94,7 @@ internal class OpprettRevurderingRouteKtTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = AttesteringHistorik.empty()
         )
         val revurderingServiceMock = mock<RevurderingService> {
             on { opprettRevurdering(any()) } doReturn opprettetRevurdering.right()

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OpprettRevurderingRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OpprettRevurderingRouteKtTest.kt
@@ -16,7 +16,7 @@ import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.NavIdentBruker
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.revurdering.InformasjonSomRevurderes
@@ -94,7 +94,7 @@ internal class OpprettRevurderingRouteKtTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
         val revurderingServiceMock = mock<RevurderingService> {
             on { opprettRevurdering(any()) } doReturn opprettetRevurdering.right()

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingJsonTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingJsonTest.kt
@@ -11,7 +11,7 @@ import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.common.serialize
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.revurdering.BeregnetRevurdering
@@ -80,7 +80,7 @@ internal class RevurderingJsonTest {
                     Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert,
                 ),
             ),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingJson =
@@ -157,7 +157,7 @@ internal class RevurderingJsonTest {
                     Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert,
                 ),
             ),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingJson =
@@ -239,7 +239,7 @@ internal class RevurderingJsonTest {
                     Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert,
                 ),
             ),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingJson =
@@ -321,7 +321,7 @@ internal class RevurderingJsonTest {
                     Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert,
                 ),
             ),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingJson =
@@ -404,7 +404,7 @@ internal class RevurderingJsonTest {
                     Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert,
                 ),
             ),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingJson =
@@ -491,7 +491,7 @@ internal class RevurderingJsonTest {
                     Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert,
                 ),
             ),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingJson =
@@ -578,7 +578,7 @@ internal class RevurderingJsonTest {
                     Revurderingsteg.Inntekt to Vurderingstatus.Vurdert,
                 ),
             ),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingJson =
@@ -666,7 +666,7 @@ internal class RevurderingJsonTest {
                     Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert,
                 ),
             ),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingJson =
@@ -754,7 +754,7 @@ internal class RevurderingJsonTest {
                     Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert,
                 ),
             ),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingJson =
@@ -828,12 +828,12 @@ internal class RevurderingJsonTest {
             beregning = beregning,
             simulering = mock(),
             oppgaveId = OppgaveId("OppgaveId"),
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(
                 Attestering.Underkjent(
                     attestant = NavIdentBruker.Attestant("attestant"),
                     grunn = Attestering.Underkjent.Grunn.DOKUMENTASJON_MANGLER,
                     kommentar = "Dokumentasjon mangler",
-                    tidspunkt = attesteringOpprettet
+                    opprettet = attesteringOpprettet
                 )
             ),
             fritekstTilBrev = "",
@@ -874,6 +874,7 @@ internal class RevurderingJsonTest {
                 },
                 "attestering": {
                     "attestant": "attestant",
+                    "opprettet": "$attesteringOpprettet",
                     "underkjennelse": {
                         "grunn": "DOKUMENTASJON_MANGLER",
                         "kommentar": "Dokumentasjon mangler"
@@ -931,12 +932,12 @@ internal class RevurderingJsonTest {
             beregning = beregning,
             simulering = mock(),
             oppgaveId = OppgaveId("OppgaveId"),
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(
                 Attestering.Underkjent(
                     attestant = NavIdentBruker.Attestant("attestant"),
                     grunn = Attestering.Underkjent.Grunn.DOKUMENTASJON_MANGLER,
                     kommentar = "Dokumentasjon mangler",
-                    tidspunkt = attesteringOpprettet
+                    opprettet = attesteringOpprettet
                 )
             ),
             fritekstTilBrev = "",
@@ -977,6 +978,7 @@ internal class RevurderingJsonTest {
                 },
                 "attestering": {
                     "attestant": "attestant",
+                    "opprettet": "$attesteringOpprettet",
                     "underkjennelse": {
                         "grunn": "DOKUMENTASJON_MANGLER",
                         "kommentar": "Dokumentasjon mangler"
@@ -1033,12 +1035,12 @@ internal class RevurderingJsonTest {
             saksbehandler = NavIdentBruker.Saksbehandler("Petter"),
             beregning = beregning,
             oppgaveId = OppgaveId("OppgaveId"),
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(
                 Attestering.Underkjent(
                     attestant = NavIdentBruker.Attestant("attestant"),
                     grunn = Attestering.Underkjent.Grunn.DOKUMENTASJON_MANGLER,
                     kommentar = "Dokumentasjon mangler",
-                    tidspunkt = attesteringOpprettet
+                    opprettet = attesteringOpprettet
                 )
             ),
             fritekstTilBrev = "",
@@ -1077,6 +1079,7 @@ internal class RevurderingJsonTest {
                 },
                 "attestering": {
                     "attestant": "attestant",
+                    "opprettet": "$attesteringOpprettet",
                     "underkjennelse": {
                         "grunn": "DOKUMENTASJON_MANGLER",
                         "kommentar": "Dokumentasjon mangler"
@@ -1134,7 +1137,7 @@ internal class RevurderingJsonTest {
             oppgaveId = OppgaveId("OppgaveId"),
             beregning = beregning,
             simulering = mock(),
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), attesteringOpprettet)),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), attesteringOpprettet)),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
             forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
@@ -1224,7 +1227,7 @@ internal class RevurderingJsonTest {
             oppgaveId = OppgaveId("OppgaveId"),
             beregning = beregning,
             simulering = mock(),
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), attesteringOpprettet)),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), attesteringOpprettet)),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
             forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
@@ -1313,7 +1316,7 @@ internal class RevurderingJsonTest {
             saksbehandler = NavIdentBruker.Saksbehandler("Petter"),
             oppgaveId = OppgaveId("OppgaveId"),
             beregning = beregning,
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), attesteringOpprettet)),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), attesteringOpprettet)),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
             forhåndsvarsel = null,

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingJsonTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingJsonTest.kt
@@ -11,6 +11,7 @@ import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.common.serialize
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.revurdering.BeregnetRevurdering
@@ -79,6 +80,7 @@ internal class RevurderingJsonTest {
                     Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert,
                 ),
             ),
+            attesteringer = AttesteringHistorik.empty()
         )
 
         val revurderingJson =
@@ -155,6 +157,7 @@ internal class RevurderingJsonTest {
                     Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert,
                 ),
             ),
+            attesteringer = AttesteringHistorik.empty()
         )
 
         val revurderingJson =
@@ -236,6 +239,7 @@ internal class RevurderingJsonTest {
                     Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert,
                 ),
             ),
+            attesteringer = AttesteringHistorik.empty()
         )
 
         val revurderingJson =
@@ -317,6 +321,7 @@ internal class RevurderingJsonTest {
                     Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert,
                 ),
             ),
+            attesteringer = AttesteringHistorik.empty()
         )
 
         val revurderingJson =
@@ -399,6 +404,7 @@ internal class RevurderingJsonTest {
                     Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert,
                 ),
             ),
+            attesteringer = AttesteringHistorik.empty()
         )
 
         val revurderingJson =
@@ -485,6 +491,7 @@ internal class RevurderingJsonTest {
                     Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert,
                 ),
             ),
+            attesteringer = AttesteringHistorik.empty()
         )
 
         val revurderingJson =
@@ -571,6 +578,7 @@ internal class RevurderingJsonTest {
                     Revurderingsteg.Inntekt to Vurderingstatus.Vurdert,
                 ),
             ),
+            attesteringer = AttesteringHistorik.empty()
         )
 
         val revurderingJson =
@@ -658,6 +666,7 @@ internal class RevurderingJsonTest {
                     Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert,
                 ),
             ),
+            attesteringer = AttesteringHistorik.empty()
         )
 
         val revurderingJson =
@@ -745,6 +754,7 @@ internal class RevurderingJsonTest {
                     Revurderingsteg.Inntekt to Vurderingstatus.IkkeVurdert,
                 ),
             ),
+            attesteringer = AttesteringHistorik.empty()
         )
 
         val revurderingJson =
@@ -807,6 +817,7 @@ internal class RevurderingJsonTest {
         val id = UUID.randomUUID()
         val opprettet = Tidspunkt.now()
         val beregning = TestBeregning
+        val attesteringOpprettet = Tidspunkt.now()
 
         val revurdering = UnderkjentRevurdering.Innvilget(
             id = id,
@@ -817,10 +828,13 @@ internal class RevurderingJsonTest {
             beregning = beregning,
             simulering = mock(),
             oppgaveId = OppgaveId("OppgaveId"),
-            attestering = Attestering.Underkjent(
-                attestant = NavIdentBruker.Attestant("attestant"),
-                grunn = Attestering.Underkjent.Grunn.DOKUMENTASJON_MANGLER,
-                kommentar = "Dokumentasjon mangler",
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(
+                Attestering.Underkjent(
+                    attestant = NavIdentBruker.Attestant("attestant"),
+                    grunn = Attestering.Underkjent.Grunn.DOKUMENTASJON_MANGLER,
+                    kommentar = "Dokumentasjon mangler",
+                    tidspunkt = attesteringOpprettet
+                )
             ),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
@@ -906,6 +920,7 @@ internal class RevurderingJsonTest {
         val id = UUID.randomUUID()
         val opprettet = Tidspunkt.now()
         val beregning = TestBeregning
+        val attesteringOpprettet = Tidspunkt.now()
 
         val revurdering = UnderkjentRevurdering.Opphørt(
             id = id,
@@ -916,10 +931,13 @@ internal class RevurderingJsonTest {
             beregning = beregning,
             simulering = mock(),
             oppgaveId = OppgaveId("OppgaveId"),
-            attestering = Attestering.Underkjent(
-                attestant = NavIdentBruker.Attestant("attestant"),
-                grunn = Attestering.Underkjent.Grunn.DOKUMENTASJON_MANGLER,
-                kommentar = "Dokumentasjon mangler",
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(
+                Attestering.Underkjent(
+                    attestant = NavIdentBruker.Attestant("attestant"),
+                    grunn = Attestering.Underkjent.Grunn.DOKUMENTASJON_MANGLER,
+                    kommentar = "Dokumentasjon mangler",
+                    tidspunkt = attesteringOpprettet
+                )
             ),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
@@ -1005,6 +1023,7 @@ internal class RevurderingJsonTest {
         val id = UUID.randomUUID()
         val opprettet = Tidspunkt.now()
         val beregning = TestBeregning
+        val attesteringOpprettet = Tidspunkt.now()
 
         val revurdering = UnderkjentRevurdering.IngenEndring(
             id = id,
@@ -1014,10 +1033,13 @@ internal class RevurderingJsonTest {
             saksbehandler = NavIdentBruker.Saksbehandler("Petter"),
             beregning = beregning,
             oppgaveId = OppgaveId("OppgaveId"),
-            attestering = Attestering.Underkjent(
-                attestant = NavIdentBruker.Attestant("attestant"),
-                grunn = Attestering.Underkjent.Grunn.DOKUMENTASJON_MANGLER,
-                kommentar = "Dokumentasjon mangler",
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(
+                Attestering.Underkjent(
+                    attestant = NavIdentBruker.Attestant("attestant"),
+                    grunn = Attestering.Underkjent.Grunn.DOKUMENTASJON_MANGLER,
+                    kommentar = "Dokumentasjon mangler",
+                    tidspunkt = attesteringOpprettet
+                )
             ),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
@@ -1101,6 +1123,7 @@ internal class RevurderingJsonTest {
         val id = UUID.randomUUID()
         val opprettet = Tidspunkt.now()
         val beregning = TestBeregning
+        val attesteringOpprettet = Tidspunkt.now()
 
         val revurdering = IverksattRevurdering.Innvilget(
             id = id,
@@ -1111,7 +1134,7 @@ internal class RevurderingJsonTest {
             oppgaveId = OppgaveId("OppgaveId"),
             beregning = beregning,
             simulering = mock(),
-            attestering = Attestering.Iverksatt(NavIdentBruker.Attestant("attestant")),
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), attesteringOpprettet)),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
             forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
@@ -1190,6 +1213,7 @@ internal class RevurderingJsonTest {
         val id = UUID.randomUUID()
         val opprettet = Tidspunkt.now()
         val beregning = TestBeregning
+        val attesteringOpprettet = Tidspunkt.now()
 
         val revurdering = IverksattRevurdering.Opphørt(
             id = id,
@@ -1200,7 +1224,7 @@ internal class RevurderingJsonTest {
             oppgaveId = OppgaveId("OppgaveId"),
             beregning = beregning,
             simulering = mock(),
-            attestering = Attestering.Iverksatt(NavIdentBruker.Attestant("attestant")),
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), attesteringOpprettet)),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
             forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
@@ -1279,6 +1303,7 @@ internal class RevurderingJsonTest {
         val id = UUID.randomUUID()
         val opprettet = Tidspunkt.now()
         val beregning = TestBeregning
+        val attesteringOpprettet = Tidspunkt.now()
 
         val revurdering = IverksattRevurdering.IngenEndring(
             id = id,
@@ -1288,7 +1313,7 @@ internal class RevurderingJsonTest {
             saksbehandler = NavIdentBruker.Saksbehandler("Petter"),
             oppgaveId = OppgaveId("OppgaveId"),
             beregning = beregning,
-            attestering = Attestering.Iverksatt(NavIdentBruker.Attestant("attestant")),
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), attesteringOpprettet)),
             fritekstTilBrev = "",
             revurderingsårsak = revurderingsårsak,
             forhåndsvarsel = null,

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingJsonTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingJsonTest.kt
@@ -872,14 +872,14 @@ internal class RevurderingJsonTest {
                     "fraOgMed": "2020-01-01",
                     "tilOgMed": "2020-12-31"
                 },
-                "attestering": {
+                "attesteringer": [{
                     "attestant": "attestant",
                     "opprettet": "$attesteringOpprettet",
                     "underkjennelse": {
                         "grunn": "DOKUMENTASJON_MANGLER",
                         "kommentar": "Dokumentasjon mangler"
                     }
-                },
+                }],
                 "fritekstTilBrev": "",
                 "skalFøreTilBrevutsending": true,
                 "årsak": "MELDING_FRA_BRUKER",
@@ -976,14 +976,14 @@ internal class RevurderingJsonTest {
                     "fraOgMed": "2020-01-01",
                     "tilOgMed": "2020-12-31"
                 },
-                "attestering": {
+                "attesteringer": [{
                     "attestant": "attestant",
                     "opprettet": "$attesteringOpprettet",
                     "underkjennelse": {
                         "grunn": "DOKUMENTASJON_MANGLER",
                         "kommentar": "Dokumentasjon mangler"
                     }
-                },
+                }],
                 "fritekstTilBrev": "",
                 "skalFøreTilBrevutsending": true,
                 "årsak": "MELDING_FRA_BRUKER",
@@ -1077,14 +1077,14 @@ internal class RevurderingJsonTest {
                     "fraOgMed": "2020-01-01",
                     "tilOgMed": "2020-12-31"
                 },
-                "attestering": {
+                "attesteringer": [{
                     "attestant": "attestant",
                     "opprettet": "$attesteringOpprettet",
                     "underkjennelse": {
                         "grunn": "DOKUMENTASJON_MANGLER",
                         "kommentar": "Dokumentasjon mangler"
                     }
-                },
+                }],
                 "fritekstTilBrev": "",
                 "skalFøreTilBrevutsending": false,
                 "årsak": "MELDING_FRA_BRUKER",

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingJsonTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingJsonTest.kt
@@ -123,7 +123,8 @@ internal class RevurderingJsonTest {
                 "informasjonSomRevurderes": {
                   "Uførhet": "IkkeVurdert",
                   "Inntekt": "IkkeVurdert"
-                }
+                },
+                "attesteringer": []
             }
             """.trimIndent()
 
@@ -205,7 +206,8 @@ internal class RevurderingJsonTest {
                 "informasjonSomRevurderes": {
                   "Uførhet": "IkkeVurdert",
                   "Inntekt": "IkkeVurdert"
-                }
+                },
+                "attesteringer": []
             }
             """.trimIndent()
 
@@ -287,7 +289,8 @@ internal class RevurderingJsonTest {
                 "informasjonSomRevurderes": {
                   "Uførhet": "IkkeVurdert",
                   "Inntekt": "IkkeVurdert"
-                }
+                },
+                "attesteringer": []
             }
             """.trimIndent()
 
@@ -369,7 +372,8 @@ internal class RevurderingJsonTest {
                 "informasjonSomRevurderes": {
                   "Uførhet": "IkkeVurdert",
                   "Inntekt": "IkkeVurdert"
-                }
+                },
+                "attesteringer": []
             }
             """.trimIndent()
 
@@ -456,7 +460,8 @@ internal class RevurderingJsonTest {
                 "informasjonSomRevurderes": {
                   "Uførhet": "IkkeVurdert",
                   "Inntekt": "IkkeVurdert"
-                }
+                },
+                "attesteringer": []
             }
             """.trimIndent()
 
@@ -543,7 +548,8 @@ internal class RevurderingJsonTest {
                 "informasjonSomRevurderes": {
                   "Uførhet": "IkkeVurdert",
                   "Inntekt": "IkkeVurdert"
-                }
+                },
+                "attesteringer": []
             }
             """.trimIndent()
 
@@ -631,7 +637,8 @@ internal class RevurderingJsonTest {
                 "informasjonSomRevurderes": {
                   "Uførhet": "Vurdert",
                   "Inntekt": "Vurdert"
-                }
+                },
+                "attesteringer": []
             }
             """.trimIndent()
 
@@ -719,7 +726,8 @@ internal class RevurderingJsonTest {
                 "informasjonSomRevurderes": {
                   "Uførhet": "IkkeVurdert",
                   "Inntekt": "IkkeVurdert"
-                }
+                },
+                "attesteringer": []
             }
             """.trimIndent()
 
@@ -804,7 +812,8 @@ internal class RevurderingJsonTest {
                 "informasjonSomRevurderes": {
                   "Uførhet": "IkkeVurdert",
                   "Inntekt": "IkkeVurdert"
-                }
+                },
+                "attesteringer": []
             }
             """.trimIndent()
 
@@ -1174,7 +1183,6 @@ internal class RevurderingJsonTest {
                     "fraOgMed": "2020-01-01",
                     "tilOgMed": "2020-12-31"
                 },
-                "attestant": "attestant",
                 "fritekstTilBrev": "",
                 "skalFøreTilBrevutsending": true,
                 "årsak": "MELDING_FRA_BRUKER",
@@ -1203,7 +1211,8 @@ internal class RevurderingJsonTest {
                 "informasjonSomRevurderes": {
                   "Uførhet": "IkkeVurdert",
                   "Inntekt": "IkkeVurdert"
-                }
+                },
+                "attesteringer": [{"attestant":"attestant", "opprettet": "$attesteringOpprettet", "underkjennelse": null}]
             }
             """.trimIndent()
 
@@ -1264,7 +1273,6 @@ internal class RevurderingJsonTest {
                     "fraOgMed": "2020-01-01",
                     "tilOgMed": "2020-12-31"
                 },
-                "attestant": "attestant",
                 "fritekstTilBrev": "",
                 "skalFøreTilBrevutsending": true,
                 "årsak": "MELDING_FRA_BRUKER",
@@ -1293,7 +1301,8 @@ internal class RevurderingJsonTest {
                 "informasjonSomRevurderes": {
                   "Uførhet": "IkkeVurdert",
                   "Inntekt": "IkkeVurdert"
-                }
+                },
+                "attesteringer": [{"attestant": "attestant", "opprettet": "$attesteringOpprettet", "underkjennelse": null}]
             }
             """.trimIndent()
 
@@ -1351,7 +1360,6 @@ internal class RevurderingJsonTest {
                     "fraOgMed": "2020-01-01",
                     "tilOgMed": "2020-12-31"
                 },
-                "attestant": "attestant",
                 "fritekstTilBrev": "",
                 "skalFøreTilBrevutsending": true,
                 "årsak": "MELDING_FRA_BRUKER",
@@ -1380,7 +1388,9 @@ internal class RevurderingJsonTest {
                 "informasjonSomRevurderes": {
                   "Uførhet": "IkkeVurdert",
                   "Inntekt": "IkkeVurdert"
-                }
+                },
+                "attesteringer": [{"attestant": "attestant", "opprettet": "$attesteringOpprettet", "underkjennelse": null}]
+
             }
             """.trimIndent()
 

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingRoutesTestData.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingRoutesTestData.kt
@@ -12,7 +12,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Formuegrunnlag
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
@@ -74,7 +74,7 @@ object RevurderingRoutesTestData {
             beregning = TestBeregning,
             simulering = mock(),
             saksbehandler = NavIdentBruker.Saksbehandler("saks"),
-            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), Tidspunkt.now())),
+            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), Tidspunkt.now())),
             fritekstTilBrev = "",
             stønadsperiode = stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
@@ -101,7 +101,7 @@ object RevurderingRoutesTestData {
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
         informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-        attesteringer = AttesteringHistorik.empty()
+        attesteringer = Attesteringshistorikk.empty()
     )
 
     internal fun formueVilkår(periode: Periode) = Vilkår.Formue.Vurdert.createFromGrunnlag(

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingRoutesTestData.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingRoutesTestData.kt
@@ -12,6 +12,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Formuegrunnlag
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
@@ -73,7 +74,7 @@ object RevurderingRoutesTestData {
             beregning = TestBeregning,
             simulering = mock(),
             saksbehandler = NavIdentBruker.Saksbehandler("saks"),
-            attestering = Attestering.Iverksatt(NavIdentBruker.Attestant("attestant")),
+            attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("attestant"), Tidspunkt.now())),
             fritekstTilBrev = "",
             stønadsperiode = stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
@@ -100,6 +101,7 @@ object RevurderingRoutesTestData {
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
         informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+        attesteringer = AttesteringHistorik.empty()
     )
 
     internal fun formueVilkår(periode: Periode) = Vilkår.Formue.Vurdert.createFromGrunnlag(

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/SendRevurderingTilAttesteringRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/SendRevurderingTilAttesteringRouteKtTest.kt
@@ -15,7 +15,7 @@ import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.NavIdentBruker
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
@@ -98,7 +98,7 @@ internal class SendRevurderingTilAttesteringRouteKtTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingServiceMock = mock<RevurderingService> {
@@ -146,7 +146,7 @@ internal class SendRevurderingTilAttesteringRouteKtTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingServiceMock = mock<RevurderingService> {
@@ -196,7 +196,7 @@ internal class SendRevurderingTilAttesteringRouteKtTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val revurderingServiceMock = mock<RevurderingService> {

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/SendRevurderingTilAttesteringRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/SendRevurderingTilAttesteringRouteKtTest.kt
@@ -15,6 +15,7 @@ import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.NavIdentBruker
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
@@ -97,6 +98,7 @@ internal class SendRevurderingTilAttesteringRouteKtTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = AttesteringHistorik.empty()
         )
 
         val revurderingServiceMock = mock<RevurderingService> {
@@ -144,6 +146,7 @@ internal class SendRevurderingTilAttesteringRouteKtTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = AttesteringHistorik.empty()
         )
 
         val revurderingServiceMock = mock<RevurderingService> {
@@ -193,6 +196,7 @@ internal class SendRevurderingTilAttesteringRouteKtTest {
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
+            attesteringer = AttesteringHistorik.empty()
         )
 
         val revurderingServiceMock = mock<RevurderingService> {

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/BehandlingTestUtils.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/BehandlingTestUtils.kt
@@ -12,6 +12,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.journal.JournalpostId
@@ -136,7 +137,7 @@ object BehandlingTestUtils {
             periodeList = listOf(),
         ),
         saksbehandler = NavIdentBruker.Saksbehandler("pro-saksbehandler"),
-        attestering = Attestering.Iverksatt(NavIdentBruker.Attestant("kjella")),
+        attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("kjella"), Tidspunkt.EPOCH)),
         fritekstTilBrev = "",
         stønadsperiode = stønadsperiode,
         grunnlagsdata = Grunnlagsdata(

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/BehandlingTestUtils.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/BehandlingTestUtils.kt
@@ -12,7 +12,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.journal.JournalpostId
@@ -137,7 +137,7 @@ object BehandlingTestUtils {
             periodeList = listOf(),
         ),
         saksbehandler = NavIdentBruker.Saksbehandler("pro-saksbehandler"),
-        attesteringer = AttesteringHistorik.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("kjella"), Tidspunkt.EPOCH)),
+        attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(Attestering.Iverksatt(NavIdentBruker.Attestant("kjella"), Tidspunkt.EPOCH)),
         fritekstTilBrev = "",
         stønadsperiode = stønadsperiode,
         grunnlagsdata = Grunnlagsdata(

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/GrunnlagBosituasjonEpsRoutesTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/GrunnlagBosituasjonEpsRoutesTest.kt
@@ -16,7 +16,7 @@ import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.Saksnummer
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
@@ -52,7 +52,7 @@ class GrunnlagBosituasjonEpsRoutesTest {
         stønadsperiode = stønadsperiode,
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
-        attesteringer = AttesteringHistorik.empty()
+        attesteringer = Attesteringshistorikk.empty()
     )
 
     @Test

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/GrunnlagBosituasjonEpsRoutesTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/GrunnlagBosituasjonEpsRoutesTest.kt
@@ -16,6 +16,7 @@ import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.Saksnummer
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
@@ -51,6 +52,7 @@ class GrunnlagBosituasjonEpsRoutesTest {
         stønadsperiode = stønadsperiode,
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+        attesteringer = AttesteringHistorik.empty()
     )
 
     @Test

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/GrunnlagBosituasjonFullførRoutesTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/GrunnlagBosituasjonFullførRoutesTest.kt
@@ -16,7 +16,7 @@ import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.Saksnummer
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
@@ -52,7 +52,7 @@ class GrunnlagBosituasjonFullførRoutesTest {
         stønadsperiode = stønadsperiode,
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
-        attesteringer = AttesteringHistorik.empty()
+        attesteringer = Attesteringshistorikk.empty()
     )
 
     @Test

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/GrunnlagBosituasjonFullførRoutesTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/GrunnlagBosituasjonFullførRoutesTest.kt
@@ -16,6 +16,7 @@ import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.Saksnummer
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
@@ -51,6 +52,7 @@ class GrunnlagBosituasjonFullførRoutesTest {
         stønadsperiode = stønadsperiode,
         grunnlagsdata = Grunnlagsdata.EMPTY,
         vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+        attesteringer = AttesteringHistorik.empty()
     )
 
     @Test

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/NyBehandlingRoutesTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/NyBehandlingRoutesTest.kt
@@ -16,6 +16,7 @@ import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.Saksnummer
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
@@ -55,6 +56,7 @@ class NyBehandlingRoutesTest {
             stønadsperiode = stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+            attesteringer = AttesteringHistorik.empty()
         )
         val saksbehandlingServiceMock = mock<SøknadsbehandlingService> {
             on { opprett(any()) } doReturn søknadsbehandling.right()

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/NyBehandlingRoutesTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/NyBehandlingRoutesTest.kt
@@ -16,7 +16,7 @@ import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.Saksnummer
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
@@ -56,7 +56,7 @@ class NyBehandlingRoutesTest {
             stønadsperiode = stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
         val saksbehandlingServiceMock = mock<SøknadsbehandlingService> {
             on { opprett(any()) } doReturn søknadsbehandling.right()

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/OppdaterStønadsperiodeTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/OppdaterStønadsperiodeTest.kt
@@ -14,6 +14,7 @@ import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.Saksnummer
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
@@ -161,6 +162,7 @@ class OppdaterStønadsperiodeTest {
             stønadsperiode = BehandlingTestUtils.stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+            attesteringer = AttesteringHistorik.empty()
         )
 
         val serviceMock = mock<SøknadsbehandlingService> {

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/OppdaterStønadsperiodeTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/OppdaterStønadsperiodeTest.kt
@@ -14,7 +14,7 @@ import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.Saksnummer
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
@@ -162,7 +162,7 @@ class OppdaterStønadsperiodeTest {
             stønadsperiode = BehandlingTestUtils.stønadsperiode,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
 
         val serviceMock = mock<SøknadsbehandlingService> {

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingJsonTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingJsonTest.kt
@@ -4,7 +4,7 @@ import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.deserialize
 import no.nav.su.se.bakover.common.serialize
-import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
@@ -119,7 +119,7 @@ internal class SøknadsbehandlingJsonTest {
             "totalBruttoYtelse": 0,
             "perioder": []
           },
-          "attestering" : { "attestant" : "kjella", "underkjennelse":  null},
+          "attesteringer" : [{ "attestant" : "kjella", "underkjennelse":  null, "opprettet": "${Tidspunkt.EPOCH}"}],
           "saksbehandler" : "pro-saksbehandler",
           "sakId": "$sakId",
           "hendelser": [],
@@ -179,7 +179,7 @@ internal class SøknadsbehandlingJsonTest {
             stønadsperiode = null,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
-            attesteringer = AttesteringHistorik.empty()
+            attesteringer = Attesteringshistorikk.empty()
         )
         val opprettetTidspunkt = DateTimeFormatter.ISO_INSTANT.format(behandlingWithNulls.opprettet)
 
@@ -206,7 +206,7 @@ internal class SøknadsbehandlingJsonTest {
           "status": "OPPRETTET",
           "simulering": null,
           "opprettet": "$opprettetTidspunkt",
-          "attestering": null,
+          "attesteringer": [],
           "saksbehandler": null,
           "sakId": "$sakId",
           "hendelser": [],

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingJsonTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingJsonTest.kt
@@ -4,6 +4,7 @@ import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.deserialize
 import no.nav.su.se.bakover.common.serialize
+import no.nav.su.se.bakover.domain.behandling.AttesteringHistorik
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
@@ -178,6 +179,7 @@ internal class SøknadsbehandlingJsonTest {
             stønadsperiode = null,
             grunnlagsdata = Grunnlagsdata.EMPTY,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
+            attesteringer = AttesteringHistorik.empty()
         )
         val opprettetTidspunkt = DateTimeFormatter.ISO_INSTANT.format(behandlingWithNulls.opprettet)
 

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutesKtTest.kt
@@ -476,7 +476,7 @@ internal class SøknadsbehandlingRoutesKtTest {
                     .apply {
                         response.status() shouldBe HttpStatusCode.OK
                         deserialize<BehandlingJson>(response.content!!).let { behandlingJson ->
-                            behandlingJson.attestering?.attestant shouldBe navIdentAttestant
+                            behandlingJson.attesteringer.last().attestant shouldBe navIdentAttestant
                             behandlingJson.status shouldBe "IVERKSATT_INNVILGET"
                             behandlingJson.saksbehandler shouldBe navIdentSaksbehandler
                         }


### PR DESCRIPTION
- Endret sån att attestering er nå en liste med attesteringer. Dette er sån att vi kan se historikken over alle hendelser(underkjent/iverksatt) knyttet till attestering.

- Lagt til `opprettet`-tidspunkt for attesteringer. Disse får vedtaket:s opprettet-tidspunkt hvis det finnes, annars så blir det behandlingens.