### PR TITLE
Fjern nettobeløp fra kontrollsimuleringssjekk

### DIFF
--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/Simulering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/Simulering.kt
@@ -17,12 +17,22 @@ data class Simulering(
 
     fun harFeilutbetalinger() = TolketSimulering(this).simulertePerioder.any { it.harFeilutbetalinger() }
 
+    /**
+     * Nettobeløpet påvirkes av skatt, så tas ikke med i equals-sjekken.
+     * Bruttobeløpet, altså summen av månedsbeløpene, brukes i stedet .
+     */
     override fun equals(other: Any?) = other is Simulering &&
         other.gjelderId == this.gjelderId &&
         other.gjelderNavn == this.gjelderNavn &&
-        other.nettoBeløp == this.nettoBeløp &&
         other.periodeList == this.periodeList &&
         other.bruttoYtelse() == this.bruttoYtelse()
+
+    override fun hashCode(): Int {
+        var result = gjelderId.hashCode()
+        result = 31 * result + gjelderNavn.hashCode()
+        result = 31 * result + periodeList.hashCode()
+        return result
+    }
 }
 
 data class SimulertPeriode(
@@ -55,6 +65,15 @@ data class SimulertUtbetaling(
         other.utbetalesTilNavn == this.utbetalesTilNavn &&
         other.feilkonto == this.feilkonto &&
         other.detaljer == this.detaljer
+
+    override fun hashCode(): Int {
+        var result = fagSystemId.hashCode()
+        result = 31 * result + utbetalesTilId.hashCode()
+        result = 31 * result + utbetalesTilNavn.hashCode()
+        result = 31 * result + feilkonto.hashCode()
+        result = 31 * result + detaljer.hashCode()
+        return result
+    }
 }
 
 data class SimulertDetaljer(

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/SimuleringTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/SimuleringTest.kt
@@ -31,13 +31,12 @@ internal class SimuleringTest {
     }
 
     @Test
-    fun `equals`() {
+    fun equals() {
         simulering shouldBe simulering
         simulering shouldBe simulering.copy()
 
         simulering shouldNotBe simulering.copy(gjelderId = Fnr("10101010101"))
         simulering shouldNotBe simulering.copy(gjelderNavn = "MYGG DUM")
-        simulering shouldNotBe simulering.copy(nettoBeløp = 70)
         simulering shouldNotBe simulering.copy(periodeList = emptyList())
     }
 

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingServiceImplTest.kt
@@ -499,7 +499,7 @@ internal class UtbetalingServiceImplTest {
         }
 
         val simuleringClientMock = mock<SimuleringClient> {
-            on { simulerUtbetaling(any()) } doReturn simulering.copy(nettoBeløp = 1234).right()
+            on { simulerUtbetaling(any()) } doReturn simulering.copy(gjelderNavn = "Anne T. Navn").right()
         }
 
         val utbetalingRepoMock = mock<UtbetalingRepo>()


### PR DESCRIPTION
TL;DR: Nettobeløpet innebefatter skatt, og endres av oppdrag over tid.

Eksempelvis så vil en saksbehandling for måneden juli gjort i juli føre til at oppdrag bruker brukerens tabellkort for denne måneden, men hvis attestant kjører simuleringen i august, så vil oppdrag bruke den faste skatteprosenten på 32%. Denne vil typisk være høyere enn tabellkortet (som gjerne kan gi 0 kr i skatt), og da vil nettobeløpet være forskjellig i saksbehandlers og attestants simulering.