### PR TITLE
Oppgi behandlingsstart-tidspunkt for de åpne behandlingene

### DIFF
--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/DatabaseEx.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/DatabaseEx.kt
@@ -57,6 +57,7 @@ internal fun Row.uuidOrNull(name: String) = stringOrNull(name)?.let { uuid(name)
 internal fun Row.uuid30(name: String) = UUID30.fromString(string(name))
 internal fun Row.uuid30OrNull(name: String) = stringOrNull(name)?.let { UUID30.fromString(it) }
 internal fun Row.tidspunkt(name: String) = this.instant(name).toTidspunkt()
+internal fun Row.tidspunktOrNull(name: String) = this.instantOrNull(name)?.toTidspunkt()
 
 internal fun Session.inClauseWith(values: List<String>): Array =
     this.connection.underlying.createArrayOf("text", values.toTypedArray())

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/sak/SakRestansRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/sak/SakRestansRepo.kt
@@ -17,7 +17,7 @@ internal class SakRestansRepo(
     private val dbMetrics: DbMetrics,
 ) {
     /**
-     * Henter åpne behandlinger, åpne revurderinger, og nye søknader
+     * Henter åpne søknadsbehandlinger, åpne revurderinger, og nye søknader
      */
     fun hentSakRestanser(): List<SakRestans> {
         return dbMetrics.timeQuery("hentSakRestanser") {

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepoTest.kt
@@ -63,28 +63,28 @@ internal class SakPostgresRepoTest {
                     behandlingsId = sak.søknad.id,
                     restansType = SakRestans.RestansType.SØKNADSBEHANDLING,
                     status = SakRestans.RestansStatus.NY_SØKNAD,
-                    opprettet = sak.søknad.opprettet,
+                    behandlingStartet = null,
                 ),
                 SakRestans(
                     saksnummer = Saksnummer(nummer = 2022),
                     behandlingsId = søknadsbehandling.id,
                     restansType = SakRestans.RestansType.SØKNADSBEHANDLING,
                     status = SakRestans.RestansStatus.UNDER_BEHANDLING,
-                    opprettet = søknadsbehandling.opprettet,
+                    behandlingStartet = søknadsbehandling.opprettet,
                 ),
                 SakRestans(
                     saksnummer = Saksnummer(nummer = 2023),
                     behandlingsId = underkjent.id,
                     restansType = SakRestans.RestansType.SØKNADSBEHANDLING,
                     status = SakRestans.RestansStatus.UNDERKJENT,
-                    opprettet = underkjent.opprettet,
+                    behandlingStartet = underkjent.opprettet,
                 ),
                 SakRestans(
                     saksnummer = Saksnummer(nummer = 2024),
                     behandlingsId = tilAttestering.id,
                     restansType = SakRestans.RestansType.SØKNADSBEHANDLING,
                     status = SakRestans.RestansStatus.TIL_ATTESTERING,
-                    opprettet = tilAttestering.opprettet,
+                    behandlingStartet = tilAttestering.opprettet,
                 ),
                 // Vi hopper over 1 saksnummer siden den blir lagret som en del når vi lager en revurdering gjennom
                 // hjelpe funksjoner
@@ -93,21 +93,21 @@ internal class SakPostgresRepoTest {
                     behandlingsId = opprettetRevurdering.id,
                     restansType = SakRestans.RestansType.REVURDERING,
                     status = SakRestans.RestansStatus.UNDER_BEHANDLING,
-                    opprettet = opprettetRevurdering.opprettet,
+                    behandlingStartet = opprettetRevurdering.opprettet,
                 ),
                 SakRestans(
                     saksnummer = Saksnummer(nummer = 2027),
                     behandlingsId = tilAttesteringRevurdering.id,
                     restansType = SakRestans.RestansType.REVURDERING,
                     status = SakRestans.RestansStatus.TIL_ATTESTERING,
-                    opprettet = tilAttesteringRevurdering.opprettet,
+                    behandlingStartet = tilAttesteringRevurdering.opprettet,
                 ),
                 SakRestans(
                     saksnummer = Saksnummer(nummer = 2028),
                     behandlingsId = underkjentRevurdering.id,
                     restansType = SakRestans.RestansType.REVURDERING,
                     status = SakRestans.RestansStatus.UNDERKJENT,
-                    opprettet = underkjentRevurdering.opprettet,
+                    behandlingStartet = underkjentRevurdering.opprettet,
                 ),
             )
         }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakRestans.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakRestans.kt
@@ -9,7 +9,7 @@ data class SakRestans(
     val behandlingsId: UUID,
     val restansType: RestansType,
     val status: RestansStatus,
-    val opprettet: Tidspunkt,
+    val behandlingStartet: Tidspunkt?,
 ) {
     enum class RestansType {
         SØKNADSBEHANDLING,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/sak/SakServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/sak/SakServiceImplTest.kt
@@ -78,7 +78,7 @@ internal class SakServiceImplTest {
                     behandlingsId = nySakMedjournalførtSøknadOgOppgave.id,
                     restansType = SakRestans.RestansType.SØKNADSBEHANDLING,
                     status = SakRestans.RestansStatus.NY_SØKNAD,
-                    opprettet = nySakMedjournalførtSøknadOgOppgave.opprettet,
+                    behandlingStartet = nySakMedjournalførtSøknadOgOppgave.opprettet,
                 ),
             )
         }
@@ -92,7 +92,7 @@ internal class SakServiceImplTest {
                 behandlingsId = nySakMedjournalførtSøknadOgOppgave.id,
                 restansType = SakRestans.RestansType.SØKNADSBEHANDLING,
                 status = SakRestans.RestansStatus.NY_SØKNAD,
-                opprettet = nySakMedjournalførtSøknadOgOppgave.opprettet,
+                behandlingStartet = nySakMedjournalførtSøknadOgOppgave.opprettet,
             ),
         )
     }
@@ -113,21 +113,21 @@ internal class SakServiceImplTest {
                     behandlingsId = uavklartSøkandsbehandling.id,
                     restansType = SakRestans.RestansType.SØKNADSBEHANDLING,
                     status = SakRestans.RestansStatus.UNDER_BEHANDLING,
-                    opprettet = uavklartSøkandsbehandling.opprettet,
+                    behandlingStartet = uavklartSøkandsbehandling.opprettet,
                 ),
                 SakRestans(
                     saksnummer = saksnr1,
                     behandlingsId = underkjentSøknadsbehandling.id,
                     restansType = SakRestans.RestansType.SØKNADSBEHANDLING,
                     status = SakRestans.RestansStatus.UNDERKJENT,
-                    opprettet = underkjentSøknadsbehandling.opprettet,
+                    behandlingStartet = underkjentSøknadsbehandling.opprettet,
                 ),
                 SakRestans(
                     saksnummer = saksnr2,
                     behandlingsId = tilAttesteringSøknadsbehandling.id,
                     restansType = SakRestans.RestansType.SØKNADSBEHANDLING,
                     status = SakRestans.RestansStatus.TIL_ATTESTERING,
-                    opprettet = tilAttesteringSøknadsbehandling.opprettet,
+                    behandlingStartet = tilAttesteringSøknadsbehandling.opprettet,
                 ),
             )
         }
@@ -141,21 +141,21 @@ internal class SakServiceImplTest {
                 behandlingsId = uavklartSøkandsbehandling.id,
                 restansType = SakRestans.RestansType.SØKNADSBEHANDLING,
                 status = SakRestans.RestansStatus.UNDER_BEHANDLING,
-                opprettet = uavklartSøkandsbehandling.opprettet,
+                behandlingStartet = uavklartSøkandsbehandling.opprettet,
             ),
             SakRestans(
                 saksnummer = saksnr1,
                 behandlingsId = underkjentSøknadsbehandling.id,
                 restansType = SakRestans.RestansType.SØKNADSBEHANDLING,
                 status = SakRestans.RestansStatus.UNDERKJENT,
-                opprettet = underkjentSøknadsbehandling.opprettet,
+                behandlingStartet = underkjentSøknadsbehandling.opprettet,
             ),
             SakRestans(
                 saksnummer = saksnr2,
                 behandlingsId = tilAttesteringSøknadsbehandling.id,
                 restansType = SakRestans.RestansType.SØKNADSBEHANDLING,
                 status = SakRestans.RestansStatus.TIL_ATTESTERING,
-                opprettet = tilAttesteringSøknadsbehandling.opprettet,
+                behandlingStartet = tilAttesteringSøknadsbehandling.opprettet,
             ),
         )
     }
@@ -180,28 +180,28 @@ internal class SakServiceImplTest {
                     behandlingsId = opprettetRevurdering.id,
                     restansType = SakRestans.RestansType.REVURDERING,
                     status = SakRestans.RestansStatus.UNDER_BEHANDLING,
-                    opprettet = opprettetRevurdering.opprettet,
+                    behandlingStartet = opprettetRevurdering.opprettet,
                 ),
                 SakRestans(
                     saksnummer = saknr1,
                     behandlingsId = simulertRevurdering.id,
                     restansType = SakRestans.RestansType.REVURDERING,
                     status = SakRestans.RestansStatus.UNDER_BEHANDLING,
-                    opprettet = simulertRevurdering.opprettet,
+                    behandlingStartet = simulertRevurdering.opprettet,
                 ),
                 SakRestans(
                     saksnummer = saknr2,
                     behandlingsId = underkjentInnvilgetRevurdering.id,
                     restansType = SakRestans.RestansType.REVURDERING,
                     status = SakRestans.RestansStatus.UNDERKJENT,
-                    opprettet = underkjentInnvilgetRevurdering.opprettet,
+                    behandlingStartet = underkjentInnvilgetRevurdering.opprettet,
                 ),
                 SakRestans(
                     saksnummer = saknr2,
                     behandlingsId = tilAttesteringRevurdering.id,
                     restansType = SakRestans.RestansType.REVURDERING,
                     status = SakRestans.RestansStatus.TIL_ATTESTERING,
-                    opprettet = tilAttesteringRevurdering.opprettet,
+                    behandlingStartet = tilAttesteringRevurdering.opprettet,
                 ),
             )
         }
@@ -215,28 +215,28 @@ internal class SakServiceImplTest {
                 behandlingsId = opprettetRevurdering.id,
                 restansType = SakRestans.RestansType.REVURDERING,
                 status = SakRestans.RestansStatus.UNDER_BEHANDLING,
-                opprettet = opprettetRevurdering.opprettet,
+                behandlingStartet = opprettetRevurdering.opprettet,
             ),
             SakRestans(
                 saksnummer = saknr1,
                 behandlingsId = simulertRevurdering.id,
                 restansType = SakRestans.RestansType.REVURDERING,
                 status = SakRestans.RestansStatus.UNDER_BEHANDLING,
-                opprettet = simulertRevurdering.opprettet,
+                behandlingStartet = simulertRevurdering.opprettet,
             ),
             SakRestans(
                 saksnummer = saknr2,
                 behandlingsId = underkjentInnvilgetRevurdering.id,
                 restansType = SakRestans.RestansType.REVURDERING,
                 status = SakRestans.RestansStatus.UNDERKJENT,
-                opprettet = underkjentInnvilgetRevurdering.opprettet,
+                behandlingStartet = underkjentInnvilgetRevurdering.opprettet,
             ),
             SakRestans(
                 saksnummer = saknr2,
                 behandlingsId = tilAttesteringRevurdering.id,
                 restansType = SakRestans.RestansType.REVURDERING,
                 status = SakRestans.RestansStatus.TIL_ATTESTERING,
-                opprettet = tilAttesteringRevurdering.opprettet,
+                behandlingStartet = tilAttesteringRevurdering.opprettet,
             ),
         )
     }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/sak/SakRestansJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/sak/SakRestansJson.kt
@@ -7,7 +7,7 @@ internal data class SakRestansJson(
     val behandlingId: String,
     val typeBehandling: String,
     val status: String,
-    val opprettet: String,
+    val behandlingStartet: String?,
 ) {
     companion object {
         fun List<SakRestans>.toJson() = this.map {
@@ -16,7 +16,7 @@ internal data class SakRestansJson(
                 behandlingId = it.behandlingsId.toString(),
                 typeBehandling = it.restansType.toString(),
                 status = it.status.toString(),
-                opprettet = it.opprettet.toString(),
+                behandlingStartet = it.behandlingStartet?.toString(),
             )
         }
     }


### PR DESCRIPTION
Dette betyr også at tidspunktet fjernes for nye søknader, som det jo ikke er startet behandling på enda.

Helt konkret så er endringen at vi endrer feltnavn fra `opprettet` til `behandlingStartet`, og tillater at det er null for nye søknader.