### PR TITLE
Endepunkt for uthenting av persisterte dokumenter.

### DIFF
--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
@@ -44,6 +44,7 @@ import no.nav.su.se.bakover.domain.vedtak.Vedtak
 import no.nav.su.se.bakover.service.avstemming.AvstemmingFeilet
 import no.nav.su.se.bakover.service.avstemming.AvstemmingService
 import no.nav.su.se.bakover.service.brev.BrevService
+import no.nav.su.se.bakover.service.brev.HentDokumenterForIdType
 import no.nav.su.se.bakover.service.brev.KunneIkkeBestilleBrevForDokument
 import no.nav.su.se.bakover.service.brev.KunneIkkeJournalføreDokument
 import no.nav.su.se.bakover.service.grunnlag.GrunnlagService
@@ -289,6 +290,17 @@ open class AccessCheckProxy(
 
                 override fun journalførDokument(dokumentdistribusjon: Dokumentdistribusjon): Either<KunneIkkeJournalføreDokument, Dokumentdistribusjon> {
                     kastKanKunKallesFraAnnenService()
+                }
+
+                override fun hentDokumenterFor(hentDokumenterForIdType: HentDokumenterForIdType): List<Dokument> {
+                    when (hentDokumenterForIdType) {
+                        is HentDokumenterForIdType.Revurdering -> assertHarTilgangTilRevurdering(hentDokumenterForIdType.id)
+                        is HentDokumenterForIdType.Sak -> assertHarTilgangTilSak(hentDokumenterForIdType.id)
+                        is HentDokumenterForIdType.Søknad -> assertHarTilgangTilSøknad(hentDokumenterForIdType.id)
+                        is HentDokumenterForIdType.Vedtak -> TODO("rart at vi ikke henter ut noe med vedtak id fra før?")
+                    }.let {
+                        return services.brev.hentDokumenterFor(hentDokumenterForIdType)
+                    }
                 }
             },
             lukkSøknad = object : LukkSøknadService {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/brev/BrevService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/brev/BrevService.kt
@@ -7,6 +7,7 @@ import no.nav.su.se.bakover.domain.brev.LagBrevRequest
 import no.nav.su.se.bakover.domain.dokument.Dokument
 import no.nav.su.se.bakover.domain.dokument.Dokumentdistribusjon
 import no.nav.su.se.bakover.domain.journal.JournalpostId
+import java.util.UUID
 
 interface BrevService {
     fun lagBrev(request: LagBrevRequest): Either<KunneIkkeLageBrev, ByteArray>
@@ -17,6 +18,20 @@ interface BrevService {
     fun journalførDokument(dokumentdistribusjon: Dokumentdistribusjon): Either<KunneIkkeJournalføreDokument, Dokumentdistribusjon>
     fun distribuerDokument(dokumentdistribusjon: Dokumentdistribusjon): Either<KunneIkkeBestilleBrevForDokument, Dokumentdistribusjon>
     fun hentDokumenterForDistribusjon(): List<Dokumentdistribusjon>
+    fun hentDokumenterFor(hentDokumenterForIdType: HentDokumenterForIdType): List<Dokument>
+}
+
+/**
+ * Informasjon om id og hvilken type instans denne id'en stammer fra.
+ * Avgjør hvilke [Dokument.Metadata] som benyttes for oppslag.
+ */
+sealed class HentDokumenterForIdType {
+    abstract val id: UUID
+
+    data class Sak(override val id: UUID) : HentDokumenterForIdType()
+    data class Søknad(override val id: UUID) : HentDokumenterForIdType()
+    data class Revurdering(override val id: UUID) : HentDokumenterForIdType()
+    data class Vedtak(override val id: UUID) : HentDokumenterForIdType()
 }
 
 sealed class KunneIkkeLageBrev {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/brev/BrevServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/brev/BrevServiceImpl.kt
@@ -135,6 +135,15 @@ internal class BrevServiceImpl(
         return dokumentRepo.hentDokumenterForDistribusjon()
     }
 
+    override fun hentDokumenterFor(hentDokumenterForIdType: HentDokumenterForIdType): List<Dokument> {
+        return when (hentDokumenterForIdType) {
+            is HentDokumenterForIdType.Sak -> dokumentRepo.hentForSak(hentDokumenterForIdType.id)
+            is HentDokumenterForIdType.Søknad -> dokumentRepo.hentForSøknad(hentDokumenterForIdType.id)
+            is HentDokumenterForIdType.Revurdering -> dokumentRepo.hentForRevurdering(hentDokumenterForIdType.id)
+            is HentDokumenterForIdType.Vedtak -> dokumentRepo.hentForVedtak(hentDokumenterForIdType.id)
+        }
+    }
+
     private fun lagPdf(brevInnhold: BrevInnhold): Either<KunneIkkeLageBrev, ByteArray> {
         return pdfGenerator.genererPdf(brevInnhold)
             .mapLeft { KunneIkkeLageBrev.KunneIkkeGenererePDF }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/AccessCheckProxyTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/AccessCheckProxyTest.kt
@@ -92,9 +92,10 @@ internal class AccessCheckProxyTest {
                             Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
 
                         override fun hentAktørId(fnr: Fnr) = throw NotImplementedError()
-                        override fun sjekkTilgangTilPerson(fnr: Fnr) = Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
-                    }
-                )
+                        override fun sjekkTilgangTilPerson(fnr: Fnr) =
+                            Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
+                    },
+                ),
             ).proxy()
 
             shouldThrow<Tilgangssjekkfeil> { proxied.sak.hentSak(UUID.randomUUID()) }
@@ -113,9 +114,10 @@ internal class AccessCheckProxyTest {
                             Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
 
                         override fun hentAktørId(fnr: Fnr) = throw NotImplementedError()
-                        override fun sjekkTilgangTilPerson(fnr: Fnr) = Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
+                        override fun sjekkTilgangTilPerson(fnr: Fnr) =
+                            Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
                     },
-                )
+                ),
             ).proxy()
 
             shouldThrow<Tilgangssjekkfeil> { proxied.søknad.hentSøknad(UUID.randomUUID()) }
@@ -134,14 +136,15 @@ internal class AccessCheckProxyTest {
                             Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
 
                         override fun hentAktørId(fnr: Fnr) = throw NotImplementedError()
-                        override fun sjekkTilgangTilPerson(fnr: Fnr) = Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
-                    }
-                )
+                        override fun sjekkTilgangTilPerson(fnr: Fnr) =
+                            Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
+                    },
+                ),
             ).proxy()
 
             shouldThrow<Tilgangssjekkfeil> {
                 proxied.søknadsbehandling.hent(
-                    SøknadsbehandlingService.HentRequest(UUID.randomUUID())
+                    SøknadsbehandlingService.HentRequest(UUID.randomUUID()),
                 )
             }
         }
@@ -159,9 +162,10 @@ internal class AccessCheckProxyTest {
                             Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
 
                         override fun hentAktørId(fnr: Fnr) = throw NotImplementedError()
-                        override fun sjekkTilgangTilPerson(fnr: Fnr) = Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
-                    }
-                )
+                        override fun sjekkTilgangTilPerson(fnr: Fnr) =
+                            Either.Left(KunneIkkeHentePerson.IkkeTilgangTilPerson)
+                    },
+                ),
             ).proxy()
 
             shouldThrow<Tilgangssjekkfeil> { proxied.utbetaling.hentUtbetaling(UUID30.randomUUID()) }
@@ -211,8 +215,8 @@ internal class AccessCheckProxyTest {
             services = servicesReturningSak.copy(
                 person = mock {
                     on { sjekkTilgangTilPerson(any()) } doReturn Unit.right()
-                }
-            )
+                },
+            ),
         ).proxy()
 
         @Test

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/Application.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/Application.kt
@@ -58,6 +58,7 @@ import no.nav.su.se.bakover.web.metrics.DbMicrometerMetrics
 import no.nav.su.se.bakover.web.metrics.SuMetrics
 import no.nav.su.se.bakover.web.metrics.SøknadMicrometerMetrics
 import no.nav.su.se.bakover.web.routes.avstemming.avstemmingRoutes
+import no.nav.su.se.bakover.web.routes.dokument.dokumentRoutes
 import no.nav.su.se.bakover.web.routes.drift.driftRoutes
 import no.nav.su.se.bakover.web.routes.installMetrics
 import no.nav.su.se.bakover.web.routes.me.meRoutes
@@ -245,6 +246,7 @@ internal fun Application.susebakover(
                     gjenopptaUtbetalingRoutes(accessProtectedServices.utbetaling)
                     driftRoutes(accessProtectedServices.søknad, accessProtectedServices.ferdigstillVedtak)
                     revurderingRoutes(accessProtectedServices.revurdering, accessProtectedServices.vedtakService, clock)
+                    dokumentRoutes(accessProtectedServices.brev)
                 }
             }
         }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/dokument/DokumentJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/dokument/DokumentJson.kt
@@ -9,6 +9,7 @@ internal fun List<Dokument>.toJson(): List<DokumentJson> {
 
 internal fun Dokument.toJson(): DokumentJson {
     return DokumentJson(
+        id = id.toString(),
         tittel = tittel,
         opprettet = DateTimeFormatter.ISO_INSTANT.format(opprettet),
         dokument = generertDokument,
@@ -16,6 +17,7 @@ internal fun Dokument.toJson(): DokumentJson {
 }
 
 internal data class DokumentJson(
+    val id: String,
     val tittel: String,
     val opprettet: String,
     val dokument: ByteArray,

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/dokument/DokumentJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/dokument/DokumentJson.kt
@@ -1,0 +1,22 @@
+package no.nav.su.se.bakover.web.routes.dokument
+
+import no.nav.su.se.bakover.domain.dokument.Dokument
+import java.time.format.DateTimeFormatter
+
+internal fun List<Dokument>.toJson(): List<DokumentJson> {
+    return map { it.toJson() }
+}
+
+internal fun Dokument.toJson(): DokumentJson {
+    return DokumentJson(
+        tittel = tittel,
+        opprettet = DateTimeFormatter.ISO_INSTANT.format(opprettet),
+        dokument = generertDokument,
+    )
+}
+
+internal data class DokumentJson(
+    val tittel: String,
+    val opprettet: String,
+    val dokument: ByteArray,
+)

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/dokument/DokumentRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/dokument/DokumentRoutes.kt
@@ -1,0 +1,119 @@
+package no.nav.su.se.bakover.web.routes.dokument
+
+import arrow.core.Either
+import arrow.core.getOrHandle
+import arrow.core.left
+import arrow.core.right
+import io.ktor.application.call
+import io.ktor.http.HttpStatusCode
+import io.ktor.routing.Route
+import io.ktor.routing.get
+import no.nav.su.se.bakover.common.serialize
+import no.nav.su.se.bakover.domain.Brukerrolle
+import no.nav.su.se.bakover.service.brev.BrevService
+import no.nav.su.se.bakover.service.brev.HentDokumenterForIdType
+import no.nav.su.se.bakover.web.Resultat
+import no.nav.su.se.bakover.web.errorJson
+import no.nav.su.se.bakover.web.features.authorize
+import no.nav.su.se.bakover.web.parameter
+import no.nav.su.se.bakover.web.svar
+import no.nav.su.se.bakover.web.toUUID
+import java.util.UUID
+
+private const val idParameter = "id"
+private const val idTypeParameter = "idType"
+
+internal fun Route.dokumentRoutes(
+    brevService: BrevService,
+) {
+    authorize(Brukerrolle.Saksbehandler) {
+        get("/dokumenter") {
+            val id = call.parameter(idParameter)
+                .getOrHandle {
+                    return@get call.svar(
+                        HttpStatusCode.BadRequest.errorJson(
+                            "Parameter '$idParameter' mangler",
+                            "mangler_$idParameter",
+                        ),
+                    )
+                }
+            val type = call.parameter(idTypeParameter)
+                .getOrHandle {
+                    return@get call.svar(
+                        HttpStatusCode.BadRequest.errorJson(
+                            "Parameter '$idTypeParameter' mangler",
+                            "mangler_$idTypeParameter",
+                        ),
+                    )
+                }
+
+            val parameters = HentDokumentParameters.tryCreate(id, type)
+                .getOrHandle { error ->
+                    return@get when (error) {
+                        HentDokumentParameters.Companion.UgyldigParameter.UgyldigType -> {
+                            call.svar(
+                                HttpStatusCode.BadRequest.errorJson(
+                                    "Ugyldig parameter '$idTypeParameter'",
+                                    "ugyldig_parameter_$idTypeParameter",
+                                ),
+                            )
+                        }
+                        HentDokumentParameters.Companion.UgyldigParameter.UgyldigUUID -> {
+                            call.svar(
+                                HttpStatusCode.BadRequest.errorJson(
+                                    "Ugyldig parameter '$idParameter'",
+                                    "ugyldig_parameter_$idParameter",
+                                ),
+                            )
+                        }
+                    }
+                }
+
+            val dokumenter = brevService.hentDokumenterFor(parameters.toDomain())
+
+            call.svar(
+                Resultat.json(
+                    httpCode = HttpStatusCode.OK,
+                    json = serialize(dokumenter.toJson()),
+                ),
+            )
+        }
+    }
+}
+
+private data class HentDokumentParameters(
+    val id: UUID,
+    val idType: IdType,
+) {
+    companion object {
+        fun tryCreate(id: String, type: String): Either<UgyldigParameter, HentDokumentParameters> {
+            return HentDokumentParameters(
+                id = id.toUUID()
+                    .getOrHandle { return UgyldigParameter.UgyldigUUID.left() },
+                idType = Either.catch { IdType.valueOf(type.uppercase()) }
+                    .getOrHandle { return UgyldigParameter.UgyldigType.left() },
+            ).right()
+        }
+
+        sealed class UgyldigParameter {
+            object UgyldigUUID : UgyldigParameter()
+            object UgyldigType : UgyldigParameter()
+        }
+    }
+
+    fun toDomain(): HentDokumenterForIdType {
+        return when (idType) {
+            IdType.SAK -> HentDokumenterForIdType.Sak(id)
+            IdType.SØKNAD -> HentDokumenterForIdType.Søknad(id)
+            IdType.VEDTAK -> HentDokumenterForIdType.Vedtak(id)
+            IdType.REVURDERING -> HentDokumenterForIdType.Revurdering(id)
+        }
+    }
+}
+
+private enum class IdType {
+    SAK,
+    SØKNAD,
+    VEDTAK,
+    REVURDERING
+}

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/dokument/DokumentJsonKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/dokument/DokumentJsonKtTest.kt
@@ -1,0 +1,56 @@
+package no.nav.su.se.bakover.web.routes.dokument
+
+import no.nav.su.se.bakover.common.Tidspunkt
+import no.nav.su.se.bakover.common.serialize
+import no.nav.su.se.bakover.domain.dokument.Dokument
+import org.junit.jupiter.api.Test
+import org.skyscreamer.jsonassert.JSONAssert
+import java.util.UUID
+
+internal class DokumentJsonKtTest {
+    @Test
+    fun `serialiserer json`() {
+        val expected = """
+            {
+                "id": "5ea19f74-7363-47ee-a8d7-5abf3a261817",
+                "opprettet": "1970-01-01T00:00:00Z",
+                "tittel": "vedtak om json",
+                "dokument": "ZG9rdW1lbnRldA==",
+            }
+        """.trimIndent()
+
+        val dokument = Dokument.UtenMetadata.Vedtak(
+            id = UUID.fromString("5ea19f74-7363-47ee-a8d7-5abf3a261817"),
+            opprettet = Tidspunkt.EPOCH,
+            tittel = "vedtak om json",
+            generertDokument = "dokumentet".toByteArray(),
+            generertDokumentJson = "{}",
+        )
+
+        JSONAssert.assertEquals(expected, serialize(dokument.toJson()), true)
+    }
+
+    @Test
+    fun `serialiserer liste json`() {
+        val expected = """
+               [
+                {
+                    "id": "5ea19f74-7363-47ee-a8d7-5abf3a261817",
+                    "opprettet": "1970-01-01T00:00:00Z",
+                    "tittel": "vedtak om json",
+                    "dokument": "ZG9rdW1lbnRldA==",
+                }
+               ]
+        """.trimIndent()
+
+        val dokument = Dokument.UtenMetadata.Vedtak(
+            id = UUID.fromString("5ea19f74-7363-47ee-a8d7-5abf3a261817"),
+            opprettet = Tidspunkt.EPOCH,
+            tittel = "vedtak om json",
+            generertDokument = "dokumentet".toByteArray(),
+            generertDokumentJson = "{}",
+        )
+
+        JSONAssert.assertEquals(expected, serialize(listOf(dokument).toJson()), true)
+    }
+}

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/dokument/DokumentRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/dokument/DokumentRoutesKtTest.kt
@@ -1,0 +1,159 @@
+package no.nav.su.se.bakover.web.routes.dokument
+
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.ktor.http.HttpMethod.Companion.Get
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.withTestApplication
+import no.nav.su.se.bakover.common.Tidspunkt
+import no.nav.su.se.bakover.common.deserializeList
+import no.nav.su.se.bakover.domain.Brukerrolle
+import no.nav.su.se.bakover.domain.dokument.Dokument
+import no.nav.su.se.bakover.service.brev.HentDokumenterForIdType
+import no.nav.su.se.bakover.web.TestServicesBuilder
+import no.nav.su.se.bakover.web.argThat
+import no.nav.su.se.bakover.web.defaultRequest
+import no.nav.su.se.bakover.web.testSusebakover
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+internal class DokumentRoutesKtTest {
+
+    @Test
+    fun `sjekker tilganger`() {
+        val mockServices = TestServicesBuilder.services()
+        withTestApplication(
+            (
+                {
+                    testSusebakover(
+                        services = mockServices,
+                    )
+                }
+                ),
+        ) {
+            Brukerrolle.values()
+                .filterNot { it == Brukerrolle.Saksbehandler }
+                .forEach { rolle ->
+                    defaultRequest(
+                        Get,
+                        "/dokumenter?id=39f05293-39e0-47be-ba35-a7e0b233b630&idType=vedtak",
+                        listOf(rolle),
+                    ).response.let {
+                        it.status() shouldBe HttpStatusCode.Forbidden
+                    }
+                }
+        }
+    }
+
+    @Test
+    fun `validerer request`() {
+        val mockServices = TestServicesBuilder.services()
+        withTestApplication(
+            (
+                {
+                    testSusebakover(
+                        services = mockServices,
+                    )
+                }
+                ),
+        ) {
+            defaultRequest(
+                Get,
+                "/dokumenter",
+                listOf(Brukerrolle.Saksbehandler),
+            ).response.let {
+                it.status() shouldBe HttpStatusCode.BadRequest
+                it.content shouldContain "Parameter 'id' mangler"
+            }
+
+            defaultRequest(
+                Get,
+                "/dokumenter?id=1231231",
+                listOf(Brukerrolle.Saksbehandler),
+            ).response.let {
+                it.status() shouldBe HttpStatusCode.BadRequest
+                it.content shouldContain "Parameter 'idType' mangler"
+            }
+
+            defaultRequest(
+                Get,
+                "/dokumenter?id=1231231&idType=jess",
+                listOf(Brukerrolle.Saksbehandler),
+            ).response.let {
+                it.status() shouldBe HttpStatusCode.BadRequest
+                it.content shouldContain "Ugyldig parameter 'id'"
+            }
+
+            defaultRequest(
+                Get,
+                "/dokumenter?id=39f05293-39e0-47be-ba35-a7e0b233b630&idType=jess",
+                listOf(Brukerrolle.Saksbehandler),
+            ).response.let {
+                it.status() shouldBe HttpStatusCode.BadRequest
+                it.content shouldContain "Ugyldig parameter 'idType'"
+            }
+        }
+    }
+
+    @Test
+    fun `happy cases`() {
+        val services = TestServicesBuilder.services().copy(
+            brev = mock {
+                on { hentDokumenterFor(argThat { it is HentDokumenterForIdType.Sak }) } doReturn emptyList()
+                on { hentDokumenterFor(argThat { it is HentDokumenterForIdType.Søknad }) } doReturn listOf(
+                    Dokument.UtenMetadata.Informasjon(
+                        id = UUID.randomUUID(),
+                        opprettet = Tidspunkt.EPOCH,
+                        tittel = "en fin tittel",
+                        generertDokument = "".toByteArray(),
+                        generertDokumentJson = "",
+                    ),
+                )
+            },
+        )
+
+        withTestApplication(
+            (
+                {
+                    testSusebakover(
+                        services = services,
+                    )
+                }
+                ),
+        ) {
+            defaultRequest(
+                method = Get,
+                uri = "/dokumenter?id=39f05293-39e0-47be-ba35-a7e0b233b630&idType=sak",
+                roller = listOf(Brukerrolle.Saksbehandler),
+            ).response.let {
+                it.status() shouldBe HttpStatusCode.OK
+                verify(services.brev).hentDokumenterFor(
+                    HentDokumenterForIdType.Sak(
+                        UUID.fromString("39f05293-39e0-47be-ba35-a7e0b233b630"),
+                    ),
+                )
+            }
+
+            defaultRequest(
+                method = Get,
+                uri = "/dokumenter?id=39f05293-39e0-47be-ba35-a7e0b233b630&idType=søknad",
+                roller = listOf(Brukerrolle.Saksbehandler),
+            ).response.let {
+                it.status() shouldBe HttpStatusCode.OK
+                verify(services.brev).hentDokumenterFor(
+                    HentDokumenterForIdType.Søknad(
+                        UUID.fromString("39f05293-39e0-47be-ba35-a7e0b233b630"),
+                    ),
+                )
+                it.content!!.deserializeList<DokumentJson>().first().let { dokumentJson ->
+                    dokumentJson.tittel shouldBe "en fin tittel"
+                    dokumentJson.opprettet shouldBe "1970-01-01T00:00:00Z"
+                    dokumentJson.dokument contentEquals "".toByteArray()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Enkelt endepunkt som søker opp dokumenter knyttet til en gitt id. I tillegg til id tar endepunktet i mot informasjon om hvilken type id det er snakk om (sak/vedtak/revurdering). Det legges dermed opp til at den som kaller selv må avgjøre hva man ønsker å slå opp dokumenter for (kan bruke samme endepunkt for å hente ut alle dokumenter for en sak, et spesifikt vedtak etc). Valgte denne varianten fremfor å la alle domeneobjektene ha dokumenter knyttet til seg.