### PR TITLE
oppdaterer periodene i grunnlag når stønadsperioden endres

### DIFF
--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/grunnlag/Grunnlagsdata.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/grunnlag/Grunnlagsdata.kt
@@ -10,6 +10,7 @@ import no.nav.su.se.bakover.domain.grunnlag.Grunnlag.Bosituasjon
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag.Bosituasjon.Companion.oppdaterBosituasjonsperiode
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag.Fradragsgrunnlag
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag.Fradragsgrunnlag.Companion.oppdaterFradragsperiode
+import no.nav.su.se.bakover.domain.grunnlag.Grunnlag.Fradragsgrunnlag.Companion.periode
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag.Uføregrunnlag
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 
@@ -96,14 +97,6 @@ sealed class KunneIkkeLageGrunnlagsdata {
 }
 
 fun List<Uføregrunnlag>.harForventetInntektStørreEnn0() = this.sumOf { it.forventetInntekt } > 0
-fun List<Fradragsgrunnlag>.harEpsInntekt() = this.any { it.fradrag.tilhørerEps() }
-fun List<Fradragsgrunnlag>.periode(): Periode? = this.map { it.fradrag.periode }.let { perioder ->
-    if (perioder.isEmpty()) null else
-        Periode.create(
-            fraOgMed = perioder.minOf { it.fraOgMed },
-            tilOgMed = perioder.maxOf { it.tilOgMed },
-        )
-}
 
 @JvmName("bosituasjonperiode")
 fun List<Bosituasjon>.periode(): Periode? = this.map { it.periode }.let { perioder ->

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/grunnlag/Grunnlagsdata.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/grunnlag/Grunnlagsdata.kt
@@ -21,6 +21,15 @@ data class Grunnlagsdata private constructor(
      * */
     val bosituasjon: List<Grunnlag.Bosituasjon>,
 ) {
+    fun oppdaterGrunnlagsperioder(
+        oppdatertPeriode: Periode,
+    ): Grunnlagsdata {
+        return tryCreate(
+            fradragsgrunnlag = fradragsgrunnlag.oppdaterFradragsperiode(oppdatertPeriode),
+            bosituasjon = bosituasjon.oppdaterBosituasjonsperiode(oppdatertPeriode),
+        ).getOrHandle { throw IllegalStateException("Kunne ikke oppdatere stønadsperiode for grunnlagsdata") }
+    }
+
     val periode: Periode? by lazy {
         fradragsgrunnlag.map { it.fradrag.periode }.plus(bosituasjon.map { it.periode }).ifNotEmpty {
             Periode.create(
@@ -90,11 +99,21 @@ fun List<Grunnlag.Fradragsgrunnlag>.periode(): Periode? = this.map { it.fradrag.
         )
 }
 
+fun List<Grunnlag.Fradragsgrunnlag>.oppdaterFradragsperiode(
+    oppdatertPeriode: Periode,
+): List<Grunnlag.Fradragsgrunnlag> {
+    return this.map { it.oppdaterFradragsperiode(oppdatertPeriode) }
+}
+
+fun List<Grunnlag.Bosituasjon>.oppdaterBosituasjonsperiode(oppdatertPeriode: Periode): List<Grunnlag.Bosituasjon> {
+    return this.map { it.oppdaterBosituasjonsperiode(oppdatertPeriode) }
+}
+
 @JvmName("bosituasjonperiode")
 fun List<Grunnlag.Bosituasjon>.periode(): Periode? = this.map { it.periode }.let { perioder ->
     if (perioder.isEmpty()) null else
         Periode.create(
             fraOgMed = perioder.minOf { it.fraOgMed },
-            tilOgMed = perioder.maxOf { it.tilOgMed }
+            tilOgMed = perioder.maxOf { it.tilOgMed },
         )
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/grunnlag/SjekkOmGrunnlagErKonsistent.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/grunnlag/SjekkOmGrunnlagErKonsistent.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
 import arrow.core.separateEither
+import no.nav.su.se.bakover.domain.grunnlag.Grunnlag.Fradragsgrunnlag.Companion.harEpsInntekt
 
 data class SjekkOmGrunnlagErKonsistent(
     private val formuegrunnlag: List<Formuegrunnlag>,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Statusovergang.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Statusovergang.kt
@@ -1,6 +1,7 @@
 package no.nav.su.se.bakover.domain.søknadsbehandling
 
 import arrow.core.Either
+import arrow.core.getOrHandle
 import arrow.core.left
 import arrow.core.right
 import no.nav.su.se.bakover.common.UUID30
@@ -8,6 +9,7 @@ import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.behandling.Attestering
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.beregning.Beregning
+import no.nav.su.se.bakover.domain.grunnlag.KunneIkkeLageGrunnlagsdata
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimuleringFeilet
 
@@ -209,105 +211,67 @@ abstract class Statusovergang<L, T> : StatusovergangVisitor {
 
     class OppdaterStønadsperiode(
         private val oppdatertStønadsperiode: Stønadsperiode,
-    ) : Statusovergang<Nothing, Søknadsbehandling.Vilkårsvurdert>() {
+    ) : Statusovergang<OppdaterStønadsperiode.KunneIkkeOppdatereStønadsperiode, Søknadsbehandling.Vilkårsvurdert>() {
 
-        override fun visit(søknadsbehandling: Søknadsbehandling.Vilkårsvurdert.Uavklart) {
-            result = søknadsbehandling.copy(
+        sealed class KunneIkkeOppdatereStønadsperiode {
+            data class KunneIkkeOppdatereGrunnlagsdata(val feil: KunneIkkeLageGrunnlagsdata) :
+                KunneIkkeOppdatereStønadsperiode()
+        }
+
+        private fun oppdater(søknadsbehandling: Søknadsbehandling): Either<KunneIkkeOppdatereStønadsperiode, Søknadsbehandling.Vilkårsvurdert> {
+            return Søknadsbehandling.Vilkårsvurdert.Uavklart(
+                id = søknadsbehandling.id,
+                opprettet = søknadsbehandling.opprettet,
+                sakId = søknadsbehandling.sakId,
+                saksnummer = søknadsbehandling.saksnummer,
+                søknad = søknadsbehandling.søknad,
+                oppgaveId = søknadsbehandling.oppgaveId,
+                behandlingsinformasjon = søknadsbehandling.behandlingsinformasjon,
+                fnr = søknadsbehandling.fnr,
+                fritekstTilBrev = søknadsbehandling.fritekstTilBrev,
                 stønadsperiode = oppdatertStønadsperiode,
-                vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(oppdatertStønadsperiode),
                 grunnlagsdata = søknadsbehandling.grunnlagsdata.oppdaterGrunnlagsperioder(
                     oppdatertPeriode = oppdatertStønadsperiode.periode,
-                ),
-            )
-                .tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
+                ).getOrHandle { return KunneIkkeOppdatereStønadsperiode.KunneIkkeOppdatereGrunnlagsdata(it).left() },
+                vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(oppdatertStønadsperiode),
+                attesteringer = søknadsbehandling.attesteringer,
+            ).tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
+        }
+
+        override fun visit(søknadsbehandling: Søknadsbehandling.Vilkårsvurdert.Uavklart) {
+            result = oppdater(søknadsbehandling)
         }
 
         override fun visit(søknadsbehandling: Søknadsbehandling.Vilkårsvurdert.Innvilget) {
-            result = søknadsbehandling.copy(
-                stønadsperiode = oppdatertStønadsperiode,
-                vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(oppdatertStønadsperiode),
-                grunnlagsdata = søknadsbehandling.grunnlagsdata.oppdaterGrunnlagsperioder(
-                    oppdatertPeriode = oppdatertStønadsperiode.periode,
-                ),
-            )
-                .tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
+            result = oppdater(søknadsbehandling)
         }
 
         override fun visit(søknadsbehandling: Søknadsbehandling.Vilkårsvurdert.Avslag) {
-            result = søknadsbehandling.copy(
-                stønadsperiode = oppdatertStønadsperiode,
-                vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(oppdatertStønadsperiode),
-                grunnlagsdata = søknadsbehandling.grunnlagsdata.oppdaterGrunnlagsperioder(
-                    oppdatertPeriode = oppdatertStønadsperiode.periode,
-                ),
-            )
-                .tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
+            result = oppdater(søknadsbehandling)
         }
 
         override fun visit(søknadsbehandling: Søknadsbehandling.Beregnet.Innvilget) {
-            result = søknadsbehandling.copy(
-                stønadsperiode = oppdatertStønadsperiode,
-                vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(oppdatertStønadsperiode),
-                grunnlagsdata = søknadsbehandling.grunnlagsdata.oppdaterGrunnlagsperioder(
-                    oppdatertPeriode = oppdatertStønadsperiode.periode,
-                ),
-            )
-                .tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
+            result = oppdater(søknadsbehandling)
         }
 
         override fun visit(søknadsbehandling: Søknadsbehandling.Beregnet.Avslag) {
-            result = søknadsbehandling.copy(
-                stønadsperiode = oppdatertStønadsperiode,
-                vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(oppdatertStønadsperiode),
-                grunnlagsdata = søknadsbehandling.grunnlagsdata.oppdaterGrunnlagsperioder(
-                    oppdatertPeriode = oppdatertStønadsperiode.periode,
-                ),
-            )
-                .tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
+            result = oppdater(søknadsbehandling)
         }
 
         override fun visit(søknadsbehandling: Søknadsbehandling.Simulert) {
-            result = søknadsbehandling.copy(
-                stønadsperiode = oppdatertStønadsperiode,
-                vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(oppdatertStønadsperiode),
-                grunnlagsdata = søknadsbehandling.grunnlagsdata.oppdaterGrunnlagsperioder(
-                    oppdatertPeriode = oppdatertStønadsperiode.periode,
-                ),
-            )
-                .tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
+            result = oppdater(søknadsbehandling)
         }
 
         override fun visit(søknadsbehandling: Søknadsbehandling.Underkjent.Innvilget) {
-            result = søknadsbehandling.copy(
-                stønadsperiode = oppdatertStønadsperiode,
-                vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(oppdatertStønadsperiode),
-                grunnlagsdata = søknadsbehandling.grunnlagsdata.oppdaterGrunnlagsperioder(
-                    oppdatertPeriode = oppdatertStønadsperiode.periode,
-                ),
-            )
-                .tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
+            result = oppdater(søknadsbehandling)
         }
 
         override fun visit(søknadsbehandling: Søknadsbehandling.Underkjent.Avslag.MedBeregning) {
-            result = søknadsbehandling.copy(
-                stønadsperiode = oppdatertStønadsperiode,
-                vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(oppdatertStønadsperiode),
-                grunnlagsdata = søknadsbehandling.grunnlagsdata.oppdaterGrunnlagsperioder(
-                    oppdatertPeriode = oppdatertStønadsperiode.periode,
-                ),
-            )
-                .tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
+            result = oppdater(søknadsbehandling)
         }
 
         override fun visit(søknadsbehandling: Søknadsbehandling.Underkjent.Avslag.UtenBeregning) {
-            result = søknadsbehandling.copy(
-                stønadsperiode = oppdatertStønadsperiode,
-                vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(oppdatertStønadsperiode),
-                grunnlagsdata = søknadsbehandling.grunnlagsdata.oppdaterGrunnlagsperioder(
-                    oppdatertPeriode = oppdatertStønadsperiode.periode,
-                ),
-            )
-                .tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
+            result = oppdater(søknadsbehandling)
         }
     }
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Statusovergang.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Statusovergang.kt
@@ -208,43 +208,106 @@ abstract class Statusovergang<L, T> : StatusovergangVisitor {
     }
 
     class OppdaterStønadsperiode(
-        private val stønadsperiode: Stønadsperiode,
+        private val oppdatertStønadsperiode: Stønadsperiode,
     ) : Statusovergang<Nothing, Søknadsbehandling.Vilkårsvurdert>() {
 
         override fun visit(søknadsbehandling: Søknadsbehandling.Vilkårsvurdert.Uavklart) {
-            result = søknadsbehandling.copy(stønadsperiode = stønadsperiode, vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(stønadsperiode)).tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
+            result = søknadsbehandling.copy(
+                stønadsperiode = oppdatertStønadsperiode,
+                vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(oppdatertStønadsperiode),
+                grunnlagsdata = søknadsbehandling.grunnlagsdata.oppdaterGrunnlagsperioder(
+                    oppdatertPeriode = oppdatertStønadsperiode.periode,
+                ),
+            )
+                .tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
         }
 
         override fun visit(søknadsbehandling: Søknadsbehandling.Vilkårsvurdert.Innvilget) {
-            result = søknadsbehandling.copy(stønadsperiode = stønadsperiode, vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(stønadsperiode)).tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
+            result = søknadsbehandling.copy(
+                stønadsperiode = oppdatertStønadsperiode,
+                vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(oppdatertStønadsperiode),
+                grunnlagsdata = søknadsbehandling.grunnlagsdata.oppdaterGrunnlagsperioder(
+                    oppdatertPeriode = oppdatertStønadsperiode.periode,
+                ),
+            )
+                .tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
         }
 
         override fun visit(søknadsbehandling: Søknadsbehandling.Vilkårsvurdert.Avslag) {
-            result = søknadsbehandling.copy(stønadsperiode = stønadsperiode, vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(stønadsperiode)).tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
+            result = søknadsbehandling.copy(
+                stønadsperiode = oppdatertStønadsperiode,
+                vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(oppdatertStønadsperiode),
+                grunnlagsdata = søknadsbehandling.grunnlagsdata.oppdaterGrunnlagsperioder(
+                    oppdatertPeriode = oppdatertStønadsperiode.periode,
+                ),
+            )
+                .tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
         }
 
         override fun visit(søknadsbehandling: Søknadsbehandling.Beregnet.Innvilget) {
-            result = søknadsbehandling.copy(stønadsperiode = stønadsperiode, vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(stønadsperiode)).tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
+            result = søknadsbehandling.copy(
+                stønadsperiode = oppdatertStønadsperiode,
+                vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(oppdatertStønadsperiode),
+                grunnlagsdata = søknadsbehandling.grunnlagsdata.oppdaterGrunnlagsperioder(
+                    oppdatertPeriode = oppdatertStønadsperiode.periode,
+                ),
+            )
+                .tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
         }
 
         override fun visit(søknadsbehandling: Søknadsbehandling.Beregnet.Avslag) {
-            result = søknadsbehandling.copy(stønadsperiode = stønadsperiode, vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(stønadsperiode)).tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
+            result = søknadsbehandling.copy(
+                stønadsperiode = oppdatertStønadsperiode,
+                vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(oppdatertStønadsperiode),
+                grunnlagsdata = søknadsbehandling.grunnlagsdata.oppdaterGrunnlagsperioder(
+                    oppdatertPeriode = oppdatertStønadsperiode.periode,
+                ),
+            )
+                .tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
         }
 
         override fun visit(søknadsbehandling: Søknadsbehandling.Simulert) {
-            result = søknadsbehandling.copy(stønadsperiode = stønadsperiode, vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(stønadsperiode)).tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
+            result = søknadsbehandling.copy(
+                stønadsperiode = oppdatertStønadsperiode,
+                vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(oppdatertStønadsperiode),
+                grunnlagsdata = søknadsbehandling.grunnlagsdata.oppdaterGrunnlagsperioder(
+                    oppdatertPeriode = oppdatertStønadsperiode.periode,
+                ),
+            )
+                .tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
         }
 
         override fun visit(søknadsbehandling: Søknadsbehandling.Underkjent.Innvilget) {
-            result = søknadsbehandling.copy(stønadsperiode = stønadsperiode, vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(stønadsperiode)).tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
+            result = søknadsbehandling.copy(
+                stønadsperiode = oppdatertStønadsperiode,
+                vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(oppdatertStønadsperiode),
+                grunnlagsdata = søknadsbehandling.grunnlagsdata.oppdaterGrunnlagsperioder(
+                    oppdatertPeriode = oppdatertStønadsperiode.periode,
+                ),
+            )
+                .tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
         }
 
         override fun visit(søknadsbehandling: Søknadsbehandling.Underkjent.Avslag.MedBeregning) {
-            result = søknadsbehandling.copy(stønadsperiode = stønadsperiode, vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(stønadsperiode)).tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
+            result = søknadsbehandling.copy(
+                stønadsperiode = oppdatertStønadsperiode,
+                vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(oppdatertStønadsperiode),
+                grunnlagsdata = søknadsbehandling.grunnlagsdata.oppdaterGrunnlagsperioder(
+                    oppdatertPeriode = oppdatertStønadsperiode.periode,
+                ),
+            )
+                .tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
         }
 
         override fun visit(søknadsbehandling: Søknadsbehandling.Underkjent.Avslag.UtenBeregning) {
-            result = søknadsbehandling.copy(stønadsperiode = stønadsperiode, vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(stønadsperiode)).tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
+            result = søknadsbehandling.copy(
+                stønadsperiode = oppdatertStønadsperiode,
+                vilkårsvurderinger = søknadsbehandling.vilkårsvurderinger.oppdaterStønadsperiode(oppdatertStønadsperiode),
+                grunnlagsdata = søknadsbehandling.grunnlagsdata.oppdaterGrunnlagsperioder(
+                    oppdatertPeriode = oppdatertStønadsperiode.periode,
+                ),
+            )
+                .tilVilkårsvurdert(søknadsbehandling.behandlingsinformasjon).right()
         }
     }
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Søknadsbehandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Søknadsbehandling.kt
@@ -20,9 +20,9 @@ import no.nav.su.se.bakover.domain.behandling.avslag.Avslagsgrunn
 import no.nav.su.se.bakover.domain.behandling.avslag.Avslagsgrunn.Companion.toAvslagsgrunn
 import no.nav.su.se.bakover.domain.beregning.Beregning
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
+import no.nav.su.se.bakover.domain.grunnlag.Grunnlag.Fradragsgrunnlag.Companion.periode
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.grunnlag.KunneIkkeLageGrunnlagsdata
-import no.nav.su.se.bakover.domain.grunnlag.periode
 import no.nav.su.se.bakover.domain.oppdrag.UtbetalingFeilet
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/grunnlag/BosituasjonTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/grunnlag/BosituasjonTest.kt
@@ -2,10 +2,13 @@ package no.nav.su.se.bakover.domain.grunnlag
 
 import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.Tidspunkt
+import no.nav.su.se.bakover.common.desember
+import no.nav.su.se.bakover.common.februar
 import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.juni
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.Fnr
+import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.generer
 import org.junit.jupiter.api.Test
 import java.util.UUID
@@ -90,7 +93,21 @@ internal class BosituasjonTest {
         Grunnlag.Bosituasjon.Ufullstendig.HarIkkeEps(
             id = UUID.randomUUID(),
             opprettet = Tidspunkt.now(),
-            periode = Periode.create(fraOgMed = 1.januar(2021), tilOgMed = 30.juni(2021))
+            periode = Periode.create(fraOgMed = 1.januar(2021), tilOgMed = 30.juni(2021)),
         ).harEndretEllerFjernetEktefelle(gjeldendeBosituasjon) shouldBe true
+    }
+
+    @Test
+    fun `oppdaterer periode i bosituasjon`() {
+        val oppdatertPeriode = Periode.create(1.februar(2021), 31.januar(2022))
+        val gjeldendeBosituasjon = Grunnlag.Bosituasjon.Ufullstendig.HarIkkeEps(
+            id = UUID.randomUUID(),
+            opprettet = fixedTidspunkt,
+            periode = Periode.create(1.januar(2021), 31.desember(2021)),
+        )
+
+        gjeldendeBosituasjon.oppdaterBosituasjonsperiode(oppdatertPeriode) shouldBe gjeldendeBosituasjon.copy(
+            periode = oppdatertPeriode,
+        )
     }
 }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/grunnlag/FradragsgrunnlagTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/grunnlag/FradragsgrunnlagTest.kt
@@ -2,8 +2,12 @@ package no.nav.su.se.bakover.domain.grunnlag
 
 import arrow.core.left
 import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.common.august
+import no.nav.su.se.bakover.common.desember
+import no.nav.su.se.bakover.common.februar
 import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.juli
+import no.nav.su.se.bakover.common.mai
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragFactory
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragTilhører
@@ -71,5 +75,77 @@ internal class FradragsgrunnlagTest {
                 opprettet = fixedTidspunkt,
             ).isRight() shouldBe true
         }
+    }
+
+    @Test
+    fun `fradrag med periode som er lik stønadsperiode, blir oppdatert til å gjelde for hele stønadsperioden`() {
+        val oppdatertPeriode = Periode.create(1.januar(2022), 31.desember(2022))
+        val fradragsgrunnlag = Grunnlag.Fradragsgrunnlag.create(
+            fradrag = FradragFactory.ny(
+                type = Fradragstype.Kontantstøtte,
+                månedsbeløp = 200.0,
+                periode = Periode.create(1.januar(2021), 31.desember(2021)),
+                utenlandskInntekt = null,
+                tilhører = FradragTilhører.BRUKER,
+            ),
+        )
+
+        fradragsgrunnlag.oppdaterFradragsperiode(
+            oppdatertPeriode,
+        ).periode shouldBe oppdatertPeriode
+    }
+
+    @Test
+    fun `fraOgMed blir kuttet og satt lik stønadsperiode FOM når oppdatertPeriode er etter fraOgMed `() {
+        val oppdatertPeriode = Periode.create(1.mai(2021), 31.desember(2021))
+        val fradragsgrunnlag = Grunnlag.Fradragsgrunnlag.create(
+            fradrag = FradragFactory.ny(
+                type = Fradragstype.Kontantstøtte,
+                månedsbeløp = 200.0,
+                periode = Periode.create(1.februar(2021), 31.desember(2021)),
+                utenlandskInntekt = null,
+                tilhører = FradragTilhører.BRUKER,
+            ),
+        )
+
+        fradragsgrunnlag.oppdaterFradragsperiode(
+            oppdatertPeriode,
+        ).periode shouldBe oppdatertPeriode
+    }
+
+    @Test
+    fun `tilOgMed blir kuttet og satt lik stønadsperiode TOM når oppdatertPeriode er før tilOgMed `() {
+        val oppdatertPeriode = Periode.create(1.januar(2021), 31.august(2021))
+        val fradragsgrunnlag = Grunnlag.Fradragsgrunnlag.create(
+            fradrag = FradragFactory.ny(
+                type = Fradragstype.Kontantstøtte,
+                månedsbeløp = 200.0,
+                periode = Periode.create(1.januar(2021), 31.august(2021)),
+                utenlandskInntekt = null,
+                tilhører = FradragTilhører.BRUKER,
+            ),
+        )
+
+        fradragsgrunnlag.oppdaterFradragsperiode(
+            oppdatertPeriode,
+        ).periode shouldBe oppdatertPeriode
+    }
+
+    @Test
+    fun `fradrag med deler av periode i 2022, oppdaterer periode til å gjelde for 2021, får fradragene til å gjelde for hele 2021`() {
+        val oppdatertPeriode = Periode.create(1.januar(2021), 31.desember(2021))
+        val fradragsgrunnlag = Grunnlag.Fradragsgrunnlag.create(
+            fradrag = FradragFactory.ny(
+                type = Fradragstype.Kontantstøtte,
+                månedsbeløp = 200.0,
+                periode = Periode.create(1.februar(2022), 31.august(2022)),
+                utenlandskInntekt = null,
+                tilhører = FradragTilhører.BRUKER,
+            ),
+        )
+
+        fradragsgrunnlag.oppdaterFradragsperiode(
+            oppdatertPeriode,
+        ).periode shouldBe oppdatertPeriode
     }
 }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/grunnlag/FradragsgrunnlagTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/grunnlag/FradragsgrunnlagTest.kt
@@ -92,7 +92,7 @@ internal class FradragsgrunnlagTest {
 
         fradragsgrunnlag.oppdaterFradragsperiode(
             oppdatertPeriode,
-        ).periode shouldBe oppdatertPeriode
+        ).orNull()!!.periode shouldBe oppdatertPeriode
     }
 
     @Test
@@ -110,7 +110,7 @@ internal class FradragsgrunnlagTest {
 
         fradragsgrunnlag.oppdaterFradragsperiode(
             oppdatertPeriode,
-        ).periode shouldBe oppdatertPeriode
+        ).orNull()!!.periode shouldBe oppdatertPeriode
     }
 
     @Test
@@ -128,7 +128,7 @@ internal class FradragsgrunnlagTest {
 
         fradragsgrunnlag.oppdaterFradragsperiode(
             oppdatertPeriode,
-        ).periode shouldBe oppdatertPeriode
+        ).orNull()!!.periode shouldBe oppdatertPeriode
     }
 
     @Test
@@ -146,6 +146,6 @@ internal class FradragsgrunnlagTest {
 
         fradragsgrunnlag.oppdaterFradragsperiode(
             oppdatertPeriode,
-        ).periode shouldBe oppdatertPeriode
+        ).orNull()!!.periode shouldBe oppdatertPeriode
     }
 }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/grunnlag/GrunnlagsdataOgVilkårsvurderingerTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/grunnlag/GrunnlagsdataOgVilkårsvurderingerTest.kt
@@ -1,6 +1,7 @@
 package no.nav.su.se.bakover.domain.grunnlag
 
 import arrow.core.nonEmptyListOf
+import arrow.core.right
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.april
@@ -153,7 +154,7 @@ internal class GrunnlagsdataOgVilkårsvurderingerTest {
 
         tomGrunnlagsdata.oppdaterGrunnlagsperioder(
             oppdatertPeriode = Periode.create(1.januar(2021), 31.januar(2021)),
-        ) shouldBe Grunnlagsdata.create(emptyList(), emptyList())
+        ) shouldBe Grunnlagsdata.create(emptyList(), emptyList()).right()
     }
 
     @Test
@@ -182,7 +183,7 @@ internal class GrunnlagsdataOgVilkårsvurderingerTest {
 
         val actual = grunnlagsdata.oppdaterGrunnlagsperioder(
             oppdatertPeriode = oppdatertPeriode,
-        )
+        ).orNull()!!
 
         actual.fradragsgrunnlag.size shouldBe 1
         actual.fradragsgrunnlag.first().periode shouldBe oppdatertPeriode

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/grunnlag/GrunnlagsdataOgVilkårsvurderingerTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/grunnlag/GrunnlagsdataOgVilkårsvurderingerTest.kt
@@ -4,9 +4,13 @@ import arrow.core.nonEmptyListOf
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.april
+import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.mai
 import no.nav.su.se.bakover.common.periode.Periode
+import no.nav.su.se.bakover.domain.beregning.fradrag.FradragFactory
+import no.nav.su.se.bakover.domain.beregning.fradrag.FradragTilhører
+import no.nav.su.se.bakover.domain.beregning.fradrag.Fradragstype
 import no.nav.su.se.bakover.domain.vilkår.Vilkår
 import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
 import no.nav.su.se.bakover.test.fixedTidspunkt
@@ -141,5 +145,48 @@ internal class GrunnlagsdataOgVilkårsvurderingerTest {
             grunnlagsdata = Grunnlagsdata.IkkeVurdert,
             vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
         )
+    }
+
+    @Test
+    fun `oppdaterGrunnlagsperioder på tomme lister`() {
+        val tomGrunnlagsdata = Grunnlagsdata.create(emptyList(), emptyList())
+
+        tomGrunnlagsdata.oppdaterGrunnlagsperioder(
+            oppdatertPeriode = Periode.create(1.januar(2021), 31.januar(2021)),
+        ) shouldBe Grunnlagsdata.create(emptyList(), emptyList())
+    }
+
+    @Test
+    fun `oppdaterer periodene på grunnlagene`() {
+        val forrigePeriode = Periode.create(1.januar(2021), 31.desember(2021))
+        val oppdatertPeriode = Periode.create(1.januar(2021), 31.januar(2021))
+        val fradragsgrunnlag = Grunnlag.Fradragsgrunnlag.create(
+            fradrag = FradragFactory.ny(
+                type = Fradragstype.Kontantstøtte,
+                månedsbeløp = 0.0,
+                periode = forrigePeriode,
+                utenlandskInntekt = null,
+                tilhører = FradragTilhører.BRUKER,
+            ),
+        )
+        val bosiutasjongrunnlag = Grunnlag.Bosituasjon.Fullstendig.Enslig(
+            id = UUID.randomUUID(),
+            opprettet = fixedTidspunkt,
+            periode = forrigePeriode,
+            begrunnelse = null,
+        )
+        val grunnlagsdata = Grunnlagsdata.create(
+            fradragsgrunnlag = listOf(fradragsgrunnlag),
+            bosituasjon = listOf(bosiutasjongrunnlag),
+        )
+
+        val actual = grunnlagsdata.oppdaterGrunnlagsperioder(
+            oppdatertPeriode = oppdatertPeriode,
+        )
+
+        actual.fradragsgrunnlag.size shouldBe 1
+        actual.fradragsgrunnlag.first().periode shouldBe oppdatertPeriode
+        actual.bosituasjon.size shouldBe 1
+        actual.bosituasjon.first().periode shouldBe oppdatertPeriode
     }
 }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/StatusovergangTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/StatusovergangTest.kt
@@ -769,7 +769,7 @@ internal class StatusovergangTest {
                 underkjentInnvilget,
             ).forEach {
                 assertDoesNotThrow {
-                    statusovergang(
+                    forsøkStatusovergang(
                         søknadsbehandling = it,
                         statusovergang = Statusovergang.OppdaterStønadsperiode(stønadsperiode),
                     )
@@ -788,7 +788,7 @@ internal class StatusovergangTest {
                 iverksattInnvilget,
             ).forEach {
                 assertThrows<StatusovergangVisitor.UgyldigStatusovergangException>("Kastet ikke exception: ${it.status}") {
-                    statusovergang(
+                    forsøkStatusovergang(
                         søknadsbehandling = it,
                         statusovergang = Statusovergang.OppdaterStønadsperiode(stønadsperiode),
                     )
@@ -822,7 +822,7 @@ internal class StatusovergangTest {
             )
 
             val nyPeriode = Periode.create(1.februar(2021), 31.mars(2021))
-            val actual = statusovergang(
+            val actual = forsøkStatusovergang(
                 søknadsbehandling = opprettetMedGrunnlag,
                 statusovergang = Statusovergang.OppdaterStønadsperiode(
                     Stønadsperiode.create(
@@ -832,8 +832,8 @@ internal class StatusovergangTest {
                 ),
             )
 
-            actual.periode shouldBe nyPeriode
-            actual.vilkårsvurderinger.uføre.grunnlag.first().periode shouldBe nyPeriode
+            actual.orNull()!!.periode shouldBe nyPeriode
+            actual.orNull()!!.vilkårsvurderinger.uføre.grunnlag.first().periode shouldBe nyPeriode
         }
     }
 }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingService.kt
@@ -8,6 +8,7 @@ import no.nav.su.se.bakover.domain.grunnlag.KunneIkkeLageGrunnlagsdata
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimuleringFeilet
 import no.nav.su.se.bakover.domain.søknadsbehandling.BehandlingsStatus
 import no.nav.su.se.bakover.domain.søknadsbehandling.KunneIkkeIverksette
+import no.nav.su.se.bakover.domain.søknadsbehandling.Statusovergang
 import no.nav.su.se.bakover.domain.søknadsbehandling.Stønadsperiode
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
 import no.nav.su.se.bakover.service.grunnlag.LeggTilFradragsgrunnlagRequest
@@ -137,6 +138,8 @@ interface SøknadsbehandlingService {
         object FantIkkeBehandling : SøknadsbehandlingService.KunneIkkeOppdatereStønadsperiode()
         object FraOgMedDatoKanIkkeVæreFør2021 : SøknadsbehandlingService.KunneIkkeOppdatereStønadsperiode()
         object PeriodeKanIkkeVæreLengreEnn12Måneder : SøknadsbehandlingService.KunneIkkeOppdatereStønadsperiode()
+        data class KunneIkkeOppdatereStønadsperiode(val feil: Statusovergang.OppdaterStønadsperiode.KunneIkkeOppdatereStønadsperiode) :
+            SøknadsbehandlingService.KunneIkkeOppdatereStønadsperiode()
     }
 
     data class OppdaterStønadsperiodeRequest(

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceImpl.kt
@@ -492,6 +492,8 @@ internal class SøknadsbehandlingServiceImpl(
                 it.id,
                 it.vilkårsvurderinger,
             )
+            grunnlagService.lagreBosituasjongrunnlag(it.id, it.grunnlagsdata.bosituasjon)
+            grunnlagService.lagreFradragsgrunnlag(it.id, it.grunnlagsdata.fradragsgrunnlag)
             it.right()
         }
     }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutes.kt
@@ -156,6 +156,10 @@ internal fun Route.søknadsbehandlingRoutes(
                                                     "stønadsperiode_max_12mnd",
                                                 )
                                             }
+                                            is SøknadsbehandlingService.KunneIkkeOppdatereStønadsperiode.KunneIkkeOppdatereStønadsperiode -> InternalServerError.errorJson(
+                                                message = "Feil ved oppdatering av stønadsperiode",
+                                                code = "oppdatering_av_stønadsperiode",
+                                            )
                                         },
                                     )
                                 }


### PR DESCRIPTION
eksempel: 
stønadsperiode: 01.2022 - 12.2022
fradrag: 01.2022 - 06.2022
oppdaterer periode: 04.2022 - 12.2022
fradrag blir: 04.2022 - 06.2022

stønadsperiode: 01.2022 - 12.2022
fradrag: 01.2022 - 06.2022
oppdaterer periode: 01.2021 - 12.2021 (går ett år tilbake)
fradrag blir: 01.2021 - 12.2021

saksbehandler må sjekke over fradragene uansett etter endring av stønadsperiode, så hvis det ikke finnes en overlapp mellom den nye perioden, og fradrags-perioden, blir dem bare satt til hele stønadsperioden.