### PR TITLE
Få med opphørsgrunn i brevet, også dersom det er høy inntekt.

### DIFF
--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPosgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPosgresRepo.kt
@@ -22,6 +22,7 @@ import no.nav.su.se.bakover.database.withTransaction
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.behandling.Behandling
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
+import no.nav.su.se.bakover.domain.revurdering.IverksattRevurdering
 import no.nav.su.se.bakover.domain.revurdering.Revurdering
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
 import no.nav.su.se.bakover.domain.vedtak.Vedtak
@@ -126,22 +127,44 @@ internal class VedtakPosgresRepo(
         val beregning = stringOrNull("beregning")?.let { objectMapper.readValue<PersistertBeregning>(it) }
         val simulering = stringOrNull("simulering")?.let { objectMapper.readValue<Simulering>(it) }
 
-        return when (val vedtakType = VedtakType.valueOf(string("vedtaktype"))) {
-            VedtakType.SØKNAD,
-            VedtakType.ENDRING,
-            VedtakType.OPPHØR,
-            -> {
-                Vedtak.EndringIYtelse(
+        return when (VedtakType.valueOf(string("vedtaktype"))) {
+            VedtakType.SØKNAD -> {
+                Vedtak.EndringIYtelse.InnvilgetSøknadsbehandling(
                     id = id,
                     opprettet = opprettet,
-                    behandling = behandling,
+                    behandling = behandling as Søknadsbehandling.Iverksatt.Innvilget,
                     saksbehandler = saksbehandler,
                     attestant = attestant,
                     periode = periode,
                     beregning = beregning!!,
                     simulering = simulering!!,
                     utbetalingId = utbetalingId!!,
-                    vedtakType = vedtakType,
+                )
+            }
+            VedtakType.ENDRING -> {
+                Vedtak.EndringIYtelse.InnvilgetRevurdering(
+                    id = id,
+                    opprettet = opprettet,
+                    behandling = behandling as IverksattRevurdering.Innvilget,
+                    saksbehandler = saksbehandler,
+                    attestant = attestant,
+                    periode = periode,
+                    beregning = beregning!!,
+                    simulering = simulering!!,
+                    utbetalingId = utbetalingId!!,
+                )
+            }
+            VedtakType.OPPHØR -> {
+                Vedtak.EndringIYtelse.OpphørtRevurdering(
+                    id = id,
+                    opprettet = opprettet,
+                    behandling = behandling as IverksattRevurdering.Opphørt,
+                    saksbehandler = saksbehandler,
+                    attestant = attestant,
+                    periode = periode,
+                    beregning = beregning!!,
+                    simulering = simulering!!,
+                    utbetalingId = utbetalingId!!,
                 )
             }
             VedtakType.AVSLAG -> {
@@ -150,7 +173,7 @@ internal class VedtakPosgresRepo(
                         id = id,
                         opprettet = opprettet,
                         // AVSLAG gjelder kun for søknadsbehandling
-                        behandling = behandling as Søknadsbehandling,
+                        behandling = behandling as Søknadsbehandling.Iverksatt.Avslag.MedBeregning,
                         beregning = beregning,
                         saksbehandler = saksbehandler,
                         attestant = attestant,
@@ -161,7 +184,7 @@ internal class VedtakPosgresRepo(
                         id = id,
                         opprettet = opprettet,
                         // AVSLAG gjelder kun for søknadsbehandling
-                        behandling = behandling as Søknadsbehandling,
+                        behandling = behandling as Søknadsbehandling.Iverksatt.Avslag.UtenBeregning,
                         saksbehandler = saksbehandler,
                         attestant = attestant,
                         periode = periode,
@@ -171,7 +194,7 @@ internal class VedtakPosgresRepo(
             VedtakType.INGEN_ENDRING -> Vedtak.IngenEndringIYtelse(
                 id = id,
                 opprettet = opprettet,
-                behandling = behandling,
+                behandling = behandling as IverksattRevurdering.IngenEndring,
                 saksbehandler = saksbehandler,
                 attestant = attestant,
                 periode = periode,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/Vedtak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/Vedtak.kt
@@ -67,7 +67,7 @@ sealed class Vedtak : VedtakFelles, Visitable<VedtakVisitor> {
             utbetalingId: UUID30,
             clock: Clock,
         ) =
-            EndringIYtelse(
+            EndringIYtelse.InnvilgetSøknadsbehandling(
                 id = UUID.randomUUID(),
                 opprettet = Tidspunkt.now(clock),
                 periode = søknadsbehandling.periode,
@@ -77,7 +77,6 @@ sealed class Vedtak : VedtakFelles, Visitable<VedtakVisitor> {
                 saksbehandler = søknadsbehandling.saksbehandler,
                 attestant = søknadsbehandling.attesteringer.hentSisteAttestering().attestant,
                 utbetalingId = utbetalingId,
-                vedtakType = VedtakType.SØKNAD,
             )
 
         fun from(revurdering: IverksattRevurdering.IngenEndring, clock: Clock) = IngenEndringIYtelse(
@@ -90,55 +89,106 @@ sealed class Vedtak : VedtakFelles, Visitable<VedtakVisitor> {
             attestant = revurdering.attestering.attestant,
         )
 
-        fun from(revurdering: IverksattRevurdering.Innvilget, utbetalingId: UUID30, clock: Clock) = EndringIYtelse(
-            id = UUID.randomUUID(),
-            opprettet = Tidspunkt.now(clock),
-            behandling = revurdering,
-            periode = revurdering.periode,
-            beregning = revurdering.beregning,
-            simulering = revurdering.simulering,
-            saksbehandler = revurdering.saksbehandler,
-            attestant = revurdering.attestering.attestant,
-            utbetalingId = utbetalingId,
-            vedtakType = VedtakType.ENDRING,
-        )
+        fun from(revurdering: IverksattRevurdering.Innvilget, utbetalingId: UUID30, clock: Clock) =
+            EndringIYtelse.InnvilgetRevurdering(
+                id = UUID.randomUUID(),
+                opprettet = Tidspunkt.now(clock),
+                behandling = revurdering,
+                periode = revurdering.periode,
+                beregning = revurdering.beregning,
+                simulering = revurdering.simulering,
+                saksbehandler = revurdering.saksbehandler,
+                attestant = revurdering.attestering.attestant,
+                utbetalingId = utbetalingId,
+            )
 
-        fun from(revurdering: IverksattRevurdering.Opphørt, utbetalingId: UUID30, clock: Clock) = EndringIYtelse(
-            id = UUID.randomUUID(),
-            opprettet = Tidspunkt.now(clock),
-            behandling = revurdering,
-            periode = revurdering.periode,
-            beregning = revurdering.beregning,
-            simulering = revurdering.simulering,
-            saksbehandler = revurdering.saksbehandler,
-            attestant = revurdering.attestering.attestant,
-            utbetalingId = utbetalingId,
-            vedtakType = VedtakType.OPPHØR,
-        )
+        fun from(revurdering: IverksattRevurdering.Opphørt, utbetalingId: UUID30, clock: Clock) =
+            EndringIYtelse.OpphørtRevurdering(
+                id = UUID.randomUUID(),
+                opprettet = Tidspunkt.now(clock),
+                behandling = revurdering,
+                periode = revurdering.periode,
+                beregning = revurdering.beregning,
+                simulering = revurdering.simulering,
+                saksbehandler = revurdering.saksbehandler,
+                attestant = revurdering.attestering.attestant,
+                utbetalingId = utbetalingId,
+            )
     }
 
-    data class EndringIYtelse(
-        override val id: UUID,
-        override val opprettet: Tidspunkt,
-        override val behandling: Behandling,
-        override val saksbehandler: NavIdentBruker.Saksbehandler,
-        override val attestant: NavIdentBruker.Attestant,
-        override val periode: Periode,
-        override val beregning: Beregning,
-        val simulering: Simulering,
-        val utbetalingId: UUID30,
-        override val vedtakType: VedtakType,
-    ) : Vedtak(), VedtakSomKanRevurderes {
+    sealed class EndringIYtelse : Vedtak(), VedtakSomKanRevurderes {
+        abstract override val id: UUID
+        abstract override val opprettet: Tidspunkt
+        abstract override val behandling: Behandling
+        abstract override val saksbehandler: NavIdentBruker.Saksbehandler
+        abstract override val attestant: NavIdentBruker.Attestant
+        abstract override val periode: Periode
+        abstract override val beregning: Beregning
+        abstract val simulering: Simulering
+        abstract val utbetalingId: UUID30
+        abstract override val vedtakType: VedtakType
 
-        override fun accept(visitor: VedtakVisitor) {
-            visitor.visit(this)
+        data class InnvilgetSøknadsbehandling(
+            override val id: UUID,
+            override val opprettet: Tidspunkt,
+            override val behandling: Søknadsbehandling.Iverksatt.Innvilget,
+            override val saksbehandler: NavIdentBruker.Saksbehandler,
+            override val attestant: NavIdentBruker.Attestant,
+            override val periode: Periode,
+            override val beregning: Beregning,
+            override val simulering: Simulering,
+            override val utbetalingId: UUID30,
+        ) : EndringIYtelse() {
+            override val vedtakType: VedtakType = VedtakType.SØKNAD
+
+            override fun accept(visitor: VedtakVisitor) {
+                visitor.visit(this)
+            }
+        }
+
+        data class InnvilgetRevurdering(
+            override val id: UUID,
+            override val opprettet: Tidspunkt,
+            override val behandling: IverksattRevurdering.Innvilget,
+            override val saksbehandler: NavIdentBruker.Saksbehandler,
+            override val attestant: NavIdentBruker.Attestant,
+            override val periode: Periode,
+            override val beregning: Beregning,
+            override val simulering: Simulering,
+            override val utbetalingId: UUID30,
+        ) : EndringIYtelse() {
+            override val vedtakType: VedtakType = VedtakType.ENDRING
+
+            override fun accept(visitor: VedtakVisitor) {
+                visitor.visit(this)
+            }
+        }
+
+        data class OpphørtRevurdering(
+            override val id: UUID,
+            override val opprettet: Tidspunkt,
+            override val behandling: IverksattRevurdering.Opphørt,
+            override val saksbehandler: NavIdentBruker.Saksbehandler,
+            override val attestant: NavIdentBruker.Attestant,
+            override val periode: Periode,
+            override val beregning: Beregning,
+            override val simulering: Simulering,
+            override val utbetalingId: UUID30,
+        ) : EndringIYtelse() {
+            override val vedtakType: VedtakType = VedtakType.OPPHØR
+
+            fun utledOpphørsgrunner() = behandling.utledOpphørsgrunner()
+
+            override fun accept(visitor: VedtakVisitor) {
+                visitor.visit(this)
+            }
         }
     }
 
     data class IngenEndringIYtelse(
         override val id: UUID,
         override val opprettet: Tidspunkt,
-        override val behandling: Behandling,
+        override val behandling: IverksattRevurdering.IngenEndring,
         override val saksbehandler: NavIdentBruker.Saksbehandler,
         override val attestant: NavIdentBruker.Attestant,
         override val periode: Periode,
@@ -186,7 +236,7 @@ sealed class Vedtak : VedtakFelles, Visitable<VedtakVisitor> {
         data class AvslagVilkår(
             override val id: UUID,
             override val opprettet: Tidspunkt,
-            override val behandling: Søknadsbehandling,
+            override val behandling: Søknadsbehandling.Iverksatt.Avslag.UtenBeregning,
             override val saksbehandler: NavIdentBruker.Saksbehandler,
             override val attestant: NavIdentBruker.Attestant,
             override val periode: Periode,
@@ -202,7 +252,7 @@ sealed class Vedtak : VedtakFelles, Visitable<VedtakVisitor> {
         data class AvslagBeregning(
             override val id: UUID,
             override val opprettet: Tidspunkt,
-            override val behandling: Søknadsbehandling,
+            override val behandling: Søknadsbehandling.Iverksatt.Avslag.MedBeregning,
             override val saksbehandler: NavIdentBruker.Saksbehandler,
             override val attestant: NavIdentBruker.Attestant,
             override val periode: Periode,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakVisitor.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakVisitor.kt
@@ -3,7 +3,9 @@ package no.nav.su.se.bakover.domain.vedtak
 import no.nav.su.se.bakover.domain.visitor.Visitor
 
 interface VedtakVisitor : Visitor {
-    fun visit(vedtak: Vedtak.EndringIYtelse)
+    fun visit(vedtak: Vedtak.EndringIYtelse.InnvilgetSøknadsbehandling)
+    fun visit(vedtak: Vedtak.EndringIYtelse.InnvilgetRevurdering)
+    fun visit(vedtak: Vedtak.EndringIYtelse.OpphørtRevurdering)
     fun visit(vedtak: Vedtak.Avslag.AvslagVilkår)
     fun visit(vedtak: Vedtak.Avslag.AvslagBeregning)
     fun visit(vedtak: Vedtak.IngenEndringIYtelse)

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitor.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitor.kt
@@ -31,7 +31,6 @@ import no.nav.su.se.bakover.domain.søknadsbehandling.FinnSaksbehandlerVisitor
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
 import no.nav.su.se.bakover.domain.søknadsbehandling.SøknadsbehandlingVisitor
 import no.nav.su.se.bakover.domain.vedtak.Vedtak
-import no.nav.su.se.bakover.domain.vedtak.VedtakType
 import no.nav.su.se.bakover.domain.vedtak.VedtakVisitor
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 import java.time.Clock
@@ -211,26 +210,16 @@ class LagBrevRequestVisitor(
         brevRequest = revurderingIngenEndring(revurdering, revurdering.beregning)
     }
 
-    override fun visit(vedtak: Vedtak.EndringIYtelse) {
-        brevRequest = when (vedtak.vedtakType) {
-            VedtakType.SØKNAD -> {
-                innvilgetVedtakSøknadsbehandling(vedtak)
-            }
-            VedtakType.ENDRING -> {
-                innvilgetVedtakRevurdering(vedtak)
-            }
-            VedtakType.OPPHØR -> {
-                opphørsvedtak(vedtak)
-            }
-            VedtakType.AVSLAG,
-            VedtakType.INGEN_ENDRING,
-            -> {
-                throw KunneIkkeLageBrevRequest.UgyldigKombinasjonAvVedtakOgTypeException(
-                    vedtak::class,
-                    vedtak.vedtakType,
-                )
-            }
-        }
+    override fun visit(vedtak: Vedtak.EndringIYtelse.InnvilgetSøknadsbehandling) {
+        brevRequest = innvilgetVedtakSøknadsbehandling(vedtak)
+    }
+
+    override fun visit(vedtak: Vedtak.EndringIYtelse.InnvilgetRevurdering) {
+        brevRequest = innvilgetVedtakRevurdering(vedtak)
+    }
+
+    override fun visit(vedtak: Vedtak.EndringIYtelse.OpphørtRevurdering) {
+        brevRequest = opphørsvedtak(vedtak)
     }
 
     override fun visit(vedtak: Vedtak.Avslag.AvslagVilkår) {
@@ -411,15 +400,9 @@ class LagBrevRequestVisitor(
             val instans: KClass<*>,
             val msg: String = "Kan ikke lage brevrequest for instans av typen: ${instans.qualifiedName}",
         ) : RuntimeException(msg)
-
-        data class UgyldigKombinasjonAvVedtakOgTypeException(
-            val instans: KClass<*>,
-            val vedtakType: VedtakType,
-            val msg: String = "Kombinasjon av ${instans.qualifiedName} og vedtakType: $vedtakType er ugyldig!",
-        ) : RuntimeException(msg)
     }
 
-    private fun innvilgetVedtakSøknadsbehandling(vedtak: Vedtak.EndringIYtelse) =
+    private fun innvilgetVedtakSøknadsbehandling(vedtak: Vedtak.EndringIYtelse.InnvilgetSøknadsbehandling) =
         hentPersonOgNavn(
             fnr = vedtak.behandling.fnr,
             saksbehandler = vedtak.saksbehandler,
@@ -429,18 +412,12 @@ class LagBrevRequestVisitor(
                 personOgNavn = it,
                 bosituasjon = vedtak.behandling.grunnlagsdata.bosituasjon.singleFullstendigOrThrow(),
                 beregning = vedtak.beregning,
-                fritekst =
-                // TODO ia: kommer vi oss unna denne? Hadde kanskje gått dersom vi lagret de genererte brevene.
-                // Gjelder også de andre metodene her inne som går på vedtak
-                when (val b = vedtak.behandling) {
-                    is Søknadsbehandling -> b.fritekstTilBrev
-                    else -> ""
-                },
+                fritekst = vedtak.behandling.fritekstTilBrev,
                 uføregrunnlag = vedtak.behandling.vilkårsvurderinger.uføre.grunnlag,
             )
         }
 
-    private fun innvilgetVedtakRevurdering(vedtak: Vedtak.EndringIYtelse) =
+    private fun innvilgetVedtakRevurdering(vedtak: Vedtak.EndringIYtelse.InnvilgetRevurdering) =
         hentPersonOgNavn(
             fnr = vedtak.behandling.fnr,
             saksbehandler = vedtak.saksbehandler,
@@ -451,16 +428,13 @@ class LagBrevRequestVisitor(
                 saksbehandlerNavn = it.saksbehandlerNavn,
                 attestantNavn = it.attestantNavn,
                 revurdertBeregning = vedtak.beregning,
-                fritekst = when (val b = vedtak.behandling) {
-                    is Revurdering -> b.fritekstTilBrev
-                    else -> ""
-                },
+                fritekst = vedtak.behandling.fritekstTilBrev,
                 harEktefelle = vedtak.behandling.grunnlagsdata.bosituasjon.harEktefelle(),
                 forventetInntektStørreEnn0 = vedtak.behandling.vilkårsvurderinger.uføre.grunnlag.harForventetInntektStørreEnn0(),
             )
         }
 
-    private fun opphørsvedtak(vedtak: Vedtak.EndringIYtelse) =
+    private fun opphørsvedtak(vedtak: Vedtak.EndringIYtelse.OpphørtRevurdering) =
         hentPersonOgNavn(
             fnr = vedtak.behandling.fnr,
             saksbehandler = vedtak.saksbehandler,
@@ -471,13 +445,10 @@ class LagBrevRequestVisitor(
                 saksbehandlerNavn = it.saksbehandlerNavn,
                 attestantNavn = it.attestantNavn,
                 beregning = vedtak.beregning,
-                fritekst = when (val b = vedtak.behandling) {
-                    is Revurdering -> b.fritekstTilBrev
-                    else -> ""
-                },
+                fritekst = vedtak.behandling.fritekstTilBrev,
                 harEktefelle = vedtak.behandling.grunnlagsdata.bosituasjon.harEktefelle(),
                 forventetInntektStørreEnn0 = vedtak.behandling.vilkårsvurderinger.uføre.grunnlag.harForventetInntektStørreEnn0(),
-                opphørsgrunner = vedtak.behandling.vilkårsvurderinger.utledOpphørsgrunner(),
+                opphørsgrunner = vedtak.utledOpphørsgrunner(),
             )
         }
 
@@ -497,9 +468,9 @@ class LagBrevRequestVisitor(
                     is Vedtak.Avslag.AvslagBeregning -> vedtak.beregning
                     is Vedtak.Avslag.AvslagVilkår -> null
                 },
-                fritekst = when (val b = vedtak.behandling) {
-                    is Søknadsbehandling -> b.fritekstTilBrev // TODO ia: kommer vi oss unna denne?
-                    else -> ""
+                fritekst = when (vedtak) {
+                    is Vedtak.Avslag.AvslagBeregning -> vedtak.behandling.fritekstTilBrev
+                    is Vedtak.Avslag.AvslagVilkår -> vedtak.behandling.fritekstTilBrev
                 },
                 uføregrunnlag = vedtak.behandling.vilkårsvurderinger.uføre.grunnlag,
             )
@@ -537,10 +508,7 @@ class LagBrevRequestVisitor(
                 requestIngenEndring(
                     personOgNavn = personOgNavn,
                     beregning = vedtak.beregning,
-                    fritekst = when (val b = vedtak.behandling) {
-                        is Revurdering -> b.fritekstTilBrev
-                        else -> ""
-                    },
+                    fritekst = vedtak.behandling.fritekstTilBrev,
                     harEktefelle = vedtak.behandling.grunnlagsdata.bosituasjon.harEktefelle(),
                     uføregrunnlag = vedtak.behandling.vilkårsvurderinger.uføre.grunnlag,
                     gjeldendeMånedsutbetaling = gjeldendeUtbetaling,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/visitor/SkalSendeBrevVisitor.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/visitor/SkalSendeBrevVisitor.kt
@@ -9,7 +9,15 @@ import kotlin.properties.Delegates
 internal class SkalSendeBrevVisitor : VedtakVisitor {
     var sendBrev by Delegates.notNull<Boolean>()
 
-    override fun visit(vedtak: Vedtak.EndringIYtelse) {
+    override fun visit(vedtak: Vedtak.EndringIYtelse.InnvilgetSøknadsbehandling) {
+        sendBrev = !vedtak.innvilgetGRegulering()
+    }
+
+    override fun visit(vedtak: Vedtak.EndringIYtelse.InnvilgetRevurdering) {
+        sendBrev = !vedtak.innvilgetGRegulering()
+    }
+
+    override fun visit(vedtak: Vedtak.EndringIYtelse.OpphørtRevurdering) {
         sendBrev = !vedtak.innvilgetGRegulering()
     }
 
@@ -34,7 +42,7 @@ internal class SkalSendeBrevVisitor : VedtakVisitor {
     }
 
     private fun Vedtak.IngenEndringIYtelse.sendBrevErValgt(): Boolean {
-        return (behandling as IverksattRevurdering.IngenEndring).skalFøreTilBrevutsending
+        return behandling.skalFøreTilBrevutsending
     }
 
     /**

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitorTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitorTest.kt
@@ -1,6 +1,7 @@
 package no.nav.su.se.bakover.domain.visitor
 
 import arrow.core.Either
+import arrow.core.getOrHandle
 import arrow.core.left
 import arrow.core.nonEmptyListOf
 import arrow.core.right
@@ -9,7 +10,6 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.beOfType
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.UUID30
-import no.nav.su.se.bakover.common.april
 import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.periode.Periode
@@ -45,7 +45,7 @@ import no.nav.su.se.bakover.domain.fixedClock
 import no.nav.su.se.bakover.domain.fixedTidspunkt
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
-import no.nav.su.se.bakover.domain.grunnlag.Uføregrad
+import no.nav.su.se.bakover.domain.grunnlag.GrunnlagsdataOgVilkårsvurderinger
 import no.nav.su.se.bakover.domain.grunnlag.harEktefelle
 import no.nav.su.se.bakover.domain.grunnlag.singleFullstendigOrThrow
 import no.nav.su.se.bakover.domain.innvilgetFormueVilkår
@@ -56,6 +56,7 @@ import no.nav.su.se.bakover.domain.revurdering.InformasjonSomRevurderes
 import no.nav.su.se.bakover.domain.revurdering.IverksattRevurdering
 import no.nav.su.se.bakover.domain.revurdering.Revurderingsteg
 import no.nav.su.se.bakover.domain.revurdering.Revurderingsårsak
+import no.nav.su.se.bakover.domain.revurdering.SimulertRevurdering
 import no.nav.su.se.bakover.domain.søknadsbehandling.Stønadsperiode
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
 import no.nav.su.se.bakover.domain.vedtak.Vedtak
@@ -63,10 +64,17 @@ import no.nav.su.se.bakover.domain.vilkår.Resultat
 import no.nav.su.se.bakover.domain.vilkår.Vilkår
 import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
 import no.nav.su.se.bakover.domain.vilkår.Vurderingsperiode
+import no.nav.su.se.bakover.test.bosituasjongrunnlagEnslig
 import no.nav.su.se.bakover.test.create
+import no.nav.su.se.bakover.test.fradragsgrunnlagArbeidsinntekt
 import no.nav.su.se.bakover.test.generer
+import no.nav.su.se.bakover.test.oppgaveIdRevurdering
+import no.nav.su.se.bakover.test.opprettetRevurderingFraInnvilgetSøknadsbehandlingsVedtak
+import no.nav.su.se.bakover.test.vilkårsvurderingerAvslåttUføreOgInnvilgetFormue
+import no.nav.su.se.bakover.test.vilkårsvurderingerInnvilget
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.fail
 import org.mockito.kotlin.mock
 import java.time.Clock
 import java.time.ZoneOffset
@@ -848,61 +856,40 @@ internal class LagBrevRequestVisitorTest {
     @Test
     fun `lager opphørsvedtak med opphørsgrunn for uførhet`() {
         val utbetalingId = UUID30.randomUUID()
-        val søknadsbehandling =
-            uavklart.tilVilkårsvurdert(Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt())
-                .tilBeregnet(innvilgetBeregning)
-                .tilSimulert(simulering)
-                .tilAttestering(saksbehandler, "Fritekst!")
-                .tilIverksatt(Attestering.Iverksatt(attestant, Tidspunkt.now(clock)))
-
         val opphørsperiode = Periode.create(fraOgMed = 1.januar(2021), tilOgMed = 31.desember(2021))
-        val revurdering = IverksattRevurdering.Opphørt(
-            id = UUID.randomUUID(),
-            periode = opphørsperiode,
-            opprettet = Tidspunkt.now(clock),
-            tilRevurdering = Vedtak.fromSøknadsbehandling(søknadsbehandling, utbetalingId, fixedClock),
-            saksbehandler = saksbehandler,
-            oppgaveId = OppgaveId("15"),
-            beregning = innvilgetBeregning,
-            simulering = simulering,
-            attesteringer = Attesteringshistorikk.empty()
-                .leggTilNyAttestering(Attestering.Iverksatt(attestant, Tidspunkt.now(clock))),
-            fritekstTilBrev = "FRITEKST REVURDERING",
-            revurderingsårsak = Revurderingsårsak(
-                Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
-                Revurderingsårsak.Begrunnelse.create("Ny informasjon"),
-            ),
-            forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
-            grunnlagsdata = Grunnlagsdata.create(
-                bosituasjon = listOf(
-                    Grunnlag.Bosituasjon.Fullstendig.Enslig(
-                        id = UUID.randomUUID(),
-                        opprettet = fixedTidspunkt,
-                        periode = opphørsperiode,
-                        begrunnelse = null,
-                    ),
-                ),
-            ),
-            vilkårsvurderinger = Vilkårsvurderinger(
-                uføre = Vilkår.Uførhet.Vurdert.create(
-                    vurderingsperioder = nonEmptyListOf(
-                        Vurderingsperiode.Uføre.create(
-                            resultat = Resultat.Avslag,
-                            grunnlag = Grunnlag.Uføregrunnlag(
-                                periode = Periode.create(1.januar(2021), 30.april(2021)),
-                                uføregrad = Uføregrad.parse(20),
-                                forventetInntekt = 10_000,
-                                opprettet = fixedTidspunkt,
+
+        val revurdering = (
+            opprettetRevurderingFraInnvilgetSøknadsbehandlingsVedtak(
+                revurderingsperiode = opphørsperiode,
+                grunnlagsdataOgVilkårsvurderinger = GrunnlagsdataOgVilkårsvurderinger(
+                    grunnlagsdata = Grunnlagsdata.create(
+                        fradragsgrunnlag = listOf(
+                            fradragsgrunnlagArbeidsinntekt(
+                                arbeidsinntekt = 150000.0,
+                                periode = opphørsperiode,
                             ),
-                            periode = Periode.create(1.januar(2021), 30.april(2021)),
-                            begrunnelse = "",
-                            opprettet = fixedTidspunkt,
+                        ),
+                        bosituasjon = listOf(
+                            bosituasjongrunnlagEnslig(opphørsperiode),
                         ),
                     ),
+                    vilkårsvurderinger = vilkårsvurderingerAvslåttUføreOgInnvilgetFormue(
+                        periode = opphørsperiode,
+                    ),
                 ),
-            ),
-            informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-        )
+            ).second
+                .beregn(eksisterendeUtbetalinger = emptyList())
+                .getOrHandle { fail("Skulle gått bra") }
+                .toSimulert(simulering) as SimulertRevurdering.Opphørt
+            )
+            .tilAttestering(
+                attesteringsoppgaveId = oppgaveIdRevurdering,
+                saksbehandler = saksbehandler,
+                forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
+                fritekstTilBrev = "FRITEKST REVURDERING",
+            ).getOrHandle { fail("Skulle gått bra") }
+            .tilIverksatt(attestant) { utbetalingId.right() }
+            .getOrHandle { fail("Skulle gått bra") }
 
         val opphørsvedtak = Vedtak.from(revurdering, utbetalingId, fixedClock)
 
@@ -928,8 +915,75 @@ internal class LagBrevRequestVisitorTest {
             saksbehandlerNavn = saksbehandlerNavn,
             attestantNavn = attestantNavn,
             fritekst = "FRITEKST REVURDERING",
-            forventetInntektStørreEnn0 = true,
+            forventetInntektStørreEnn0 = false,
             opphørsgrunner = listOf(Opphørsgrunn.UFØRHET),
+        ).right()
+    }
+
+    @Test
+    fun `lager opphørsvedtak med opphørsgrunn for høy inntekt`() {
+        val utbetalingId = UUID30.randomUUID()
+        val opphørsperiode = Periode.create(fraOgMed = 1.januar(2021), tilOgMed = 31.desember(2021))
+
+        val revurdering = (
+            opprettetRevurderingFraInnvilgetSøknadsbehandlingsVedtak(
+                revurderingsperiode = opphørsperiode,
+                grunnlagsdataOgVilkårsvurderinger = GrunnlagsdataOgVilkårsvurderinger(
+                    grunnlagsdata = Grunnlagsdata.create(
+                        fradragsgrunnlag = listOf(
+                            fradragsgrunnlagArbeidsinntekt(
+                                arbeidsinntekt = 150000.0,
+                                periode = opphørsperiode,
+                            ),
+                        ),
+                        bosituasjon = listOf(
+                            bosituasjongrunnlagEnslig(opphørsperiode),
+                        ),
+                    ),
+                    vilkårsvurderinger = vilkårsvurderingerInnvilget(
+                        periode = opphørsperiode,
+                    ),
+                ),
+            ).second
+                .beregn(eksisterendeUtbetalinger = emptyList())
+                .getOrHandle { fail("Skulle gått bra") }
+                .toSimulert(simulering) as SimulertRevurdering.Opphørt
+            )
+            .tilAttestering(
+                attesteringsoppgaveId = oppgaveIdRevurdering,
+                saksbehandler = saksbehandler,
+                forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
+                fritekstTilBrev = "FRITEKST REVURDERING",
+            ).getOrHandle { fail("Skulle gått bra") }
+            .tilIverksatt(attestant) { utbetalingId.right() }
+            .getOrHandle { fail("Skulle gått bra") }
+
+        val opphørsvedtak = Vedtak.from(revurdering, utbetalingId, fixedClock)
+
+        val brevRevurdering = LagBrevRequestVisitor(
+            hentPerson = { person.right() },
+            hentNavn = { hentNavn(it) },
+            hentGjeldendeUtbetaling = { _, _ -> 0.right() },
+            clock = clock,
+        ).apply { revurdering.accept(this) }
+
+        val brevVedtak = LagBrevRequestVisitor(
+            hentPerson = { person.right() },
+            hentNavn = { hentNavn(it) },
+            hentGjeldendeUtbetaling = { _, _ -> 0.right() },
+            clock = clock,
+        ).apply { opphørsvedtak.accept(this) }
+
+        brevRevurdering.brevRequest shouldBe brevVedtak.brevRequest
+        brevRevurdering.brevRequest shouldBe LagBrevRequest.Opphørsvedtak(
+            person = person,
+            beregning = revurdering.beregning,
+            harEktefelle = revurdering.grunnlagsdata.bosituasjon.harEktefelle(),
+            saksbehandlerNavn = saksbehandlerNavn,
+            attestantNavn = attestantNavn,
+            fritekst = "FRITEKST REVURDERING",
+            forventetInntektStørreEnn0 = false,
+            opphørsgrunner = listOf(Opphørsgrunn.FOR_HØY_INNTEKT),
         ).right()
     }
 

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/SkalSendeBrevVisitorTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/SkalSendeBrevVisitorTest.kt
@@ -9,6 +9,7 @@ import no.nav.su.se.bakover.test.iverksattRevurderingIngenEndringFraInnvilgetSø
 import no.nav.su.se.bakover.test.iverksattRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak
 import no.nav.su.se.bakover.test.søknadsbehandlingIverksattAvslagMedBeregning
 import no.nav.su.se.bakover.test.søknadsbehandlingIverksattAvslagUtenBeregning
+import no.nav.su.se.bakover.test.søknadsbehandlingIverksattInnvilget
 import org.junit.jupiter.api.Test
 
 internal class SkalSendeBrevVisitorTest {
@@ -105,5 +106,20 @@ internal class SkalSendeBrevVisitorTest {
             it.sendBrev
         } shouldBe false
         skalIkkeSendeBrev.skalSendeBrev() shouldBe false
+    }
+
+    @Test
+    fun `vedtak for innvilget søknadsbehandling skal sende brev`() {
+        val vedtak = Vedtak.fromSøknadsbehandling(
+            søknadsbehandling = søknadsbehandlingIverksattInnvilget().second,
+            utbetalingId = UUID30.randomUUID(),
+            fixedClock,
+        )
+
+        SkalSendeBrevVisitor().let {
+            vedtak.accept(it)
+            it.sendBrev
+        } shouldBe true
+        vedtak.skalSendeBrev() shouldBe true
     }
 }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OppdaterRevurderingServiceTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OppdaterRevurderingServiceTest.kt
@@ -36,7 +36,6 @@ import no.nav.su.se.bakover.domain.revurdering.Revurderingsteg
 import no.nav.su.se.bakover.domain.revurdering.Revurderingsårsak
 import no.nav.su.se.bakover.domain.revurdering.Vurderingstatus
 import no.nav.su.se.bakover.domain.søknadsbehandling.Stønadsperiode
-import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
 import no.nav.su.se.bakover.domain.vedtak.GjeldendeVedtaksdata
 import no.nav.su.se.bakover.domain.vedtak.Vedtak
 import no.nav.su.se.bakover.domain.vedtak.VedtakSomKanRevurderes
@@ -533,7 +532,7 @@ internal class OppdaterRevurderingServiceTest {
         val andreVedtakFormueVilkår = formueVilkår(periodePlussEtÅr)
         val andreVedtak = vedtakSøknadsbehandlingIverksattInnvilget().second.copy(
             periode = periodePlussEtÅr,
-            behandling = (vedtakSøknadsbehandlingIverksattInnvilget().second.behandling as Søknadsbehandling.Iverksatt.Innvilget).copy(
+            behandling = vedtakSøknadsbehandlingIverksattInnvilget().second.behandling.copy(
                 stønadsperiode = Stønadsperiode.create(periodePlussEtÅr),
                 grunnlagsdata = Grunnlagsdata.create(bosituasjon = listOf(bosituasjon)),
                 vilkårsvurderinger = Vilkårsvurderinger(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
@@ -438,7 +438,7 @@ internal class RevurderingServiceImplTest {
             verify(utbetalingMock, times(2)).id
             verify(vedtakRepoMock).lagre(
                 argThat {
-                    it should beOfType<Vedtak.EndringIYtelse>()
+                    it should beOfType<Vedtak.EndringIYtelse.InnvilgetRevurdering>()
                     it.vedtakType shouldBe VedtakType.ENDRING
                 },
             )
@@ -510,7 +510,7 @@ internal class RevurderingServiceImplTest {
             )
             verify(vedtakRepoMock).lagre(
                 argThat {
-                    it should beOfType<Vedtak.EndringIYtelse>()
+                    it should beOfType<Vedtak.EndringIYtelse.OpphørtRevurdering>()
                     it.vedtakType shouldBe VedtakType.OPPHØR
                 },
             )

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceIverksettTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceIverksettTest.kt
@@ -335,7 +335,7 @@ internal class SøknadsbehandlingServiceIverksettTest {
             verify(vedtakRepoMock).lagre(
                 argThat {
                     it.behandling shouldBe expected
-                    it should beOfType<Vedtak.EndringIYtelse>()
+                    it should beOfType<Vedtak.EndringIYtelse.InnvilgetSøknadsbehandling>()
                     it.vedtakType shouldBe VedtakType.SØKNAD
                 },
             )

--- a/test-common/src/main/kotlin/VedtakTestData.kt
+++ b/test-common/src/main/kotlin/VedtakTestData.kt
@@ -32,7 +32,7 @@ fun vedtakSøknadsbehandlingIverksattInnvilget(
     beregning: Beregning = beregning(),
     utbetalingId: UUID30 = UUID30.randomUUID(),
     clock: Clock = fixedClock,
-): Pair<Sak, Vedtak.EndringIYtelse> {
+): Pair<Sak, Vedtak.EndringIYtelse.InnvilgetSøknadsbehandling> {
     return søknadsbehandlingIverksattInnvilget(
         saksnummer = saksnummer,
         stønadsperiode = stønadsperiode,


### PR DESCRIPTION
-Innført mulighet for å utlede opphørsgrunner direkte fra opphørsvedtak.
-Sterkere typer på behandlinger knyttet til vedtak.

https://trello.com/c/WLgqBrmO/911-brev-for-opph%C3%B8r-pga-inntekt-viser-ikke-%C3%A5rsak