### PR TITLE
Lytt på exceptions fra JMS/MQ

### DIFF
--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/utbetaling/kvittering/UtbetalingKvitteringIbmMqConsumer.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/utbetaling/kvittering/UtbetalingKvitteringIbmMqConsumer.kt
@@ -16,6 +16,8 @@ class UtbetalingKvitteringIbmMqConsumer(
     private val jmsContext = globalJmsContext.createContext(Session.AUTO_ACKNOWLEDGE)
     private val consumer = jmsContext.createConsumer(jmsContext.createQueue(kvitteringQueueName))
 
+    // TODO: Vurder å gjøre om dette til en jobb som poller med receive, i stedet for asynkron messageListener
+    // Da slipper vi sannsynligvis exceptionListeneren og vi har litt mer kontroll på når/hvordan tråden kjører
     init {
         consumer.setMessageListener { message ->
             try {
@@ -31,6 +33,9 @@ class UtbetalingKvitteringIbmMqConsumer(
                 throw ex
             }
         }
+
+        jmsContext.setExceptionListener { exception -> log.error("Feil mot $kvitteringQueueName", exception) }
+
         jmsContext.start()
     }
 }


### PR DESCRIPTION
Ser ut som måten man fanger opp at køen f.eks. går ned er ved å sette opp en exceptionListener. Logger bare i første omgang, så får vi se senere om vi også ønsker å prøve å reconnecte e.l.