### PR TITLE
Fiks bug som stopper opphør unødvendig

### DIFF
--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/IdentifiserRevurderingsutfallSomIkkeStøttesTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/IdentifiserRevurderingsutfallSomIkkeStøttesTest.kt
@@ -5,6 +5,7 @@ import arrow.core.nonEmptyListOf
 import arrow.core.right
 import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.desember
+import no.nav.su.se.bakover.common.februar
 import no.nav.su.se.bakover.common.mai
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.behandling.avslag.Opphørsgrunn
@@ -14,6 +15,7 @@ import no.nav.su.se.bakover.domain.vilkår.Resultat
 import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
 import no.nav.su.se.bakover.test.beregning
 import no.nav.su.se.bakover.test.fradragsgrunnlagArbeidsinntekt
+import no.nav.su.se.bakover.test.periode2021
 import no.nav.su.se.bakover.test.periodeDesember2021
 import no.nav.su.se.bakover.test.periodeJuni2021
 import no.nav.su.se.bakover.test.periodeNovember2021
@@ -32,6 +34,7 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
     fun `identifiserer at opphør ikke skjer fra samme dato som den første i beregningen`() {
         val beregning = beregning(periode = Periode.create(1.mai(2021), 31.desember(2021)))
         IdentifiserSaksbehandlingsutfallSomIkkeStøttes.MedBeregning(
+            revurderingsperiode = beregning.periode,
             vilkårsvurderinger = vilkårsvurderingerAvslåttUføreOgInnvilgetFormue(periode = periodeJuni2021),
             tidligereBeregning = beregning,
             nyBeregning = beregning,
@@ -44,6 +47,7 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
     fun `identifiserer at flere vilkår har opphørt`() {
         val beregning = beregning(periode = periodeDesember2021)
         IdentifiserSaksbehandlingsutfallSomIkkeStøttes.MedBeregning(
+            revurderingsperiode = beregning.periode,
             vilkårsvurderinger = vilkårsvurderingerAvslåttAlle(periode = periodeDesember2021),
             tidligereBeregning = beregning,
             nyBeregning = beregning,
@@ -55,6 +59,7 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
     @Test
     fun `identifiserer at opphør av uførevilkår skjer i kombinasjon med beløpsendringer`() {
         IdentifiserSaksbehandlingsutfallSomIkkeStøttes.MedBeregning(
+            revurderingsperiode = periode2021,
             vilkårsvurderinger = vilkårsvurderingerAvslåttUføreOgInnvilgetFormue(periode = periodeJuni2021),
             tidligereBeregning = beregning(
                 periode = periodeDesember2021,
@@ -122,6 +127,7 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
         }
 
         IdentifiserSaksbehandlingsutfallSomIkkeStøttes.MedBeregning(
+            revurderingsperiode = periode2021,
             vilkårsvurderinger = vilkårsvurderingerMock,
             tidligereBeregning = tidligereBeregningMock,
             nyBeregning = nyBeregningMock,
@@ -167,6 +173,7 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
         }
 
         IdentifiserSaksbehandlingsutfallSomIkkeStøttes.MedBeregning(
+            revurderingsperiode = periode2021,
             vilkårsvurderinger = vilkårsvurderingerMock,
             tidligereBeregning = tidligereBeregningMock,
             nyBeregning = nyBeregningMock,
@@ -214,6 +221,7 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
         }
 
         IdentifiserSaksbehandlingsutfallSomIkkeStøttes.MedBeregning(
+            revurderingsperiode = periode2021,
             vilkårsvurderinger = vilkårsvurderingerMock,
             tidligereBeregning = tidligereBeregningMock,
             nyBeregning = nyBeregningMock,
@@ -256,6 +264,7 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
         }
 
         IdentifiserSaksbehandlingsutfallSomIkkeStøttes.MedBeregning(
+            revurderingsperiode = periode2021,
             vilkårsvurderinger = vilkårsvurderingerMock,
             tidligereBeregning = tidligereBeregningMock,
             nyBeregning = nyBeregningMock,
@@ -300,6 +309,7 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
         }
 
         IdentifiserSaksbehandlingsutfallSomIkkeStøttes.MedBeregning(
+            revurderingsperiode = periode2021,
             vilkårsvurderinger = vilkårsvurderingerMock,
             tidligereBeregning = tidligereBeregningMock,
             nyBeregning = nyBeregningMock,
@@ -313,6 +323,7 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
         val beregning = beregning(periode = periodeNovember2021)
 
         IdentifiserSaksbehandlingsutfallSomIkkeStøttes.MedBeregning(
+            revurderingsperiode = periode2021,
             vilkårsvurderinger = vilkårsvurderingerInnvilget(periodeDesember2021),
             tidligereBeregning = beregning,
             nyBeregning = beregning,
@@ -322,7 +333,8 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
     @Test
     fun `identifiserer ingen problemer ved opphør av uførevilkår med endring i forventet inntekt`() {
         IdentifiserSaksbehandlingsutfallSomIkkeStøttes.MedBeregning(
-            vilkårsvurderinger = vilkårsvurderingerAvslåttUføreOgInnvilgetFormue(periode = periodeJuni2021),
+            revurderingsperiode = periodeDesember2021,
+            vilkårsvurderinger = vilkårsvurderingerAvslåttUføreOgInnvilgetFormue(periode = periodeDesember2021),
             tidligereBeregning = beregning(
                 periode = periodeDesember2021,
                 uføregrunnlag = nonEmptyListOf(
@@ -352,14 +364,13 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
                     ),
                 ),
             ),
-        ).resultat shouldBe setOf(
-            RevurderingsutfallSomIkkeStøttes.OpphørErIkkeFraFørsteMåned,
-        ).left()
+        ).resultat shouldBe Unit.right()
     }
 
     @Test
     fun `skal ikke kunne opphøre og legge til fradrag i kombinasjon`() {
         IdentifiserSaksbehandlingsutfallSomIkkeStøttes.MedBeregning(
+            revurderingsperiode = periodeDesember2021,
             vilkårsvurderinger = vilkårsvurderingerAvslåttUføreOgInnvilgetFormue(periode = periodeDesember2021),
             tidligereBeregning = beregning(periode = periodeDesember2021),
             nyBeregning = beregning(
@@ -379,6 +390,7 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
     @Test
     fun `skal ikke kunne opphøre og fjerne fradrag i kombinasjon`() {
         IdentifiserSaksbehandlingsutfallSomIkkeStøttes.MedBeregning(
+            revurderingsperiode = periodeDesember2021,
             vilkårsvurderinger = vilkårsvurderingerAvslåttUføreOgInnvilgetFormue(periode = periodeDesember2021),
             tidligereBeregning = beregning(
                 periode = periodeDesember2021,
@@ -393,5 +405,32 @@ internal class IdentifiserRevurderingsutfallSomIkkeStøttesTest {
         ).resultat shouldBe setOf(
             RevurderingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon,
         ).left()
+    }
+
+    @Test
+    fun `identifiserer ingen problemer ved uføre-opphør og likt fradrag med forskjellig periode`() {
+        val februarOgUt2021 = Periode.create(1.februar(2021), 31.desember(2021))
+        IdentifiserSaksbehandlingsutfallSomIkkeStøttes.MedBeregning(
+            revurderingsperiode = februarOgUt2021,
+            vilkårsvurderinger = vilkårsvurderingerAvslåttUføreOgInnvilgetFormue(periode = februarOgUt2021),
+            tidligereBeregning = beregning(
+                periode = periode2021,
+                fradragsgrunnlag = listOf(
+                    fradragsgrunnlagArbeidsinntekt(
+                        periode = periode2021,
+                        arbeidsinntekt = 5000.0,
+                    )
+                ),
+            ),
+            nyBeregning = beregning(
+                periode = februarOgUt2021,
+                fradragsgrunnlag = listOf(
+                    fradragsgrunnlagArbeidsinntekt(
+                        periode = februarOgUt2021,
+                        arbeidsinntekt = 5000.0,
+                    )
+                ),
+            ),
+        ).resultat shouldBe Unit.right()
     }
 }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -334,6 +334,7 @@ internal class RevurderingServiceImpl(
             }
             is BeregnetRevurdering -> {
                 identifiserUtfallSomIkkeStøttes(
+                    revurderingsperiode = revurdering.periode,
                     vilkårsvurderinger = revurdering.vilkårsvurderinger,
                     tidligereBeregning = revurdering.tilRevurdering.beregning,
                     nyBeregning = revurdering.beregning,
@@ -341,6 +342,7 @@ internal class RevurderingServiceImpl(
             }
             is SimulertRevurdering -> {
                 identifiserUtfallSomIkkeStøttes(
+                    revurderingsperiode = revurdering.periode,
                     vilkårsvurderinger = revurdering.vilkårsvurderinger,
                     tidligereBeregning = revurdering.tilRevurdering.beregning,
                     nyBeregning = revurdering.beregning,
@@ -549,10 +551,12 @@ internal class RevurderingServiceImpl(
     }
 
     private fun identifiserUtfallSomIkkeStøttes(
+        revurderingsperiode: Periode,
         vilkårsvurderinger: Vilkårsvurderinger,
         tidligereBeregning: Beregning,
         nyBeregning: Beregning,
     ) = IdentifiserSaksbehandlingsutfallSomIkkeStøttes.MedBeregning(
+        revurderingsperiode = revurderingsperiode,
         vilkårsvurderinger = vilkårsvurderinger,
         tidligereBeregning = tidligereBeregning,
         nyBeregning = nyBeregning,
@@ -735,6 +739,7 @@ internal class RevurderingServiceImpl(
         when (revurdering) {
             is BeregnetRevurdering.IngenEndring -> {
                 identifiserUtfallSomIkkeStøttes(
+                    revurdering.periode,
                     revurdering.vilkårsvurderinger,
                     revurdering.tilRevurdering.beregning,
                     revurdering.beregning,
@@ -744,6 +749,7 @@ internal class RevurderingServiceImpl(
             }
             is SimulertRevurdering -> {
                 identifiserUtfallSomIkkeStøttes(
+                    revurdering.periode,
                     revurdering.vilkårsvurderinger,
                     revurdering.tilRevurdering.beregning,
                     revurdering.beregning,
@@ -755,6 +761,7 @@ internal class RevurderingServiceImpl(
             }
             is UnderkjentRevurdering.Innvilget -> {
                 identifiserUtfallSomIkkeStøttes(
+                    revurdering.periode,
                     revurdering.vilkårsvurderinger,
                     revurdering.tilRevurdering.beregning,
                     revurdering.beregning,
@@ -766,6 +773,7 @@ internal class RevurderingServiceImpl(
             }
             is UnderkjentRevurdering.Opphørt -> {
                 identifiserUtfallSomIkkeStøttes(
+                    revurdering.periode,
                     revurdering.vilkårsvurderinger,
                     revurdering.tilRevurdering.beregning,
                     revurdering.beregning,
@@ -777,6 +785,7 @@ internal class RevurderingServiceImpl(
             }
             is UnderkjentRevurdering.IngenEndring -> {
                 identifiserUtfallSomIkkeStøttes(
+                    revurdering.periode,
                     revurdering.vilkårsvurderinger,
                     revurdering.tilRevurdering.beregning,
                     revurdering.beregning,


### PR DESCRIPTION
IdentifiserSaksbehandlingsutfallSomIkkeStøttes flagget feilaktig revurderinger av opphør som `ikke støttet` dersom revurderingsperioden var forskjellig fra stønadsperioden, og noen av fradragene fra stønadsperioden da var *utenfor* revurderingsperioden.