### PR TITLE
Skill mellom førstegang og ny periode ved opprettelse av oppgaver

### DIFF
--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/oppgave/OppgaveHttpClient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/oppgave/OppgaveHttpClient.kt
@@ -96,7 +96,7 @@ internal class OppgaveHttpClient(
         token: String,
     ): Either<OppgaveFeil.KunneIkkeOppretteOppgave, OppgaveId> {
         val beskrivelse = when (config) {
-            is OppgaveConfig.Attestering, is OppgaveConfig.Saksbehandling ->
+            is OppgaveConfig.AttesterSøknadsbehandling, is OppgaveConfig.NySøknad ->
                 "--- ${
                 Tidspunkt.now(clock).toOppgaveFormat()
                 } - Opprettet av Supplerende Stønad ---\nSøknadId : ${config.saksreferanse}"

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/oppgave/OppgavebeskrivelseMapper.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/oppgave/OppgavebeskrivelseMapper.kt
@@ -21,7 +21,7 @@ object OppgavebeskrivelseMapper {
         }
     }
 
-    fun SivilstandTyper.toReadableName() = when (this) {
+    private fun SivilstandTyper.toReadableName() = when (this) {
         SivilstandTyper.UOPPGITT -> "Uppgitt"
         SivilstandTyper.UGIFT -> "Ugift"
         SivilstandTyper.GIFT -> "Gift"

--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/oppgave/OppgaveHttpClientTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/oppgave/OppgaveHttpClientTest.kt
@@ -26,6 +26,7 @@ import no.nav.su.se.bakover.domain.journal.JournalpostId
 import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
 import no.nav.su.se.bakover.domain.oppgave.OppgaveFeil
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
+import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadstype
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -48,7 +49,7 @@ internal class OppgaveHttpClientTest : WiremockBase {
     private val saksnummer = Saksnummer(12345)
 
     @Test
-    fun `opprett sakbehandling oppgave`() {
+    fun `opprett sakbehandling oppgave ny periode`() {
         //language=JSON
         val expectedSaksbehandlingRequest =
             """
@@ -61,7 +62,7 @@ internal class OppgaveHttpClientTest : WiremockBase {
                     "beskrivelse": "--- 01.01.1970 01:00 - Opprettet av Supplerende Stønad ---\nSøknadId : $søknadId",
                     "oppgavetype": "BEH_SAK",
                     "behandlingstema": "ab0431",
-                    "behandlingstype": "ae0245",
+                    "behandlingstype": "ae0244",
                     "aktivDato": "1970-01-01",
                     "fristFerdigstillelse": "1970-01-31",
                     "prioritet": "NORM",
@@ -85,7 +86,7 @@ internal class OppgaveHttpClientTest : WiremockBase {
                                                       "beskrivelse": "--- 01.01.1970 01:00 - Opprettet av Supplerende Stønad ---\nSøknadId : $søknadId ",
                                                       "behandlingstema": "ab0431",
                                                       "oppgavetype": "BEH_SAK",
-                                                      "behandlingstype": "ae0245",
+                                                      "behandlingstype": "ae0244",
                                                       "versjon": 1,
                                                       "fristFerdigstillelse": "2020-06-06",
                                                       "aktivDato": "2020-06-06",
@@ -119,11 +120,12 @@ internal class OppgaveHttpClientTest : WiremockBase {
         )
 
         client.opprettOppgave(
-            OppgaveConfig.Saksbehandling(
+            OppgaveConfig.NySøknad(
                 journalpostId,
                 søknadId,
                 AktørId(aktørId),
-                clock = fixedEpochClock
+                clock = fixedEpochClock,
+                søknadstype = Søknadstype.NY_PERIODE,
             ),
         ) shouldBe OppgaveId("111").right()
 
@@ -134,11 +136,12 @@ internal class OppgaveHttpClientTest : WiremockBase {
         verifyNoMoreInteractions(oathMock, tokenoppslagMock)
 
         client.opprettOppgaveMedSystembruker(
-            OppgaveConfig.Saksbehandling(
+            OppgaveConfig.NySøknad(
                 journalpostId,
                 søknadId,
                 AktørId(aktørId),
-                clock = fixedEpochClock
+                clock = fixedEpochClock,
+                søknadstype = Søknadstype.NY_PERIODE,
             ),
         ) shouldBe OppgaveId("111").right()
 
@@ -214,12 +217,13 @@ internal class OppgaveHttpClientTest : WiremockBase {
             clock = fixedEpochClock,
         )
         client.opprettOppgave(
-            OppgaveConfig.Saksbehandling(
+            OppgaveConfig.NySøknad(
                 journalpostId = journalpostId,
                 søknadId = søknadId,
                 aktørId = AktørId(aktørId),
                 tilordnetRessurs = saksbehandler,
-                clock = fixedEpochClock
+                clock = fixedEpochClock,
+                søknadstype = Søknadstype.FØRSTEGANGSSØKNAD,
             ),
         ) shouldBe OppgaveId("111").right()
     }
@@ -290,10 +294,11 @@ internal class OppgaveHttpClientTest : WiremockBase {
             clock = fixedEpochClock,
         )
         client.opprettOppgave(
-            OppgaveConfig.Attestering(
+            OppgaveConfig.AttesterSøknadsbehandling(
                 søknadId = søknadId,
                 aktørId = AktørId(aktørId),
-                clock = fixedEpochClock
+                clock = fixedEpochClock,
+                søknadstype = Søknadstype.FØRSTEGANGSSØKNAD,
             ),
         ) shouldBe OppgaveId("111").right()
     }
@@ -315,11 +320,12 @@ internal class OppgaveHttpClientTest : WiremockBase {
             clock = fixedEpochClock,
         )
         client.opprettOppgave(
-            OppgaveConfig.Saksbehandling(
+            OppgaveConfig.NySøknad(
                 journalpostId,
                 søknadId,
                 AktørId(aktørId),
-                clock = fixedEpochClock
+                clock = fixedEpochClock,
+                søknadstype = Søknadstype.FØRSTEGANGSSØKNAD,
             ),
         ) shouldBe OppgaveFeil.KunneIkkeOppretteOppgave.left()
     }

--- a/common/src/main/kotlin/no/nav/su/se/bakover/common/periode/Periode.kt
+++ b/common/src/main/kotlin/no/nav/su/se/bakover/common/periode/Periode.kt
@@ -13,7 +13,7 @@ import java.time.Period
 data class Periode private constructor(
     val fraOgMed: LocalDate,
     val tilOgMed: LocalDate,
-) {
+) : Comparable<Periode> {
     @JsonIgnore
     fun getAntallMåneder() = Period.between(fraOgMed, tilOgMed.plusDays(1)).toTotalMonths().toInt()
     fun tilMånedsperioder(): List<Periode> {
@@ -124,4 +124,6 @@ data class Periode private constructor(
             override fun toString(): String = this.javaClass.simpleName
         }
     }
+
+    override fun compareTo(other: Periode) = fraOgMed.compareTo(other.fraOgMed)
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Kodeverk.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Kodeverk.kt
@@ -19,6 +19,7 @@ enum class Tema(val value: String) {
  */
 enum class Behandlingstype(val value: String) {
     FØRSTEGANGSSØKNAD("ae0245"),
+    NY_PERIODE("ae0244"),
     REVURDERING("ae0028");
 
     override fun toString() = this.value

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Stønadsperiode.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Stønadsperiode.kt
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.TestOnly
 data class Stønadsperiode private constructor(
     val periode: Periode,
     val begrunnelse: String,
-) {
+) : Comparable<Stønadsperiode> {
 
     infix fun inneholder(periode: Periode) = this.periode.inneholder(periode)
     infix fun inneholder(stønadsperiode: Stønadsperiode) = this.periode.inneholder(stønadsperiode.periode)
@@ -38,4 +38,6 @@ data class Stønadsperiode private constructor(
         object PeriodeKanIkkeVæreLengreEnn12Måneder : UgyldigStønadsperiode()
         object FraOgMedDatoKanIkkeVæreFør2021 : UgyldigStønadsperiode()
     }
+
+    override fun compareTo(other: Stønadsperiode) = periode.compareTo(other.periode)
 }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/SøknadsbehandlingTest_Søknadstype.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/SøknadsbehandlingTest_Søknadstype.kt
@@ -1,0 +1,145 @@
+package no.nav.su.se.bakover.domain.søknadsbehandling
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.test.søknadsbehandlingIverksattAvslagMedBeregning
+import no.nav.su.se.bakover.test.søknadsbehandlingIverksattAvslagUtenBeregning
+import no.nav.su.se.bakover.test.søknadsbehandlingIverksattInnvilget
+import no.nav.su.se.bakover.test.søknadsbehandlingSimulert
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+internal class SøknadsbehandlingTest_Søknadstype {
+
+    @Test
+    fun `eksisterende åpen og ny åpen - exception`() {
+        shouldThrow<RuntimeException> {
+            listOf<Søknadsbehandling>(
+                søknadsbehandlingSimulert().second,
+            ).hentSøknadstypeFor(UUID.randomUUID())
+        }
+    }
+
+    @Test
+    fun `eksisterende åpen og eksisterende åpen samme som parameter - exception`() {
+        shouldThrow<RuntimeException> {
+            val underBehandling = søknadsbehandlingSimulert().second
+            listOf<Søknadsbehandling>(
+                søknadsbehandlingSimulert().second,
+                underBehandling,
+            ).hentSøknadstypeFor(underBehandling.id)
+        }
+    }
+
+    @Test
+    fun `eksisterende åpen og eksisterende innvilget samme som parameter - exception`() {
+        shouldThrow<RuntimeException> {
+            val underBehandling = søknadsbehandlingIverksattInnvilget().second
+            listOf(
+                søknadsbehandlingSimulert().second,
+                underBehandling,
+            ).hentSøknadstypeFor(underBehandling.id)
+        }
+    }
+
+    @Test
+    fun `ny åpen - førstegang`() {
+        listOf<Søknadsbehandling>().hentSøknadstypeFor(UUID.randomUUID()) shouldBe Søknadstype.FØRSTEGANGSSØKNAD
+    }
+
+    @Test
+    fun `iverksatt avslag og ny åpen - førstegang`() {
+        listOf<Søknadsbehandling>(
+            søknadsbehandlingIverksattAvslagMedBeregning().second,
+            søknadsbehandlingIverksattAvslagUtenBeregning().second,
+        ).hentSøknadstypeFor(UUID.randomUUID()) shouldBe Søknadstype.FØRSTEGANGSSØKNAD
+    }
+
+    @Test
+    fun `eksisterende åpen samme som current - førstegang`() {
+        val underBehandling = søknadsbehandlingSimulert().second
+        listOf<Søknadsbehandling>(
+            underBehandling,
+        ).hentSøknadstypeFor(underBehandling.id) shouldBe Søknadstype.FØRSTEGANGSSØKNAD
+    }
+
+    @Test
+    fun `eksisterende åpen er samme som parameter - førstegang`() {
+        søknadsbehandlingSimulert().second.let {
+            listOf<Søknadsbehandling>(it).hentSøknadstypeFor(it.id)
+        } shouldBe Søknadstype.FØRSTEGANGSSØKNAD
+    }
+
+    @Test
+    fun `eksisterende innvilget samme som parameter - førstegang`() {
+        val underBehandling = søknadsbehandlingIverksattInnvilget().second
+        listOf<Søknadsbehandling>(
+            underBehandling,
+        ).hentSøknadstypeFor(underBehandling.id) shouldBe Søknadstype.FØRSTEGANGSSØKNAD
+    }
+
+    @Test
+    fun `eksisterende innvilget og eksisterende innvilget samme som parameter - førstegang`() {
+        val underBehandling = søknadsbehandlingIverksattInnvilget().second
+        listOf<Søknadsbehandling>(
+            søknadsbehandlingIverksattInnvilget().second,
+            underBehandling,
+        ).hentSøknadstypeFor(underBehandling.id) shouldBe Søknadstype.NY_PERIODE
+    }
+
+    @Test
+    fun `iverksatt avslag og innvilget og ny åpen - ny periode`() {
+        listOf<Søknadsbehandling>(
+            søknadsbehandlingIverksattInnvilget().second,
+            søknadsbehandlingIverksattAvslagUtenBeregning().second,
+            søknadsbehandlingIverksattAvslagMedBeregning().second,
+        ).hentSøknadstypeFor(UUID.randomUUID()) shouldBe Søknadstype.NY_PERIODE
+    }
+
+    @Test
+    fun `innvilget og eksisterende åpen samme som current - ny periode`() {
+        val underBehandling = søknadsbehandlingSimulert().second
+        listOf(
+            søknadsbehandlingIverksattInnvilget().second,
+            søknadsbehandlingIverksattAvslagUtenBeregning().second,
+            søknadsbehandlingIverksattAvslagMedBeregning().second,
+            underBehandling,
+        ).hentSøknadstypeFor(underBehandling.id) shouldBe Søknadstype.NY_PERIODE
+    }
+
+    @Test
+    fun `eksisterende åpen - exception`() {
+        shouldThrow<RuntimeException> {
+            listOf<Søknadsbehandling>(
+                søknadsbehandlingSimulert().second,
+            ).hentSøknadstypeUtenBehandling()
+        }
+    }
+
+    @Test
+    fun `flere eksisterende åpen - exception`() {
+        shouldThrow<RuntimeException> {
+            listOf<Søknadsbehandling>(
+                søknadsbehandlingSimulert().second,
+                søknadsbehandlingSimulert().second,
+            ).hentSøknadstypeUtenBehandling()
+        }
+    }
+
+    @Test
+    fun `avslag - førstegangssøknad`() {
+        listOf<Søknadsbehandling>(
+            søknadsbehandlingIverksattAvslagMedBeregning().second,
+            søknadsbehandlingIverksattAvslagUtenBeregning().second,
+        ).hentSøknadstypeUtenBehandling() shouldBe Søknadstype.FØRSTEGANGSSØKNAD
+    }
+
+    @Test
+    fun `innvilget - ny periode`() {
+        listOf<Søknadsbehandling>(
+            søknadsbehandlingIverksattAvslagMedBeregning().second,
+            søknadsbehandlingIverksattAvslagUtenBeregning().second,
+            søknadsbehandlingIverksattInnvilget().second,
+        ).hentSøknadstypeUtenBehandling() shouldBe Søknadstype.NY_PERIODE
+    }
+}

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/SøknadsbehandlingVisitorTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/SøknadsbehandlingVisitorTest.kt
@@ -11,9 +11,9 @@ internal class SøknadsbehandlingVisitorTest {
         SøknadsbehandlingVisitor::class.declaredFunctions.count() shouldBe findSealedSubclassCount(Søknadsbehandling::class)
     }
 
-    fun findSealedSubclassCount(clazz: KClass<*>): Int {
+    private fun findSealedSubclassCount(clazz: KClass<*>): Int {
         var sum = 0
-        when (clazz.sealedSubclasses.count() == 0) {
+        when (clazz.sealedSubclasses.isEmpty()) {
             true -> sum += 1
             false -> clazz.sealedSubclasses.forEach {
                 sum += findSealedSubclassCount(it)

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceImpl.kt
@@ -36,6 +36,7 @@ import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling.KunneIk
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling.KunneIkkeLeggeTilFradragsgrunnlag.IkkeLovÅLeggeTilFradragIDenneStatusen
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling.KunneIkkeLeggeTilFradragsgrunnlag.PeriodeMangler
 import no.nav.su.se.bakover.domain.søknadsbehandling.forsøkStatusovergang
+import no.nav.su.se.bakover.domain.søknadsbehandling.hentSøknadstypeFor
 import no.nav.su.se.bakover.domain.søknadsbehandling.medFritekstTilBrev
 import no.nav.su.se.bakover.domain.søknadsbehandling.statusovergang
 import no.nav.su.se.bakover.domain.vedtak.Vedtak
@@ -228,10 +229,14 @@ internal class SøknadsbehandlingServiceImpl(
         val tilordnetRessurs: NavIdentBruker.Attestant? =
             søknadsbehandlingRepo.hentEventuellTidligereAttestering(søknadsbehandling.id)?.attestant
 
+        val søknadstype =
+            søknadsbehandlingRepo.hentForSak(søknadsbehandling.sakId).hentSøknadstypeFor(søknadsbehandling.id)
+
         val nyOppgaveId: OppgaveId = oppgaveService.opprettOppgave(
-            OppgaveConfig.Attestering(
-                søknadsbehandling.søknad.id,
+            OppgaveConfig.AttesterSøknadsbehandling(
+                søknadId = søknadsbehandling.søknad.id,
                 aktørId = aktørId,
+                søknadstype = søknadstype,
                 // Første gang den sendes til attestering er attestant null, de påfølgende gangene vil den være attestanten som har underkjent.
                 tilordnetRessurs = tilordnetRessurs,
             ),
@@ -282,10 +287,13 @@ internal class SøknadsbehandlingServiceImpl(
 
             val journalpostId: JournalpostId = underkjent.søknad.journalpostId
             val eksisterendeOppgaveId = underkjent.oppgaveId
+            val søknadstype =
+                søknadsbehandlingRepo.hentForSak(søknadsbehandling.sakId).hentSøknadstypeFor(søknadsbehandling.id)
             val nyOppgaveId = oppgaveService.opprettOppgave(
-                OppgaveConfig.Saksbehandling(
+                OppgaveConfig.NySøknad(
                     journalpostId = journalpostId,
                     søknadId = underkjent.søknad.id,
+                    søknadstype = søknadstype,
                     aktørId = aktørId,
                     tilordnetRessurs = underkjent.saksbehandler,
                 ),

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/OpprettManglendeJournalpostOgOppgaveTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/OpprettManglendeJournalpostOgOppgaveTest.kt
@@ -22,6 +22,7 @@ import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.person.KunneIkkeHentePerson
 import no.nav.su.se.bakover.domain.søknad.SøknadPdfInnhold
+import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadstype
 import no.nav.su.se.bakover.service.argThat
 import no.nav.su.se.bakover.service.fixedClock
 import no.nav.su.se.bakover.service.oppgave.OppgaveService
@@ -296,12 +297,13 @@ class OpprettManglendeJournalpostOgOppgaveTest {
             verify(personServiceMock).hentPersonMedSystembruker(argThat { it shouldBe fnr })
             verify(oppgaveServiceMock).opprettOppgaveMedSystembruker(
                 argThat {
-                    it shouldBe OppgaveConfig.Saksbehandling(
+                    it shouldBe OppgaveConfig.NySøknad(
                         journalpostId = journalførtSøknad.journalpostId,
                         søknadId = journalførtSøknad.id,
-                        aktørId = person.ident.aktørId
+                        aktørId = person.ident.aktørId,
+                        søknadstype = Søknadstype.FØRSTEGANGSSØKNAD
                     )
-                }
+                },
             )
         }
         verifyNoMoreInteractions(personServiceMock, sakServiceMock, søknadRepoMock, oppgaveServiceMock)
@@ -394,12 +396,13 @@ class OpprettManglendeJournalpostOgOppgaveTest {
             verify(personServiceMock).hentPersonMedSystembruker(argThat { it shouldBe fnr })
             verify(oppgaveServiceMock).opprettOppgaveMedSystembruker(
                 argThat {
-                    it shouldBe OppgaveConfig.Saksbehandling(
+                    it shouldBe OppgaveConfig.NySøknad(
                         journalpostId = journalførtSøknad.journalpostId,
                         søknadId = journalførtSøknad.id,
-                        aktørId = person.ident.aktørId
+                        aktørId = person.ident.aktørId,
+                        søknadstype = Søknadstype.FØRSTEGANGSSØKNAD
                     )
-                }
+                },
             )
             verify(søknadRepoMock).oppdaterOppgaveId(
                 argThat {

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/SøknadserviceOgMocks.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/SøknadserviceOgMocks.kt
@@ -1,0 +1,62 @@
+package no.nav.su.se.bakover.service.søknad
+
+import no.nav.su.se.bakover.client.dokarkiv.DokArkiv
+import no.nav.su.se.bakover.client.pdf.PdfGenerator
+import no.nav.su.se.bakover.database.søknad.SøknadRepo
+import no.nav.su.se.bakover.domain.SakFactory
+import no.nav.su.se.bakover.domain.søknad.SøknadMetrics
+import no.nav.su.se.bakover.service.oppgave.OppgaveService
+import no.nav.su.se.bakover.service.person.PersonService
+import no.nav.su.se.bakover.service.sak.SakService
+import no.nav.su.se.bakover.test.fixedClock
+import org.mockito.kotlin.mock
+import java.time.Clock
+
+/**
+ * Kjører verifyNoMoreInteractions() etter runTest
+ */
+internal data class SøknadserviceOgMocks(
+    val søknadRepo: SøknadRepo = mock(),
+    val sakService: SakService = mock(),
+    val sakFactory: SakFactory = SakFactory(clock = fixedClock),
+    val pdfGenerator: PdfGenerator = mock(),
+    val dokArkiv: DokArkiv = mock(),
+    val personService: PersonService = mock(),
+    val oppgaveService: OppgaveService = mock(),
+    val søknadMetrics: SøknadMetrics = mock(),
+    val clock: Clock = fixedClock,
+    val runTest: SøknadserviceOgMocks.() -> Unit,
+) {
+    val service = SøknadServiceImpl(
+        søknadRepo = søknadRepo,
+        sakService = sakService,
+        sakFactory = sakFactory,
+        pdfGenerator = pdfGenerator,
+        dokArkiv = dokArkiv,
+        personService = personService,
+        oppgaveService = oppgaveService,
+        søknadMetrics = søknadMetrics,
+        clock = no.nav.su.se.bakover.service.fixedClock,
+    )
+
+    init {
+        runTest()
+        verifyNoMoreInteractions()
+    }
+
+    fun allMocks() = listOf(
+        søknadRepo,
+        sakService,
+        pdfGenerator,
+        dokArkiv,
+        personService,
+        oppgaveService,
+        søknadMetrics,
+    ).toTypedArray()
+
+    private fun verifyNoMoreInteractions() {
+        org.mockito.kotlin.verifyNoMoreInteractions(
+            *allMocks(),
+        )
+    }
+}

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceAttesteringTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceAttesteringTest.kt
@@ -28,6 +28,7 @@ import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.person.KunneIkkeHentePerson
 import no.nav.su.se.bakover.domain.søknadsbehandling.Stønadsperiode
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
+import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadstype
 import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
 import no.nav.su.se.bakover.service.argThat
 import no.nav.su.se.bakover.service.beregning.TestBeregning
@@ -38,6 +39,7 @@ import no.nav.su.se.bakover.service.statistikk.EventObserver
 import no.nav.su.se.bakover.test.generer
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
@@ -139,12 +141,15 @@ class SøknadsbehandlingServiceAttesteringTest {
             verify(søknadsbehandlingRepoMock).hent(simulertBehandling.id)
             verify(personServiceMock).hentAktørId(fnr)
             verify(søknadsbehandlingRepoMock).hentEventuellTidligereAttestering(simulertBehandling.id)
+            verify(søknadsbehandlingRepoMock).defaultSessionContext()
+            verify(søknadsbehandlingRepoMock).hentForSak(argThat { it shouldBe sakId }, anyOrNull())
             verify(oppgaveServiceMock).opprettOppgave(
-                config = OppgaveConfig.Attestering(
+                config = OppgaveConfig.AttesterSøknadsbehandling(
                     søknadId = søknadId,
                     aktørId = aktørId,
-                    tilordnetRessurs = null
-                )
+                    tilordnetRessurs = null,
+                    søknadstype = Søknadstype.FØRSTEGANGSSØKNAD,
+                ),
             )
             verify(søknadsbehandlingRepoMock).lagre(expected)
             verify(oppgaveServiceMock).lukkOppgave(oppgaveId)
@@ -233,12 +238,15 @@ class SøknadsbehandlingServiceAttesteringTest {
         verify(søknadsbehandlingRepoMock).hent(simulertBehandling.id)
         verify(personServiceMock).hentAktørId(simulertBehandling.fnr)
         verify(søknadsbehandlingRepoMock).hentEventuellTidligereAttestering(simulertBehandling.id)
+        verify(søknadsbehandlingRepoMock).defaultSessionContext()
+        verify(søknadsbehandlingRepoMock).hentForSak(argThat { it shouldBe sakId }, anyOrNull())
         verify(oppgaveServiceMock).opprettOppgave(
-            OppgaveConfig.Attestering(
+            OppgaveConfig.AttesterSøknadsbehandling(
                 søknadId = simulertBehandling.søknad.id,
                 aktørId = aktørId,
-                tilordnetRessurs = null
-            )
+                tilordnetRessurs = null,
+                søknadstype = Søknadstype.FØRSTEGANGSSØKNAD,
+            ),
         )
 
         verifyNoMoreInteractions(søknadsbehandlingRepoMock, personServiceMock, oppgaveServiceMock, eventObserver)
@@ -296,12 +304,15 @@ class SøknadsbehandlingServiceAttesteringTest {
             verify(søknadsbehandlingRepoMock).hent(simulertBehandling.id)
             verify(personServiceMock).hentAktørId(fnr)
             verify(søknadsbehandlingRepoMock).hentEventuellTidligereAttestering(simulertBehandling.id)
+            verify(søknadsbehandlingRepoMock).defaultSessionContext()
+            verify(søknadsbehandlingRepoMock).hentForSak(argThat { it shouldBe sakId }, anyOrNull())
             verify(oppgaveServiceMock).opprettOppgave(
-                config = OppgaveConfig.Attestering(
+                config = OppgaveConfig.AttesterSøknadsbehandling(
                     søknadId = søknadId,
                     aktørId = aktørId,
-                    tilordnetRessurs = null
-                )
+                    tilordnetRessurs = null,
+                    søknadstype = Søknadstype.FØRSTEGANGSSØKNAD,
+                ),
             )
             verify(søknadsbehandlingRepoMock).lagre(expected)
             verify(oppgaveServiceMock).lukkOppgave(oppgaveId)

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceLeggTilFradragsgrunnlagTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceLeggTilFradragsgrunnlagTest.kt
@@ -15,7 +15,6 @@ import no.nav.su.se.bakover.service.argThat
 import no.nav.su.se.bakover.service.grunnlag.GrunnlagService
 import no.nav.su.se.bakover.service.grunnlag.LeggTilFradragsgrunnlagRequest
 import no.nav.su.se.bakover.test.lagFradragsgrunnlag
-import no.nav.su.se.bakover.test.søknadsbehandlingId
 import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertInnvilget
 import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertUavklart
 import org.junit.jupiter.api.Test
@@ -26,6 +25,7 @@ import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
+import java.util.UUID
 
 class SøknadsbehandlingServiceLeggTilFradragsgrunnlagTest {
     @Test
@@ -103,7 +103,7 @@ class SøknadsbehandlingServiceLeggTilFradragsgrunnlagTest {
             søknadsbehandlingRepo = søknadsbehandlingRepoMock,
             grunnlagService = grunnlagServiceMock,
         )
-
+        val søknadsbehandlingId = UUID.randomUUID()
         val request = LeggTilFradragsgrunnlagRequest(
             behandlingId = søknadsbehandlingId,
             fradragsgrunnlag = listOf(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceUnderkjennTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceUnderkjennTest.kt
@@ -34,6 +34,7 @@ import no.nav.su.se.bakover.domain.person.KunneIkkeHentePerson
 import no.nav.su.se.bakover.domain.søknadsbehandling.StatusovergangVisitor
 import no.nav.su.se.bakover.domain.søknadsbehandling.Stønadsperiode
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
+import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadstype
 import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
 import no.nav.su.se.bakover.service.argThat
 import no.nav.su.se.bakover.service.beregning.TestBeregning
@@ -44,6 +45,7 @@ import no.nav.su.se.bakover.service.statistikk.EventObserver
 import no.nav.su.se.bakover.test.generer
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
@@ -102,11 +104,12 @@ class SøknadsbehandlingServiceUnderkjennTest {
         attesteringer = Attesteringshistorikk.empty(),
     )
 
-    private val oppgaveConfig = OppgaveConfig.Saksbehandling(
+    private val oppgaveConfig = OppgaveConfig.NySøknad(
         journalpostId = journalpostId,
         søknadId = søknadId,
         aktørId = aktørId,
-        tilordnetRessurs = saksbehandler
+        tilordnetRessurs = saksbehandler,
+        søknadstype = Søknadstype.FØRSTEGANGSSØKNAD,
     )
 
     @Test
@@ -308,6 +311,8 @@ class SøknadsbehandlingServiceUnderkjennTest {
         inOrder(søknadsbehandlingRepoMock, personServiceMock, oppgaveServiceMock) {
             verify(søknadsbehandlingRepoMock).hent(argThat { it shouldBe innvilgetBehandlingTilAttestering.id })
             verify(personServiceMock).hentAktørId(argThat { it shouldBe fnr })
+            verify(søknadsbehandlingRepoMock).defaultSessionContext()
+            verify(søknadsbehandlingRepoMock).hentForSak(argThat { it shouldBe sakId }, anyOrNull())
             verify(oppgaveServiceMock).opprettOppgave(argThat { it shouldBe oppgaveConfig })
         }
 
@@ -379,6 +384,8 @@ class SøknadsbehandlingServiceUnderkjennTest {
         ) {
             verify(søknadsbehandlingRepoMock).hent(argThat { it shouldBe innvilgetBehandlingTilAttestering.id })
             verify(personServiceMock).hentAktørId(argThat { it shouldBe fnr })
+            verify(søknadsbehandlingRepoMock).defaultSessionContext()
+            verify(søknadsbehandlingRepoMock).hentForSak(argThat { it shouldBe sakId }, anyOrNull())
             verify(oppgaveServiceMock).opprettOppgave(
                 argThat {
                     it shouldBe oppgaveConfig
@@ -409,6 +416,7 @@ class SøknadsbehandlingServiceUnderkjennTest {
     fun `underkjenner behandling`() {
         val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
             on { hent(any()) } doReturn innvilgetBehandlingTilAttestering
+            on { hentForSak(any(), anyOrNull()) } doReturn emptyList()
         }
 
         val personServiceMock: PersonService = mock {
@@ -463,6 +471,8 @@ class SøknadsbehandlingServiceUnderkjennTest {
         ) {
             verify(søknadsbehandlingRepoMock).hent(argThat { it shouldBe innvilgetBehandlingTilAttestering.id })
             verify(personServiceMock).hentAktørId(argThat { it shouldBe fnr })
+            verify(søknadsbehandlingRepoMock).defaultSessionContext()
+            verify(søknadsbehandlingRepoMock).hentForSak(argThat { it shouldBe sakId }, anyOrNull())
             verify(oppgaveServiceMock).opprettOppgave(
                 argThat {
                     it shouldBe oppgaveConfig

--- a/test-common/src/main/kotlin/SøknadsbehandlingTestData.kt
+++ b/test-common/src/main/kotlin/SøknadsbehandlingTestData.kt
@@ -15,8 +15,6 @@ import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
 import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
 import java.util.UUID
 
-val søknadsbehandlingId: UUID = UUID.randomUUID()
-
 val behandlingsinformasjonAlleVilkårUavklart = Behandlingsinformasjon
     .lagTomBehandlingsinformasjon()
 
@@ -43,7 +41,7 @@ fun søknadsbehandlingVilkårsvurdertUavklart(
         fnr = fnr,
     ).let { (sak, journalførtSøknadMedOppgave) ->
         val søknadsbehandling = Søknadsbehandling.Vilkårsvurdert.Uavklart(
-            id = søknadsbehandlingId,
+            id = UUID.randomUUID(),
             opprettet = fixedTidspunkt,
             sakId = sak.id,
             saksnummer = sak.saksnummer,

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutesKtTest.kt
@@ -184,7 +184,7 @@ internal class SøknadRoutesKtTest {
             on { sjekkTilgangTilPerson(any()) } doReturn PersonOppslagStub.sjekkTilgangTilPerson(fnr)
         }
         val oppgaveClient: OppgaveClient = mock {
-            on { opprettOppgave(any<OppgaveConfig.Saksbehandling>()) } doReturn OppgaveId("11").right()
+            on { opprettOppgave(any<OppgaveConfig.NySøknad>()) } doReturn OppgaveId("11").right()
         }
         withMigratedDb { dataSource ->
             val repos = DatabaseBuilder.build(


### PR DESCRIPTION
La inn sjekk på ulovlige tilstander som ved opprettelse/oppdatering av søknadsbehandling som kaster exception; siden det finnes behandlingskombinasjoner der vi ikke kan avgjøre om det vil være en førstegangssøknad eller ny periode (typisk ved fler åpne søknadsbehandlinger)