### PR TITLE
Sett oppgave til NyPeriode dersom det finnes en annen iverksatt innvilget

### DIFF
--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
@@ -15,6 +15,9 @@ import no.nav.su.se.bakover.domain.revurdering.AbstraktRevurdering
 import no.nav.su.se.bakover.domain.revurdering.GjenopptaYtelseRevurdering
 import no.nav.su.se.bakover.domain.revurdering.StansAvYtelseRevurdering
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
+import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadstype
+import no.nav.su.se.bakover.domain.søknadsbehandling.hentSøknadstypeFor
+import no.nav.su.se.bakover.domain.søknadsbehandling.hentSøknadstypeUtenBehandling
 import no.nav.su.se.bakover.domain.tidslinje.TidslinjeForUtbetalinger
 import no.nav.su.se.bakover.domain.vedtak.GjeldendeVedtaksdata
 import no.nav.su.se.bakover.domain.vedtak.Vedtak
@@ -95,6 +98,14 @@ data class Sak(
 
     fun harÅpenRevurderingForGjenopptakAvYtelse(): Boolean {
         return revurderinger.filterIsInstance<GjenopptaYtelseRevurdering.SimulertGjenopptakAvYtelse>().isNotEmpty()
+    }
+
+    fun hentSøknadstypeUtenBehandling(): Søknadstype {
+        return this.søknadsbehandlinger.hentSøknadstypeUtenBehandling()
+    }
+
+    fun hentSøknadstypeFor(behandlingId: UUID): Søknadstype {
+        return this.søknadsbehandlinger.hentSøknadstypeFor(behandlingId)
     }
 }
 

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Statusovergang.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Statusovergang.kt
@@ -12,7 +12,6 @@ import no.nav.su.se.bakover.domain.beregning.Beregning
 import no.nav.su.se.bakover.domain.grunnlag.KunneIkkeLageGrunnlagsdata
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimuleringFeilet
-import no.nav.su.se.bakover.domain.søknadsbehandling.BehandlingsStatus.IVERKSATT_AVSLAG
 
 abstract class Statusovergang<L, T> : StatusovergangVisitor {
 
@@ -226,7 +225,7 @@ abstract class Statusovergang<L, T> : StatusovergangVisitor {
         private fun oppdater(søknadsbehandling: Søknadsbehandling): Either<KunneIkkeOppdatereStønadsperiode, Søknadsbehandling.Vilkårsvurdert> {
             // En foreløpig begrensning er at vi ikke kan starte en ny søknadsbehandling for opphørte måneder.
             val tidligerePerioder = tidligereSøknadsbehandlinger
-                .filterNot { it.status == IVERKSATT_AVSLAG }
+                .filterNot { it is Søknadsbehandling.Iverksatt.Avslag }
                 .mapNotNull { it.stønadsperiode?.periode }
             if (oppdatertStønadsperiode.periode overlapper tidligerePerioder) {
                 return KunneIkkeOppdatereStønadsperiode.StønadsperiodeOverlapperMedEksisterendeSøknadsbehandling.left()

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Søknadsbehandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Søknadsbehandling.kt
@@ -35,6 +35,8 @@ import java.util.UUID
 sealed class Søknadsbehandling : BehandlingMedOppgave, BehandlingMedAttestering, Visitable<SøknadsbehandlingVisitor> {
     abstract val søknad: Søknad.Journalført.MedOppgave
     abstract val behandlingsinformasjon: Behandlingsinformasjon
+
+    // TODO jah: Denne kan fjernes fra domenet og heller la mappingen ligge i infrastruktur-laget
     abstract val status: BehandlingsStatus
     abstract val stønadsperiode: Stønadsperiode?
     abstract override val grunnlagsdata: Grunnlagsdata
@@ -1345,47 +1347,40 @@ sealed class KunneIkkeIverksette {
     object KunneIkkeGenerereVedtaksbrev : KunneIkkeIverksette()
 }
 
-private fun List<Søknadsbehandling>.kastHvisDetFinnesEnAnnenÅpenBehandling(behandlingId: UUID) {
-    this
-        .filter { b -> b.id != behandlingId }
-        .filterNot { it.status == BehandlingsStatus.IVERKSATT_INNVILGET || it.status == BehandlingsStatus.IVERKSATT_AVSLAG }
-        .ifNotEmpty {
-            throw IllegalStateException("Det finnes flere behandlinger under behandling")
-        }
-    // TODO jah: Kan på sikt flytte disse valideringene til Sak og/eller database-laget.
-}
-
-private fun List<Søknadsbehandling>.kastHvisDetFinnesEnÅpenBehandling() {
-    this
-        .filterNot { it.status == BehandlingsStatus.IVERKSATT_INNVILGET || it.status == BehandlingsStatus.IVERKSATT_AVSLAG }
-        .ifNotEmpty {
-            throw IllegalStateException("Det finnes flere behandlinger under behandling")
-        }
-    // TODO jah: Kan på sikt flytte disse valideringene til Sak og/eller database-laget.
-}
-
 fun List<Søknadsbehandling>.hentSøknadstypeUtenBehandling(): Søknadstype {
-    this.kastHvisDetFinnesEnÅpenBehandling()
-
-    this
-        .filter { it.status == BehandlingsStatus.IVERKSATT_INNVILGET }
-        .ifNotEmpty {
-            return Søknadstype.NY_PERIODE
-        }
-
+    if (any { it is Søknadsbehandling.Iverksatt.Innvilget }) {
+        return Søknadstype.NY_PERIODE
+    }
+    if (this.filterNot { it is Søknadsbehandling.Iverksatt.Avslag }.isNotEmpty()) {
+        // TODO : Legge inn stopp for at vi kan ha fler åpne søknadsbehandlinger og søknader.
+        throw IllegalStateException("Kan ikke avgjøre om det er en førstegangssøknad eller ny periode. Det finnes ingen iverksatt innvilget behandlinger og det finnes en eller fler åpne behandlinger.")
+    }
     return Søknadstype.FØRSTEGANGSSØKNAD
 }
 
 fun List<Søknadsbehandling>.hentSøknadstypeFor(behandlingId: UUID): Søknadstype {
-    this.kastHvisDetFinnesEnAnnenÅpenBehandling(behandlingId)
-
     this
-        .filter { b -> b.id != behandlingId }
-        .filter { it.status == BehandlingsStatus.IVERKSATT_INNVILGET }
+        .filterIsInstance<Søknadsbehandling.Iverksatt.Innvilget>()
+        .sortedBy { it.stønadsperiode }
         .ifNotEmpty {
-            return Søknadstype.NY_PERIODE
+            if (this.first().id == behandlingId) {
+                // Denne behandlingen er den første iverksatt innvilga søknadbehandling, altså en førstegangssøknad.
+                return Søknadstype.FØRSTEGANGSSØKNAD
+            }
         }
-
+    this
+        .filterNot { b -> b.id == behandlingId }
+        .also {
+            if (it.any { b -> b is Søknadsbehandling.Iverksatt.Innvilget }) {
+                // Hvis det finnes en iverksatt innvilget søknadsbehandling som ikke er denne behandlinga, vil denne behandlinga være en ny periode
+                return Søknadstype.NY_PERIODE
+            }
+        }
+        .filterNot { it is Søknadsbehandling.Iverksatt }
+        .ifNotEmpty {
+            // Dette bør ikke skje i praksis, siden det bør være stoppet i et tidligere steg.
+            throw IllegalStateException("Kan ikke avgjøre om det er en førstegangssøknad eller ny periode. Det finnes ingen iverksatt innvilget behandlinger og det finnes en eller fler åpne behandlinger som ikke er denne behandlinga $behandlingId")
+        }
     return Søknadstype.FØRSTEGANGSSØKNAD
 }
 

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/SøknadsbehandlingTest_Søknadstype.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/SøknadsbehandlingTest_Søknadstype.kt
@@ -32,17 +32,6 @@ internal class SøknadsbehandlingTest_Søknadstype {
     }
 
     @Test
-    fun `eksisterende åpen og eksisterende innvilget samme som parameter - exception`() {
-        shouldThrow<RuntimeException> {
-            val underBehandling = søknadsbehandlingIverksattInnvilget().second
-            listOf(
-                søknadsbehandlingSimulert().second,
-                underBehandling,
-            ).hentSøknadstypeFor(underBehandling.id)
-        }
-    }
-
-    @Test
     fun `ny åpen - førstegang`() {
         listOf<Søknadsbehandling>().hentSøknadstypeFor(UUID.randomUUID()) shouldBe Søknadstype.FØRSTEGANGSSØKNAD
     }
@@ -82,6 +71,34 @@ internal class SøknadsbehandlingTest_Søknadstype {
     fun `eksisterende innvilget og eksisterende innvilget samme som parameter - førstegang`() {
         val underBehandling = søknadsbehandlingIverksattInnvilget().second
         listOf<Søknadsbehandling>(
+            søknadsbehandlingIverksattInnvilget().second,
+            underBehandling,
+        ).hentSøknadstypeFor(underBehandling.id) shouldBe Søknadstype.NY_PERIODE
+    }
+
+    @Test
+    fun `eksisterende åpen og eksisterende innvilget samme som parameter - førstegang`() {
+        val underBehandling = søknadsbehandlingIverksattInnvilget().second
+        listOf(
+            søknadsbehandlingSimulert().second,
+            underBehandling,
+        ).hentSøknadstypeFor(underBehandling.id) shouldBe Søknadstype.FØRSTEGANGSSØKNAD
+    }
+
+    @Test
+    fun `åpen behandling og senere eksisterende innvilget og eksisterende innvilget samme som parameter - førstegang`() {
+        val underBehandling = søknadsbehandlingIverksattInnvilget().second
+        listOf(
+            søknadsbehandlingSimulert().second,
+            underBehandling,
+            søknadsbehandlingIverksattInnvilget().second,
+        ).hentSøknadstypeFor(underBehandling.id) shouldBe Søknadstype.FØRSTEGANGSSØKNAD
+    }
+
+    @Test
+    fun `eksisterende innvilget og senere eksisterende innvilget samme som parameter - ny periode`() {
+        val underBehandling = søknadsbehandlingIverksattInnvilget().second
+        listOf(
             søknadsbehandlingIverksattInnvilget().second,
             underBehandling,
         ).hentSøknadstypeFor(underBehandling.id) shouldBe Søknadstype.NY_PERIODE


### PR DESCRIPTION
Siden det opprettes en oppgave med en gang en søknad sendes inn, vil vi nå få en 500 ved søknadsinnsending dersom det finnes en åpen søknadsbehandling. Dette fikser i hvert fall slik at hvis det finnes en iverksatt innvilget, så blir det ny periode. Det vil fremdeles feile dersom det kun er åpne søknader.

Ryddet opp litt generelt og la på mer beskrivende tekst.