### PR TITLE
Tillat innvilgelse av ny periode dersom ikke overlapp med aktiv periode

### DIFF
--- a/common/src/test/kotlin/no/nav/su/se/bakover/common/periode/PeriodeTest.kt
+++ b/common/src/test/kotlin/no/nav/su/se/bakover/common/periode/PeriodeTest.kt
@@ -1,6 +1,7 @@
 package no.nav.su.se.bakover.common.periode
 
 import arrow.core.left
+import arrow.core.right
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.matchers.collections.shouldHaveSize
@@ -454,18 +455,22 @@ internal class PeriodeTest {
     @Test
     fun `slår sammen perioder hvis mulig`() {
         Periode.create(1.januar(2021), 31.januar(2021)) slåSammen
-            Periode.create(1.februar(2021), 28.februar(2021)) shouldBe (Periode.create(1.januar(2021), 28.februar(2021)))
+            Periode.create(1.februar(2021), 28.februar(2021)) shouldBe (Periode.create(1.januar(2021), 28.februar(2021))).right()
+
+        Periode.create(1.januar(2021), 31.juli(2021)) slåSammen
+            Periode.create(1.februar(2021), 28.februar(2021)) shouldBe (Periode.create(1.januar(2021), 31.juli(2021))).right()
+
+        Periode.create(1.september(2021), 31.desember(2021)) slåSammen
+            Periode.create(1.mars(2021), 31.oktober(2021)) shouldBe (Periode.create(1.mars(2021), 31.desember(2021))).right()
 
         Periode.create(1.mars(2021), 31.mars(2021)) slåSammen
-            Periode.create(1.april(2021), 30.april(2021)) shouldBe (Periode.create(1.mars(2021), 30.april(2021)))
+            Periode.create(1.april(2021), 30.april(2021)) shouldBe (Periode.create(1.mars(2021), 30.april(2021))).right()
 
         Periode.create(1.juni(2021), 31.desember(2021)) slåSammen
-            Periode.create(1.mars(2021), 31.mai(2021)) shouldBe (Periode.create(1.mars(2021), 31.desember(2021)))
+            Periode.create(1.mars(2021), 31.mai(2021)) shouldBe (Periode.create(1.mars(2021), 31.desember(2021))).right()
 
-        assertThrows<IllegalStateException> {
-            Periode.create(1.juni(2021), 31.juli(2021)) slåSammen
-                Periode.create(1.oktober(2021), 31.desember(2021))
-        }
+        Periode.create(1.juni(2021), 31.juli(2021)) slåSammen
+            Periode.create(1.oktober(2021), 31.desember(2021)) shouldBe Periode.PerioderKanIkkeSlåsSammen.left()
     }
 
     @Test

--- a/common/src/test/kotlin/no/nav/su/se/bakover/common/periode/PeriodeTest.kt
+++ b/common/src/test/kotlin/no/nav/su/se/bakover/common/periode/PeriodeTest.kt
@@ -450,4 +450,71 @@ internal class PeriodeTest {
 
         deserialized shouldBe Periode.create(1.januar(2021), 31.desember(2021))
     }
+
+    @Test
+    fun `slår sammen perioder hvis mulig`() {
+        Periode.create(1.januar(2021), 31.januar(2021)) slåSammen
+            Periode.create(1.februar(2021), 28.februar(2021)) shouldBe (Periode.create(1.januar(2021), 28.februar(2021)))
+
+        Periode.create(1.mars(2021), 31.mars(2021)) slåSammen
+            Periode.create(1.april(2021), 30.april(2021)) shouldBe (Periode.create(1.mars(2021), 30.april(2021)))
+
+        Periode.create(1.juni(2021), 31.desember(2021)) slåSammen
+            Periode.create(1.mars(2021), 31.mai(2021)) shouldBe (Periode.create(1.mars(2021), 31.desember(2021)))
+
+        assertThrows<IllegalStateException> {
+            Periode.create(1.juni(2021), 31.juli(2021)) slåSammen
+                Periode.create(1.oktober(2021), 31.desember(2021))
+        }
+    }
+
+    @Test
+    fun `reduserer perioder`() {
+        listOf(
+            Periode.create(1.januar(2021), 31.januar(2021)),
+            Periode.create(1.februar(2021), 28.februar(2021)),
+            Periode.create(1.mars(2021), 31.mars(2021)),
+            Periode.create(1.april(2021), 30.april(2021)),
+        ).reduser() shouldBe listOf(
+            Periode.create(1.januar(2021), 30.april(2021)),
+        )
+
+        listOf(
+            Periode.create(1.januar(2021), 31.mars(2021)),
+            Periode.create(1.februar(2021), 30.april(2021)),
+        ).reduser() shouldBe listOf(
+            Periode.create(1.januar(2021), 30.april(2021)),
+        )
+
+        listOf(
+            Periode.create(1.januar(2021), 31.mars(2021)),
+            Periode.create(1.mars(2021), 31.desember(2021)),
+        ).reduser() shouldBe listOf(
+            Periode.create(1.januar(2021), 31.desember(2021)),
+        )
+
+        listOf(
+            Periode.create(1.april(2021), 31.juli(2021)),
+            Periode.create(1.februar(2021), 31.mars(2021)),
+            Periode.create(1.februar(2021), 31.desember(2021)),
+        ).reduser() shouldBe listOf(
+            Periode.create(1.februar(2021), 31.desember(2021)),
+        )
+
+        listOf(
+            Periode.create(1.april(2021), 31.juli(2021)),
+            Periode.create(1.februar(2022), 31.mars(2022)),
+        ).reduser() shouldBe listOf(
+            Periode.create(1.april(2021), 31.juli(2021)),
+            Periode.create(1.februar(2022), 31.mars(2022)),
+        )
+
+        listOf(
+            Periode.create(1.april(2021), 31.juli(2021)),
+        ).reduser() shouldBe listOf(
+            Periode.create(1.april(2021), 31.juli(2021))
+        )
+
+        emptyList<Periode>().reduser() shouldBe emptyList()
+    }
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Statusovergang.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Statusovergang.kt
@@ -219,14 +219,14 @@ abstract class Statusovergang<L, T> : StatusovergangVisitor {
             data class KunneIkkeOppdatereGrunnlagsdata(val feil: KunneIkkeLageGrunnlagsdata) :
                 KunneIkkeOppdatereStønadsperiode()
 
-            object StønadsperiodeOverlapperMedEksisterendeStønadsperiode : KunneIkkeOppdatereStønadsperiode()
+            object StønadsperiodeOverlapperMedLøpendeStønadsperiode : KunneIkkeOppdatereStønadsperiode()
             object StønadsperiodeForSenerePeriodeEksisterer : KunneIkkeOppdatereStønadsperiode()
         }
 
         private fun oppdater(søknadsbehandling: Søknadsbehandling): Either<KunneIkkeOppdatereStønadsperiode, Søknadsbehandling.Vilkårsvurdert> {
-            sak.hentAktiveStønadsperioder().let { stønadsperioder ->
+            sak.hentPerioderMedLøpendeYtelse().let { stønadsperioder ->
                 if (stønadsperioder.any { it overlapper oppdatertStønadsperiode.periode }) {
-                    return KunneIkkeOppdatereStønadsperiode.StønadsperiodeOverlapperMedEksisterendeStønadsperiode.left()
+                    return KunneIkkeOppdatereStønadsperiode.StønadsperiodeOverlapperMedLøpendeStønadsperiode.left()
                 }
                 if (stønadsperioder.any { it.starterSamtidigEllerSenere(oppdatertStønadsperiode.periode) }) {
                     return KunneIkkeOppdatereStønadsperiode.StønadsperiodeForSenerePeriodeEksisterer.left()

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/Vedtak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/Vedtak.kt
@@ -41,7 +41,18 @@ interface VedtakFelles {
     val periode: Periode
 }
 
-sealed interface VedtakSomKanRevurderes : VedtakFelles
+sealed interface VedtakSomKanRevurderes : VedtakFelles {
+    fun erOpphør(): Boolean {
+        return when (this) {
+            is Vedtak.EndringIYtelse.GjenopptakAvYtelse -> false
+            is Vedtak.EndringIYtelse.InnvilgetRevurdering -> false
+            is Vedtak.EndringIYtelse.InnvilgetSøknadsbehandling -> false
+            is Vedtak.EndringIYtelse.OpphørtRevurdering -> true
+            is Vedtak.EndringIYtelse.StansAvYtelse -> false
+            is Vedtak.IngenEndringIYtelse -> false
+        }
+    }
+}
 
 sealed class Vedtak : VedtakFelles, Visitable<VedtakVisitor> {
 

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/SakTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/SakTest.kt
@@ -7,122 +7,225 @@ import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.februar
 import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.juli
+import no.nav.su.se.bakover.common.juni
 import no.nav.su.se.bakover.common.mai
+import no.nav.su.se.bakover.common.november
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.søknadsbehandling.Stønadsperiode
+import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.generer
+import no.nav.su.se.bakover.test.plus
 import no.nav.su.se.bakover.test.saksnummer
+import no.nav.su.se.bakover.test.stønadsperiode2021
 import no.nav.su.se.bakover.test.vedtakIverksattGjenopptakAvYtelseFraIverksattStans
 import no.nav.su.se.bakover.test.vedtakIverksattStansAvYtelseFraIverksattSøknadsbehandlingsvedtak
 import no.nav.su.se.bakover.test.vedtakRevurderingIverksattInnvilget
 import no.nav.su.se.bakover.test.vedtakRevurderingOpphørtUføreFraInnvilgetSøknadsbehandlingsVedtak
 import no.nav.su.se.bakover.test.vedtakSøknadsbehandlingIverksattInnvilget
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 internal class SakTest {
 
-    @Test
-    fun `henter tom liste dersom ingen eksisterer`() {
-        Sak(
-            id = UUID.randomUUID(),
-            saksnummer = saksnummer,
-            opprettet = no.nav.su.se.bakover.test.fixedTidspunkt,
-            fnr = Fnr.generer(),
-            søknader = listOf(),
-            søknadsbehandlinger = listOf(),
-            utbetalinger = listOf(),
-            revurderinger = listOf(),
-            vedtakListe = listOf(),
-        ).hentAktiveStønadsperioder() shouldBe emptyList()
-    }
+    @Nested
+    inner class HentPerioderMedLøpendeYtelse {
 
-    @Test
-    fun `henter en stønadsperiode`() {
-        val (sak, _) = vedtakSøknadsbehandlingIverksattInnvilget()
+        @Test
+        fun `henter tom liste dersom ingen eksisterer`() {
+            Sak(
+                id = UUID.randomUUID(),
+                saksnummer = saksnummer,
+                opprettet = fixedTidspunkt,
+                fnr = Fnr.generer(),
+                søknader = listOf(),
+                søknadsbehandlinger = listOf(),
+                utbetalinger = listOf(),
+                revurderinger = listOf(),
+                vedtakListe = listOf(),
+            ).hentPerioderMedLøpendeYtelse() shouldBe emptyList()
+        }
 
-        sak.hentAktiveStønadsperioder() shouldBe listOf(
-            Periode.create(1.januar(2021), 31.desember(2021)),
-        )
-    }
+        @Test
+        fun `henter en stønadsperiode`() {
+            val (sak, _) = vedtakSøknadsbehandlingIverksattInnvilget()
 
-    @Test
-    fun `henter stønadsperioder og justerer varigheten dersom de er delvis opphørt`() {
-        val (sak, _) = vedtakRevurderingOpphørtUføreFraInnvilgetSøknadsbehandlingsVedtak(
-            sakOgVedtakSomKanRevurderes = vedtakSøknadsbehandlingIverksattInnvilget(),
-            revurderingsperiode = Periode.create(1.mai(2021), 31.desember(2021)),
-        )
-
-        sak.hentAktiveStønadsperioder() shouldBe listOf(
-            Periode.create(1.januar(2021), 30.april(2021)),
-        )
-    }
-
-    @Test
-    fun `henter stønadsperioder med opphold mellom`() {
-        val (sak, stønadsperiode1) = vedtakSøknadsbehandlingIverksattInnvilget()
-
-        val (_, stønadsperiode2) = vedtakSøknadsbehandlingIverksattInnvilget(
-            stønadsperiode = Stønadsperiode.create(
-                periode = Periode.create(1.januar(2023), 31.desember(2023)),
-                begrunnelse = "ny periode da vett",
-            ),
-        )
-
-        sak.copy(
-            søknadsbehandlinger = sak.søknadsbehandlinger + stønadsperiode2.behandling,
-            vedtakListe = sak.vedtakListe + stønadsperiode2,
-        ).let {
-            it.hentAktiveStønadsperioder() shouldBe listOf(
+            sak.hentPerioderMedLøpendeYtelse() shouldBe listOf(
                 Periode.create(1.januar(2021), 31.desember(2021)),
-                Periode.create(1.januar(2023), 31.desember(2023)),
-            )
-            it.vedtakListe shouldContainAll listOf(
-                stønadsperiode1,
-                stønadsperiode2,
             )
         }
-    }
 
-    @Test
-    fun `henter stønadsperioder som har blitt revurdert`() {
-        val (sakFørRevurdering, søknadsvedtak) = vedtakSøknadsbehandlingIverksattInnvilget()
+        @Test
+        fun `henter stønadsperioder og justerer varigheten dersom de er delvis opphørt`() {
+            val (sak, _) = vedtakRevurderingOpphørtUføreFraInnvilgetSøknadsbehandlingsVedtak(
+                sakOgVedtakSomKanRevurderes = vedtakSøknadsbehandlingIverksattInnvilget(),
+                revurderingsperiode = Periode.create(1.mai(2021), 31.desember(2021)),
+            )
 
-        sakFørRevurdering.hentAktiveStønadsperioder() shouldBe listOf(
-            Periode.create(1.januar(2021), 31.desember(2021)),
-        )
+            sak.hentPerioderMedLøpendeYtelse() shouldBe listOf(
+                Periode.create(1.januar(2021), 30.april(2021)),
+            )
+        }
 
-        val (sakEtterStans, stans) = vedtakIverksattStansAvYtelseFraIverksattSøknadsbehandlingsvedtak(
-            periode = Periode.create(1.februar(2021), 31.desember(2021)),
-            sakOgVedtakSomKanRevurderes = sakFørRevurdering to søknadsvedtak,
-        )
+        @Test
+        fun `henter stønadsperioder for tidligere opphørt periode som er innvilget og revurdert igjen`() {
+            val (sak, vedtak) = vedtakSøknadsbehandlingIverksattInnvilget()
 
-        sakEtterStans.hentAktiveStønadsperioder() shouldBe listOf(
-            Periode.create(1.januar(2021), 31.desember(2021)),
-        )
+            val (sakEtterOpphør, opphør) = vedtakRevurderingOpphørtUføreFraInnvilgetSøknadsbehandlingsVedtak(
+                revurderingsperiode = Periode.create(1.mai(2021), 31.desember(2021)),
+                sakOgVedtakSomKanRevurderes = sak to vedtak,
+            )
 
-        val (sakEtterGjenopptak, gjenopptak) = vedtakIverksattGjenopptakAvYtelseFraIverksattStans(
-            periode = Periode.create(1.februar(2021), 31.desember(2021)),
-            sakOgVedtakSomKanRevurderes = sakEtterStans to stans,
-        )
+            sakEtterOpphør.hentPerioderMedLøpendeYtelse() shouldBe listOf(
+                Periode.create(1.januar(2021), 30.april(2021)),
+            )
 
-        sakEtterGjenopptak.hentAktiveStønadsperioder() shouldBe listOf(
-            Periode.create(1.januar(2021), 31.desember(2021)),
-        )
+            val (sakEtterNyPeriode, nyPeriode) = vedtakSøknadsbehandlingIverksattInnvilget(
+                stønadsperiode = Stønadsperiode.create(
+                    periode = Periode.create(1.juni(2021), 31.desember(2021)),
+                    begrunnelse = "beg",
+                ),
+                clock = fixedClock.plus(1, ChronoUnit.DAYS),
+            )
 
-        val (sakEtterRevurdering, revurdering) = vedtakRevurderingIverksattInnvilget(
-            revurderingsperiode = Periode.create(1.juli(2021), 31.desember(2021)),
-            sakOgVedtakSomKanRevurderes = sakEtterGjenopptak to gjenopptak,
-        )
+            val sakEtterOpphørOgNyPeriode = sakEtterOpphør.copy(
+                revurderinger = sakEtterOpphør.revurderinger + sakEtterNyPeriode.revurderinger,
+                søknadsbehandlinger = sakEtterOpphør.søknadsbehandlinger + sakEtterNyPeriode.søknadsbehandlinger,
+                vedtakListe = sakEtterOpphør.vedtakListe + sakEtterNyPeriode.vedtakListe,
+                utbetalinger = sakEtterOpphør.utbetalinger + sakEtterNyPeriode.utbetalinger,
+            )
 
-        sakEtterRevurdering.hentAktiveStønadsperioder() shouldBe listOf(
-            Periode.create(1.januar(2021), 31.desember(2021)),
-        )
-        sakEtterRevurdering.vedtakListe shouldContainAll listOf(
-            søknadsvedtak,
-            stans,
-            gjenopptak,
-            revurdering,
-        )
+            val (sakEtterRevurdering, revurdering) = vedtakRevurderingIverksattInnvilget(
+                revurderingsperiode = Periode.create(1.november(2021), 31.desember(2021)),
+                sakOgVedtakSomKanRevurderes = sakEtterOpphørOgNyPeriode to nyPeriode,
+            )
+
+            sakEtterRevurdering.let {
+                it.hentPerioderMedLøpendeYtelse() shouldBe listOf(
+                    Periode.create(1.januar(2021), 30.april(2021)),
+                    Periode.create(1.juni(2021), 31.desember(2021)),
+                )
+                it.vedtakListe shouldContainAll listOf(
+                    vedtak,
+                    opphør,
+                    nyPeriode,
+                    revurdering,
+                )
+            }
+        }
+
+        @Test
+        fun `henter stønadsperioder med opphold mellom`() {
+            val (sak, stønadsperiode1) = vedtakSøknadsbehandlingIverksattInnvilget()
+
+            val (_, stønadsperiode2) = vedtakSøknadsbehandlingIverksattInnvilget(
+                stønadsperiode = Stønadsperiode.create(
+                    periode = Periode.create(1.januar(2023), 31.desember(2023)),
+                    begrunnelse = "ny periode da vett",
+                ),
+            )
+
+            sak.copy(
+                søknadsbehandlinger = sak.søknadsbehandlinger + stønadsperiode2.behandling,
+                vedtakListe = sak.vedtakListe + stønadsperiode2,
+            ).let {
+                it.hentPerioderMedLøpendeYtelse() shouldBe listOf(
+                    Periode.create(1.januar(2021), 31.desember(2021)),
+                    Periode.create(1.januar(2023), 31.desember(2023)),
+                )
+                it.vedtakListe shouldContainAll listOf(
+                    stønadsperiode1,
+                    stønadsperiode2,
+                )
+            }
+        }
+
+        @Test
+        fun `henter stønadsperioder med revurdering og med opphold mellom`() {
+            val (sakStønadsperiode1, stønadsperiode1) = vedtakSøknadsbehandlingIverksattInnvilget(
+                stønadsperiode = stønadsperiode2021,
+            )
+
+            val (sakRevurdering1, revurderingPeriode1) = vedtakRevurderingIverksattInnvilget(
+                revurderingsperiode = Periode.create(1.mai(2021), 31.desember(2021)),
+                sakOgVedtakSomKanRevurderes = sakStønadsperiode1 to stønadsperiode1,
+            )
+
+            val stønadsperiode2023 = Stønadsperiode.create(
+                periode = Periode.create(1.januar(2023), 31.desember(2023)),
+                begrunnelse = "ny periode da vett",
+            )
+
+            val (sakStønadsperiode2, stønadsperiode2) = vedtakSøknadsbehandlingIverksattInnvilget(
+                stønadsperiode = stønadsperiode2023,
+            )
+
+            val (sakRevurdering2, revurderingPeriode2) = vedtakRevurderingIverksattInnvilget(
+                stønadsperiode = stønadsperiode2023,
+                revurderingsperiode = Periode.create(1.november(2023), 31.desember(2023)),
+                sakOgVedtakSomKanRevurderes = sakStønadsperiode2 to stønadsperiode2,
+            )
+
+            sakStønadsperiode1.copy(
+                søknadsbehandlinger = sakRevurdering1.søknadsbehandlinger + sakRevurdering2.søknadsbehandlinger,
+                revurderinger = sakRevurdering1.revurderinger + sakRevurdering2.revurderinger,
+                vedtakListe = sakRevurdering1.vedtakListe + sakRevurdering2.vedtakListe,
+                utbetalinger = sakRevurdering1.utbetalinger + sakRevurdering2.utbetalinger,
+            ).let {
+                it.hentPerioderMedLøpendeYtelse() shouldBe listOf(
+                    Periode.create(1.januar(2021), 31.desember(2021)),
+                    Periode.create(1.januar(2023), 31.desember(2023)),
+                )
+                it.vedtakListe shouldContainAll listOf(
+                    stønadsperiode1,
+                    revurderingPeriode1,
+                    stønadsperiode2,
+                    revurderingPeriode2,
+                )
+            }
+        }
+
+        @Test
+        fun `henter stønadsperioder som har blitt revurdert`() {
+            val (sakFørRevurdering, søknadsvedtak) = vedtakSøknadsbehandlingIverksattInnvilget()
+
+            sakFørRevurdering.hentPerioderMedLøpendeYtelse() shouldBe listOf(
+                Periode.create(1.januar(2021), 31.desember(2021)),
+            )
+
+            val (sakEtterStans, stans) = vedtakIverksattStansAvYtelseFraIverksattSøknadsbehandlingsvedtak(
+                periode = Periode.create(1.februar(2021), 31.desember(2021)),
+                sakOgVedtakSomKanRevurderes = sakFørRevurdering to søknadsvedtak,
+            )
+
+            sakEtterStans.hentPerioderMedLøpendeYtelse() shouldBe listOf(
+                Periode.create(1.januar(2021), 31.desember(2021)),
+            )
+
+            val (sakEtterGjenopptak, gjenopptak) = vedtakIverksattGjenopptakAvYtelseFraIverksattStans(
+                periode = Periode.create(1.februar(2021), 31.desember(2021)),
+                sakOgVedtakSomKanRevurderes = sakEtterStans to stans,
+            )
+
+            sakEtterGjenopptak.hentPerioderMedLøpendeYtelse() shouldBe listOf(
+                Periode.create(1.januar(2021), 31.desember(2021)),
+            )
+
+            val (sakEtterRevurdering, revurdering) = vedtakRevurderingIverksattInnvilget(
+                revurderingsperiode = Periode.create(1.juli(2021), 31.desember(2021)),
+                sakOgVedtakSomKanRevurderes = sakEtterGjenopptak to gjenopptak,
+            )
+
+            sakEtterRevurdering.hentPerioderMedLøpendeYtelse() shouldBe listOf(
+                Periode.create(1.januar(2021), 31.desember(2021)),
+            )
+            sakEtterRevurdering.vedtakListe shouldContainAll listOf(
+                søknadsvedtak,
+                stans,
+                gjenopptak,
+                revurdering,
+            )
+        }
     }
 }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/SakTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/SakTest.kt
@@ -1,0 +1,128 @@
+package no.nav.su.se.bakover.domain
+
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.common.april
+import no.nav.su.se.bakover.common.desember
+import no.nav.su.se.bakover.common.februar
+import no.nav.su.se.bakover.common.januar
+import no.nav.su.se.bakover.common.juli
+import no.nav.su.se.bakover.common.mai
+import no.nav.su.se.bakover.common.periode.Periode
+import no.nav.su.se.bakover.domain.søknadsbehandling.Stønadsperiode
+import no.nav.su.se.bakover.test.generer
+import no.nav.su.se.bakover.test.saksnummer
+import no.nav.su.se.bakover.test.vedtakIverksattGjenopptakAvYtelseFraIverksattStans
+import no.nav.su.se.bakover.test.vedtakIverksattStansAvYtelseFraIverksattSøknadsbehandlingsvedtak
+import no.nav.su.se.bakover.test.vedtakRevurderingIverksattInnvilget
+import no.nav.su.se.bakover.test.vedtakRevurderingOpphørtUføreFraInnvilgetSøknadsbehandlingsVedtak
+import no.nav.su.se.bakover.test.vedtakSøknadsbehandlingIverksattInnvilget
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+internal class SakTest {
+
+    @Test
+    fun `henter tom liste dersom ingen eksisterer`() {
+        Sak(
+            id = UUID.randomUUID(),
+            saksnummer = saksnummer,
+            opprettet = no.nav.su.se.bakover.test.fixedTidspunkt,
+            fnr = Fnr.generer(),
+            søknader = listOf(),
+            søknadsbehandlinger = listOf(),
+            utbetalinger = listOf(),
+            revurderinger = listOf(),
+            vedtakListe = listOf(),
+        ).hentAktiveStønadsperioder() shouldBe emptyList()
+    }
+
+    @Test
+    fun `henter en stønadsperiode`() {
+        val (sak, _) = vedtakSøknadsbehandlingIverksattInnvilget()
+
+        sak.hentAktiveStønadsperioder() shouldBe listOf(
+            Periode.create(1.januar(2021), 31.desember(2021)),
+        )
+    }
+
+    @Test
+    fun `henter stønadsperioder og justerer varigheten dersom de er delvis opphørt`() {
+        val (sak, _) = vedtakRevurderingOpphørtUføreFraInnvilgetSøknadsbehandlingsVedtak(
+            sakOgVedtakSomKanRevurderes = vedtakSøknadsbehandlingIverksattInnvilget(),
+            revurderingsperiode = Periode.create(1.mai(2021), 31.desember(2021)),
+        )
+
+        sak.hentAktiveStønadsperioder() shouldBe listOf(
+            Periode.create(1.januar(2021), 30.april(2021)),
+        )
+    }
+
+    @Test
+    fun `henter stønadsperioder med opphold mellom`() {
+        val (sak, stønadsperiode1) = vedtakSøknadsbehandlingIverksattInnvilget()
+
+        val (_, stønadsperiode2) = vedtakSøknadsbehandlingIverksattInnvilget(
+            stønadsperiode = Stønadsperiode.create(
+                periode = Periode.create(1.januar(2023), 31.desember(2023)),
+                begrunnelse = "ny periode da vett",
+            ),
+        )
+
+        sak.copy(
+            søknadsbehandlinger = sak.søknadsbehandlinger + stønadsperiode2.behandling,
+            vedtakListe = sak.vedtakListe + stønadsperiode2,
+        ).let {
+            it.hentAktiveStønadsperioder() shouldBe listOf(
+                Periode.create(1.januar(2021), 31.desember(2021)),
+                Periode.create(1.januar(2023), 31.desember(2023)),
+            )
+            it.vedtakListe shouldContainAll listOf(
+                stønadsperiode1,
+                stønadsperiode2,
+            )
+        }
+    }
+
+    @Test
+    fun `henter stønadsperioder som har blitt revurdert`() {
+        val (sakFørRevurdering, søknadsvedtak) = vedtakSøknadsbehandlingIverksattInnvilget()
+
+        sakFørRevurdering.hentAktiveStønadsperioder() shouldBe listOf(
+            Periode.create(1.januar(2021), 31.desember(2021)),
+        )
+
+        val (sakEtterStans, stans) = vedtakIverksattStansAvYtelseFraIverksattSøknadsbehandlingsvedtak(
+            periode = Periode.create(1.februar(2021), 31.desember(2021)),
+            sakOgVedtakSomKanRevurderes = sakFørRevurdering to søknadsvedtak,
+        )
+
+        sakEtterStans.hentAktiveStønadsperioder() shouldBe listOf(
+            Periode.create(1.januar(2021), 31.desember(2021)),
+        )
+
+        val (sakEtterGjenopptak, gjenopptak) = vedtakIverksattGjenopptakAvYtelseFraIverksattStans(
+            periode = Periode.create(1.februar(2021), 31.desember(2021)),
+            sakOgVedtakSomKanRevurderes = sakEtterStans to stans,
+        )
+
+        sakEtterGjenopptak.hentAktiveStønadsperioder() shouldBe listOf(
+            Periode.create(1.januar(2021), 31.desember(2021)),
+        )
+
+        val (sakEtterRevurdering, revurdering) = vedtakRevurderingIverksattInnvilget(
+            revurderingsperiode = Periode.create(1.juli(2021), 31.desember(2021)),
+            sakOgVedtakSomKanRevurderes = sakEtterGjenopptak to gjenopptak,
+        )
+
+        sakEtterRevurdering.hentAktiveStønadsperioder() shouldBe listOf(
+            Periode.create(1.januar(2021), 31.desember(2021)),
+        )
+        sakEtterRevurdering.vedtakListe shouldContainAll listOf(
+            søknadsvedtak,
+            stans,
+            gjenopptak,
+            revurdering,
+        )
+    }
+}

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/StatusovergangTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/StatusovergangTest.kt
@@ -7,9 +7,11 @@ import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.februar
+import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.mars
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.NavIdentBruker
+import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.behandling.Attestering
 import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
@@ -17,15 +19,19 @@ import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.behandling.withVilkårAvslått
 import no.nav.su.se.bakover.domain.behandling.withVilkårIkkeVurdert
 import no.nav.su.se.bakover.domain.fixedTidspunkt
+import no.nav.su.se.bakover.domain.fnrUnder67
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimuleringFeilet
 import no.nav.su.se.bakover.test.attesteringUnderkjent
 import no.nav.su.se.bakover.test.beregning
+import no.nav.su.se.bakover.test.sakId
 import no.nav.su.se.bakover.test.saksbehandler
+import no.nav.su.se.bakover.test.saksnummer
 import no.nav.su.se.bakover.test.stønadsperiode2021
 import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertInnvilget
 import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertUavklart
 import no.nav.su.se.bakover.test.uføregrunnlagForventetInntekt
 import no.nav.su.se.bakover.test.uføregrunnlagForventetInntekt12000
+import no.nav.su.se.bakover.test.vedtakSøknadsbehandlingIverksattInnvilget
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -203,7 +209,8 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentInnvilget,
                 Statusovergang.TilVilkårsvurdert(Behandlingsinformasjon().withAlleVilkårOppfylt()),
-            ) shouldBe vilkårsvurdertInnvilget.medFritekstTilBrev(underkjentInnvilget.fritekstTilBrev).copy(attesteringer = Attesteringshistorikk(listOf(underkjentInnvilget.attesteringer.hentSisteAttestering())))
+            ) shouldBe vilkårsvurdertInnvilget.medFritekstTilBrev(underkjentInnvilget.fritekstTilBrev)
+                .copy(attesteringer = Attesteringshistorikk(listOf(underkjentInnvilget.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -211,7 +218,8 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentInnvilget,
                 Statusovergang.TilVilkårsvurdert(Behandlingsinformasjon().withVilkårAvslått()),
-            ) shouldBe vilkårsvurdertAvslag.medFritekstTilBrev(underkjentInnvilget.fritekstTilBrev).copy(attesteringer = Attesteringshistorikk(listOf(underkjentInnvilget.attesteringer.hentSisteAttestering())))
+            ) shouldBe vilkårsvurdertAvslag.medFritekstTilBrev(underkjentInnvilget.fritekstTilBrev)
+                .copy(attesteringer = Attesteringshistorikk(listOf(underkjentInnvilget.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -219,7 +227,8 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentAvslagVilkår,
                 Statusovergang.TilVilkårsvurdert(Behandlingsinformasjon().withAlleVilkårOppfylt()),
-            ) shouldBe vilkårsvurdertInnvilget.medFritekstTilBrev(underkjentAvslagVilkår.fritekstTilBrev).copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagVilkår.attesteringer.hentSisteAttestering())))
+            ) shouldBe vilkårsvurdertInnvilget.medFritekstTilBrev(underkjentAvslagVilkår.fritekstTilBrev)
+                .copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagVilkår.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -227,7 +236,8 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentAvslagVilkår,
                 Statusovergang.TilVilkårsvurdert(Behandlingsinformasjon().withVilkårAvslått()),
-            ) shouldBe vilkårsvurdertAvslag.medFritekstTilBrev(underkjentAvslagVilkår.fritekstTilBrev).copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagVilkår.attesteringer.hentSisteAttestering())))
+            ) shouldBe vilkårsvurdertAvslag.medFritekstTilBrev(underkjentAvslagVilkår.fritekstTilBrev)
+                .copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagVilkår.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -235,7 +245,8 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentAvslagBeregning,
                 Statusovergang.TilVilkårsvurdert(Behandlingsinformasjon().withAlleVilkårOppfylt()),
-            ) shouldBe vilkårsvurdertInnvilget.medFritekstTilBrev(underkjentAvslagBeregning.fritekstTilBrev).copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagBeregning.attesteringer.hentSisteAttestering())))
+            ) shouldBe vilkårsvurdertInnvilget.medFritekstTilBrev(underkjentAvslagBeregning.fritekstTilBrev)
+                .copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagBeregning.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -243,7 +254,8 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentAvslagBeregning,
                 Statusovergang.TilVilkårsvurdert(Behandlingsinformasjon().withVilkårAvslått()),
-            ) shouldBe vilkårsvurdertAvslag.medFritekstTilBrev(underkjentAvslagBeregning.fritekstTilBrev).copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagBeregning.attesteringer.hentSisteAttestering())))
+            ) shouldBe vilkårsvurdertAvslag.medFritekstTilBrev(underkjentAvslagBeregning.fritekstTilBrev)
+                .copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagBeregning.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -343,7 +355,8 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentAvslagBeregning,
                 Statusovergang.TilBeregnet { innvilgetBeregning },
-            ) shouldBe beregnetInnvilget.medFritekstTilBrev(underkjentAvslagBeregning.fritekstTilBrev).copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagBeregning.attesteringer.hentSisteAttestering())))
+            ) shouldBe beregnetInnvilget.medFritekstTilBrev(underkjentAvslagBeregning.fritekstTilBrev)
+                .copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagBeregning.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -351,7 +364,8 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentAvslagBeregning,
                 Statusovergang.TilBeregnet { avslagBeregning },
-            ) shouldBe beregnetAvslag.medFritekstTilBrev(underkjentAvslagBeregning.fritekstTilBrev).copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagBeregning.attesteringer.hentSisteAttestering())))
+            ) shouldBe beregnetAvslag.medFritekstTilBrev(underkjentAvslagBeregning.fritekstTilBrev)
+                .copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagBeregning.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -359,7 +373,8 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentInnvilget,
                 Statusovergang.TilBeregnet { innvilgetBeregning },
-            ) shouldBe beregnetInnvilget.medFritekstTilBrev(underkjentInnvilget.fritekstTilBrev).copy(attesteringer = Attesteringshistorikk(listOf(underkjentInnvilget.attesteringer.hentSisteAttestering())))
+            ) shouldBe beregnetInnvilget.medFritekstTilBrev(underkjentInnvilget.fritekstTilBrev)
+                .copy(attesteringer = Attesteringshistorikk(listOf(underkjentInnvilget.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -367,7 +382,8 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentInnvilget,
                 Statusovergang.TilBeregnet { avslagBeregning },
-            ) shouldBe beregnetAvslag.medFritekstTilBrev(underkjentInnvilget.fritekstTilBrev).copy(attesteringer = Attesteringshistorikk(listOf(underkjentInnvilget.attesteringer.hentSisteAttestering())))
+            ) shouldBe beregnetAvslag.medFritekstTilBrev(underkjentInnvilget.fritekstTilBrev)
+                .copy(attesteringer = Attesteringshistorikk(listOf(underkjentInnvilget.attesteringer.hentSisteAttestering())))
         }
 
         @Test
@@ -458,7 +474,11 @@ internal class StatusovergangTest {
                 Statusovergang.TilSimulert {
                     simulering.right()
                 },
-            ) shouldBe simulert.copy(fritekstTilBrev = "Fritekst til brev", attesteringer = Attesteringshistorikk(listOf(underkjentInnvilget.attesteringer.hentSisteAttestering()))).right()
+            ) shouldBe simulert.copy(
+                fritekstTilBrev = "Fritekst til brev",
+                attesteringer = Attesteringshistorikk(listOf(underkjentInnvilget.attesteringer.hentSisteAttestering())),
+            )
+                .right()
         }
 
         @Test
@@ -518,7 +538,13 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentAvslagVilkår,
                 Statusovergang.TilAttestering(saksbehandler, fritekstTilBrev),
-            ) shouldBe tilAttesteringAvslagVilkår.copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagVilkår.attesteringer.hentSisteAttestering())))
+            ) shouldBe tilAttesteringAvslagVilkår.copy(
+                attesteringer = Attesteringshistorikk(
+                    listOf(
+                        underkjentAvslagVilkår.attesteringer.hentSisteAttestering(),
+                    ),
+                ),
+            )
         }
 
         @Test
@@ -526,7 +552,13 @@ internal class StatusovergangTest {
             statusovergang(
                 underkjentAvslagBeregning,
                 Statusovergang.TilAttestering(saksbehandler, fritekstTilBrev),
-            ) shouldBe tilAttesteringAvslagBeregning.copy(attesteringer = Attesteringshistorikk(listOf(underkjentAvslagBeregning.attesteringer.hentSisteAttestering())))
+            ) shouldBe tilAttesteringAvslagBeregning.copy(
+                attesteringer = Attesteringshistorikk(
+                    listOf(
+                        underkjentAvslagBeregning.attesteringer.hentSisteAttestering(),
+                    ),
+                ),
+            )
         }
 
         @Test
@@ -595,7 +627,7 @@ internal class StatusovergangTest {
                         attestant = NavIdentBruker.Attestant("sneaky"),
                         grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
                         kommentar = "",
-                        opprettet = fixedTidspunkt
+                        opprettet = fixedTidspunkt,
                     ),
                 ),
             ) shouldBe Statusovergang.SaksbehandlerOgAttestantKanIkkeVæreSammePerson.left()
@@ -610,7 +642,7 @@ internal class StatusovergangTest {
                         attestant = NavIdentBruker.Attestant("sneaky"),
                         grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
                         kommentar = "",
-                        opprettet = fixedTidspunkt
+                        opprettet = fixedTidspunkt,
                     ),
                 ),
             ) shouldBe Statusovergang.SaksbehandlerOgAttestantKanIkkeVæreSammePerson.left()
@@ -625,7 +657,7 @@ internal class StatusovergangTest {
                         attestant = NavIdentBruker.Attestant("sneaky"),
                         grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
                         kommentar = "",
-                        opprettet = fixedTidspunkt
+                        opprettet = fixedTidspunkt,
                     ),
                 ),
             ) shouldBe Statusovergang.SaksbehandlerOgAttestantKanIkkeVæreSammePerson.left()
@@ -747,6 +779,17 @@ internal class StatusovergangTest {
 
     @Nested
     inner class OppdaterStønadsperiode {
+        val sak = Sak(
+            id = sakId,
+            saksnummer = saksnummer,
+            opprettet = no.nav.su.se.bakover.test.fixedTidspunkt,
+            fnr = fnrUnder67(),
+            søknader = listOf(),
+            søknadsbehandlinger = listOf(),
+            utbetalinger = listOf(),
+            revurderinger = listOf(),
+            vedtakListe = listOf(),
+        )
 
         @Test
         fun `lovlige overganger`() {
@@ -764,7 +807,7 @@ internal class StatusovergangTest {
                 assertDoesNotThrow {
                     forsøkStatusovergang(
                         søknadsbehandling = it,
-                        statusovergang = Statusovergang.OppdaterStønadsperiode(stønadsperiode, emptyList()),
+                        statusovergang = Statusovergang.OppdaterStønadsperiode(stønadsperiode, sak),
                     )
                 }
             }
@@ -772,6 +815,17 @@ internal class StatusovergangTest {
 
         @Test
         fun `ulovlige overganger`() {
+            val sak = Sak(
+                id = sakId,
+                saksnummer = saksnummer,
+                opprettet = no.nav.su.se.bakover.test.fixedTidspunkt,
+                fnr = fnrUnder67(),
+                søknader = listOf(),
+                søknadsbehandlinger = listOf(),
+                utbetalinger = listOf(),
+                revurderinger = listOf(),
+                vedtakListe = listOf(),
+            )
             listOf(
                 tilAttesteringAvslagBeregning,
                 tilAttesteringAvslagVilkår,
@@ -783,7 +837,10 @@ internal class StatusovergangTest {
                 assertThrows<StatusovergangVisitor.UgyldigStatusovergangException>("Kastet ikke exception: ${it.status}") {
                     forsøkStatusovergang(
                         søknadsbehandling = it,
-                        statusovergang = Statusovergang.OppdaterStønadsperiode(stønadsperiode, emptyList()),
+                        statusovergang = Statusovergang.OppdaterStønadsperiode(
+                            oppdatertStønadsperiode = stønadsperiode,
+                            sak = sak,
+                        ),
                     )
                 }
             }
@@ -791,14 +848,14 @@ internal class StatusovergangTest {
 
         @Test
         fun `oppdaterer perioden riktig`() {
-            val opprettetSøknadsbehandling = søknadsbehandlingVilkårsvurdertInnvilget().second
+            val (sak, vilkårsvurdert) = søknadsbehandlingVilkårsvurdertInnvilget()
 
             val nyPeriode = Periode.create(1.februar(2022), 31.mars(2022))
             val actual = forsøkStatusovergang(
-                søknadsbehandling = opprettetSøknadsbehandling,
+                søknadsbehandling = vilkårsvurdert,
                 statusovergang = Statusovergang.OppdaterStønadsperiode(
-                    Stønadsperiode.create(nyPeriode, ""),
-                    tidligereSøknadsbehandlinger = listOf(søknadsbehandlingVilkårsvurdertUavklart().second),
+                    oppdatertStønadsperiode = Stønadsperiode.create(nyPeriode, ""),
+                    sak = sak,
                 ),
             )
             actual.orNull()!!.periode shouldBe nyPeriode
@@ -809,17 +866,62 @@ internal class StatusovergangTest {
 
         @Test
         fun `stønadsperioder skal ikke kunne overlappe`() {
+            val (sak, _) = vedtakSøknadsbehandlingIverksattInnvilget(
+                stønadsperiode = Stønadsperiode.create(
+                    periode = Periode.create(1.januar(2021), 31.desember(2021)),
+                    begrunnelse = "kek",
+                ),
+            )
             val opprettetSøknadsbehandling = søknadsbehandlingVilkårsvurdertUavklart().second
 
             val nyPeriode = Periode.create(1.desember(2021), 31.mars(2022))
+
             val actual = forsøkStatusovergang(
                 søknadsbehandling = opprettetSøknadsbehandling,
                 statusovergang = Statusovergang.OppdaterStønadsperiode(
-                    Stønadsperiode.create(nyPeriode, ""),
-                    tidligereSøknadsbehandlinger = listOf(søknadsbehandlingVilkårsvurdertUavklart().second),
+                    oppdatertStønadsperiode = Stønadsperiode.create(nyPeriode, ""),
+                    sak = sak,
                 ),
             )
-            actual shouldBe Statusovergang.OppdaterStønadsperiode.KunneIkkeOppdatereStønadsperiode.StønadsperiodeOverlapperMedEksisterendeSøknadsbehandling.left()
+            actual shouldBe Statusovergang.OppdaterStønadsperiode.KunneIkkeOppdatereStønadsperiode.StønadsperiodeOverlapperMedEksisterendeStønadsperiode.left()
+        }
+
+        @Test
+        fun `stønadsperioder skal ikke kunne legges forut for eksisterende stønadsperioder`() {
+            val (sak, stønadsperiode1) = vedtakSøknadsbehandlingIverksattInnvilget()
+
+            val (_, stønadsperiode2) = vedtakSøknadsbehandlingIverksattInnvilget(
+                stønadsperiode = Stønadsperiode.create(
+                    periode = Periode.create(1.januar(2023), 31.desember(2023)),
+                    begrunnelse = "ny periode da vett",
+                ),
+            )
+
+            val mellomToAndrePerioder = søknadsbehandlingVilkårsvurdertUavklart().second
+
+            val nyPeriode = Stønadsperiode.create(
+                periode = Periode.create(1.januar(2022), 31.desember(2022)),
+                begrunnelse = "ny periode da vett",
+            )
+
+            val sakMedBehandlingOgVedtak = sak.copy(
+                søknadsbehandlinger = listOf(
+                    stønadsperiode1.behandling,
+                    stønadsperiode2.behandling,
+                    mellomToAndrePerioder,
+                ),
+                vedtakListe = listOf(stønadsperiode1, stønadsperiode2),
+            )
+
+            forsøkStatusovergang(
+                søknadsbehandling = mellomToAndrePerioder,
+                statusovergang = Statusovergang.OppdaterStønadsperiode(
+                    oppdatertStønadsperiode = nyPeriode,
+                    sak = sakMedBehandlingOgVedtak,
+                ),
+            ).let {
+                it shouldBe Statusovergang.OppdaterStønadsperiode.KunneIkkeOppdatereStønadsperiode.StønadsperiodeForSenerePeriodeEksisterer.left()
+            }
         }
     }
 }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/StatusovergangTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/StatusovergangTest.kt
@@ -11,7 +11,6 @@ import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.mars
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.NavIdentBruker
-import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.behandling.Attestering
 import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
@@ -19,13 +18,10 @@ import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.behandling.withVilkårAvslått
 import no.nav.su.se.bakover.domain.behandling.withVilkårIkkeVurdert
 import no.nav.su.se.bakover.domain.fixedTidspunkt
-import no.nav.su.se.bakover.domain.fnrUnder67
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimuleringFeilet
 import no.nav.su.se.bakover.test.attesteringUnderkjent
 import no.nav.su.se.bakover.test.beregning
-import no.nav.su.se.bakover.test.sakId
 import no.nav.su.se.bakover.test.saksbehandler
-import no.nav.su.se.bakover.test.saksnummer
 import no.nav.su.se.bakover.test.stønadsperiode2021
 import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertInnvilget
 import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertUavklart
@@ -55,9 +51,13 @@ internal class StatusovergangTest {
         ),
     )
 
-    private val opprettet = søknadsbehandlingVilkårsvurdertUavklart(
+    private val sakOgUavklart = søknadsbehandlingVilkårsvurdertUavklart(
         stønadsperiode = stønadsperiode,
-    ).second
+    )
+
+    private val sak = sakOgUavklart.first
+
+    private val opprettet = sakOgUavklart.second
 
     private val simulering = no.nav.su.se.bakover.test.simuleringNy()
 
@@ -779,18 +779,6 @@ internal class StatusovergangTest {
 
     @Nested
     inner class OppdaterStønadsperiode {
-        val sak = Sak(
-            id = sakId,
-            saksnummer = saksnummer,
-            opprettet = no.nav.su.se.bakover.test.fixedTidspunkt,
-            fnr = fnrUnder67(),
-            søknader = listOf(),
-            søknadsbehandlinger = listOf(),
-            utbetalinger = listOf(),
-            revurderinger = listOf(),
-            vedtakListe = listOf(),
-        )
-
         @Test
         fun `lovlige overganger`() {
             listOf(
@@ -815,17 +803,6 @@ internal class StatusovergangTest {
 
         @Test
         fun `ulovlige overganger`() {
-            val sak = Sak(
-                id = sakId,
-                saksnummer = saksnummer,
-                opprettet = no.nav.su.se.bakover.test.fixedTidspunkt,
-                fnr = fnrUnder67(),
-                søknader = listOf(),
-                søknadsbehandlinger = listOf(),
-                utbetalinger = listOf(),
-                revurderinger = listOf(),
-                vedtakListe = listOf(),
-            )
             listOf(
                 tilAttesteringAvslagBeregning,
                 tilAttesteringAvslagVilkår,
@@ -883,7 +860,7 @@ internal class StatusovergangTest {
                     sak = sak,
                 ),
             )
-            actual shouldBe Statusovergang.OppdaterStønadsperiode.KunneIkkeOppdatereStønadsperiode.StønadsperiodeOverlapperMedEksisterendeStønadsperiode.left()
+            actual shouldBe Statusovergang.OppdaterStønadsperiode.KunneIkkeOppdatereStønadsperiode.StønadsperiodeOverlapperMedLøpendeStønadsperiode.left()
         }
 
         @Test

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/ServiceBuilder.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/ServiceBuilder.kt
@@ -165,6 +165,7 @@ object ServiceBuilder {
                 ferdigstillVedtakService = ferdigstillVedtakService,
                 vilkårsvurderingService = vilkårsvurderingService,
                 grunnlagService = grunnlagService,
+                sakService = sakService,
             ).apply {
                 addObserver(statistikkService)
             },

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingService.kt
@@ -128,13 +128,12 @@ interface SøknadsbehandlingService {
     )
 
     object FantIkkeBehandling
-    object KunneIkkeHenteAktiveBehandlinger
 
     sealed class KunneIkkeOppdatereStønadsperiode {
         object FantIkkeBehandling : SøknadsbehandlingService.KunneIkkeOppdatereStønadsperiode()
+        object FantIkkeSak : SøknadsbehandlingService.KunneIkkeOppdatereStønadsperiode()
         data class KunneIkkeOppdatereStønadsperiode(val feil: Statusovergang.OppdaterStønadsperiode.KunneIkkeOppdatereStønadsperiode) :
             SøknadsbehandlingService.KunneIkkeOppdatereStønadsperiode()
-        object StønadsperiodeOverlapperMedEksisterendeSøknadsbehandling : SøknadsbehandlingService.KunneIkkeOppdatereStønadsperiode()
     }
 
     data class OppdaterStønadsperiodeRequest(

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceImpl.kt
@@ -51,6 +51,7 @@ import no.nav.su.se.bakover.service.grunnlag.LeggTilFradragsgrunnlagRequest
 import no.nav.su.se.bakover.service.grunnlag.VilkårsvurderingService
 import no.nav.su.se.bakover.service.oppgave.OppgaveService
 import no.nav.su.se.bakover.service.person.PersonService
+import no.nav.su.se.bakover.service.sak.SakService
 import no.nav.su.se.bakover.service.statistikk.Event
 import no.nav.su.se.bakover.service.statistikk.EventObserver
 import no.nav.su.se.bakover.service.søknad.SøknadService
@@ -85,6 +86,7 @@ internal class SøknadsbehandlingServiceImpl(
     private val ferdigstillVedtakService: FerdigstillVedtakService,
     private val vilkårsvurderingService: VilkårsvurderingService,
     private val grunnlagService: GrunnlagService,
+    private val sakService: SakService,
 ) : SøknadsbehandlingService {
 
     private val log = LoggerFactory.getLogger(this::class.java)
@@ -199,7 +201,12 @@ internal class SøknadsbehandlingServiceImpl(
         return forsøkStatusovergang(
             søknadsbehandling = saksbehandling,
             statusovergang = Statusovergang.TilSimulert { beregning ->
-                utbetalingService.simulerUtbetaling(saksbehandling.sakId, request.saksbehandler, beregning, saksbehandling.vilkårsvurderinger.uføre.grunnlag)
+                utbetalingService.simulerUtbetaling(
+                    saksbehandling.sakId,
+                    request.saksbehandler,
+                    beregning,
+                    saksbehandling.vilkårsvurderinger.uføre.grunnlag,
+                )
                     .map {
                         it.simulering
                     }
@@ -346,7 +353,7 @@ internal class SøknadsbehandlingServiceImpl(
                     attestant = request.attestering.attestant,
                     beregning = it.beregning,
                     simulering = it.simulering,
-                    uføregrunnlag = it.vilkårsvurderinger.uføre.grunnlag
+                    uføregrunnlag = it.vilkårsvurderinger.uføre.grunnlag,
                 ).mapLeft { kunneIkkeUtbetale ->
                     log.error("Kunne ikke innvilge behandling ${søknadsbehandling.id} siden utbetaling feilet. Feiltype: $kunneIkkeUtbetale")
                     KunneIkkeIverksette.KunneIkkeUtbetale(kunneIkkeUtbetale)
@@ -499,25 +506,31 @@ internal class SøknadsbehandlingServiceImpl(
         val søknadsbehandling = søknadsbehandlingRepo.hent(request.behandlingId)
             ?: return SøknadsbehandlingService.KunneIkkeOppdatereStønadsperiode.FantIkkeBehandling.left()
 
-        val tidligereSøknadsbehandlinger = søknadsbehandlingRepo.hentForSak(søknadsbehandling.sakId)
-            .filter { it.id != søknadsbehandling.id }
+        val sak = sakService.hentSak(søknadsbehandling.sakId)
+            .getOrHandle { return SøknadsbehandlingService.KunneIkkeOppdatereStønadsperiode.FantIkkeSak.left() }
 
         return forsøkStatusovergang(
             søknadsbehandling = søknadsbehandling,
-            statusovergang = Statusovergang.OppdaterStønadsperiode(request.stønadsperiode, tidligereSøknadsbehandlinger),
+            statusovergang = Statusovergang.OppdaterStønadsperiode(
+                oppdatertStønadsperiode = request.stønadsperiode,
+                sak = sak,
+            ),
         ).mapLeft {
-            when (it) {
-                is Statusovergang.OppdaterStønadsperiode.KunneIkkeOppdatereStønadsperiode.KunneIkkeOppdatereGrunnlagsdata -> SøknadsbehandlingService.KunneIkkeOppdatereStønadsperiode.KunneIkkeOppdatereStønadsperiode(it)
-                Statusovergang.OppdaterStønadsperiode.KunneIkkeOppdatereStønadsperiode.StønadsperiodeOverlapperMedEksisterendeSøknadsbehandling -> SøknadsbehandlingService.KunneIkkeOppdatereStønadsperiode.StønadsperiodeOverlapperMedEksisterendeSøknadsbehandling
-            }
+            SøknadsbehandlingService.KunneIkkeOppdatereStønadsperiode.KunneIkkeOppdatereStønadsperiode(it)
         }.map {
             søknadsbehandlingRepo.lagre(it)
             vilkårsvurderingService.lagre(
-                it.id,
-                it.vilkårsvurderinger,
+                behandlingId = it.id,
+                vilkårsvurderinger = it.vilkårsvurderinger,
             )
-            grunnlagService.lagreBosituasjongrunnlag(it.id, it.grunnlagsdata.bosituasjon)
-            grunnlagService.lagreFradragsgrunnlag(it.id, it.grunnlagsdata.fradragsgrunnlag)
+            grunnlagService.lagreBosituasjongrunnlag(
+                behandlingId = it.id,
+                bosituasjongrunnlag = it.grunnlagsdata.bosituasjon,
+            )
+            grunnlagService.lagreFradragsgrunnlag(
+                behandlingId = it.id,
+                fradragsgrunnlag = it.grunnlagsdata.fradragsgrunnlag,
+            )
             it
         }
     }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/GjenopptakAvYtelseServiceTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/GjenopptakAvYtelseServiceTest.kt
@@ -32,7 +32,7 @@ import no.nav.su.se.bakover.test.simuleringFeilutbetaling
 import no.nav.su.se.bakover.test.simulertGjenopptakUtbetaling
 import no.nav.su.se.bakover.test.simulertGjenopptakelseAvytelseFraVedtakStansAvYtelse
 import no.nav.su.se.bakover.test.simulertRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak
-import no.nav.su.se.bakover.test.vedtakIverksattStansAvYtelse
+import no.nav.su.se.bakover.test.vedtakIverksattStansAvYtelseFraIverksattSøknadsbehandlingsvedtak
 import no.nav.su.se.bakover.test.vedtakSøknadsbehandlingIverksattInnvilget
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -105,7 +105,7 @@ class GjenopptakAvYtelseServiceTest {
             tilOgMed = periode2021.tilOgMed,
         )
 
-        val (sak, _) = vedtakIverksattStansAvYtelse(periode)
+        val (sak, _) = vedtakIverksattStansAvYtelseFraIverksattSøknadsbehandlingsvedtak(periode)
 
         val sakServiceMock = mock<SakService>() {
             on { hentSak(any<UUID>()) } doReturn sak.right()
@@ -155,7 +155,7 @@ class GjenopptakAvYtelseServiceTest {
             fraOgMed = LocalDate.now(fixedClock).plusMonths(1).startOfMonth(),
             tilOgMed = periode2021.tilOgMed,
         )
-        val (sak, vedtak) = vedtakIverksattStansAvYtelse(periode)
+        val (sak, vedtak) = vedtakIverksattStansAvYtelseFraIverksattSøknadsbehandlingsvedtak(periode)
 
         val sakServiceMock = mock<SakService>() {
             on { hentSak(any<UUID>()) } doReturn sak.right()
@@ -228,7 +228,7 @@ class GjenopptakAvYtelseServiceTest {
             fraOgMed = LocalDate.now(fixedClock).plusMonths(1).startOfMonth(),
             tilOgMed = periode2021.tilOgMed,
         )
-        val (sak, vedtak) = vedtakIverksattStansAvYtelse(periode)
+        val (sak, vedtak) = vedtakIverksattStansAvYtelseFraIverksattSøknadsbehandlingsvedtak(periode)
 
         val sakServiceMock = mock<SakService>() {
             on { hentSak(any<UUID>()) } doReturn sak.right()

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceOppdaterStønadsperiodeTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceOppdaterStønadsperiodeTest.kt
@@ -1,41 +1,24 @@
 package no.nav.su.se.bakover.service.søknadsbehandling
 
 import arrow.core.left
-import arrow.core.nonEmptyListOf
 import arrow.core.right
 import io.kotest.matchers.shouldBe
-import no.nav.su.se.bakover.common.Tidspunkt
-import no.nav.su.se.bakover.common.desember
-import no.nav.su.se.bakover.common.februar
-import no.nav.su.se.bakover.common.januar
+import io.kotest.matchers.shouldNotBe
+import no.nav.su.se.bakover.common.juni
 import no.nav.su.se.bakover.common.mars
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.database.søknadsbehandling.SøknadsbehandlingRepo
-import no.nav.su.se.bakover.domain.Fnr
-import no.nav.su.se.bakover.domain.NavIdentBruker.Saksbehandler
-import no.nav.su.se.bakover.domain.Saksnummer
-import no.nav.su.se.bakover.domain.Søknad
-import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
-import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
-import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
-import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
-import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
-import no.nav.su.se.bakover.domain.grunnlag.Uføregrad
-import no.nav.su.se.bakover.domain.journal.JournalpostId
-import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.søknadsbehandling.StatusovergangVisitor
 import no.nav.su.se.bakover.domain.søknadsbehandling.Stønadsperiode
-import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
-import no.nav.su.se.bakover.domain.vilkår.Resultat
-import no.nav.su.se.bakover.domain.vilkår.Vilkår
-import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
-import no.nav.su.se.bakover.domain.vilkår.Vurderingsperiode
 import no.nav.su.se.bakover.service.argThat
-import no.nav.su.se.bakover.service.behandling.BehandlingTestUtils.behandlingsinformasjon
-import no.nav.su.se.bakover.service.fixedTidspunkt
-import no.nav.su.se.bakover.service.grunnlag.VilkårsvurderingService
-import no.nav.su.se.bakover.test.create
-import no.nav.su.se.bakover.test.generer
+import no.nav.su.se.bakover.service.behandling.BehandlingTestUtils.behandlingId
+import no.nav.su.se.bakover.service.sak.FantIkkeSak
+import no.nav.su.se.bakover.service.sak.SakService
+import no.nav.su.se.bakover.test.getOrFail
+import no.nav.su.se.bakover.test.stønadsperiode2021
+import no.nav.su.se.bakover.test.søknadsbehandlingTilAttesteringAvslagUtenBeregning
+import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertInnvilget
+import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertUavklart
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
@@ -43,15 +26,9 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoMoreInteractions
 import java.util.UUID
 
 internal class SøknadsbehandlingServiceOppdaterStønadsperiodeTest {
-
-    private val sakId = UUID.randomUUID()
-    private val behandlingId = UUID.randomUUID()
-    private val oppgaveId = OppgaveId("o")
-    private val stønadsperiode = Stønadsperiode.create(Periode.create(1.januar(2021), 31.desember(2021)))
 
     @Test
     fun `svarer med feil hvis man ikke finner behandling`() {
@@ -59,183 +36,132 @@ internal class SøknadsbehandlingServiceOppdaterStønadsperiodeTest {
             on { hent(any()) } doReturn null
         }
 
-        val response = createSøknadsbehandlingService(
+        SøknadsbehandlingServiceAndMocks(
             søknadsbehandlingRepo = søknadsbehandlingRepoMock,
-        ).oppdaterStønadsperiode(
-            SøknadsbehandlingService.OppdaterStønadsperiodeRequest(behandlingId, stønadsperiode),
-        )
+        ).let {
+            val response = it.søknadsbehandlingService.oppdaterStønadsperiode(
+                SøknadsbehandlingService.OppdaterStønadsperiodeRequest(
+                    behandlingId = behandlingId,
+                    stønadsperiode = stønadsperiode2021,
+                ),
+            )
+            response shouldBe SøknadsbehandlingService.KunneIkkeOppdatereStønadsperiode.FantIkkeBehandling.left()
 
-        response shouldBe SøknadsbehandlingService.KunneIkkeOppdatereStønadsperiode.FantIkkeBehandling.left()
+            verify(it.søknadsbehandlingRepo).hent(behandlingId)
+            it.verifyNoMoreInteractions()
+        }
+    }
 
-        verify(søknadsbehandlingRepoMock).hent(argThat { it shouldBe behandlingId })
-        verifyNoMoreInteractions(søknadsbehandlingRepoMock)
+    @Test
+    fun `svarer med feil hvis man ikke finner sak`() {
+        val (sak, behandling) = søknadsbehandlingVilkårsvurdertUavklart()
+
+        val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
+            on { hent(any()) } doReturn behandling
+        }
+        val sakServiceMock = mock<SakService> {
+            on { hentSak(any<UUID>()) } doReturn FantIkkeSak.left()
+        }
+
+        SøknadsbehandlingServiceAndMocks(
+            søknadsbehandlingRepo = søknadsbehandlingRepoMock,
+            sakService = sakServiceMock,
+        ).let {
+            val response = it.søknadsbehandlingService.oppdaterStønadsperiode(
+                SøknadsbehandlingService.OppdaterStønadsperiodeRequest(
+                    behandlingId = behandling.id,
+                    stønadsperiode = stønadsperiode2021,
+                ),
+            )
+            response shouldBe SøknadsbehandlingService.KunneIkkeOppdatereStønadsperiode.FantIkkeSak.left()
+
+            verify(it.søknadsbehandlingRepo).hent(behandling.id)
+            verify(it.sakService).hentSak(sak.id)
+            it.verifyNoMoreInteractions()
+        }
     }
 
     @Test
     fun `kaster exception ved hvs søknadsbehandling er i ugyldig tilstand for oppdatering av stønadsperiode`() {
-        val tilAttestering = Søknadsbehandling.Vilkårsvurdert.Avslag(
-            id = behandlingId,
-            opprettet = Tidspunkt.now(),
-            sakId = sakId,
-            saksnummer = Saksnummer(2021),
-            søknad = Søknad.Journalført.MedOppgave(
-                id = UUID.randomUUID(),
-                opprettet = Tidspunkt.EPOCH,
-                sakId = sakId,
-                søknadInnhold = SøknadInnholdTestdataBuilder.build(),
-                oppgaveId = oppgaveId,
-                journalpostId = JournalpostId("j"),
-            ),
-            oppgaveId = oppgaveId,
-            behandlingsinformasjon = behandlingsinformasjon,
-            fnr = Fnr.generer(),
-            fritekstTilBrev = "",
-            stønadsperiode = stønadsperiode,
-            grunnlagsdata = Grunnlagsdata.IkkeVurdert,
-            vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
-            attesteringer = Attesteringshistorikk.empty(),
-        ).tilAttestering(Saksbehandler("saksa"), "")
+        val (sak, tilAttestering) = søknadsbehandlingTilAttesteringAvslagUtenBeregning()
 
         val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
             on { hent(any()) } doReturn tilAttestering
         }
 
+        val sakServiceMock = mock<SakService>() {
+            on { hentSak(any<UUID>()) } doReturn sak.right()
+        }
+
         assertThrows<StatusovergangVisitor.UgyldigStatusovergangException> {
-            createSøknadsbehandlingService(
+            SøknadsbehandlingServiceAndMocks(
                 søknadsbehandlingRepo = søknadsbehandlingRepoMock,
-            ).oppdaterStønadsperiode(
-                SøknadsbehandlingService.OppdaterStønadsperiodeRequest(behandlingId, stønadsperiode),
+                sakService = sakServiceMock,
+            ).søknadsbehandlingService.oppdaterStønadsperiode(
+                SøknadsbehandlingService.OppdaterStønadsperiodeRequest(behandlingId, stønadsperiode2021),
             )
         }
     }
 
     @Test
-    fun `happy case`() {
-        val uavklart = Søknadsbehandling.Vilkårsvurdert.Uavklart(
-            id = behandlingId,
-            opprettet = Tidspunkt.now(),
-            sakId = sakId,
-            saksnummer = Saksnummer(2021),
-            søknad = Søknad.Journalført.MedOppgave(
-                id = UUID.randomUUID(),
-                opprettet = Tidspunkt.EPOCH,
-                sakId = sakId,
-                søknadInnhold = SøknadInnholdTestdataBuilder.build(),
-                oppgaveId = oppgaveId,
-                journalpostId = JournalpostId("j"),
-            ),
-            oppgaveId = oppgaveId,
-            behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon(),
-            fnr = Fnr.generer(),
-            fritekstTilBrev = "",
-            stønadsperiode = null,
-            grunnlagsdata = Grunnlagsdata.IkkeVurdert,
-            vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
-            attesteringer = Attesteringshistorikk.empty(),
-        )
+    fun `oppdaterer stønadsperiode for behandling, grunnlagsdata og vilkårsvurderinger`() {
+        val (sak, uavklart) = søknadsbehandlingVilkårsvurdertInnvilget()
+
         val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
             on { hent(any()) } doReturn uavklart
             on { hentForSak(any(), anyOrNull()) } doReturn emptyList()
         }
 
-        val expected = uavklart.copy(
-            stønadsperiode = stønadsperiode,
-        )
-
-        val response = createSøknadsbehandlingService(
-            søknadsbehandlingRepo = søknadsbehandlingRepoMock,
-        ).oppdaterStønadsperiode(
-            SøknadsbehandlingService.OppdaterStønadsperiodeRequest(behandlingId, stønadsperiode),
-        )
-
-        response shouldBe expected.right()
-
-        verify(søknadsbehandlingRepoMock).hent(argThat { it shouldBe behandlingId })
-        verify(søknadsbehandlingRepoMock).lagre(argThat { it shouldBe expected })
-        verify(søknadsbehandlingRepoMock).defaultSessionContext()
-        verify(søknadsbehandlingRepoMock).hentForSak(argThat { it shouldBe sakId }, anyOrNull())
-        verifyNoMoreInteractions(søknadsbehandlingRepoMock)
-    }
-
-    @Test
-    fun `endrer stønadsperioden på behandling og lagrer ny periode på grunnlag og vilkårsvurdering`() {
-        val vilkårsvurderingId = UUID.randomUUID()
-        val grunnlagId = UUID.randomUUID()
-        val uavklart = Søknadsbehandling.Vilkårsvurdert.Uavklart(
-            id = behandlingId,
-            opprettet = Tidspunkt.now(),
-            sakId = sakId,
-            saksnummer = Saksnummer(2021),
-            søknad = Søknad.Journalført.MedOppgave(
-                id = UUID.randomUUID(),
-                opprettet = Tidspunkt.EPOCH,
-                sakId = sakId,
-                søknadInnhold = SøknadInnholdTestdataBuilder.build(),
-                oppgaveId = oppgaveId,
-                journalpostId = JournalpostId("j"),
-            ),
-            oppgaveId = oppgaveId,
-            behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon(),
-            fnr = Fnr.generer(),
-            fritekstTilBrev = "",
-            stønadsperiode = stønadsperiode,
-            grunnlagsdata = Grunnlagsdata.IkkeVurdert,
-            vilkårsvurderinger = createVilkårsvurdering(stønadsperiode.periode, vilkårsvurderingId, grunnlagId),
-            attesteringer = Attesteringshistorikk.empty(),
-        )
-        val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
-            on { hent(any()) } doReturn uavklart
-            on { hentForSak(any(), anyOrNull()) } doReturn emptyList()
+        val sakServiceMock = mock<SakService>() {
+            on { hentSak(any<UUID>()) } doReturn sak.right()
         }
-        val vilkårsvurderingServiceMock = mock<VilkårsvurderingService>()
 
-        val nyPeriode = Periode.create(1.februar(2021), 31.mars(2021))
-        val expected = uavklart.copy(
-            vilkårsvurderinger = createVilkårsvurdering(nyPeriode, vilkårsvurderingId, grunnlagId),
-            stønadsperiode = uavklart.stønadsperiode?.copy(periode = nyPeriode)
+        val nyStønadsperiode = Stønadsperiode.create(
+            periode = Periode.create(1.juni(2021), 31.mars(2022)),
+            begrunnelse = "begg",
         )
 
-        val response = createSøknadsbehandlingService(
+        SøknadsbehandlingServiceAndMocks(
             søknadsbehandlingRepo = søknadsbehandlingRepoMock,
-            vilkårsvurderingService = vilkårsvurderingServiceMock,
-        ).oppdaterStønadsperiode(
-            SøknadsbehandlingService.OppdaterStønadsperiodeRequest(
-                behandlingId,
-                uavklart.stønadsperiode!!.copy(periode = nyPeriode),
-            ),
-        )
-
-        response shouldBe expected.right()
-
-        verify(søknadsbehandlingRepoMock).hent(argThat { it shouldBe behandlingId })
-        verify(søknadsbehandlingRepoMock).lagre(argThat { it shouldBe expected })
-        verify(vilkårsvurderingServiceMock).lagre(
-            argThat { it shouldBe behandlingId },
-            argThat { it shouldBe expected.vilkårsvurderinger },
-        )
-        verify(søknadsbehandlingRepoMock).defaultSessionContext()
-        verify(søknadsbehandlingRepoMock).hentForSak(argThat { it shouldBe sakId }, anyOrNull())
-        verifyNoMoreInteractions(søknadsbehandlingRepoMock, vilkårsvurderingServiceMock)
-    }
-
-    private fun createVilkårsvurdering(periode: Periode, vilkårsvurderingId: UUID, grunnlagId: UUID) = Vilkårsvurderinger(
-        uføre = Vilkår.Uførhet.Vurdert.create(
-            vurderingsperioder = nonEmptyListOf(
-                Vurderingsperiode.Uføre.create(
-                    id = vilkårsvurderingId,
-                    opprettet = fixedTidspunkt,
-                    resultat = Resultat.Innvilget,
-                    grunnlag = Grunnlag.Uføregrunnlag(
-                        id = grunnlagId,
-                        opprettet = fixedTidspunkt,
-                        periode = periode,
-                        uføregrad = Uføregrad.parse(20),
-                        forventetInntekt = 10,
-                    ),
-                    periode = periode,
-                    begrunnelse = "ok2k",
+            sakService = sakServiceMock,
+        ).let { it ->
+            val response = it.søknadsbehandlingService.oppdaterStønadsperiode(
+                SøknadsbehandlingService.OppdaterStønadsperiodeRequest(
+                    behandlingId = uavklart.id,
+                    stønadsperiode = nyStønadsperiode,
                 ),
-            ),
-        ),
-    )
+            ).getOrFail("feil i testdataoppsett")
+
+            uavklart.stønadsperiode.periode shouldNotBe nyStønadsperiode
+
+            verify(it.søknadsbehandlingRepo).hent(uavklart.id)
+            verify(it.sakService).hentSak(sak.id)
+            verify(it.søknadsbehandlingRepo).lagre(
+                argThat {
+                    it shouldBe response
+                    it.stønadsperiode shouldBe nyStønadsperiode
+                },
+            )
+            verify(it.vilkårsvurderingService).lagre(
+                argThat { it shouldBe uavklart.id },
+                argThat { vilkårsvurderinger ->
+                    vilkårsvurderinger.uføre.grunnlag.all { it.periode == nyStønadsperiode.periode } shouldBe true
+                    vilkårsvurderinger.formue.grunnlag.all { it.periode == nyStønadsperiode.periode } shouldBe true
+                },
+            )
+            verify(it.grunnlagService).lagreBosituasjongrunnlag(
+                argThat { it shouldBe uavklart.id },
+                argThat { bosituasjon ->
+                    bosituasjon.all { it.periode == nyStønadsperiode.periode } shouldBe true
+                },
+            )
+            verify(it.grunnlagService).lagreFradragsgrunnlag(
+                argThat { it shouldBe uavklart.id },
+                argThat { fradrag ->
+                    fradrag.all { it.periode == nyStønadsperiode.periode } shouldBe true
+                },
+            )
+            it.verifyNoMoreInteractions()
+        }
+    }
 }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingTestUtils.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingTestUtils.kt
@@ -15,6 +15,7 @@ import no.nav.su.se.bakover.service.grunnlag.GrunnlagService
 import no.nav.su.se.bakover.service.grunnlag.VilkårsvurderingService
 import no.nav.su.se.bakover.service.oppgave.OppgaveService
 import no.nav.su.se.bakover.service.person.PersonService
+import no.nav.su.se.bakover.service.sak.SakService
 import no.nav.su.se.bakover.service.statistikk.EventObserver
 import no.nav.su.se.bakover.service.søknad.SøknadService
 import no.nav.su.se.bakover.service.utbetaling.UtbetalingService
@@ -50,6 +51,7 @@ internal fun createSøknadsbehandlingService(
     ferdigstillVedtakService: FerdigstillVedtakService = mock(),
     vilkårsvurderingService: VilkårsvurderingService = mock(),
     grunnlagService: GrunnlagService = mock(),
+    sakService: SakService = mock(),
 ) = SøknadsbehandlingServiceImpl(
     søknadService,
     søknadRepo,
@@ -66,6 +68,7 @@ internal fun createSøknadsbehandlingService(
     ferdigstillVedtakService,
     vilkårsvurderingService,
     grunnlagService,
+    sakService,
 ).apply { addObserver(observer) }
 
 internal data class SøknadsbehandlingServiceAndMocks(
@@ -85,6 +88,7 @@ internal data class SøknadsbehandlingServiceAndMocks(
     val ferdigstillVedtakService: FerdigstillVedtakService = mock(),
     val vilkårsvurderingService: VilkårsvurderingService = mock(),
     val grunnlagService: GrunnlagService = mock(),
+    val sakService: SakService = mock()
 ) {
     val søknadsbehandlingService = SøknadsbehandlingServiceImpl(
         søknadService = søknadService,
@@ -102,6 +106,7 @@ internal data class SøknadsbehandlingServiceAndMocks(
         ferdigstillVedtakService = ferdigstillVedtakService,
         vilkårsvurderingService = vilkårsvurderingService,
         grunnlagService = grunnlagService,
+        sakService = sakService,
     ).apply { addObserver(observer) }
 
     fun all(): List<Any> {
@@ -121,6 +126,7 @@ internal data class SøknadsbehandlingServiceAndMocks(
             ferdigstillVedtakService,
             vilkårsvurderingService,
             grunnlagService,
+            sakService,
         )
     }
 
@@ -141,6 +147,7 @@ internal data class SøknadsbehandlingServiceAndMocks(
             ferdigstillVedtakService,
             vilkårsvurderingService,
             grunnlagService,
+            sakService,
         )
     }
 }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/utbetaling/GjenopptaUtbetalingerServiceTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/utbetaling/GjenopptaUtbetalingerServiceTest.kt
@@ -41,7 +41,7 @@ import no.nav.su.se.bakover.test.simuleringGjenopptak
 import no.nav.su.se.bakover.test.simulertGjenopptakUtbetaling
 import no.nav.su.se.bakover.test.simulertGjenopptakelseAvytelseFraVedtakStansAvYtelse
 import no.nav.su.se.bakover.test.utbetalingsRequest
-import no.nav.su.se.bakover.test.vedtakIverksattStansAvYtelse
+import no.nav.su.se.bakover.test.vedtakIverksattStansAvYtelseFraIverksattSøknadsbehandlingsvedtak
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
@@ -62,7 +62,7 @@ internal class GjenopptaUtbetalingerServiceTest {
             tilOgMed = periode2021.tilOgMed,
         )
 
-        val (sak, _) = vedtakIverksattStansAvYtelse(periode)
+        val (sak, _) = vedtakIverksattStansAvYtelseFraIverksattSøknadsbehandlingsvedtak(periode)
 
         val sakServiceMock = mock<SakService> {
             on { hentSak(any<UUID>()) } doReturn sak.right()
@@ -162,7 +162,7 @@ internal class GjenopptaUtbetalingerServiceTest {
 
     @Test
     fun `Simulering feiler`() {
-        val (sak, _) = vedtakIverksattStansAvYtelse()
+        val (sak, _) = vedtakIverksattStansAvYtelseFraIverksattSøknadsbehandlingsvedtak()
 
         val sakServiceMock = mock<SakService> {
             on { hentSak(any<UUID>()) } doReturn sak.right()
@@ -206,7 +206,7 @@ internal class GjenopptaUtbetalingerServiceTest {
 
     @Test
     fun `Utbetaling feilet`() {
-        val (sak, _) = vedtakIverksattStansAvYtelse()
+        val (sak, _) = vedtakIverksattStansAvYtelseFraIverksattSøknadsbehandlingsvedtak()
 
         val sakServiceMock = mock<SakService> {
             on { hentSak(any<UUID>()) } doReturn sak.right()

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/Feilresponser.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/Feilresponser.kt
@@ -15,6 +15,11 @@ internal object Feilresponser {
         "fant_ikke_behandling",
     )
 
+    val fantIkkeSak = NotFound.errorJson(
+        "Fant ikke sak",
+        "fant_ikke_sak",
+    )
+
     val fantIkkePerson = NotFound.errorJson(
         "Fant ikke person",
         "fant_ikke_person",

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutes.kt
@@ -168,8 +168,9 @@ internal fun Route.søknadsbehandlingRoutes(
                                                 fantIkkeSak
                                             }
                                             is SøknadsbehandlingService.KunneIkkeOppdatereStønadsperiode.KunneIkkeOppdatereStønadsperiode -> {
-                                                when (error.feil) {
+                                                when (val feil = error.feil) {
                                                     is Statusovergang.OppdaterStønadsperiode.KunneIkkeOppdatereStønadsperiode.KunneIkkeOppdatereGrunnlagsdata -> {
+                                                        log.error("Feil ved oppdatering av stønadsperiode: ${feil.feil}")
                                                         InternalServerError.errorJson(
                                                             "Feil ved oppdatering av stønadsperiode",
                                                             "oppdatering_av_stønadsperiode",
@@ -181,7 +182,7 @@ internal fun Route.søknadsbehandlingRoutes(
                                                             "senere_stønadsperioder_eksisterer",
                                                         )
                                                     }
-                                                    Statusovergang.OppdaterStønadsperiode.KunneIkkeOppdatereStønadsperiode.StønadsperiodeOverlapperMedEksisterendeStønadsperiode -> {
+                                                    Statusovergang.OppdaterStønadsperiode.KunneIkkeOppdatereStønadsperiode.StønadsperiodeOverlapperMedLøpendeStønadsperiode -> {
                                                         BadRequest.errorJson(
                                                             "Stønadsperioden overlapper med eksisterende stønadsperiode",
                                                             "stønadsperioden_overlapper_med_eksisterende_søknadsbehandling",


### PR DESCRIPTION
-Stønadsperioder som er delvis opphørt ansees bare som "aktiv" for perioden hvor ytelsen ikke er opphørt
-Stønadsperioder som er helto opphørt ansees ikke som aktive
-Sperrer fra å velge stønadsperioder forut for aktive eksisterende stønadsperioder