### PR TITLE
Konsolider duplisert logikk for opprettelse av brev.

### DIFF
--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/ServiceBuilder.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/ServiceBuilder.kt
@@ -87,10 +87,6 @@ object ServiceBuilder {
             brevService = brevService,
             oppgaveService = oppgaveService,
             vedtakRepo = databaseRepos.vedtakRepo,
-            personService = personService,
-            utbetalingService = utbetalingService,
-            microsoftGraphApiOppslag = clients.microsoftGraphApiClient,
-            clock = clock,
             behandlingMetrics = behandlingMetrics,
         )
 
@@ -132,13 +128,11 @@ object ServiceBuilder {
 
         val søknadsbehandlingService = SøknadsbehandlingServiceImpl(
             søknadService = søknadService,
-            søknadRepo = databaseRepos.søknad,
             søknadsbehandlingRepo = databaseRepos.søknadsbehandling,
             utbetalingService = utbetalingService,
             personService = personService,
             oppgaveService = oppgaveService,
             behandlingMetrics = behandlingMetrics,
-            microsoftGraphApiClient = clients.microsoftGraphApiClient,
             brevService = brevService,
             opprettVedtakssnapshotService = opprettVedtakssnapshotService,
             clock = clock,

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/vedtak/FerdigstillVedtakService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/vedtak/FerdigstillVedtakService.kt
@@ -4,41 +4,26 @@ import arrow.core.Either
 import arrow.core.getOrHandle
 import arrow.core.left
 import arrow.core.right
-import no.nav.su.se.bakover.client.person.MicrosoftGraphApiOppslag
 import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.database.vedtak.VedtakRepo
-import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.behandling.BehandlingMedOppgave
 import no.nav.su.se.bakover.domain.behandling.BehandlingMetrics
-import no.nav.su.se.bakover.domain.brev.LagBrevRequest
 import no.nav.su.se.bakover.domain.dokument.Dokument
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppgave.OppgaveFeil.KunneIkkeLukkeOppgave
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
 import no.nav.su.se.bakover.domain.vedtak.Vedtak
-import no.nav.su.se.bakover.domain.visitor.LagBrevRequestVisitor
-import no.nav.su.se.bakover.domain.visitor.Visitable
 import no.nav.su.se.bakover.service.brev.BrevService
 import no.nav.su.se.bakover.service.oppgave.OppgaveService
-import no.nav.su.se.bakover.service.person.PersonService
-import no.nav.su.se.bakover.service.utbetaling.UtbetalingService
 import no.nav.su.se.bakover.service.vedtak.FerdigstillVedtakService.KunneIkkeFerdigstilleVedtak
 import org.slf4j.LoggerFactory
-import java.time.Clock
 
 interface FerdigstillVedtakService {
     fun ferdigstillVedtakEtterUtbetaling(utbetaling: Utbetaling.OversendtUtbetaling.MedKvittering)
     fun lukkOppgaveMedBruker(vedtak: Vedtak): Either<KunneIkkeFerdigstilleVedtak.KunneIkkeLukkeOppgave, Vedtak>
 
     sealed class KunneIkkeFerdigstilleVedtak {
-
-        sealed class KunneIkkeJournalføreBrev : KunneIkkeFerdigstilleVedtak() {
-            object FantIkkeNavnPåSaksbehandlerEllerAttestant : KunneIkkeJournalføreBrev()
-            object FantIkkePerson : KunneIkkeJournalføreBrev()
-            object KunneIkkeFinneGjeldendeUtbetaling : KunneIkkeJournalføreBrev()
-        }
-
         object KunneIkkeGenerereBrev : KunneIkkeFerdigstilleVedtak()
         object KunneIkkeLukkeOppgave : KunneIkkeFerdigstilleVedtak()
     }
@@ -48,10 +33,6 @@ internal class FerdigstillVedtakServiceImpl(
     private val brevService: BrevService,
     private val oppgaveService: OppgaveService,
     private val vedtakRepo: VedtakRepo,
-    private val personService: PersonService,
-    private val utbetalingService: UtbetalingService,
-    private val microsoftGraphApiOppslag: MicrosoftGraphApiOppslag,
-    private val clock: Clock,
     private val behandlingMetrics: BehandlingMetrics,
 ) : FerdigstillVedtakService {
     private val log = LoggerFactory.getLogger(this::class.java)
@@ -96,70 +77,24 @@ internal class FerdigstillVedtakServiceImpl(
     }
 
     fun lagreDokumentJournalførOgDistribuer(vedtak: Vedtak): Either<KunneIkkeFerdigstilleVedtak, Vedtak> {
-        val brevRequest = lagBrevRequest(vedtak)
-            .getOrHandle { return it.left() }
-        val dokument = brevRequest.tilDokument {
-            brevService.lagBrev(it)
-                .mapLeft { LagBrevRequest.KunneIkkeGenererePdf }
-        }.map {
-            it.leggTilMetadata(
-                metadata = Dokument.Metadata(
-                    sakId = vedtak.behandling.sakId,
-                    søknadId = null,
-                    vedtakId = vedtak.id,
-                    revurderingId = null,
-                    bestillBrev = true,
-                ),
-            )
-        }.getOrHandle { return KunneIkkeFerdigstilleVedtak.KunneIkkeGenerereBrev.left() }
-
-        brevService.lagreDokument(dokument)
-
-        return vedtak.right()
-    }
-
-    private fun lagBrevRequest(visitable: Visitable<LagBrevRequestVisitor>): Either<KunneIkkeFerdigstilleVedtak.KunneIkkeJournalføreBrev, LagBrevRequest> {
-        return lagBrevVisitor().let { visitor ->
-            visitable.accept(visitor)
-            visitor.brevRequest
-                .mapLeft {
-                    when (it) {
-                        LagBrevRequestVisitor.KunneIkkeLageBrevRequest.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant -> {
-                            KunneIkkeFerdigstilleVedtak.KunneIkkeJournalføreBrev.FantIkkeNavnPåSaksbehandlerEllerAttestant
-                        }
-                        LagBrevRequestVisitor.KunneIkkeLageBrevRequest.KunneIkkeHentePerson -> {
-                            KunneIkkeFerdigstilleVedtak.KunneIkkeJournalføreBrev.FantIkkePerson
-                        }
-                        LagBrevRequestVisitor.KunneIkkeLageBrevRequest.KunneIkkeFinneGjeldendeUtbetaling -> {
-                            KunneIkkeFerdigstilleVedtak.KunneIkkeJournalføreBrev.KunneIkkeFinneGjeldendeUtbetaling
-                        }
-                    }
-                }
-        }
-    }
-
-    private fun lagBrevVisitor(): LagBrevRequestVisitor = LagBrevRequestVisitor(
-        hentPerson = { fnr ->
-            personService.hentPersonMedSystembruker(fnr)
-                .mapLeft { LagBrevRequestVisitor.KunneIkkeLageBrevRequest.KunneIkkeHentePerson }
-        },
-        hentNavn = { ident ->
-            hentNavnForNavIdent(ident)
-                .mapLeft { LagBrevRequestVisitor.KunneIkkeLageBrevRequest.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant }
-        },
-        hentGjeldendeUtbetaling = { sakId, forDato ->
-            utbetalingService.hentGjeldendeUtbetaling(sakId, forDato)
-                .bimap(
-                    { LagBrevRequestVisitor.KunneIkkeLageBrevRequest.KunneIkkeFinneGjeldendeUtbetaling },
-                    { it.beløp },
+        return brevService.lagDokument(vedtak)
+            .mapLeft {
+                KunneIkkeFerdigstilleVedtak.KunneIkkeGenerereBrev
+            }
+            .map {
+                brevService.lagreDokument(
+                    it.leggTilMetadata(
+                        metadata = Dokument.Metadata(
+                            sakId = vedtak.behandling.sakId,
+                            søknadId = null,
+                            vedtakId = vedtak.id,
+                            revurderingId = null,
+                            bestillBrev = true,
+                        ),
+                    ),
                 )
-        },
-        clock = clock,
-    )
-
-    private fun hentNavnForNavIdent(navIdent: NavIdentBruker): Either<KunneIkkeFerdigstilleVedtak.KunneIkkeJournalføreBrev.FantIkkeNavnPåSaksbehandlerEllerAttestant, String> {
-        return microsoftGraphApiOppslag.hentNavnForNavIdent(navIdent)
-            .mapLeft { KunneIkkeFerdigstilleVedtak.KunneIkkeJournalføreBrev.FantIkkeNavnPåSaksbehandlerEllerAttestant }
+                vedtak
+            }
     }
 
     private fun lukkOppgaveMedSystembruker(vedtak: Vedtak): Either<KunneIkkeFerdigstilleVedtak.KunneIkkeLukkeOppgave, Vedtak> {

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceBrevTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceBrevTest.kt
@@ -3,205 +3,124 @@ package no.nav.su.se.bakover.service.søknadsbehandling
 import arrow.core.left
 import arrow.core.right
 import io.kotest.matchers.shouldBe
-import no.nav.su.se.bakover.client.person.MicrosoftGraphApiOppslag
-import no.nav.su.se.bakover.client.person.MicrosoftGraphApiOppslagFeil
-import no.nav.su.se.bakover.common.desember
-import no.nav.su.se.bakover.common.januar
-import no.nav.su.se.bakover.common.periode.Periode
-import no.nav.su.se.bakover.database.søknadsbehandling.SøknadsbehandlingRepo
-import no.nav.su.se.bakover.domain.AktørId
-import no.nav.su.se.bakover.domain.Fnr
-import no.nav.su.se.bakover.domain.Ident
-import no.nav.su.se.bakover.domain.NavIdentBruker
-import no.nav.su.se.bakover.domain.Person
-import no.nav.su.se.bakover.domain.Saksnummer
-import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
-import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
-import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
-import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
-import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
-import no.nav.su.se.bakover.domain.oppgave.OppgaveId
-import no.nav.su.se.bakover.domain.person.KunneIkkeHentePerson
-import no.nav.su.se.bakover.domain.søknadsbehandling.Stønadsperiode
-import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
-import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
+import no.nav.su.se.bakover.domain.dokument.Dokument
 import no.nav.su.se.bakover.domain.visitor.LagBrevRequestVisitor
-import no.nav.su.se.bakover.service.beregning.TestBeregning
+import no.nav.su.se.bakover.service.behandling.BehandlingTestUtils.person
 import no.nav.su.se.bakover.service.brev.BrevService
-import no.nav.su.se.bakover.service.brev.KunneIkkeLageBrev
+import no.nav.su.se.bakover.service.brev.KunneIkkeLageDokument
 import no.nav.su.se.bakover.service.person.PersonService
-import no.nav.su.se.bakover.service.revurdering.RevurderingTestUtils
 import no.nav.su.se.bakover.test.fixedTidspunkt
-import no.nav.su.se.bakover.test.generer
+import no.nav.su.se.bakover.test.søknadsbehandlingTilAttesteringInnvilget
+import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertUavklart
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
-import java.util.UUID
+import org.mockito.kotlin.verify
 
 internal class SøknadsbehandlingServiceBrevTest {
-    private val stønadsperiode = Stønadsperiode.create(Periode.create(1.januar(2021), 31.desember(2021)))
-    private val beregnetAvslag = Søknadsbehandling.TilAttestering.Innvilget(
-        id = UUID.randomUUID(),
-        opprettet = fixedTidspunkt,
-        behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
-        søknad = mock(),
-        sakId = UUID.randomUUID(),
-        saksnummer = Saksnummer(2021),
-        fnr = Fnr.generer(),
-        oppgaveId = OppgaveId("0"),
-        beregning = TestBeregning,
-        simulering = mock(),
-        saksbehandler = NavIdentBruker.Saksbehandler("saksbehandler"),
-        fritekstTilBrev = "",
-        stønadsperiode = stønadsperiode,
-        grunnlagsdata = Grunnlagsdata.create(
-            bosituasjon = listOf(
-                Grunnlag.Bosituasjon.Fullstendig.Enslig(
-                    id = UUID.randomUUID(),
-                    opprettet = fixedTidspunkt,
-                    periode = RevurderingTestUtils.periodeNesteMånedOgTreMånederFram,
-                    begrunnelse = null,
-                ),
-            ),
-        ),
-        vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
-        attesteringer = Attesteringshistorikk.empty(),
-    )
-
-    private val vilkårsvurdertUavklartSøknadsbehandling = Søknadsbehandling.Vilkårsvurdert.Uavklart(
-        id = UUID.randomUUID(),
-        opprettet = fixedTidspunkt,
-        sakId = UUID.randomUUID(),
-        saksnummer = Saksnummer(2021),
-        søknad = mock(),
-        oppgaveId = OppgaveId("0"),
-        behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon(),
-        fnr = Fnr.generer(),
-        fritekstTilBrev = "",
-        stønadsperiode = stønadsperiode,
-        grunnlagsdata = Grunnlagsdata.IkkeVurdert,
-        vilkårsvurderinger = Vilkårsvurderinger.IkkeVurdert,
-        attesteringer = Attesteringshistorikk.empty(),
-    )
-
-    private val person = Person(
-        ident = Ident(
-            fnr = Fnr.generer(),
-            aktørId = AktørId(aktørId = ""),
-        ),
-        navn = Person.Navn(fornavn = "", mellomnavn = null, etternavn = ""),
-    )
+    private val tilAttesteringInnvilget = søknadsbehandlingTilAttesteringInnvilget().second
+    private val uavklart = søknadsbehandlingVilkårsvurdertUavklart().second
 
     @Test
     fun `svarer med feil hvis vi ikke finner person`() {
-        val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
-            on { hent(any()) } doReturn beregnetAvslag
+        val brevServiceMock = mock<BrevService>() {
+            on { lagDokument(any()) } doReturn KunneIkkeLageDokument.KunneIkkeHentePerson.left()
         }
 
-        val personServiceMock = mock<PersonService> {
-            on { hentPerson(any()) } doReturn KunneIkkeHentePerson.FantIkkePerson.left()
-        }
-
-        createSøknadsbehandlingService(
-            søknadsbehandlingRepo = søknadsbehandlingRepoMock,
-            personService = personServiceMock,
-        ).brev(SøknadsbehandlingService.BrevRequest.UtenFritekst(beregnetAvslag)).let {
-            it shouldBe SøknadsbehandlingService.KunneIkkeLageBrev.FantIkkePerson.left()
+        SøknadsbehandlingServiceAndMocks(
+            brevService = brevServiceMock,
+        ).let {
+            it.søknadsbehandlingService.brev(SøknadsbehandlingService.BrevRequest.UtenFritekst(tilAttesteringInnvilget)) shouldBe SøknadsbehandlingService.KunneIkkeLageBrev.FantIkkePerson.left()
+            verify(it.brevService).lagDokument(tilAttesteringInnvilget)
+            it.verifyNoMoreInteractions()
         }
     }
 
     @Test
     fun `svarer med feil hvis vi ikke finner navn på attestant eller saksbehandler`() {
-        val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
-            on { hent(any()) } doReturn beregnetAvslag
-        }
-
         val personServiceMock = mock<PersonService> {
             on { hentPerson(any()) } doReturn person.right()
         }
 
-        val microsoftGraphApiOppslagMock = mock<MicrosoftGraphApiOppslag> {
-            on { hentNavnForNavIdent(any()) } doReturn MicrosoftGraphApiOppslagFeil.FantIkkeBrukerForNavIdent.left()
+        val brevServiceMock = mock<BrevService>() {
+            on { lagDokument(any()) } doReturn KunneIkkeLageDokument.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant.left()
         }
 
-        createSøknadsbehandlingService(
-            søknadsbehandlingRepo = søknadsbehandlingRepoMock,
+        SøknadsbehandlingServiceAndMocks(
             personService = personServiceMock,
-            microsoftGraphApiOppslag = microsoftGraphApiOppslagMock,
-        ).brev(SøknadsbehandlingService.BrevRequest.UtenFritekst(beregnetAvslag)).let {
-            it shouldBe SøknadsbehandlingService.KunneIkkeLageBrev.FikkIkkeHentetSaksbehandlerEllerAttestant.left()
+            brevService = brevServiceMock,
+        ).let {
+            it.søknadsbehandlingService.brev(SøknadsbehandlingService.BrevRequest.UtenFritekst(tilAttesteringInnvilget)) shouldBe SøknadsbehandlingService.KunneIkkeLageBrev.FikkIkkeHentetSaksbehandlerEllerAttestant.left()
+            verify(it.brevService).lagDokument(tilAttesteringInnvilget)
+            it.verifyNoMoreInteractions()
         }
     }
 
     @Test
     fun `svarer med feil hvis generering av pdf feiler`() {
-        val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
-            on { hent(any()) } doReturn beregnetAvslag
-        }
-
         val personServiceMock = mock<PersonService> {
             on { hentPerson(any()) } doReturn person.right()
         }
 
-        val microsoftGraphApiOppslagMock = mock<MicrosoftGraphApiOppslag> {
-            on { hentNavnForNavIdent(any()) } doReturn "Nav Navesen".right()
+        val brevServiceMock = mock<BrevService>() {
+            on { lagDokument(any()) } doReturn KunneIkkeLageDokument.KunneIkkeGenererePDF.left()
         }
 
-        val brevServiceMock = mock<BrevService> {
-            on { lagBrev(any()) } doReturn KunneIkkeLageBrev.KunneIkkeGenererePDF.left()
-        }
-
-        createSøknadsbehandlingService(
-            søknadsbehandlingRepo = søknadsbehandlingRepoMock,
+        SøknadsbehandlingServiceAndMocks(
             personService = personServiceMock,
-            microsoftGraphApiOppslag = microsoftGraphApiOppslagMock,
             brevService = brevServiceMock,
-        ).brev(SøknadsbehandlingService.BrevRequest.UtenFritekst(beregnetAvslag)).let {
-            it shouldBe SøknadsbehandlingService.KunneIkkeLageBrev.KunneIkkeLagePDF.left()
+        ).let {
+            it.søknadsbehandlingService.brev(SøknadsbehandlingService.BrevRequest.UtenFritekst(tilAttesteringInnvilget)) shouldBe SøknadsbehandlingService.KunneIkkeLageBrev.KunneIkkeLagePDF.left()
+            verify(it.brevService).lagDokument(tilAttesteringInnvilget)
+            it.verifyNoMoreInteractions()
         }
     }
 
     @Test
     fun `svarer med byte array dersom alt går fint`() {
-        val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
-            on { hent(any()) } doReturn beregnetAvslag
-        }
-
         val personServiceMock = mock<PersonService> {
             on { hentPerson(any()) } doReturn person.right()
         }
 
-        val microsoftGraphApiOppslagMock = mock<MicrosoftGraphApiOppslag> {
-            on { hentNavnForNavIdent(any()) } doReturn "Nav Navesen".right()
-        }
-
         val pdf = "".toByteArray()
         val brevServiceMock = mock<BrevService> {
-            on { lagBrev(any()) } doReturn pdf.right()
+            on { lagDokument(any()) } doReturn Dokument.UtenMetadata.Vedtak(
+                opprettet = fixedTidspunkt,
+                tittel = "tittel1",
+                generertDokument = pdf,
+                generertDokumentJson = "{}",
+            ).right()
         }
 
-        createSøknadsbehandlingService(
-            søknadsbehandlingRepo = søknadsbehandlingRepoMock,
+        SøknadsbehandlingServiceAndMocks(
             personService = personServiceMock,
-            microsoftGraphApiOppslag = microsoftGraphApiOppslagMock,
             brevService = brevServiceMock,
-        ).brev(SøknadsbehandlingService.BrevRequest.UtenFritekst(beregnetAvslag)).let {
-            it shouldBe pdf.right()
+        ).let {
+            it.søknadsbehandlingService.brev(SøknadsbehandlingService.BrevRequest.UtenFritekst(tilAttesteringInnvilget)) shouldBe pdf.right()
+            verify(it.brevService).lagDokument(tilAttesteringInnvilget)
+            it.verifyNoMoreInteractions()
         }
     }
 
     @Test
     fun `kaster exception hvis det ikke er mulig å opprette brev for aktuell behandling`() {
-        val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
-            on { hent(any()) } doReturn vilkårsvurdertUavklartSøknadsbehandling
+        val brevServiceMock = mock<BrevService> {
+            on { lagDokument(any()) } doThrow LagBrevRequestVisitor.KunneIkkeLageBrevRequest.KanIkkeLageBrevrequestForInstans(
+                uavklart::class,
+            )
         }
 
         assertThrows<LagBrevRequestVisitor.KunneIkkeLageBrevRequest.KanIkkeLageBrevrequestForInstans> {
-            createSøknadsbehandlingService(
-                søknadsbehandlingRepo = søknadsbehandlingRepoMock,
-            ).brev(SøknadsbehandlingService.BrevRequest.UtenFritekst(vilkårsvurdertUavklartSøknadsbehandling))
+            SøknadsbehandlingServiceAndMocks(
+                brevService = brevServiceMock,
+            ).søknadsbehandlingService.brev(
+                SøknadsbehandlingService.BrevRequest.UtenFritekst(
+                    uavklart,
+                ),
+            )
         }
     }
 }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceGrunnlagBosituasjonTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceGrunnlagBosituasjonTest.kt
@@ -170,8 +170,8 @@ internal class SøknadsbehandlingServiceGrunnlagBosituasjonTest {
 
         val response = createSøknadsbehandlingService(
             søknadsbehandlingRepo = søknadsbehandlingRepoMock,
-            grunnlagService = grunnlagServiceMock,
             clock = fixedClock,
+            grunnlagService = grunnlagServiceMock,
         ).leggTilBosituasjonEpsgrunnlag(
             LeggTilBosituasjonEpsRequest(behandlingId = behandlingId, epsFnr = null),
         ).orNull()!!
@@ -330,8 +330,8 @@ internal class SøknadsbehandlingServiceGrunnlagBosituasjonTest {
 
         val response = createSøknadsbehandlingService(
             søknadsbehandlingRepo = søknadsbehandlingRepoMock,
-            grunnlagService = grunnlagServiceMock,
             clock = fixedClock,
+            grunnlagService = grunnlagServiceMock,
         ).fullførBosituasjongrunnlag(
             FullførBosituasjonRequest(
                 behandlingId = behandlingId,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceOppdaterStønadsperiodeTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceOppdaterStønadsperiodeTest.kt
@@ -25,7 +25,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import java.util.UUID
 

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingTestUtils.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingTestUtils.kt
@@ -1,8 +1,6 @@
 package no.nav.su.se.bakover.service.søknadsbehandling
 
-import no.nav.su.se.bakover.client.person.MicrosoftGraphApiOppslag
 import no.nav.su.se.bakover.common.idag
-import no.nav.su.se.bakover.database.søknad.SøknadRepo
 import no.nav.su.se.bakover.database.søknadsbehandling.SøknadsbehandlingRepo
 import no.nav.su.se.bakover.database.vedtak.VedtakRepo
 import no.nav.su.se.bakover.domain.behandling.BehandlingMetrics
@@ -39,11 +37,9 @@ internal fun createSøknadsbehandlingService(
     utbetalingService: UtbetalingService = mock(),
     oppgaveService: OppgaveService = mock(),
     søknadService: SøknadService = mock(),
-    søknadRepo: SøknadRepo = mock(),
     personService: PersonService = mock(),
     behandlingMetrics: BehandlingMetrics = mock(),
     observer: EventObserver = mock(),
-    microsoftGraphApiOppslag: MicrosoftGraphApiOppslag = mock(),
     brevService: BrevService = mock(),
     opprettVedtakssnapshotService: OpprettVedtakssnapshotService = mock(),
     clock: Clock = Clock.systemUTC(),
@@ -54,13 +50,11 @@ internal fun createSøknadsbehandlingService(
     sakService: SakService = mock(),
 ) = SøknadsbehandlingServiceImpl(
     søknadService,
-    søknadRepo,
     søknadsbehandlingRepo,
     utbetalingService,
     personService,
     oppgaveService,
     behandlingMetrics,
-    microsoftGraphApiOppslag,
     brevService,
     opprettVedtakssnapshotService,
     clock,
@@ -76,14 +70,12 @@ internal data class SøknadsbehandlingServiceAndMocks(
     val utbetalingService: UtbetalingService = mock(),
     val oppgaveService: OppgaveService = mock(),
     val søknadService: SøknadService = mock(),
-    val søknadRepo: SøknadRepo = mock(),
     val personService: PersonService = mock(),
     val behandlingMetrics: BehandlingMetrics = mock(),
     val observer: EventObserver = mock(),
-    val microsoftGraphApiOppslag: MicrosoftGraphApiOppslag = mock(),
     val brevService: BrevService = mock(),
     val opprettVedtakssnapshotService: OpprettVedtakssnapshotService = mock(),
-    val clock: Clock = no.nav.su.se.bakover.test.fixedClock,
+    val clock: Clock = fixedClock,
     val vedtakRepo: VedtakRepo = mock(),
     val ferdigstillVedtakService: FerdigstillVedtakService = mock(),
     val vilkårsvurderingService: VilkårsvurderingService = mock(),
@@ -92,13 +84,11 @@ internal data class SøknadsbehandlingServiceAndMocks(
 ) {
     val søknadsbehandlingService = SøknadsbehandlingServiceImpl(
         søknadService = søknadService,
-        søknadRepo = søknadRepo,
         søknadsbehandlingRepo = søknadsbehandlingRepo,
         utbetalingService = utbetalingService,
         personService = personService,
         oppgaveService = oppgaveService,
         behandlingMetrics = behandlingMetrics,
-        microsoftGraphApiClient = microsoftGraphApiOppslag,
         brevService = brevService,
         opprettVedtakssnapshotService = opprettVedtakssnapshotService,
         clock = clock,
@@ -109,17 +99,15 @@ internal data class SøknadsbehandlingServiceAndMocks(
         sakService = sakService,
     ).apply { addObserver(observer) }
 
-    fun all(): List<Any> {
+    fun allMocks(): Array<Any> {
         return listOf(
             søknadsbehandlingRepo,
             utbetalingService,
             oppgaveService,
             søknadService,
-            søknadRepo,
             personService,
             behandlingMetrics,
             observer,
-            microsoftGraphApiOppslag,
             brevService,
             opprettVedtakssnapshotService,
             vedtakRepo,
@@ -127,7 +115,7 @@ internal data class SøknadsbehandlingServiceAndMocks(
             vilkårsvurderingService,
             grunnlagService,
             sakService,
-        )
+        ).toTypedArray()
     }
 
     fun verifyNoMoreInteractions() {
@@ -136,11 +124,9 @@ internal data class SøknadsbehandlingServiceAndMocks(
             utbetalingService,
             oppgaveService,
             søknadService,
-            søknadRepo,
             personService,
             behandlingMetrics,
             observer,
-            microsoftGraphApiOppslag,
             brevService,
             opprettVedtakssnapshotService,
             vedtakRepo,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/vedtak/FerdigstillVedtakServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/vedtak/FerdigstillVedtakServiceImplTest.kt
@@ -4,34 +4,24 @@ import arrow.core.left
 import arrow.core.right
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
-import io.kotest.matchers.types.instanceOf
-import no.nav.su.se.bakover.client.person.MicrosoftGraphApiOppslag
 import no.nav.su.se.bakover.database.utbetaling.UtbetalingRepo
 import no.nav.su.se.bakover.database.vedtak.VedtakRepo
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.behandling.BehandlingMedOppgave
 import no.nav.su.se.bakover.domain.behandling.BehandlingMetrics
-import no.nav.su.se.bakover.domain.brev.LagBrevRequest
 import no.nav.su.se.bakover.domain.dokument.Dokument
 import no.nav.su.se.bakover.domain.oppdrag.Kvittering
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppgave.OppgaveFeil.KunneIkkeLukkeOppgave
-import no.nav.su.se.bakover.domain.person.KunneIkkeHentePerson
 import no.nav.su.se.bakover.domain.revurdering.Revurderingsårsak
 import no.nav.su.se.bakover.domain.vedtak.Vedtak
 import no.nav.su.se.bakover.service.argThat
 import no.nav.su.se.bakover.service.brev.BrevService
-import no.nav.su.se.bakover.service.brev.KunneIkkeLageBrev
+import no.nav.su.se.bakover.service.brev.KunneIkkeLageDokument
 import no.nav.su.se.bakover.service.oppgave.OppgaveService
-import no.nav.su.se.bakover.service.person.PersonService
-import no.nav.su.se.bakover.service.utbetaling.UtbetalingService
-import no.nav.su.se.bakover.test.attestant
-import no.nav.su.se.bakover.test.attestantNavn
 import no.nav.su.se.bakover.test.fixedClock
+import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.oversendtUtbetalingMedKvittering
-import no.nav.su.se.bakover.test.person
-import no.nav.su.se.bakover.test.saksbehandler
-import no.nav.su.se.bakover.test.saksbehandlerNavn
 import no.nav.su.se.bakover.test.vedtakRevurderingIverksattInnvilget
 import no.nav.su.se.bakover.test.vedtakSøknadsbehandlingIverksattAvslagMedBeregning
 import no.nav.su.se.bakover.test.vedtakSøknadsbehandlingIverksattInnvilget
@@ -83,7 +73,6 @@ internal class FerdigstillVedtakServiceImplTest {
 
     @Test
     fun `ferdigstill NY kaster feil hvis utbetalinga ikke kan kobles til et vedtak`() {
-
         val (sak, vedtak) = innvilgetSøknadsbehandlingVedtak()
 
         FerdigstillVedtakServiceMocks(
@@ -101,43 +90,36 @@ internal class FerdigstillVedtakServiceImplTest {
 
     @Test
     fun `ferdigstill NY kaster feil hvis man ikke finner person for generering av brev`() {
-
         val (sak, vedtak) = innvilgetSøknadsbehandlingVedtak()
 
         FerdigstillVedtakServiceMocks(
             vedtakRepo = mock {
                 on { hentForUtbetaling(any()) } doReturn vedtak
             },
-            personService = mock {
-                on { hentPersonMedSystembruker(any()) } doReturn KunneIkkeHentePerson.FantIkkePerson.left()
-            },
+            brevService = mock {
+                on { lagDokument(any()) } doReturn KunneIkkeLageDokument.KunneIkkeHentePerson.left()
+            }
         ) {
             assertThrows<FerdigstillVedtakServiceImpl.KunneIkkeFerdigstilleVedtakException> {
                 service.ferdigstillVedtakEtterUtbetaling(sak.utbetalinger.first() as Utbetaling.OversendtUtbetaling.MedKvittering)
             }.message shouldContain vedtak.id.toString()
 
             verify(vedtakRepo).hentForUtbetaling(vedtak.utbetalingId)
-            verify(personService).hentPersonMedSystembruker(argThat { it shouldBe vedtak.behandling.fnr })
+            verify(brevService).lagDokument(vedtak)
         }
     }
 
     @Test
     fun `ferdigstillelse etter utbetaling kaster feil hvis generering av brev feiler`() {
         val (sak, vedtak) = innvilgetSøknadsbehandlingVedtak()
+
         FerdigstillVedtakServiceMocks(
             vedtakRepo = mock {
                 on { hentForUtbetaling(any()) } doReturn vedtak
             },
-            personService = mock {
-                on { hentPersonMedSystembruker(any()) } doReturn person().right()
-            },
-            microsoftGraphApiClient = mock {
-                on { hentNavnForNavIdent(saksbehandler) } doReturn saksbehandlerNavn.right()
-                on { hentNavnForNavIdent(attestant) } doReturn attestantNavn.right()
-            },
             brevService = mock {
-                on { lagBrev(any()) } doReturn KunneIkkeLageBrev.KunneIkkeGenererePDF.left()
-            },
+                on { lagDokument(any()) } doReturn KunneIkkeLageDokument.KunneIkkeGenererePDF.left()
+            }
         ) {
             assertThrows<FerdigstillVedtakServiceImpl.KunneIkkeFerdigstilleVedtakException> {
                 service.ferdigstillVedtakEtterUtbetaling(
@@ -149,12 +131,7 @@ internal class FerdigstillVedtakServiceImplTest {
                 *all(),
             ) {
                 verify(vedtakRepo).hentForUtbetaling(argThat { it shouldBe vedtak.utbetalingId })
-                verify(personService).hentPersonMedSystembruker(argThat { it shouldBe vedtak.behandling.fnr })
-                inOrder(microsoftGraphApiClient) {
-                    verify(microsoftGraphApiClient).hentNavnForNavIdent(saksbehandler)
-                    verify(microsoftGraphApiClient).hentNavnForNavIdent(attestant)
-                }
-                verify(brevService).lagBrev(argThat { it shouldBe instanceOf<LagBrevRequest.InnvilgetVedtak>() })
+                verify(brevService).lagDokument(argThat { it shouldBe vedtak })
             }
         }
     }
@@ -162,23 +139,22 @@ internal class FerdigstillVedtakServiceImplTest {
     @Test
     fun `ferdigstill NY etter utbetaling går fint`() {
         val (sak, vedtak) = innvilgetSøknadsbehandlingVedtak()
+
         FerdigstillVedtakServiceMocks(
-            vedtakRepo = mock {
-                on { hentForUtbetaling(any()) } doReturn vedtak
-            },
-            personService = mock {
-                on { hentPersonMedSystembruker(any()) } doReturn person().right()
-            },
-            microsoftGraphApiClient = mock {
-                on { hentNavnForNavIdent(saksbehandler) } doReturn saksbehandlerNavn.right()
-                on { hentNavnForNavIdent(attestant) } doReturn attestantNavn.right()
-            },
-            brevService = mock {
-                on { lagBrev(any()) } doReturn "brev".toByteArray().right()
-            },
             oppgaveService = mock {
                 on { lukkOppgaveMedSystembruker(any()) } doReturn Unit.right()
             },
+            vedtakRepo = mock {
+                on { hentForUtbetaling(any()) } doReturn vedtak
+            },
+            brevService = mock {
+                on { lagDokument(any()) } doReturn Dokument.UtenMetadata.Vedtak(
+                    opprettet = fixedTidspunkt,
+                    tittel = "tittel1",
+                    generertDokument = "brev".toByteArray(),
+                    generertDokumentJson = "brev",
+                ).right()
+            }
         ) {
             service.ferdigstillVedtakEtterUtbetaling(sak.utbetalinger.first() as Utbetaling.OversendtUtbetaling.MedKvittering)
 
@@ -186,12 +162,7 @@ internal class FerdigstillVedtakServiceImplTest {
                 *all(),
             ) {
                 verify(vedtakRepo).hentForUtbetaling(argThat { it shouldBe vedtak.utbetalingId })
-                verify(personService).hentPersonMedSystembruker(argThat { it shouldBe vedtak.behandling.fnr })
-                inOrder(microsoftGraphApiClient) {
-                    verify(microsoftGraphApiClient).hentNavnForNavIdent(saksbehandler)
-                    verify(microsoftGraphApiClient).hentNavnForNavIdent(attestant)
-                }
-                verify(brevService).lagBrev(argThat { it shouldBe instanceOf<LagBrevRequest.InnvilgetVedtak>() })
+                verify(brevService).lagDokument(argThat { it shouldBe vedtak })
                 verify(brevService).lagreDokument(
                     argThat {
                         it.generertDokument contentEquals "brev".toByteArray()
@@ -210,7 +181,6 @@ internal class FerdigstillVedtakServiceImplTest {
 
     @Test
     fun `ferdigstill NY av regulering av grunnbeløp etter utbetaling skal ikke sende brev men skal lukke oppgave`() {
-
         val (sak, vedtak) = vedtakRevurderingIverksattInnvilget(
             sakOgVedtakSomKanRevurderes = innvilgetSøknadsbehandlingVedtak(),
             revurderingsårsak = Revurderingsårsak(
@@ -220,11 +190,11 @@ internal class FerdigstillVedtakServiceImplTest {
         )
 
         FerdigstillVedtakServiceMocks(
-            vedtakRepo = mock {
-                on { hentForUtbetaling(any()) } doReturn vedtak
-            },
             oppgaveService = mock {
                 on { lukkOppgaveMedSystembruker(any()) } doReturn Unit.right()
+            },
+            vedtakRepo = mock {
+                on { hentForUtbetaling(any()) } doReturn vedtak
             },
         ) {
             service.ferdigstillVedtakEtterUtbetaling(sak.utbetalinger[1] as Utbetaling.OversendtUtbetaling.MedKvittering)
@@ -240,7 +210,6 @@ internal class FerdigstillVedtakServiceImplTest {
 
     @Test
     fun `svarer med feil dersom lukking av oppgave feiler`() {
-
         val vedtak = avslagsVedtak()
 
         FerdigstillVedtakServiceMocks(
@@ -260,11 +229,8 @@ internal class FerdigstillVedtakServiceImplTest {
 
     internal data class FerdigstillVedtakServiceMocks(
         val oppgaveService: OppgaveService = mock(),
-        val personService: PersonService = mock(),
         val clock: Clock = fixedClock,
-        val microsoftGraphApiClient: MicrosoftGraphApiOppslag = mock(),
         val brevService: BrevService = mock(),
-        val utbetalingService: UtbetalingService = mock(),
         val vedtakRepo: VedtakRepo = mock(),
         val utbetalingRepo: UtbetalingRepo = mock(),
         val behandlingMetrics: BehandlingMetrics = mock(),
@@ -274,10 +240,6 @@ internal class FerdigstillVedtakServiceImplTest {
             brevService = brevService,
             oppgaveService = oppgaveService,
             vedtakRepo = vedtakRepo,
-            personService = personService,
-            utbetalingService = utbetalingService,
-            microsoftGraphApiOppslag = microsoftGraphApiClient,
-            clock = clock,
             behandlingMetrics = behandlingMetrics,
         )
 
@@ -288,10 +250,7 @@ internal class FerdigstillVedtakServiceImplTest {
 
         fun all() = listOf(
             oppgaveService,
-            personService,
-            microsoftGraphApiClient,
             brevService,
-            utbetalingService,
             vedtakRepo,
             utbetalingRepo,
             behandlingMetrics,

--- a/test-common/src/main/kotlin/SøknadsbehandlingTestData.kt
+++ b/test-common/src/main/kotlin/SøknadsbehandlingTestData.kt
@@ -160,14 +160,7 @@ fun søknadsbehandlingBeregnetAvslag(
     behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,
     grunnlagsdata: Grunnlagsdata = grunnlagsdataEnsligUtenFradrag(stønadsperiode.periode),
     vilkårsvurderinger: Vilkårsvurderinger = vilkårsvurderingerInnvilget(stønadsperiode.periode),
-    beregning: Beregning = beregning(
-        uføregrunnlag = nonEmptyListOf(
-            uføregrunnlagForventetInntekt(
-                periode = stønadsperiode.periode,
-                forventetInntekt = 1_000_000,
-            ),
-        ),
-    ),
+    beregning: Beregning = beregningAvslag()
 ): Pair<Sak, Søknadsbehandling.Beregnet.Avslag> {
     return søknadsbehandlingVilkårsvurdertInnvilget(
         saksnummer = saksnummer,
@@ -248,7 +241,7 @@ fun søknadsbehandlingTilAttesteringAvslagMedBeregning(
     behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,
     grunnlagsdata: Grunnlagsdata = grunnlagsdataEnsligUtenFradrag(stønadsperiode.periode),
     vilkårsvurderinger: Vilkårsvurderinger = vilkårsvurderingerInnvilget(stønadsperiode.periode),
-    beregning: Beregning = beregning(),
+    beregning: Beregning = beregningAvslag()
 ): Pair<Sak, Søknadsbehandling.TilAttestering.Avslag.MedBeregning> {
     return søknadsbehandlingBeregnetAvslag(
         saksnummer = saksnummer,


### PR DESCRIPTION
Refaktorering av eksistedende kode for opprettelse av brev.

Konsolidert alle steder hvor brev-visitor brukes til å benytte samme funksjonalitet fra brevservice. Pr inneholder refaktorering av tester og fjerning av ubrukt kode.

-La brevservice håndtere detaljene for hvordan navn/personalia hentes.
-Refaktorering av tester og fjerning av ubrukt kode.
-Rydde litt i testdata.