### PR TITLE
Legg til noen funksjonelle metrikker

### DIFF
--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/metrics/SuMetrics.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/metrics/SuMetrics.kt
@@ -1,6 +1,7 @@
 package no.nav.su.se.bakover.web.metrics
 
 import io.micrometer.core.instrument.Clock
+import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.Tags
 import io.micrometer.prometheus.PrometheusConfig
@@ -15,7 +16,7 @@ object SuMetrics {
         collectorRegistry,
         Clock.SYSTEM
     )
-    val dbTimer = Histogram.build("db_query_latency_histogram", "Histogram av eksekveringstid for db-spørringer")
+    val dbTimer: Histogram = Histogram.build("db_query_latency_histogram", "Histogram av eksekveringstid for db-spørringer")
         .labelNames("query")
         .register(collectorRegistry)
 
@@ -29,5 +30,51 @@ object SuMetrics {
             metricName,
             Tags.of("type", type)
         ).increment()
+    }
+
+    enum class Metrikk(val navn: String) {
+        SØKNAD_MOTTATT("soknad.mottatt"),
+        BEHANDLING_STARTET("behandling.startet"),
+        VEDTAK_IVERKSATT("vedtak.iverksatt")
+    }
+
+    enum class Søknadstype(val type: String) {
+        PAPIR("papir"),
+        DIGITAL("digital"),
+    }
+
+    enum class Behandlingstype(val type: String) {
+        SØKNAD("soknadsbehandling"),
+        REVURDERING("revurdering"),
+    }
+
+    private fun counter(metrikk: Metrikk, type: String): Counter = Metrics.counter(metrikk.navn, Tags.of("type", type))
+
+    private val søknadPapirMottattCounter = counter(Metrikk.SØKNAD_MOTTATT, type = Søknadstype.PAPIR.type)
+    private val søknadDigitalMottattCounter = counter(Metrikk.SØKNAD_MOTTATT, type = Søknadstype.DIGITAL.type)
+    private val søknadsbehandlingStartetCounter = counter(Metrikk.BEHANDLING_STARTET, type = Behandlingstype.SØKNAD.type)
+    private val revurderingStartetCounter = counter(Metrikk.BEHANDLING_STARTET, type = Behandlingstype.REVURDERING.type)
+    private val vedtakSøknadsbehandlingIverksattCounter = counter(Metrikk.VEDTAK_IVERKSATT, type = Behandlingstype.SØKNAD.type)
+    private val vedtakRevurderingIverksattCounter = counter(Metrikk.VEDTAK_IVERKSATT, type = Behandlingstype.REVURDERING.type)
+
+    fun søknadMottatt(type: Søknadstype) {
+        when (type) {
+            Søknadstype.DIGITAL -> søknadDigitalMottattCounter
+            Søknadstype.PAPIR -> søknadPapirMottattCounter
+        }.increment()
+    }
+
+    fun behandlingStartet(type: Behandlingstype) {
+        when (type) {
+            Behandlingstype.SØKNAD -> søknadsbehandlingStartetCounter
+            Behandlingstype.REVURDERING -> revurderingStartetCounter
+        }.increment()
+    }
+
+    fun vedtakIverksatt(type: Behandlingstype) {
+        when (type) {
+            Behandlingstype.SØKNAD -> vedtakSøknadsbehandlingIverksattCounter
+            Behandlingstype.REVURDERING -> vedtakRevurderingIverksattCounter
+        }.increment()
     }
 }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/IverksettRevurderingRoute.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/IverksettRevurderingRoute.kt
@@ -19,6 +19,7 @@ import no.nav.su.se.bakover.web.audit
 import no.nav.su.se.bakover.web.errorJson
 import no.nav.su.se.bakover.web.features.authorize
 import no.nav.su.se.bakover.web.features.suUserContext
+import no.nav.su.se.bakover.web.metrics.SuMetrics
 import no.nav.su.se.bakover.web.routes.Feilresponser.Brev.kunneIkkeGenerereBrev
 import no.nav.su.se.bakover.web.routes.Feilresponser.fantIkkePerson
 import no.nav.su.se.bakover.web.routes.Feilresponser.tilResultat
@@ -44,6 +45,7 @@ internal fun Route.iverksettRevurderingRoute(
                     ifRight = {
                         call.sikkerlogg("Iverksatt revurdering med id $revurderingId")
                         call.audit(it.fnr, AuditLogEvent.Action.UPDATE, it.id)
+                        SuMetrics.vedtakIverksatt(SuMetrics.Behandlingstype.REVURDERING)
                         call.svar(Resultat.json(HttpStatusCode.OK, serialize(it.toJson())))
                     },
                 )

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OpprettRevurderingRoute.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OpprettRevurderingRoute.kt
@@ -25,6 +25,7 @@ import no.nav.su.se.bakover.web.audit
 import no.nav.su.se.bakover.web.errorJson
 import no.nav.su.se.bakover.web.features.authorize
 import no.nav.su.se.bakover.web.features.suUserContext
+import no.nav.su.se.bakover.web.metrics.SuMetrics
 import no.nav.su.se.bakover.web.routes.Feilresponser.fantIkkeAktørId
 import no.nav.su.se.bakover.web.routes.Feilresponser.kunneIkkeOppretteOppgave
 import no.nav.su.se.bakover.web.routes.revurdering.Revurderingsfeilresponser.OpprettelseOgOppdateringAvRevurdering.begrunnelseKanIkkeVæreTom
@@ -72,6 +73,7 @@ internal fun Route.opprettRevurderingRoute(
                         ifRight = {
                             call.sikkerlogg("Opprettet en ny revurdering på sak med id $sakId")
                             call.audit(it.fnr, AuditLogEvent.Action.CREATE, it.id)
+                            SuMetrics.behandlingStartet(SuMetrics.Behandlingstype.REVURDERING)
                             call.svar(Resultat.json(HttpStatusCode.Created, serialize(it.toJson())))
                         },
                     )

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutes.kt
@@ -48,6 +48,7 @@ import no.nav.su.se.bakover.web.deserialize
 import no.nav.su.se.bakover.web.errorJson
 import no.nav.su.se.bakover.web.features.authorize
 import no.nav.su.se.bakover.web.features.suUserContext
+import no.nav.su.se.bakover.web.metrics.SuMetrics
 import no.nav.su.se.bakover.web.routes.Feilresponser
 import no.nav.su.se.bakover.web.routes.Feilresponser.Brev.kunneIkkeGenerereBrev
 import no.nav.su.se.bakover.web.routes.Feilresponser.fantIkkeBehandling
@@ -133,6 +134,7 @@ internal fun Route.søknadsbehandlingRoutes(
                                 {
                                     call.sikkerlogg("Opprettet behandling på sak: $sakId og søknadId: $søknadId")
                                     call.audit(it.fnr, AuditLogEvent.Action.CREATE, it.id)
+                                    SuMetrics.behandlingStartet(SuMetrics.Behandlingstype.SØKNAD)
                                     call.svar(Created.jsonBody(it))
                                 },
                             )
@@ -431,6 +433,7 @@ internal fun Route.søknadsbehandlingRoutes(
                     {
                         call.sikkerlogg("Iverksatte behandling med id: $behandlingId")
                         call.audit(it.fnr, AuditLogEvent.Action.UPDATE, it.id)
+                        SuMetrics.vedtakIverksatt(SuMetrics.Behandlingstype.SØKNAD)
                         call.svar(OK.jsonBody(it))
                     },
                 )


### PR DESCRIPTION
Har prøvd å gjøre metrikk-pushingen analogt til hvordan vi gjør logging.

Har startet med å telle søknad mottatt (papir og digital), startet behandling (søknadsbehandling og revurdering) og iverksatt vedtak (søknadsbehandling og revurdering). Har satt opp *hva* som en tag, slik at det både går an å grafe totalt antall mottatte søknader (f.eks.), men også skille det på papir/digital.