### PR TITLE
Legg til mulighet for å ha en kode 6-bruker lokalt

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,4 @@
-PDFGEN_LOCAL=false #Default går denne mot su-pdfgen
+# Default går denne mot su-pdfgen
+PDFGEN_LOCAL=false
+# Sett inn et fnr du ønsker å bruke som kode6-fnr lokalt
+FNR_KODE6=fnr

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/person/PersonOppslagStub.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/person/PersonOppslagStub.kt
@@ -51,7 +51,12 @@ object PersonOppslagStub :
         fullmakt = null,
     )
 
-    override fun person(fnr: Fnr): Either<KunneIkkeHentePerson, Person> = nyTestPerson(fnr).right()
+    override fun person(fnr: Fnr): Either<KunneIkkeHentePerson, Person> =
+        if (fnr.toString() == ApplicationConfig.fnrKode6())
+            KunneIkkeHentePerson.IkkeTilgangTilPerson.left()
+        else
+            nyTestPerson(fnr).right()
+
     override fun personMedSystembruker(fnr: Fnr): Either<KunneIkkeHentePerson, Person> = nyTestPerson(fnr).right()
     override fun aktørId(fnr: Fnr) = AktørId("2437280977705").right()
     override fun aktørIdMedSystembruker(fnr: Fnr): Either<KunneIkkeHentePerson, AktørId> = AktørId("2437280977705").right()

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/person/PersonOppslagStub.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/person/PersonOppslagStub.kt
@@ -1,7 +1,9 @@
 package no.nav.su.se.bakover.client.stubs.person
 
 import arrow.core.Either
+import arrow.core.left
 import arrow.core.right
+import no.nav.su.se.bakover.common.ApplicationConfig
 import no.nav.su.se.bakover.domain.AktørId
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.Ident
@@ -9,7 +11,6 @@ import no.nav.su.se.bakover.domain.Person
 import no.nav.su.se.bakover.domain.Telefonnummer
 import no.nav.su.se.bakover.domain.person.KunneIkkeHentePerson
 import no.nav.su.se.bakover.domain.person.PersonOppslag
-import no.nav.su.se.bakover.domain.person.SivilstandTyper
 import java.time.LocalDate
 
 object PersonOppslagStub :
@@ -36,11 +37,8 @@ object PersonOppslagStub :
         statsborgerskap = "NOR",
         kjønn = "MANN",
         fødselsdato = LocalDate.of(1990, 1, 1),
-        sivilstand = Person.Sivilstand(
-            type = SivilstandTyper.GIFT,
-            relatertVedSivilstand = Fnr("15116414950"),
-        ),
-        adressebeskyttelse = null,
+        sivilstand = null,
+        adressebeskyttelse = if (fnr.toString() == ApplicationConfig.fnrKode6()) "STRENGT_FORTROLIG_ADRESSE" else null,
         skjermet = false,
         kontaktinfo = Person.Kontaktinfo(
             epostadresse = "mail@epost.com",
@@ -58,5 +56,9 @@ object PersonOppslagStub :
     override fun aktørId(fnr: Fnr) = AktørId("2437280977705").right()
     override fun aktørIdMedSystembruker(fnr: Fnr): Either<KunneIkkeHentePerson, AktørId> = AktørId("2437280977705").right()
 
-    override fun sjekkTilgangTilPerson(fnr: Fnr): Either<KunneIkkeHentePerson, Unit> = Unit.right()
+    override fun sjekkTilgangTilPerson(fnr: Fnr): Either<KunneIkkeHentePerson, Unit> =
+        if (fnr.toString() == ApplicationConfig.fnrKode6())
+            KunneIkkeHentePerson.IkkeTilgangTilPerson.left()
+        else
+            Unit.right()
 }

--- a/common/src/main/kotlin/no/nav/su/se/bakover/common/Config.kt
+++ b/common/src/main/kotlin/no/nav/su/se/bakover/common/Config.kt
@@ -491,7 +491,7 @@ data class ApplicationConfig(
             unleash = UnleashConfig.createFromEnvironmentVariables(),
             jobConfig = JobConfig(
                 personhendelse = JobConfig.Personhendelse(naisCluster())
-            )
+            ),
         )
 
         fun createLocalConfig() = ApplicationConfig(
@@ -509,7 +509,7 @@ data class ApplicationConfig(
             unleash = UnleashConfig.createFromEnvironmentVariables(),
             jobConfig = JobConfig(
                 personhendelse = JobConfig.Personhendelse(naisCluster())
-            )
+            ),
         ).also {
             log.warn("**********  Using local config (the environment variable 'NAIS_CLUSTER_NAME' is missing.)")
         }
@@ -525,6 +525,7 @@ data class ApplicationConfig(
 
         fun isRunningLocally() = naisCluster() == null
         fun isNotProd() = isRunningLocally() || naisCluster() == NaisCluster.Dev
+        fun fnrKode6() = getEnvironmentVariableOrDefault("FNR_KODE6", "default")
     }
     data class JobConfig(val personhendelse: Personhendelse) {
         data class Personhendelse(private val naisCluster: NaisCluster?) {

--- a/common/src/main/kotlin/no/nav/su/se/bakover/common/Config.kt
+++ b/common/src/main/kotlin/no/nav/su/se/bakover/common/Config.kt
@@ -4,6 +4,7 @@ import io.confluent.kafka.serializers.KafkaAvroDeserializer
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
 import io.github.cdimascio.dotenv.dotenv
 import no.nav.su.se.bakover.common.EnvironmentConfig.getEnvironmentVariableOrDefault
+import no.nav.su.se.bakover.common.EnvironmentConfig.getEnvironmentVariableOrNull
 import no.nav.su.se.bakover.common.EnvironmentConfig.getEnvironmentVariableOrThrow
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.consumer.ConsumerConfig
@@ -30,6 +31,10 @@ private object EnvironmentConfig {
 
     fun getEnvironmentVariableOrDefault(environmentVariableName: String, default: String): String {
         return env[environmentVariableName] ?: default
+    }
+
+    fun getEnvironmentVariableOrNull(environmentVariableName: String): String? {
+        return env[environmentVariableName] ?: null
     }
 
     fun exists(environmentVariableName: String): Boolean {
@@ -525,7 +530,7 @@ data class ApplicationConfig(
 
         fun isRunningLocally() = naisCluster() == null
         fun isNotProd() = isRunningLocally() || naisCluster() == NaisCluster.Dev
-        fun fnrKode6() = getEnvironmentVariableOrDefault("FNR_KODE6", "default")
+        fun fnrKode6() = getEnvironmentVariableOrNull("FNR_KODE6")
     }
     data class JobConfig(val personhendelse: Personhendelse) {
         data class Personhendelse(private val naisCluster: NaisCluster?) {

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/person/PersonRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/person/PersonRoutesKtTest.kt
@@ -110,10 +110,7 @@ internal class PersonRoutesKtTest {
                         "adressetype": "Bostedsadresse",
                         "adresseformat": "Vegadresse"
                     }],
-                    "sivilstand": {
-                    "type": "GIFT",
-                    "relatertVedSivilstand": "15116414950"
-                    },
+                    "sivilstand": null,
                     "statsborgerskap": "NOR",
                     "kjønn": "MANN",
                     "fødselsdato": "1990-01-01",


### PR DESCRIPTION
For enklere å kunne switche mellom en vanlig bruker og en kode 6-bruker når man tester lokalt. Gjør det også enklere å teste at søker *ikke* har kode 6, mens ektefelle *har* kode 6.