### PR TITLE
Lagre EPS med adressebeskyttelse eller skjerming

### DIFF
--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
@@ -469,6 +469,14 @@ open class AccessCheckProxy(
                     return services.søknadsbehandling.leggTilBosituasjonEpsgrunnlag(request)
                 }
 
+                override fun leggTilBosituasjonEpsgrunnlagSkjermet(
+                    behandlingId: UUID,
+                    epsFnr: Fnr,
+                ): Either<SøknadsbehandlingService.KunneIkkeLeggeTilBosituasjonEpsGrunnlag, Grunnlag.Bosituasjon> {
+                    assertHarTilgangTilBehandling(behandlingId)
+                    return services.søknadsbehandling.leggTilBosituasjonEpsgrunnlagSkjermet(behandlingId, epsFnr)
+                }
+
                 override fun fullførBosituasjongrunnlag(request: FullførBosituasjonRequest): Either<SøknadsbehandlingService.KunneIkkeFullføreBosituasjonGrunnlag, Søknadsbehandling> {
                     assertHarTilgangTilBehandling(request.behandlingId)
                     return services.søknadsbehandling.fullførBosituasjongrunnlag(request)

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingService.kt
@@ -2,10 +2,12 @@ package no.nav.su.se.bakover.service.søknadsbehandling
 
 import arrow.core.Either
 import no.nav.su.se.bakover.common.persistence.SessionContext
+import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.behandling.Attestering
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.avslag.AvslagManglendeDokumentasjon
+import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
 import no.nav.su.se.bakover.domain.grunnlag.KunneIkkeLageGrunnlagsdata
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimuleringFeilet
 import no.nav.su.se.bakover.domain.søknadsbehandling.KunneIkkeIverksette
@@ -33,6 +35,7 @@ interface SøknadsbehandlingService {
     fun oppdaterStønadsperiode(request: OppdaterStønadsperiodeRequest): Either<KunneIkkeOppdatereStønadsperiode, Søknadsbehandling>
     fun leggTilUføregrunnlag(request: LeggTilUførevurderingRequest): Either<KunneIkkeLeggeTilGrunnlag, Søknadsbehandling>
     fun leggTilBosituasjonEpsgrunnlag(request: LeggTilBosituasjonEpsRequest): Either<KunneIkkeLeggeTilBosituasjonEpsGrunnlag, Søknadsbehandling>
+    fun leggTilBosituasjonEpsgrunnlagSkjermet(behandlingId: UUID, epsFnr: Fnr): Either<KunneIkkeLeggeTilBosituasjonEpsGrunnlag, Grunnlag.Bosituasjon>
     fun fullførBosituasjongrunnlag(request: FullførBosituasjonRequest): Either<KunneIkkeFullføreBosituasjonGrunnlag, Søknadsbehandling>
     fun leggTilFradragsgrunnlag(request: LeggTilFradragsgrunnlagRequest): Either<KunneIkkeLeggeTilFradragsgrunnlag, Søknadsbehandling>
     fun hentForSøknad(søknadId: UUID): Søknadsbehandling?

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceImpl.kt
@@ -9,6 +9,7 @@ import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.persistence.SessionContext
 import no.nav.su.se.bakover.database.søknadsbehandling.SøknadsbehandlingRepo
 import no.nav.su.se.bakover.database.vedtak.VedtakRepo
+import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.behandling.BehandlingMedOppgave
@@ -25,6 +26,7 @@ import no.nav.su.se.bakover.domain.journal.JournalpostId
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
+import no.nav.su.se.bakover.domain.person.KunneIkkeHentePerson
 import no.nav.su.se.bakover.domain.søknadsbehandling.KunneIkkeIverksette
 import no.nav.su.se.bakover.domain.søknadsbehandling.LukketSøknadsbehandling
 import no.nav.su.se.bakover.domain.søknadsbehandling.NySøknadsbehandling
@@ -616,6 +618,37 @@ internal class SøknadsbehandlingServiceImpl(
                 )
             }.right()
         }
+    }
+
+    override fun leggTilBosituasjonEpsgrunnlagSkjermet(
+        behandlingId: UUID,
+        epsFnr: Fnr,
+    ): Either<KunneIkkeLeggeTilBosituasjonEpsGrunnlag, Grunnlag.Bosituasjon> {
+        val søknadsbehandling = søknadsbehandlingRepo.hent(behandlingId)
+            ?: return KunneIkkeLeggeTilBosituasjonEpsGrunnlag.FantIkkeBehandling.left()
+
+        if (søknadsbehandling is Søknadsbehandling.Iverksatt || søknadsbehandling is Søknadsbehandling.TilAttestering)
+            return KunneIkkeLeggeTilBosituasjonEpsGrunnlag.UgyldigTilstand(
+                søknadsbehandling::class,
+                Søknadsbehandling.Vilkårsvurdert::class,
+            ).left()
+
+        // Her vet vi egentlig at hentPerson returnerer `IkkeTilgangTilPerson`, men dobbeltsjekker at vi ikke får andre feil fra PDL
+        personService.hentPerson(epsFnr).let {
+            if (it is Either.Left && (it.value is KunneIkkeHentePerson.FantIkkePerson || it.value is KunneIkkeHentePerson.Ukjent)) {
+                return KunneIkkeLeggeTilBosituasjonEpsGrunnlag.KlarteIkkeHentePersonIPdl.left()
+            }
+        }
+
+        val bosituasjon = Grunnlag.Bosituasjon.Ufullstendig.HarEps(
+            id = UUID.randomUUID(),
+            opprettet = Tidspunkt.now(clock),
+            periode = søknadsbehandling.periode,
+            fnr = epsFnr,
+        )
+
+        grunnlagService.lagreBosituasjongrunnlag(behandlingId = behandlingId, listOf(bosituasjon))
+        return bosituasjon.right()
     }
 
     override fun fullførBosituasjongrunnlag(request: FullførBosituasjonRequest): Either<KunneIkkeFullføreBosituasjonGrunnlag, Søknadsbehandling> {

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/Resultat.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/Resultat.kt
@@ -23,6 +23,8 @@ internal data class Resultat private constructor(
     companion object {
         fun json(httpCode: HttpStatusCode, json: String): Resultat =
             Resultat(httpCode, json, contentType = ContentType.Application.Json)
+
+        fun okJson(httpCode: HttpStatusCode) = json(httpCode, """{"status": "OK"}""")
     }
 }
 

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/GrunnlagBosituasjonEpsSkjermetRoutesTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/GrunnlagBosituasjonEpsSkjermetRoutesTest.kt
@@ -1,0 +1,88 @@
+package no.nav.su.se.bakover.web.routes.søknadsbehandling
+
+import arrow.core.right
+import io.kotest.matchers.shouldBe
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.setBody
+import io.ktor.server.testing.withTestApplication
+import no.nav.su.se.bakover.common.Tidspunkt
+import no.nav.su.se.bakover.domain.Brukerrolle
+import no.nav.su.se.bakover.domain.Fnr
+import no.nav.su.se.bakover.domain.Saksnummer
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
+import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
+import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
+import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
+import no.nav.su.se.bakover.domain.oppgave.OppgaveId
+import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
+import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
+import no.nav.su.se.bakover.service.søknadsbehandling.SøknadsbehandlingService
+import no.nav.su.se.bakover.test.generer
+import no.nav.su.se.bakover.web.TestServicesBuilder
+import no.nav.su.se.bakover.web.defaultRequest
+import no.nav.su.se.bakover.web.routes.sak.sakPath
+import no.nav.su.se.bakover.web.routes.søknadsbehandling.BehandlingTestUtils.journalførtSøknadMedOppgave
+import no.nav.su.se.bakover.web.routes.søknadsbehandling.BehandlingTestUtils.stønadsperiode
+import no.nav.su.se.bakover.web.testSusebakover
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import java.util.UUID
+
+class GrunnlagBosituasjonEpsSkjermetRoutesTest {
+
+    private val services = TestServicesBuilder.services()
+    private val fnr = Fnr.generer()
+    private val søknadsbehandling: Søknadsbehandling.Vilkårsvurdert.Uavklart =
+        Søknadsbehandling.Vilkårsvurdert.Uavklart(
+            id = UUID.randomUUID(),
+            opprettet = Tidspunkt.EPOCH,
+            sakId = UUID.randomUUID(),
+            saksnummer = Saksnummer(2021),
+            søknad = journalførtSøknadMedOppgave,
+            oppgaveId = OppgaveId("oppgaveId"),
+            behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon(),
+            fnr = Fnr.generer(),
+            fritekstTilBrev = "",
+            stønadsperiode = stønadsperiode,
+            grunnlagsdata = Grunnlagsdata.IkkeVurdert,
+            vilkårsvurderinger = Vilkårsvurderinger.Søknadsbehandling.IkkeVurdert,
+            attesteringer = Attesteringshistorikk.empty(),
+        )
+    private val epsGrunnlag: Grunnlag.Bosituasjon.Ufullstendig.HarEps = Grunnlag.Bosituasjon.Ufullstendig.HarEps(
+        id = UUID.randomUUID(),
+        opprettet = Tidspunkt.now(),
+        periode = søknadsbehandling.periode,
+        fnr = fnr,
+    )
+
+    @Test
+    fun `lagre EPS når EPS har kode 6`() {
+        val søknadsbehandlingServiceMock = mock<SøknadsbehandlingService> {
+            on { leggTilBosituasjonEpsgrunnlagSkjermet(any(), any()) } doReturn epsGrunnlag.right()
+        }
+
+        withTestApplication(
+            {
+                testSusebakover(services = services.copy(søknadsbehandling = søknadsbehandlingServiceMock))
+            },
+        ) {
+            defaultRequest(
+                HttpMethod.Post,
+                "$sakPath/${søknadsbehandling.sakId}/behandlinger/${søknadsbehandling.id}/grunnlag/bosituasjon/eps/skjermet",
+                listOf(Brukerrolle.Saksbehandler),
+            ) {
+                setBody("""{ "epsFnr": "$fnr"}""".trimIndent())
+            }.apply {
+                response.status() shouldBe HttpStatusCode.Created
+                response.content shouldBe """{"status": "OK"}"""
+                verify(søknadsbehandlingServiceMock).leggTilBosituasjonEpsgrunnlagSkjermet(søknadsbehandling.id, fnr)
+                verifyNoMoreInteractions(søknadsbehandlingServiceMock)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Håndterer dette som et eget endepunkt for å ikke blande det inn i logikken som også setter mer info om EPS på behandlingsinformasjon.

https://github.com/navikt/su-se-framover/pull/1307