### PR TITLE
Håndter begge feilsituasjoner i kvittering-listeneren fra Oppdrag

### DIFF
--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
@@ -500,7 +500,7 @@ open class AccessCheckProxy(
                 }
             },
             ferdigstillVedtak = object : FerdigstillVedtakService {
-                override fun ferdigstillVedtakEtterUtbetaling(utbetaling: Utbetaling.OversendtUtbetaling.MedKvittering): Unit =
+                override fun ferdigstillVedtakEtterUtbetaling(utbetaling: Utbetaling.OversendtUtbetaling.MedKvittering): Either<FerdigstillVedtakService.KunneIkkeFerdigstilleVedtak, Unit> =
                     kastKanKunKallesFraAnnenService()
 
                 override fun lukkOppgaveMedBruker(vedtak: Vedtak): Either<FerdigstillVedtakService.KunneIkkeFerdigstilleVedtak.KunneIkkeLukkeOppgave, Vedtak> =

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceImpl.kt
@@ -359,7 +359,7 @@ internal class SøknadsbehandlingServiceImpl(
                     val vedtak = Vedtak.fromSøknadsbehandling(iverksattBehandling, utbetaling!!.id, clock)
                     vedtakRepo.lagre(vedtak)
 
-                    log.info("Iverksatt innvilgelse for behandling ${iverksattBehandling.id}")
+                    log.info("Iverksatt innvilgelse for behandling ${iverksattBehandling.id}, vedtak: ${vedtak.id}")
                     opprettVedtakssnapshotService.opprettVedtak(
                         vedtakssnapshot = Vedtakssnapshot.Innvilgelse.createFromBehandling(
                             iverksattBehandling,

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/services/utbetaling/kvittering/LokalKvitteringJobTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/services/utbetaling/kvittering/LokalKvitteringJobTest.kt
@@ -83,11 +83,12 @@ internal class LokalKvitteringJobTest {
             kvittering = kvittering
         )
         val utbetalingServiceMock = mock<UtbetalingService> {
-
             on { oppdaterMedKvittering(any(), any()) } doReturn utbetalingMedKvittering.right()
         }
         val innvilgetSøknadsbehandling = mock<Søknadsbehandling.Iverksatt.Innvilget> {}
-        val ferdigstillVedtakServiceMock = mock<FerdigstillVedtakService>()
+        val ferdigstillVedtakServiceMock = mock<FerdigstillVedtakService> {
+            on { ferdigstillVedtakEtterUtbetaling(any()) } doReturn Unit.right()
+        }
 
         val utbetalingKvitteringConsumer = UtbetalingKvitteringConsumer(
             utbetalingService = utbetalingServiceMock,

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/services/utbetaling/kvittering/UtbetalingKvitteringResponseTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/services/utbetaling/kvittering/UtbetalingKvitteringResponseTest.kt
@@ -22,7 +22,7 @@ internal class UtbetalingKvitteringResponseTest {
                 mqCompletionKode = null,
                 mqReasonKode = null,
                 programId = null,
-                sectionNavn = null
+                sectionNavn = null,
             ),
             oppdragRequest = UtbetalingRequest.OppdragRequest(
                 kodeAksjon = UtbetalingRequest.KodeAksjon.UTBETALING,
@@ -36,14 +36,14 @@ internal class UtbetalingKvitteringResponseTest {
                 avstemming = UtbetalingRequest.Avstemming(
                     kodeKomponent = "SU",
                     nokkelAvstemming = avstemmingsnøkkelIXml,
-                    tidspktMelding = avstemmingsnøkkelTidspunktIXml
+                    tidspktMelding = avstemmingsnøkkelTidspunktIXml,
                 ),
                 oppdragsEnheter = listOf(
                     UtbetalingRequest.OppdragsEnhet(
                         typeEnhet = "BOS",
                         enhet = "8020",
-                        datoEnhetFom = "1970-01-01"
-                    )
+                        datoEnhetFom = "1970-01-01",
+                    ),
                 ),
                 oppdragslinjer = listOf(
                     UtbetalingRequest.Oppdragslinje(


### PR DESCRIPTION
Vi har en race-condition mellom saksbehandler-initiert iverksett (som bl.a. legger en melding på kø til oppdrag, og så persisterer utbetaling og vedtak), og kvittering-handleren fra Oppdrag, som prøver å oppdatere/bruke den nevnte utbetalingen og vedtaket.
Vi har hatt en Grei Nok™ fiks som sover i et sekund og prøver på nytt i kvittering-handleren, men denne har kun tatt for seg feil ved henting av utbetalingen og ikke vedtaket (som den gjør nå). 

Logger også litt mer slik at vi kan spore bedre hva som faktisk skjer i hvilken rekkefølge når vi iverksetter.