### PR TITLE
Liten opprydding i web-tester

### DIFF
--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/TestDatabaseBuilder.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/TestDatabaseBuilder.kt
@@ -1,0 +1,63 @@
+package no.nav.su.se.bakover.web
+
+import no.nav.su.se.bakover.database.DatabaseRepos
+import no.nav.su.se.bakover.database.avstemming.AvstemmingRepo
+import no.nav.su.se.bakover.database.grunnlag.FormueVilkårsvurderingRepo
+import no.nav.su.se.bakover.database.grunnlag.GrunnlagRepo
+import no.nav.su.se.bakover.database.grunnlag.UføreVilkårsvurderingRepo
+import no.nav.su.se.bakover.database.hendelse.PersonhendelseRepo
+import no.nav.su.se.bakover.database.hendelseslogg.HendelsesloggRepo
+import no.nav.su.se.bakover.database.person.PersonRepo
+import no.nav.su.se.bakover.database.revurdering.RevurderingRepo
+import no.nav.su.se.bakover.database.sak.SakRepo
+import no.nav.su.se.bakover.database.søknad.SøknadRepo
+import no.nav.su.se.bakover.database.søknadsbehandling.SøknadsbehandlingRepo
+import no.nav.su.se.bakover.database.utbetaling.UtbetalingRepo
+import no.nav.su.se.bakover.database.vedtak.VedtakRepo
+import no.nav.su.se.bakover.database.vedtak.snapshot.VedtakssnapshotRepo
+import no.nav.su.se.bakover.domain.dokument.DokumentRepo
+import no.nav.su.se.bakover.domain.nøkkeltall.NøkkeltallRepo
+import no.nav.su.se.bakover.test.TestSessionFactory
+import org.mockito.kotlin.mock
+
+object TestDatabaseBuilder {
+    fun build(
+        avstemming: AvstemmingRepo = mock(),
+        utbetaling: UtbetalingRepo = mock(),
+        søknad: SøknadRepo = mock(),
+        hendelseslogg: HendelsesloggRepo = mock(),
+        sak: SakRepo = mock(),
+        person: PersonRepo = mock(),
+        vedtakssnapshot: VedtakssnapshotRepo = mock(),
+        søknadsbehandling: SøknadsbehandlingRepo = mock(),
+        revurderingRepo: RevurderingRepo = mock(),
+        vedtakRepo: VedtakRepo = mock(),
+        grunnlagRepo: GrunnlagRepo = mock(),
+        uføreVilkårsvurderingRepo: UføreVilkårsvurderingRepo = mock(),
+        formueVilkårsvurderingRepo: FormueVilkårsvurderingRepo = mock(),
+        personhendelseRepo: PersonhendelseRepo = mock(),
+        dokumentRepo: DokumentRepo = mock(),
+        nøkkeltallRepo: NøkkeltallRepo = mock(),
+        sessionFactory: TestSessionFactory = TestSessionFactory(),
+    ): DatabaseRepos {
+        return DatabaseRepos(
+            avstemming = avstemming,
+            utbetaling = utbetaling,
+            søknad = søknad,
+            hendelseslogg = hendelseslogg,
+            sak = sak,
+            person = person,
+            vedtakssnapshot = vedtakssnapshot,
+            søknadsbehandling = søknadsbehandling,
+            revurderingRepo = revurderingRepo,
+            vedtakRepo = vedtakRepo,
+            grunnlagRepo = grunnlagRepo,
+            uføreVilkårsvurderingRepo = uføreVilkårsvurderingRepo,
+            formueVilkårsvurderingRepo = formueVilkårsvurderingRepo,
+            personhendelseRepo = personhendelseRepo,
+            dokumentRepo = dokumentRepo,
+            nøkkeltallRepo = nøkkeltallRepo,
+            sessionFactory = sessionFactory,
+        )
+    }
+}

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/TestServicesBuilder.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/TestServicesBuilder.kt
@@ -1,26 +1,61 @@
 package no.nav.su.se.bakover.web
 
 import no.nav.su.se.bakover.service.Services
+import no.nav.su.se.bakover.service.avstemming.AvstemmingService
+import no.nav.su.se.bakover.service.brev.BrevService
+import no.nav.su.se.bakover.service.grunnlag.GrunnlagService
+import no.nav.su.se.bakover.service.nøkkeltall.NøkkeltallService
+import no.nav.su.se.bakover.service.oppgave.OppgaveService
+import no.nav.su.se.bakover.service.person.PersonService
+import no.nav.su.se.bakover.service.revurdering.RevurderingService
+import no.nav.su.se.bakover.service.sak.SakService
+import no.nav.su.se.bakover.service.statistikk.StatistikkService
+import no.nav.su.se.bakover.service.søknad.AvslåSøknadManglendeDokumentasjonService
+import no.nav.su.se.bakover.service.søknad.SøknadService
+import no.nav.su.se.bakover.service.søknad.lukk.LukkSøknadService
+import no.nav.su.se.bakover.service.søknadsbehandling.SøknadsbehandlingService
+import no.nav.su.se.bakover.service.toggles.ToggleService
+import no.nav.su.se.bakover.service.utbetaling.UtbetalingService
+import no.nav.su.se.bakover.service.vedtak.FerdigstillVedtakService
+import no.nav.su.se.bakover.service.vedtak.VedtakService
 import org.mockito.kotlin.mock
 
 object TestServicesBuilder {
-    fun services(): Services = Services(
-        avstemming = mock(),
-        utbetaling = mock(),
-        sak = mock(),
-        søknad = mock(),
-        brev = mock(),
-        lukkSøknad = mock(),
-        oppgave = mock(),
-        person = mock(),
-        statistikk = mock(),
-        toggles = mock(),
-        søknadsbehandling = mock(),
-        ferdigstillVedtak = mock(),
-        revurdering = mock(),
-        vedtakService = mock(),
-        grunnlagService = mock(),
-        nøkkeltallService = mock(),
-        avslåSøknadManglendeDokumentasjonService = mock(),
+    fun services(
+        avstemming: AvstemmingService = mock(),
+        utbetaling: UtbetalingService = mock(),
+        sak: SakService = mock(),
+        søknad: SøknadService = mock(),
+        brev: BrevService = mock(),
+        lukkSøknad: LukkSøknadService = mock(),
+        oppgave: OppgaveService = mock(),
+        person: PersonService = mock(),
+        statistikk: StatistikkService = mock(),
+        toggles: ToggleService = mock(),
+        søknadsbehandling: SøknadsbehandlingService = mock(),
+        ferdigstillVedtak: FerdigstillVedtakService = mock(),
+        revurdering: RevurderingService = mock(),
+        vedtakService: VedtakService = mock(),
+        grunnlagService: GrunnlagService = mock(),
+        nøkkeltallService: NøkkeltallService = mock(),
+        avslåSøknadManglendeDokumentasjonService: AvslåSøknadManglendeDokumentasjonService = mock(),
+    ): Services = Services(
+        avstemming = avstemming,
+        utbetaling = utbetaling,
+        sak = sak,
+        søknad = søknad,
+        brev = brev,
+        lukkSøknad = lukkSøknad,
+        oppgave = oppgave,
+        person = person,
+        statistikk = statistikk,
+        toggles = toggles,
+        søknadsbehandling = søknadsbehandling,
+        ferdigstillVedtak = ferdigstillVedtak,
+        revurdering = revurdering,
+        vedtakService = vedtakService,
+        grunnlagService = grunnlagService,
+        nøkkeltallService = nøkkeltallService,
+        avslåSøknadManglendeDokumentasjonService = avslåSøknadManglendeDokumentasjonService,
     )
 }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/avstemming/AvstemmingRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/avstemming/AvstemmingRoutesKtTest.kt
@@ -11,43 +11,20 @@ import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.endOfDay
 import no.nav.su.se.bakover.common.startOfDay
-import no.nav.su.se.bakover.database.DatabaseBuilder
-import no.nav.su.se.bakover.database.DatabaseRepos
-import no.nav.su.se.bakover.database.withMigratedDb
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.oppdrag.avstemming.Avstemming
-import no.nav.su.se.bakover.service.ServiceBuilder
 import no.nav.su.se.bakover.service.avstemming.AvstemmingFeilet
 import no.nav.su.se.bakover.service.avstemming.AvstemmingService
-import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.fixedLocalDate
 import no.nav.su.se.bakover.test.fixedTidspunkt
-import no.nav.su.se.bakover.web.TestClientsBuilder
-import no.nav.su.se.bakover.web.applicationConfig
-import no.nav.su.se.bakover.web.dbMetricsStub
+import no.nav.su.se.bakover.web.TestServicesBuilder
 import no.nav.su.se.bakover.web.defaultRequest
 import no.nav.su.se.bakover.web.testSusebakover
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
-import javax.sql.DataSource
 
 internal class AvstemmingRoutesKtTest {
-    private fun repos(dataSource: DataSource) = DatabaseBuilder.build(
-        embeddedDatasource = dataSource,
-        dbMetrics = dbMetricsStub,
-        clock = fixedClock,
-    )
-
-    private fun services(databaseRepos: DatabaseRepos) = ServiceBuilder.build(
-        databaseRepos = databaseRepos,
-        clients = TestClientsBuilder.build(applicationConfig),
-        behandlingMetrics = mock(),
-        søknadMetrics = mock(),
-        clock = fixedClock,
-        unleash = mock(),
-    )
 
     private val dummyAvstemming = Avstemming.Grensesnittavstemming(
         id = UUID30.randomUUID(),
@@ -58,7 +35,7 @@ internal class AvstemmingRoutesKtTest {
         avstemmingXmlRequest = null,
     )
 
-    private val happyAvstemmingService = object : AvstemmingService {
+    private fun happyAvstemmingService() = object : AvstemmingService {
         override fun grensesnittsavstemming(): Either<AvstemmingFeilet, Avstemming.Grensesnittavstemming> {
             return dummyAvstemming.right()
         }
@@ -84,27 +61,140 @@ internal class AvstemmingRoutesKtTest {
         }
     }
 
+    private fun services() = TestServicesBuilder.services().copy(
+        avstemming = happyAvstemmingService(),
+    )
+
     @Test
     fun `kall uten parametre gir OK`() {
-        withMigratedDb { dataSource ->
-            val repos = repos(dataSource)
-            val services = services(repos).copy(
-                avstemming = happyAvstemmingService,
-            )
+        withTestApplication(
+            ({ testSusebakover(services = services()) }),
+        ) {
+            defaultRequest(
+                HttpMethod.Post,
+                "/avstemming/grensesnitt",
+                listOf(Brukerrolle.Drift),
+            ).apply {
+                response.status() shouldBe HttpStatusCode.OK
+            }
+        }
+    }
 
-            withTestApplication(
-                {
-                    testSusebakover(
-                        services = services.copy(
-                            avstemming = happyAvstemmingService,
-                        ),
-                        clock = fixedClock,
-                    )
-                },
-            ) {
+    @Test
+    fun `kall med enten fraOgMed _eller_ tilOgMed feiler`() {
+        withTestApplication(
+            ({ testSusebakover(services = services()) }),
+        ) {
+            defaultRequest(
+                HttpMethod.Post,
+                "/avstemming/grensesnitt?fraOgMed=2020-11-01",
+                listOf(Brukerrolle.Drift),
+            ).apply {
+                response.status() shouldBe HttpStatusCode.BadRequest
+            }
+
+            defaultRequest(
+                HttpMethod.Post,
+                "/avstemming/grensesnitt?tilOgMed=2020-11-01",
+                listOf(Brukerrolle.Drift),
+            ).apply {
+                response.status() shouldBe HttpStatusCode.BadRequest
+            }
+        }
+    }
+
+    @Test
+    fun `kall med fraOgMed eller tilOgMed på feil format feiler`() {
+        withTestApplication(
+            ({ testSusebakover(services = services()) }),
+        ) {
+            listOf(
+                "/avstemming/grensesnitt?fraOgMed=2020-11-17T11:02:19Z&tilOgMed=2020-11-17",
+                "/avstemming/grensesnitt?fraOgMed=2020-11-12T11:02:19Z&tilOgMed=2020-11-17T11:02:19Z",
+            ).forEach {
                 defaultRequest(
                     HttpMethod.Post,
-                    "/avstemming/grensesnitt",
+                    it,
+                    listOf(Brukerrolle.Drift),
+                ).apply {
+                    response.status() shouldBe HttpStatusCode.BadRequest
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `kall med fraOgMed eller tilOgMed må ha fraOgMed før tilOgMed`() {
+        withTestApplication(
+            ({ testSusebakover(services = services()) }),
+        ) {
+            listOf(
+                "/avstemming/grensesnitt?fraOgMed=2020-11-18&tilOgMed=2020-11-17",
+                "/avstemming/grensesnitt?fraOgMed=2021-11-18&tilOgMed=2020-11-12",
+            ).forEach {
+                defaultRequest(
+                    HttpMethod.Post,
+                    it,
+                    listOf(Brukerrolle.Drift),
+                ).apply {
+                    response.status() shouldBe HttpStatusCode.BadRequest
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `kall med tilOgMed etter dagens dato feiler`() {
+        withTestApplication(
+            ({ testSusebakover(services = services()) }),
+        ) {
+            listOf(
+                "/avstemming/grensesnitt?fraOgMed=2020-11-11&tilOgMed=${
+                fixedLocalDate.plusDays(1).format(DateTimeFormatter.ISO_DATE)
+                }",
+            ).forEach {
+                defaultRequest(
+                    HttpMethod.Post,
+                    it,
+                    listOf(Brukerrolle.Drift),
+                ).apply {
+                    response.status() shouldBe HttpStatusCode.BadRequest
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `kall til konsistensavstemming uten fraOgMed går ikke`() {
+        withTestApplication(
+            ({ testSusebakover(services = services()) }),
+        ) {
+            listOf(
+                "/avstemming/konsistens",
+            ).forEach {
+                defaultRequest(
+                    HttpMethod.Post,
+                    it,
+                    listOf(Brukerrolle.Drift),
+                ).apply {
+                    response.status() shouldBe HttpStatusCode.BadRequest
+                    response.content shouldContain "'fraOgMed' mangler"
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `kall til konsistensavstemming går fint`() {
+        withTestApplication(
+            ({ testSusebakover(services = services()) }),
+        ) {
+            listOf(
+                "/avstemming/konsistens?fraOgMed=2021-01-01",
+            ).forEach {
+                defaultRequest(
+                    HttpMethod.Post,
+                    it,
                     listOf(Brukerrolle.Drift),
                 ).apply {
                     response.status() shouldBe HttpStatusCode.OK
@@ -114,189 +204,21 @@ internal class AvstemmingRoutesKtTest {
     }
 
     @Test
-    fun `kall med enten fraOgMed _eller_ tilOgMed feiler`() {
-        withMigratedDb { dataSource ->
-            val repos = repos(dataSource)
-            val services = services(repos).copy(
-                avstemming = happyAvstemmingService,
-            )
-            withTestApplication(
-                {
-                    testSusebakover(
-                        services = services,
-                    )
-                },
-            ) {
-                defaultRequest(
-                    HttpMethod.Post,
-                    "/avstemming/grensesnitt?fraOgMed=2020-11-01",
-                    listOf(Brukerrolle.Drift),
-                ).apply {
-                    response.status() shouldBe HttpStatusCode.BadRequest
-                }
-
-                defaultRequest(
-                    HttpMethod.Post,
-                    "/avstemming/grensesnitt?tilOgMed=2020-11-01",
-                    listOf(Brukerrolle.Drift),
-                ).apply {
-                    response.status() shouldBe HttpStatusCode.BadRequest
-                }
-            }
-        }
-    }
-
-    @Test
-    fun `kall med fraOgMed eller tilOgMed på feil format feiler`() {
-        withMigratedDb { dataSource ->
-            val repos = repos(dataSource)
-            val services = services(repos).copy(
-                avstemming = happyAvstemmingService,
-            )
-            withTestApplication(
-                {
-                    testSusebakover(
-                        services = services,
-                    )
-                },
-            ) {
-                listOf(
-                    "/avstemming/grensesnitt?fraOgMed=2020-11-17T11:02:19Z&tilOgMed=2020-11-17",
-                    "/avstemming/grensesnitt?fraOgMed=2020-11-12T11:02:19Z&tilOgMed=2020-11-17T11:02:19Z",
-                ).forEach {
+    fun `kun driftspersonell kan kalle endepunktet for avstemming`() {
+        withTestApplication(
+            ({ testSusebakover(services = services()) }),
+        ) {
+            Brukerrolle.values()
+                .filterNot { it == Brukerrolle.Drift }
+                .forEach {
                     defaultRequest(
                         HttpMethod.Post,
-                        it,
-                        listOf(Brukerrolle.Drift),
+                        "/avstemming/konsistens?fraOgMed=2021-01-01",
+                        listOf(Brukerrolle.Veileder),
                     ).apply {
-                        response.status() shouldBe HttpStatusCode.BadRequest
+                        response.status() shouldBe HttpStatusCode.Forbidden
                     }
                 }
-            }
-        }
-    }
-
-    @Test
-    fun `kall med fraOgMed eller tilOgMed må ha fraOgMed før tilOgMed`() {
-        withMigratedDb { dataSource ->
-            val repos = repos(dataSource)
-            val services = services(repos).copy(
-                avstemming = happyAvstemmingService,
-            )
-            withTestApplication(
-                {
-                    testSusebakover(
-                        services = services.copy(
-                            avstemming = happyAvstemmingService,
-                        ),
-                    )
-                },
-            ) {
-                listOf(
-                    "/avstemming/grensesnitt?fraOgMed=2020-11-18&tilOgMed=2020-11-17",
-                    "/avstemming/grensesnitt?fraOgMed=2021-11-18&tilOgMed=2020-11-12",
-                ).forEach {
-                    defaultRequest(
-                        HttpMethod.Post,
-                        it,
-                        listOf(Brukerrolle.Drift),
-                    ).apply {
-                        response.status() shouldBe HttpStatusCode.BadRequest
-                    }
-                }
-            }
-        }
-    }
-
-    @Test
-    fun `kall med tilOgMed etter dagens dato feiler`() {
-        withMigratedDb { dataSource ->
-            val repos = repos(dataSource)
-            val services = services(repos).copy(
-                avstemming = happyAvstemmingService,
-            )
-            withTestApplication(
-                {
-                    testSusebakover(
-                        services = services,
-                    )
-                },
-            ) {
-                listOf(
-                    "/avstemming/grensesnitt?fraOgMed=2020-11-11&tilOgMed=${
-                    fixedLocalDate.plusDays(1).format(DateTimeFormatter.ISO_DATE)
-                    }",
-                ).forEach {
-                    defaultRequest(
-                        HttpMethod.Post,
-                        it,
-                        listOf(Brukerrolle.Drift),
-                    ).apply {
-                        response.status() shouldBe HttpStatusCode.BadRequest
-                    }
-                }
-            }
-        }
-    }
-
-    @Test
-    fun `kall til konsistensavstemming uten fraOgMed går ikke`() {
-        withMigratedDb { dataSource ->
-            val repos = repos(dataSource)
-            val services = services(repos).copy(
-                avstemming = happyAvstemmingService,
-            )
-            withTestApplication(
-                {
-                    testSusebakover(
-                        services = services,
-                    )
-                },
-            ) {
-                listOf(
-                    "/avstemming/konsistens",
-                ).forEach {
-                    defaultRequest(
-                        HttpMethod.Post,
-                        it,
-                        listOf(Brukerrolle.Drift),
-                    ).apply {
-                        response.status() shouldBe HttpStatusCode.BadRequest
-                        response.content shouldContain "'fraOgMed' mangler"
-                    }
-                }
-            }
-        }
-    }
-
-    @Test
-    fun `kall til konsistensavstemming går fint`() {
-        withMigratedDb { dataSource ->
-            val repos = repos(dataSource)
-            val services = services(repos).copy(
-                avstemming = happyAvstemmingService,
-            )
-            withTestApplication(
-                {
-                    testSusebakover(
-                        services = services.copy(
-                            avstemming = happyAvstemmingService,
-                        ),
-                    )
-                },
-            ) {
-                listOf(
-                    "/avstemming/konsistens?fraOgMed=2021-01-01",
-                ).forEach {
-                    defaultRequest(
-                        HttpMethod.Post,
-                        it,
-                        listOf(Brukerrolle.Drift),
-                    ).apply {
-                        response.status() shouldBe HttpStatusCode.OK
-                    }
-                }
-            }
         }
     }
 }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/me/MeRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/me/MeRoutesKtTest.kt
@@ -9,7 +9,6 @@ import io.ktor.server.testing.handleRequest
 import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.common.deserialize
 import no.nav.su.se.bakover.domain.Brukerrolle
-import no.nav.su.se.bakover.web.TestClientsBuilder
 import no.nav.su.se.bakover.web.jwtStub
 import no.nav.su.se.bakover.web.stubs.asBearerToken
 import no.nav.su.se.bakover.web.testSusebakover
@@ -19,22 +18,22 @@ internal class MeRoutesKtTest {
 
     @Test
     fun `GET me should return NAVIdent and roller`() {
-        withTestApplication({
-            testSusebakover(
-                clients = TestClientsBuilder.testClients
-            )
-        }) {
+        withTestApplication(
+            {
+                testSusebakover()
+            },
+        ) {
             handleRequest(
                 HttpMethod.Get,
-                "/me"
+                "/me",
             ) {
                 addHeader(
                     HttpHeaders.Authorization,
                     jwtStub.createJwtToken(
                         subject = "random",
                         roller = listOf(Brukerrolle.Attestant),
-                        navIdent = "navidenten"
-                    ).asBearerToken()
+                        navIdent = "navidenten",
+                    ).asBearerToken(),
                 )
             }.apply {
                 response.status() shouldBe HttpStatusCode.OK

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/GjenopptaUtbetalingRouteKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/GjenopptaUtbetalingRouteKtTest.kt
@@ -33,20 +33,16 @@ import java.util.UUID
 
 internal class GjenopptaUtbetalingRouteKtTest {
 
-    private val mockServices = TestServicesBuilder.services()
-
     @Test
     fun `svarer med 201 ved påbegynt gjenopptak av utbetaling`() {
-        val enRevurdering = simulertGjenopptakelseAvytelseFraVedtakStansAvYtelse()
-            .second
-        val revurderingServiceMock = mock<RevurderingService> {
-            on { gjenopptaYtelse(any()) } doReturn enRevurdering.right()
-        }
+        val enRevurdering = simulertGjenopptakelseAvytelseFraVedtakStansAvYtelse().second
         withTestApplication(
             {
                 testSusebakover(
-                    services = mockServices.copy(
-                        revurdering = revurderingServiceMock,
+                    services = TestServicesBuilder.services(
+                        revurdering = mock {
+                            on { gjenopptaYtelse(any()) } doReturn enRevurdering.right()
+                        },
                     ),
                 )
             },
@@ -75,21 +71,20 @@ internal class GjenopptaUtbetalingRouteKtTest {
     @Test
     fun `svarer med 400 ved forsøk å iverksetting av ugyldig revurdering`() {
         val enRevurdering = beregnetRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak().second
-        val revurderingServiceMock = mock<RevurderingService> {
-            on {
-                iverksettGjenopptakAvYtelse(
-                    any(),
-                    any(),
-                )
-            } doReturn KunneIkkeIverksetteGjenopptakAvYtelse.UgyldigTilstand(
-                enRevurdering::class,
-            ).left()
-        }
         withTestApplication(
             {
                 testSusebakover(
-                    services = mockServices.copy(
-                        revurdering = revurderingServiceMock,
+                    services = TestServicesBuilder.services(
+                        revurdering = mock {
+                            on {
+                                iverksettGjenopptakAvYtelse(
+                                    any(),
+                                    any(),
+                                )
+                            } doReturn KunneIkkeIverksetteGjenopptakAvYtelse.UgyldigTilstand(
+                                enRevurdering::class,
+                            ).left()
+                        },
                     ),
                 )
             },
@@ -108,21 +103,20 @@ internal class GjenopptaUtbetalingRouteKtTest {
     @Test
     fun `svarer med 500 hvis utbetaling feiler`() {
         val enRevurdering = beregnetRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak().second
-        val revurderingServiceMock = mock<RevurderingService> {
-            on {
-                iverksettGjenopptakAvYtelse(
-                    any(),
-                    any(),
-                )
-            } doReturn KunneIkkeIverksetteGjenopptakAvYtelse.KunneIkkeUtbetale(
-                UtbetalGjenopptakFeil.KunneIkkeUtbetale(UtbetalingFeilet.SimuleringHarBlittEndretSidenSaksbehandlerSimulerte),
-            ).left()
-        }
         withTestApplication(
             {
                 testSusebakover(
-                    services = mockServices.copy(
-                        revurdering = revurderingServiceMock,
+                    services = TestServicesBuilder.services(
+                        revurdering = mock<RevurderingService> {
+                            on {
+                                iverksettGjenopptakAvYtelse(
+                                    any(),
+                                    any(),
+                                )
+                            } doReturn KunneIkkeIverksetteGjenopptakAvYtelse.KunneIkkeUtbetale(
+                                UtbetalGjenopptakFeil.KunneIkkeUtbetale(UtbetalingFeilet.SimuleringHarBlittEndretSidenSaksbehandlerSimulerte),
+                            ).left()
+                        },
                     ),
                 )
             },
@@ -144,20 +138,22 @@ internal class GjenopptaUtbetalingRouteKtTest {
         val simulertRevurdering = eksisterende.second
         val sisteVedtak = eksisterende.first.vedtakListe.last()
 
-        val revurderingServiceMock = mock<RevurderingService> {
-            doAnswer {
-                val args = (it.arguments[0] as GjenopptaYtelseRequest.Oppdater)
-                simulertRevurdering.copy(
-                    periode = Periode.create(sisteVedtak.periode.fraOgMed, simulertRevurdering.periode.tilOgMed),
-                    revurderingsårsak = args.revurderingsårsak,
-                ).right()
-            }.whenever(mock).gjenopptaYtelse(any())
-        }
         withTestApplication(
             {
                 testSusebakover(
-                    services = mockServices.copy(
-                        revurdering = revurderingServiceMock,
+                    services = TestServicesBuilder.services(
+                        revurdering = mock<RevurderingService> {
+                            doAnswer {
+                                val args = (it.arguments[0] as GjenopptaYtelseRequest.Oppdater)
+                                simulertRevurdering.copy(
+                                    periode = Periode.create(
+                                        sisteVedtak.periode.fraOgMed,
+                                        simulertRevurdering.periode.tilOgMed,
+                                    ),
+                                    revurderingsårsak = args.revurderingsårsak,
+                                ).right()
+                            }.whenever(mock).gjenopptaYtelse(any())
+                        },
                     ),
                 )
             },
@@ -189,14 +185,13 @@ internal class GjenopptaUtbetalingRouteKtTest {
     fun `svarer med 400 ved ugyldig input`() {
         val enRevurdering = simulertGjenopptakelseAvytelseFraVedtakStansAvYtelse()
             .second
-        val revurderingServiceMock = mock<RevurderingService> {
-            on { gjenopptaYtelse(any()) } doReturn enRevurdering.right()
-        }
         withTestApplication(
             {
                 testSusebakover(
-                    services = mockServices.copy(
-                        revurdering = revurderingServiceMock,
+                    services = TestServicesBuilder.services(
+                        revurdering = mock<RevurderingService> {
+                            on { gjenopptaYtelse(any()) } doReturn enRevurdering.right()
+                        },
                     ),
                 )
             },
@@ -225,18 +220,17 @@ internal class GjenopptaUtbetalingRouteKtTest {
 
     @Test
     fun `svarer med 500 ved forsøk på gjenopptak av opphørt periode`() {
-        val revurderingServiceMock = mock<RevurderingService> {
-            on { gjenopptaYtelse(any()) } doReturn KunneIkkeGjenopptaYtelse.KunneIkkeSimulere(
-                SimulerGjenopptakFeil.KunneIkkeGenerereUtbetaling(
-                    Utbetalingsstrategi.Gjenoppta.Feil.KanIkkeGjenopptaOpphørtePeriode,
-                ),
-            ).left()
-        }
         withTestApplication(
             {
                 testSusebakover(
-                    services = mockServices.copy(
-                        revurdering = revurderingServiceMock,
+                    services = TestServicesBuilder.services(
+                        revurdering = mock {
+                            on { gjenopptaYtelse(any()) } doReturn KunneIkkeGjenopptaYtelse.KunneIkkeSimulere(
+                                SimulerGjenopptakFeil.KunneIkkeGenerereUtbetaling(
+                                    Utbetalingsstrategi.Gjenoppta.Feil.KanIkkeGjenopptaOpphørtePeriode,
+                                ),
+                            ).left()
+                        },
                     ),
                 )
             },

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutesKtTest.kt
@@ -57,6 +57,7 @@ import no.nav.su.se.bakover.web.applicationConfig
 import no.nav.su.se.bakover.web.argThat
 import no.nav.su.se.bakover.web.dbMetricsStub
 import no.nav.su.se.bakover.web.defaultRequest
+import no.nav.su.se.bakover.web.embeddedPostgres
 import no.nav.su.se.bakover.web.routes.sak.SakJson
 import no.nav.su.se.bakover.web.routes.sak.SakJson.Companion.toJson
 import no.nav.su.se.bakover.web.routes.sak.sakPath
@@ -146,7 +147,7 @@ internal class SøknadRoutesKtTest {
         var saksnummer: Long
         withTestApplication(
             {
-                testSusebakover()
+                testSusebakover(databaseRepos = embeddedPostgres())
             },
         ) {
             val fnr = Fnr.generer()

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutesKtTest.kt
@@ -108,7 +108,7 @@ internal class SøknadsbehandlingRoutesKtTest {
     @Nested
     inner class `Henting av behandling` {
         @Test
-        fun `Forbidden når bruker veileder eller driftspersonell`() {
+        fun `Forbidden når bruker er veileder eller driftspersonell`() {
             withTestApplication(
                 {
                     testSusebakover()

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutesKtTest.kt
@@ -3,11 +3,9 @@ package no.nav.su.se.bakover.web.routes.søknadsbehandling
 import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
-import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
@@ -21,7 +19,6 @@ import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.deserialize
 import no.nav.su.se.bakover.common.juni
 import no.nav.su.se.bakover.common.mai
-import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.database.DatabaseBuilder
 import no.nav.su.se.bakover.database.DatabaseRepos
@@ -47,6 +44,7 @@ import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
 import no.nav.su.se.bakover.domain.oppgave.OppgaveFeil
 import no.nav.su.se.bakover.domain.oppgave.OppgaveFeil.KunneIkkeOppretteOppgave
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
+import no.nav.su.se.bakover.domain.søknadsbehandling.KunneIkkeIverksette
 import no.nav.su.se.bakover.domain.søknadsbehandling.NySøknadsbehandling
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
 import no.nav.su.se.bakover.service.ServiceBuilder
@@ -64,8 +62,10 @@ import no.nav.su.se.bakover.service.vilkår.LeggTilUførevurderingRequest
 import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.generer
 import no.nav.su.se.bakover.test.lagFradragsgrunnlag
+import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertInnvilget
 import no.nav.su.se.bakover.web.TestClientsBuilder
 import no.nav.su.se.bakover.web.TestClientsBuilder.testClients
+import no.nav.su.se.bakover.web.TestServicesBuilder
 import no.nav.su.se.bakover.web.applicationConfig
 import no.nav.su.se.bakover.web.dbMetricsStub
 import no.nav.su.se.bakover.web.defaultRequest
@@ -79,6 +79,8 @@ import no.nav.su.se.bakover.web.stubs.asBearerToken
 import no.nav.su.se.bakover.web.testSusebakover
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import java.util.UUID
 import javax.sql.DataSource
@@ -106,22 +108,18 @@ internal class SøknadsbehandlingRoutesKtTest {
     @Nested
     inner class `Henting av behandling` {
         @Test
-        fun `Forbidden når bruker bare er veileder`() {
-            withMigratedDb { dataSource ->
-                val repos = repos(dataSource)
-                val services = services(repos)
-                withTestApplication(
-                    {
-                        testSusebakover(
-                            services = services,
-                            databaseRepos = repos,
-                        )
-                    },
+        fun `Forbidden når bruker veileder eller driftspersonell`() {
+            withTestApplication(
+                {
+                    testSusebakover()
+                },
+            ) {
+                repeat(
+                    Brukerrolle.values().filterNot { it == Brukerrolle.Veileder || it == Brukerrolle.Drift }.size,
                 ) {
-                    val objects = setup(services, repos)
                     defaultRequest(
                         HttpMethod.Get,
-                        "$sakPath/${objects.sak.id}/behandlinger/${objects.søknadsbehandling.id}",
+                        "$sakPath/${UUID.randomUUID()}/behandlinger/${UUID.randomUUID()}",
                         listOf(Brukerrolle.Veileder),
                     ).apply {
                         response.status() shouldBe HttpStatusCode.Forbidden
@@ -131,59 +129,27 @@ internal class SøknadsbehandlingRoutesKtTest {
         }
 
         @Test
-        fun `OK når bruker er saksbehandler`() {
-            withMigratedDb { dataSource ->
-                val repos = repos(dataSource)
-                val services = services(repos)
-
-                withTestApplication(
-                    {
-                        testSusebakover(
-                            services = services,
-                            databaseRepos = repos,
-                        )
-                    },
+        fun `OK når bruker er saksbehandler eller attestant`() {
+            withTestApplication(
+                {
+                    testSusebakover(
+                        services = TestServicesBuilder.services(
+                            søknadsbehandling = mock {
+                                on { hent(any()) } doReturn søknadsbehandlingVilkårsvurdertInnvilget().second.right()
+                            },
+                        ),
+                    )
+                },
+            ) {
+                repeat(
+                    Brukerrolle.values().filterNot { it == Brukerrolle.Veileder || it == Brukerrolle.Drift }.size,
                 ) {
-                    val objects = setup(services, repos)
                     defaultRequest(
                         HttpMethod.Get,
-                        "$sakPath/${objects.sak.id}/behandlinger/${objects.søknadsbehandling.id}",
+                        "$sakPath/${UUID.randomUUID()}/behandlinger/${UUID.randomUUID()}",
                         listOf(Brukerrolle.Saksbehandler),
                     ).apply {
-                        objectMapper.readValue<BehandlingJson>(response.content!!).let {
-                            it.id shouldBe objects.søknadsbehandling.id.toString()
-                            it.behandlingsinformasjon shouldNotBe null
-                            it.søknad.id shouldBe objects.søknadsbehandling.søknad.id.toString()
-                        }
-                    }
-                }
-            }
-        }
-
-        @Test
-        fun `OK når bruker er attestant`() {
-            withMigratedDb { dataSource ->
-                val repos = repos(dataSource)
-                val services = services(repos)
-                withTestApplication(
-                    {
-                        testSusebakover(
-                            services = services,
-                            databaseRepos = repos,
-                        )
-                    },
-                ) {
-                    val objects = setup(services, repos)
-                    defaultRequest(
-                        HttpMethod.Get,
-                        "$sakPath/${objects.sak.id}/behandlinger/${objects.søknadsbehandling.id}",
-                        listOf(Brukerrolle.Attestant),
-                    ).apply {
-                        objectMapper.readValue<BehandlingJson>(response.content!!).let {
-                            it.id shouldBe objects.søknadsbehandling.id.toString()
-                            it.behandlingsinformasjon shouldNotBe null
-                            it.søknad.id shouldBe objects.søknadsbehandling.søknad.id.toString()
-                        }
+                        response.status() shouldBe HttpStatusCode.OK
                     }
                 }
             }
@@ -229,7 +195,6 @@ internal class SøknadsbehandlingRoutesKtTest {
 
     @Test
     fun `Opprette en oppgave til attestering feiler mot oppgave`() {
-
         withMigratedDb { dataSource ->
             val repos = repos(dataSource)
             val clients = testClients.copy(
@@ -444,71 +409,86 @@ internal class SøknadsbehandlingRoutesKtTest {
 
         @Test
         fun `Forbidden når bruker ikke er attestant`() {
-            withMigratedDb { dataSource ->
-                val repos = repos(dataSource)
-                val services = services(repos)
-                withFerdigbehandletSakForBruker(services, repos) {
-                    defaultRequest(
-                        HttpMethod.Patch,
-                        "$sakPath/rubbish/behandlinger/${it.søknadsbehandling.id}/iverksett",
-                        listOf(Brukerrolle.Saksbehandler),
-                        navIdentSaksbehandler,
-                    ).apply {
-                        response.status() shouldBe HttpStatusCode.Forbidden
-                    }
+            withTestApplication(
+                {
+                    testSusebakover(
+                        services = TestServicesBuilder.services(
+                            søknadsbehandling = mock {
+                                on { hent(any()) } doReturn SøknadsbehandlingService.FantIkkeBehandling.left()
+                            },
+                        ),
+                    )
+                },
+            ) {
+                defaultRequest(
+                    HttpMethod.Patch,
+                    "$sakPath/rubbish/behandlinger/${UUID.randomUUID()}/iverksett",
+                    listOf(Brukerrolle.Saksbehandler),
+                    navIdentSaksbehandler,
+                ).apply {
+                    response.status() shouldBe HttpStatusCode.Forbidden
+                }
 
-                    defaultRequest(
-                        HttpMethod.Patch,
-                        "$sakPath/${it.sak.id}/behandlinger/${UUID.randomUUID()}/iverksett",
-                        listOf(Brukerrolle.Saksbehandler),
-                    ).apply {
-                        response.status() shouldBe HttpStatusCode.Forbidden
-                    }
+                defaultRequest(
+                    HttpMethod.Patch,
+                    "$sakPath/${UUID.randomUUID()}/behandlinger/${UUID.randomUUID()}/iverksett",
+                    listOf(Brukerrolle.Saksbehandler),
+                ).apply {
+                    response.status() shouldBe HttpStatusCode.Forbidden
                 }
             }
         }
 
         @Test
         fun `BadRequest når behandlingId er ugyldig uuid eller NotFound når den ikke finnes`() {
-            withMigratedDb { dataSource ->
-                val repos = repos(dataSource)
-                val services = services(repos)
-                withFerdigbehandletSakForBruker(services, repos) {
-                    requestSomAttestant(
-                        HttpMethod.Patch,
-                        "$sakPath/rubbish/behandlinger/${UUID.randomUUID()}/iverksett",
-                        navIdentSaksbehandler,
+            withTestApplication(
+                {
+                    testSusebakover(
+                        services = TestServicesBuilder.services(
+                            søknadsbehandling = mock {
+                                on { iverksett(any()) } doReturn KunneIkkeIverksette.FantIkkeBehandling.left()
+                            },
+                        ),
                     )
-                        .apply {
-                            response.status() shouldBe HttpStatusCode.NotFound
-                        }
+                },
+            ) {
+                requestSomAttestant(
+                    HttpMethod.Patch,
+                    "$sakPath/${UUID.randomUUID()}/behandlinger/${UUID.randomUUID()}/iverksett",
+                    navIdentSaksbehandler,
+                ).apply {
+                    response.status() shouldBe HttpStatusCode.NotFound
+                }
 
-                    requestSomAttestant(
-                        HttpMethod.Patch,
-                        "$sakPath/rubbish/behandlinger/rubbish/iverksett",
-                        navIdentSaksbehandler,
-                    )
-                        .apply {
-                            response.status() shouldBe HttpStatusCode.BadRequest
-                        }
+                requestSomAttestant(
+                    HttpMethod.Patch,
+                    "$sakPath/rubbish/behandlinger/rubbish/iverksett",
+                    navIdentSaksbehandler,
+                ).apply {
+                    response.status() shouldBe HttpStatusCode.BadRequest
                 }
             }
         }
 
         @Test
         fun `NotFound når behandling ikke eksisterer`() {
-            withMigratedDb { dataSource ->
-                val repos = repos(dataSource)
-                val services = services(repos)
-                withFerdigbehandletSakForBruker(services, repos) {
-                    requestSomAttestant(
-                        HttpMethod.Patch,
-                        "$sakPath/${it.sak.id}/behandlinger/${UUID.randomUUID()}/iverksett",
-                        navIdentSaksbehandler,
+            withTestApplication(
+                {
+                    testSusebakover(
+                        services = TestServicesBuilder.services(
+                            søknadsbehandling = mock {
+                                on { iverksett(any()) } doReturn KunneIkkeIverksette.FantIkkeBehandling.left()
+                            },
+                        ),
                     )
-                        .apply {
-                            response.status() shouldBe HttpStatusCode.NotFound
-                        }
+                },
+            ) {
+                requestSomAttestant(
+                    HttpMethod.Patch,
+                    "$sakPath/${UUID.randomUUID()}/behandlinger/${UUID.randomUUID()}/iverksett",
+                    navIdentSaksbehandler,
+                ).apply {
+                    response.status() shouldBe HttpStatusCode.NotFound
                 }
             }
         }
@@ -599,79 +579,85 @@ internal class SøknadsbehandlingRoutesKtTest {
 
         @Test
         fun `Forbidden når bruker ikke er attestant`() {
-            withMigratedDb { dataSource ->
-                val repos = repos(dataSource)
-                val services = services(repos)
-                withFerdigbehandletSakForBruker(services, repos) { objects ->
-                    defaultRequest(
-                        HttpMethod.Patch,
-                        "$sakPath/rubbish/behandlinger/${objects.søknadsbehandling.id}/underkjenn",
-                        listOf(Brukerrolle.Saksbehandler),
-                        navIdentSaksbehandler,
-                    ).apply {
-                        response.status() shouldBe HttpStatusCode.Forbidden
-                    }
+            withTestApplication(
+                {
+                    testSusebakover()
+                },
+            ) {
+                defaultRequest(
+                    HttpMethod.Patch,
+                    "$sakPath/rubbish/behandlinger/${UUID.randomUUID()}/underkjenn",
+                    listOf(Brukerrolle.Saksbehandler),
+                    navIdentSaksbehandler,
+                ).apply {
+                    response.status() shouldBe HttpStatusCode.Forbidden
+                }
 
-                    defaultRequest(
-                        HttpMethod.Patch,
-                        "$sakPath/${objects.sak.id}/behandlinger/rubbish/underkjenn",
-                        listOf(Brukerrolle.Saksbehandler),
-                    ).apply {
-                        response.status() shouldBe HttpStatusCode.Forbidden
-                    }
+                defaultRequest(
+                    HttpMethod.Patch,
+                    "$sakPath/${UUID.randomUUID()}/behandlinger/rubbish/underkjenn",
+                    listOf(Brukerrolle.Saksbehandler),
+                ).apply {
+                    response.status() shouldBe HttpStatusCode.Forbidden
+                }
 
-                    defaultRequest(
-                        HttpMethod.Patch,
-                        "$sakPath/${objects.sak.id}/behandlinger/${objects.søknadsbehandling.id}/underkjenn",
-                        listOf(Brukerrolle.Saksbehandler),
-                    ).apply {
-                        response.status() shouldBe HttpStatusCode.Forbidden
-                    }
+                defaultRequest(
+                    HttpMethod.Patch,
+                    "$sakPath/${UUID.randomUUID()}/behandlinger/${UUID.randomUUID()}/underkjenn",
+                    listOf(Brukerrolle.Saksbehandler),
+                ).apply {
+                    response.status() shouldBe HttpStatusCode.Forbidden
                 }
             }
         }
 
         @Test
         fun `BadRequest når sakId eller behandlingId er ugyldig`() {
-            withMigratedDb { dataSource ->
-                val repos = repos(dataSource)
-                val services = services(repos)
-                withFerdigbehandletSakForBruker(services, repos) { objects ->
-                    requestSomAttestant(
-                        HttpMethod.Patch,
-                        "$sakPath/rubbish/behandlinger/${objects.søknadsbehandling.id}/underkjenn",
-                        navIdentSaksbehandler,
-                    ).apply {
-                        response.status() shouldBe HttpStatusCode.BadRequest
-                    }
+            withTestApplication(
+                {
+                    testSusebakover()
+                },
+            ) {
+                requestSomAttestant(
+                    HttpMethod.Patch,
+                    "$sakPath/rubbish/behandlinger/${UUID.randomUUID()}/underkjenn",
+                    navIdentSaksbehandler,
+                ).apply {
+                    response.status() shouldBe HttpStatusCode.BadRequest
+                }
 
-                    requestSomAttestant(
-                        HttpMethod.Patch,
-                        "$sakPath/${objects.sak.id}/behandlinger/rubbish/underkjenn",
-                        navIdentSaksbehandler,
-                    ).apply {
-                        response.status() shouldBe HttpStatusCode.BadRequest
-                    }
+                requestSomAttestant(
+                    HttpMethod.Patch,
+                    "$sakPath/${UUID.randomUUID()}/behandlinger/rubbish/underkjenn",
+                    navIdentSaksbehandler,
+                ).apply {
+                    response.status() shouldBe HttpStatusCode.BadRequest
                 }
             }
         }
 
         @Test
         fun `NotFound når behandling ikke finnes`() {
-            withMigratedDb { dataSource ->
-                val repos = repos(dataSource)
-                val services = services(repos)
-                withFerdigbehandletSakForBruker(services, repos) { objects ->
-                    requestSomAttestant(
-                        HttpMethod.Patch,
-                        "$sakPath/${objects.sak.id}/behandlinger/${UUID.randomUUID()}/underkjenn",
-                        navIdentSaksbehandler,
-                    ) {
-                        setBody("""{"kommentar":"b", "grunn": "BEREGNINGEN_ER_FEIL"}""")
-                    }.apply {
-                        response.content shouldContain "Fant ikke behandling"
-                        response.status() shouldBe HttpStatusCode.NotFound
-                    }
+            withTestApplication(
+                {
+                    testSusebakover(
+                        services = TestServicesBuilder.services(
+                            søknadsbehandling = mock {
+                                on { underkjenn(any()) } doReturn SøknadsbehandlingService.KunneIkkeUnderkjenne.FantIkkeBehandling.left()
+                            },
+                        ),
+                    )
+                },
+            ) {
+                requestSomAttestant(
+                    HttpMethod.Patch,
+                    "$sakPath/${UUID.randomUUID()}/behandlinger/${UUID.randomUUID()}/underkjenn",
+                    navIdentSaksbehandler,
+                ) {
+                    setBody("""{"kommentar":"b", "grunn": "BEREGNINGEN_ER_FEIL"}""")
+                }.apply {
+                    response.content shouldContain "Fant ikke behandling"
+                    response.status() shouldBe HttpStatusCode.NotFound
                 }
             }
         }

--- a/web/src/test/resources/logback-test.xml
+++ b/web/src/test/resources/logback-test.xml
@@ -11,6 +11,12 @@
     <logger name="com.zaxxer.hikari" level="ERROR"/>
     <logger name="org.flywaydb" level="ERROR"/>
 
+
+    <logger name="kafka" level="ERROR"/>
+    <logger name="io.confluent" level="ERROR"/>
+    <logger name="org.apache" level="ERROR"/>
+    <logger name="state.change.logger" level="ERROR"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>


### PR DESCRIPTION
-Sparer litt tid ved å gjøre oppsett av migrert embedded database til opt-in funksjonalitet.
-Endret en del tester som "stopper" i web-laget/mocked service til å ikke benytte en migrert embedded database da dette ikke fremstår hensiktsmessig
-Undertrykker litt log-støy fra kafka/zookeeper/confluent for tester i web