### PR TITLE
fjern kobling til vedtakId for avslutt-revurdering brev & migrer DB

### DIFF
--- a/database/src/main/resources/db/migration/V109__fjern_vedtakId_fra_avslutt_revurdering_dokument.sql
+++ b/database/src/main/resources/db/migration/V109__fjern_vedtakId_fra_avslutt_revurdering_dokument.sql
@@ -1,0 +1,1 @@
+update dokument set vedtakid = null where type = 'INFORMASJON' and tittel = 'Ikke grunnlag for revurdering'

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -1265,7 +1265,6 @@ internal class RevurderingServiceImpl(
                 val dokumentMedMetaData = dokument.leggTilMetadata(
                     metadata = Dokument.Metadata(
                         sakId = revurdering.sakId,
-                        vedtakId = revurdering.tilRevurdering.id,
                         revurderingId = revurdering.id,
                         bestillBrev = true,
                     ),

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImplTest.kt
@@ -1443,7 +1443,6 @@ internal class RevurderingServiceImplTest {
                 it.metadata shouldBe Dokument.Metadata(
                     sakId = simulert.sakId,
                     revurderingId = simulert.id,
-                    vedtakId = simulert.tilRevurdering.id,
                     bestillBrev = true,
                 )
             },
@@ -1951,7 +1950,6 @@ internal class RevurderingServiceImplTest {
                 it.metadata shouldBe Dokument.Metadata(
                     sakId = simulert.sakId,
                     revurderingId = simulert.id,
-                    vedtakId = simulert.tilRevurdering.id,
                     bestillBrev = true,
                 )
             },


### PR DESCRIPTION
Noen plasser vil vi gjerne knytte dokumentet til flere ID'er, så har ikke lagt til sperre for at vi kan bare knytte den til 1 behandling. tenker i utgangspunktet at vi fikser buggen, så ser vi på å gjøre det litt safere en annen gang. 