### PR TITLE
Hent nøkkeltall for løpende saker

### DIFF
--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/DatabaseBuilder.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/DatabaseBuilder.kt
@@ -176,7 +176,7 @@ object DatabaseBuilder {
             sessionFactory = sessionFactory,
         )
         val hendelseRepo = PersonhendelsePostgresRepo(dataSource, clock)
-        val nøkkeltallRepo = NøkkeltallPostgresRepo(dataSource)
+        val nøkkeltallRepo = NøkkeltallPostgresRepo(dataSource, clock)
 
         return DatabaseRepos(
             avstemming = AvstemmingPostgresRepo(dataSource),

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
@@ -89,7 +89,7 @@ import java.time.Clock
 import java.util.UUID
 import javax.sql.DataSource
 
-internal val stønadsperiode = Stønadsperiode.create(Periode.create(1.januar(2021), 31.januar(2021)))
+internal val stønadsperiode = Stønadsperiode.create(Periode.create(1.januar(2021), 31.desember(2021)))
 internal val tomBehandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon()
 internal val behandlingsinformasjonMedAlleVilkårOppfylt =
     Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt()
@@ -271,7 +271,7 @@ internal class TestDataHelper(
         dataSource = dataSource,
         dbMetrics = dbMetrics,
     )
-    internal val nøkkeltallRepo = NøkkeltallPostgresRepo(dataSource = dataSource)
+    internal val nøkkeltallRepo = NøkkeltallPostgresRepo(dataSource = dataSource, fixedClock)
     internal val dokumentRepo = DokumentPostgresRepo(dataSource, sessionFactory)
     internal val hendelsePostgresRepo = PersonhendelsePostgresRepo(dataSource, fixedClock)
 
@@ -829,6 +829,7 @@ internal class TestDataHelper(
         ).copy(id = utbetalingId)
         utbetalingRepo.opprettUtbetaling(utbetaling)
         søknadsbehandlingRepo.lagre(innvilget)
+        vedtakRepo.lagre(Vedtak.fromSøknadsbehandling(innvilget, utbetalingId, fixedClock))
         return innvilget to utbetaling
     }
 

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/nøkkeltall/NøkkeltallPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/nøkkeltall/NøkkeltallPostgresRepoTest.kt
@@ -25,7 +25,8 @@ internal class NøkkeltallPostgresRepoTest {
                     digitalsøknader = 0,
                     papirsøknader = 0,
                 ),
-                antallUnikePersoner = 0
+                antallUnikePersoner = 0,
+                løpendeSaker = 0,
             )
         }
     }
@@ -48,7 +49,8 @@ internal class NøkkeltallPostgresRepoTest {
                     digitalsøknader = 2,
                     papirsøknader = 0,
                 ),
-                antallUnikePersoner = 1
+                antallUnikePersoner = 1,
+                løpendeSaker = 0,
             )
         }
     }
@@ -70,7 +72,8 @@ internal class NøkkeltallPostgresRepoTest {
                     digitalsøknader = 2,
                     papirsøknader = 0,
                 ),
-                antallUnikePersoner = 2
+                antallUnikePersoner = 2,
+                løpendeSaker = 1,
             )
         }
     }
@@ -95,7 +98,8 @@ internal class NøkkeltallPostgresRepoTest {
                     digitalsøknader = 4,
                     papirsøknader = 0,
                 ),
-                antallUnikePersoner = 1
+                antallUnikePersoner = 1,
+                løpendeSaker = 0,
             )
         }
     }
@@ -125,7 +129,8 @@ internal class NøkkeltallPostgresRepoTest {
                     digitalsøknader = 0,
                     papirsøknader = 1,
                 ),
-                antallUnikePersoner = 1
+                antallUnikePersoner = 1,
+                løpendeSaker = 0,
             )
         }
     }
@@ -150,7 +155,8 @@ internal class NøkkeltallPostgresRepoTest {
                     digitalsøknader = 2,
                     papirsøknader = 0,
                 ),
-                antallUnikePersoner = 1
+                antallUnikePersoner = 1,
+                løpendeSaker = 0,
             )
         }
     }

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/søknadsbehandling/SøknadsbehandlingPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/søknadsbehandling/SøknadsbehandlingPostgresRepoTest.kt
@@ -6,10 +6,8 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeTypeOf
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.desember
-import no.nav.su.se.bakover.common.endOfMonth
 import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.periode.Periode
-import no.nav.su.se.bakover.common.startOfMonth
 import no.nav.su.se.bakover.database.TestDataHelper
 import no.nav.su.se.bakover.database.TestDataHelper.Companion.journalførtSøknadMedOppgave
 import no.nav.su.se.bakover.database.antall
@@ -53,7 +51,6 @@ import no.nav.su.se.bakover.test.getOrFail
 import no.nav.su.se.bakover.test.innvilgetUførevilkår
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.time.LocalDate
 import java.util.UUID
 
 internal class SøknadsbehandlingPostgresRepoTest {
@@ -598,15 +595,15 @@ internal class SøknadsbehandlingPostgresRepoTest {
                     attesteringer = listOf(
                         Attestering.Iverksatt(
                             attestant = NavIdentBruker.Attestant(saksbehandler.navIdent),
-                            opprettet = Tidspunkt.now(no.nav.su.se.bakover.test.fixedClock),
+                            opprettet = Tidspunkt.now(fixedClock),
                         ),
                     ),
                 ),
                 fritekstTilBrev = "hshshshs",
                 stønadsperiode = Stønadsperiode.create(
                     periode = Periode.create(
-                        fraOgMed = LocalDate.now(no.nav.su.se.bakover.test.fixedClock).startOfMonth(),
-                        tilOgMed = LocalDate.now(no.nav.su.se.bakover.test.fixedClock).endOfMonth(),
+                        fraOgMed = 1.januar(2021),
+                        tilOgMed = 31.desember(2021),
                     ),
                     begrunnelse = "",
                 ),

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPostgresRepoTest.kt
@@ -1,6 +1,7 @@
 package no.nav.su.se.bakover.database.vedtak
 
 import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.februar
 import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.mars
@@ -141,9 +142,9 @@ internal class VedtakPostgresRepoTest {
             val vedtakRepo = testDataHelper.vedtakRepo
             val (søknadsbehandling, utbetaling) = testDataHelper.nyIverksattInnvilget()
             val vedtakSomErAktivt = Vedtak.fromSøknadsbehandling(søknadsbehandling, utbetaling.id, fixedClock)
-                .copy(periode = Periode.create(1.februar(2021), 31.mars(2021)))
+                .copy(periode = Periode.create(1.januar(2021), 31.mars(2021)))
             val vedtakUtenforAktivPeriode = Vedtak.fromSøknadsbehandling(søknadsbehandling, utbetaling.id, fixedClock)
-                .copy(periode = Periode.create(1.januar(2021), 31.januar(2021)))
+                .copy(periode = Periode.create(1.januar(2020), 31.desember(2020)))
             vedtakRepo.lagre(vedtakSomErAktivt)
             vedtakRepo.lagre(vedtakUtenforAktivPeriode)
 

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/nøkkeltall/Nøkkeltall.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/nøkkeltall/Nøkkeltall.kt
@@ -3,6 +3,7 @@ package no.nav.su.se.bakover.domain.nøkkeltall
 data class Nøkkeltall(
     val søknader: Søknader,
     val antallUnikePersoner: Int,
+    val løpendeSaker: Int,
 ) {
     data class Søknader(
         val totaltAntall: Int,

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/nøkkeltall/NøkkeltallJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/nøkkeltall/NøkkeltallJson.kt
@@ -5,6 +5,7 @@ import no.nav.su.se.bakover.domain.nøkkeltall.Nøkkeltall
 internal data class NøkkeltallJson(
     val søknader: SøknaderJson,
     val antallUnikePersoner: Int,
+    val løpendeSaker: Int,
 ) {
     data class SøknaderJson(
         val totaltAntall: Int,
@@ -19,7 +20,8 @@ internal data class NøkkeltallJson(
 
 internal fun Nøkkeltall.toJson() = NøkkeltallJson(
     søknader = søknader.toJson(),
-    antallUnikePersoner = antallUnikePersoner
+    antallUnikePersoner = antallUnikePersoner,
+    løpendeSaker = løpendeSaker,
 )
 
 internal fun Nøkkeltall.Søknader.toJson() =

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/nøkkeltall/NøkkeltallRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/nøkkeltall/NøkkeltallRoutesKtTest.kt
@@ -44,6 +44,7 @@ internal class NøkkeltallRoutesKtTest {
                     papirsøknader = 0,
                 ),
                 antallUnikePersoner = 1,
+                løpendeSaker = 0,
             )
         }
 
@@ -65,7 +66,8 @@ internal class NøkkeltallRoutesKtTest {
                         "digitalsøknader" : 0,
                         "papirsøknader" : 0
                     },
-                    "antallUnikePersoner" : 1
+                    "antallUnikePersoner" : 1,
+                    "løpendeSaker": 0
                 }
             """.trimIndent()
             val actual = response.content


### PR DESCRIPTION
Regner ut løpende saker som antallet aktive innvilgelser minus antallet aktive opphør (hvor "aktive" betyr at dagens dato er innenfor perioden for vedtaket).