### PR TITLE
En event ved lukking av saksbehandling + Bruk eksisterende testdata på resten av testene

### DIFF
--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/lukk/LukkSøknadServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/lukk/LukkSøknadServiceImpl.kt
@@ -94,16 +94,15 @@ internal class LukkSøknadServiceImpl(
                                 log.warn("Kunne ikke lukke oppgave ${søknad.oppgaveId} for søknad ${søknad.id}")
                             }
                         val sak = hentSak(lukket.sakId)
+
+                        val event = if (lukketSøknadbehandling == null) {
+                            Event.Statistikk.SøknadStatistikk.SøknadLukket(søknad = lukket, saksnummer = sak.saksnummer)
+                        } else {
+                            SøknadsbehandlingLukket(lukketSøknadbehandling)
+                        }
+
                         observers.forEach { observer ->
-                            observer.handle(
-                                Event.Statistikk.SøknadStatistikk.SøknadLukket(
-                                    søknad = lukket,
-                                    saksnummer = sak.saksnummer,
-                                ),
-                            )
-                            lukketSøknadbehandling?.let {
-                                observer.handle(SøknadsbehandlingLukket(lukketSøknadbehandling))
-                            }
+                            observer.handle(event)
                         }
                         sak.right()
                     }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/StatistikkServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/StatistikkServiceImplTest.kt
@@ -9,62 +9,39 @@ import no.nav.su.se.bakover.common.endOfDay
 import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.common.periode.Periode
-import no.nav.su.se.bakover.common.toTidspunkt
 import no.nav.su.se.bakover.common.zoneIdOslo
 import no.nav.su.se.bakover.domain.AktørId
-import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NavIdentBruker
-import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
-import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
-import no.nav.su.se.bakover.domain.behandling.Behandling
-import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
-import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
-import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.journal.JournalpostId
-import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
-import no.nav.su.se.bakover.domain.revurdering.Forhåndsvarsel
-import no.nav.su.se.bakover.domain.revurdering.InformasjonSomRevurderes
-import no.nav.su.se.bakover.domain.revurdering.IverksattRevurdering
-import no.nav.su.se.bakover.domain.revurdering.OpprettetRevurdering
-import no.nav.su.se.bakover.domain.revurdering.RevurderingTilAttestering
-import no.nav.su.se.bakover.domain.revurdering.Revurderingsteg
-import no.nav.su.se.bakover.domain.revurdering.Revurderingsårsak
-import no.nav.su.se.bakover.domain.søknadsbehandling.Stønadsperiode
-import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
-import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
 import no.nav.su.se.bakover.service.argThat
-import no.nav.su.se.bakover.service.beregning.TestBeregning
 import no.nav.su.se.bakover.service.person.PersonService
 import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.fixedTidspunkt
-import no.nav.su.se.bakover.test.generer
-import no.nav.su.se.bakover.test.grunnlagsdataEnsligUtenFradrag
+import no.nav.su.se.bakover.test.iverksattRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak
+import no.nav.su.se.bakover.test.nySakMedNySøknad
+import no.nav.su.se.bakover.test.opprettetRevurderingFraInnvilgetSøknadsbehandlingsVedtak
 import no.nav.su.se.bakover.test.søknadsbehandlingIverksattAvslagUtenBeregning
 import no.nav.su.se.bakover.test.søknadsbehandlingIverksattInnvilget
 import no.nav.su.se.bakover.test.søknadsbehandlingTilAttesteringAvslagUtenBeregning
+import no.nav.su.se.bakover.test.søknadsbehandlingUnderkjentInnvilget
 import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertUavklart
+import no.nav.su.se.bakover.test.tilAttesteringRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import java.time.Clock
-import java.time.LocalDate
 import java.time.ZoneOffset
 import java.util.UUID
 
 internal class StatistikkServiceImplTest {
     private val sakTopicName = "supstonad.aapen-su-sak-statistikk-v1"
     private val behandlingTopicName = "supstonad.aapen-su-behandling-statistikk-v1"
-    private val revurderingsårsak = Revurderingsårsak(
-        Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
-        Revurderingsårsak.Begrunnelse.create("Ny informasjon"),
-    )
 
     private val clock = Clock.fixed(1.januar(2020).endOfDay(ZoneOffset.UTC).instant, ZoneOffset.UTC)
 
@@ -105,16 +82,8 @@ internal class StatistikkServiceImplTest {
         val personServiceMock: PersonService = mock {
             on { hentAktørId(any()) } doReturn AktørId("55").right()
         }
+        val sak = nySakMedNySøknad().first
 
-        val sak = Sak(
-            id = UUID.randomUUID(),
-            saksnummer = Saksnummer(nummer = 2021),
-            opprettet = fixedTidspunkt,
-            fnr = Fnr.generer(),
-            søknader = listOf(),
-            søknadsbehandlinger = listOf(),
-            utbetalinger = listOf(),
-        )
         val expected = Statistikk.Sak(
             funksjonellTid = sak.opprettet,
             tekniskTid = sak.opprettet,
@@ -292,39 +261,7 @@ internal class StatistikkServiceImplTest {
     @Test
     fun `publiserer statistikk for underkjent behandling på kafka`() {
         val kafkaPublisherMock: KafkaPublisher = mock()
-        val søknadMock: Søknad.Journalført.MedOppgave.IkkeLukket =
-            mock {
-                on { søknadInnhold } doReturn SøknadInnholdTestdataBuilder.build()
-                on { opprettet } doReturn Tidspunkt.now(clock)
-            }
-
-        val beregning = TestBeregning
-
-        val underkjent = Søknadsbehandling.Underkjent.Innvilget(
-            id = UUID.randomUUID(),
-            opprettet = Tidspunkt.now(clock),
-            sakId = UUID.randomUUID(),
-            saksnummer = Saksnummer(2021),
-            søknad = søknadMock,
-            oppgaveId = OppgaveId(value = ""),
-            behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
-            fnr = Fnr.generer(),
-            beregning = beregning,
-            simulering = mock(),
-            saksbehandler = NavIdentBruker.Saksbehandler("saksbehandler"),
-            attesteringer = Attesteringshistorikk.empty().leggTilNyAttestering(
-                Attestering.Underkjent(
-                    attestant = NavIdentBruker.Attestant("attestant"),
-                    grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
-                    kommentar = "",
-                    opprettet = Tidspunkt.now(clock),
-                ),
-            ),
-            fritekstTilBrev = "",
-            stønadsperiode = Stønadsperiode.create(stønadsperiode),
-            grunnlagsdata = grunnlagsdataEnsligUtenFradrag(stønadsperiode),
-            vilkårsvurderinger = Vilkårsvurderinger.Søknadsbehandling.IkkeVurdert,
-        )
+        val underkjent = søknadsbehandlingUnderkjentInnvilget().second
 
         val expected = Statistikk.Behandling(
             funksjonellTid = Tidspunkt.now(clock),
@@ -333,12 +270,13 @@ internal class StatistikkServiceImplTest {
             mottattDato = underkjent.opprettet.toLocalDate(zoneIdOslo),
             behandlingId = underkjent.id,
             sakId = underkjent.sakId,
+            søknadId = underkjent.søknad.id,
             saksnummer = underkjent.saksnummer.nummer,
             behandlingStatus = underkjent.status.toString(),
             behandlingStatusBeskrivelse = "Innvilget søknadsbehandling sendt tilbake fra attestant til saksbehandler",
             versjon = clock.millis(),
-            saksbehandler = "saksbehandler",
-            beslutter = "attestant",
+            saksbehandler = underkjent.saksbehandler.navIdent,
+            beslutter = underkjent.attesteringer.hentSisteAttestering().attestant.navIdent,
             behandlingType = Statistikk.Behandling.BehandlingType.SOKNAD,
             behandlingTypeBeskrivelse = Statistikk.Behandling.BehandlingType.SOKNAD.beskrivelse,
             behandlingYtelseDetaljer = listOf(Statistikk.BehandlingYtelseDetaljer(Statistikk.Stønadsklassifisering.BOR_ALENE)),
@@ -358,31 +296,10 @@ internal class StatistikkServiceImplTest {
     @Test
     fun `publiserer statistikk for opprettet revurdering på kafka`() {
         val kafkaPublisherMock: KafkaPublisher = mock()
-        val behandlingsperiode = Periode.create(1.januar(2021), 31.desember(2021))
-        val behandlingMock = mock<Behandling> {
-            on { sakId } doReturn UUID.randomUUID()
-            on { saksnummer } doReturn Saksnummer(2021)
-        }
-        val opprettetRevurdering = OpprettetRevurdering(
-            id = UUID.randomUUID(),
-            opprettet = Tidspunkt.now(clock),
-            tilRevurdering = mock {
-                on { behandling } doReturn behandlingMock
-                on { id } doReturn UUID.randomUUID()
-            },
-            saksbehandler = NavIdentBruker.Saksbehandler("saksbehandler"),
-            periode = behandlingsperiode,
-            oppgaveId = OppgaveId("oppgaveid"),
-            fritekstTilBrev = "",
-            revurderingsårsak = revurderingsårsak,
-            forhåndsvarsel = null,
-            grunnlagsdata = Grunnlagsdata.IkkeVurdert,
-            vilkårsvurderinger = Vilkårsvurderinger.Revurdering.IkkeVurdert,
-            informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-        )
+        val opprettetRevurdering = opprettetRevurderingFraInnvilgetSøknadsbehandlingsVedtak().second
 
         val expected = Statistikk.Behandling(
-            funksjonellTid = opprettetRevurdering.opprettet,
+            funksjonellTid = Tidspunkt.now(clock),
             tekniskTid = Tidspunkt.now(clock),
             registrertDato = opprettetRevurdering.opprettet.toLocalDate(zoneIdOslo),
             mottattDato = opprettetRevurdering.opprettet.toLocalDate(zoneIdOslo),
@@ -392,7 +309,7 @@ internal class StatistikkServiceImplTest {
             behandlingStatus = "OPPRETTET",
             behandlingStatusBeskrivelse = "Ny revurdering opprettet",
             versjon = clock.millis(),
-            saksbehandler = "saksbehandler",
+            saksbehandler = opprettetRevurdering.saksbehandler.navIdent,
             behandlingType = Statistikk.Behandling.BehandlingType.REVURDERING,
             behandlingTypeBeskrivelse = Statistikk.Behandling.BehandlingType.REVURDERING.beskrivelse,
             relatertBehandlingId = opprettetRevurdering.tilRevurdering.id,
@@ -412,39 +329,7 @@ internal class StatistikkServiceImplTest {
     @Test
     fun `publiserer statistikk for revurdering sendt til attestering på kafka`() {
         val kafkaPublisherMock: KafkaPublisher = mock()
-        val beregning = TestBeregning
-        val behandlingsperiode = Periode.create(1.januar(2021), 31.desember(2021))
-
-        val behandlingMock = mock<Behandling> {
-            on { sakId } doReturn UUID.randomUUID()
-            on { saksnummer } doReturn Saksnummer(2021)
-        }
-        val revurderingTilAttestering = RevurderingTilAttestering.Innvilget(
-            id = UUID.randomUUID(),
-            opprettet = LocalDate.now(clock).atStartOfDay().toTidspunkt(zoneIdOslo),
-            tilRevurdering = mock {
-                on { behandling } doReturn behandlingMock
-                on { id } doReturn UUID.randomUUID()
-            },
-            saksbehandler = NavIdentBruker.Saksbehandler("saksbehandler"),
-            periode = behandlingsperiode,
-            beregning = beregning,
-            simulering = Simulering(
-                gjelderId = Fnr.generer(),
-                gjelderNavn = "Mr. Asd",
-                datoBeregnet = LocalDate.now(clock),
-                nettoBeløp = 100,
-                periodeList = listOf(),
-            ),
-            oppgaveId = OppgaveId("55"),
-            fritekstTilBrev = "",
-            revurderingsårsak = revurderingsårsak,
-            forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
-            grunnlagsdata = Grunnlagsdata.IkkeVurdert,
-            vilkårsvurderinger = Vilkårsvurderinger.Revurdering.IkkeVurdert,
-            informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-            attesteringer = Attesteringshistorikk.empty(),
-        )
+        val revurderingTilAttestering = tilAttesteringRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak().second
 
         val expected = Statistikk.Behandling(
             funksjonellTid = Tidspunkt.now(clock),
@@ -457,7 +342,7 @@ internal class StatistikkServiceImplTest {
             behandlingStatus = "TIL_ATTESTERING_INNVILGET",
             behandlingStatusBeskrivelse = "Innvilget revurdering sendt til attestering",
             versjon = clock.millis(),
-            saksbehandler = "saksbehandler",
+            saksbehandler = revurderingTilAttestering.saksbehandler.navIdent,
             behandlingType = Statistikk.Behandling.BehandlingType.REVURDERING,
             behandlingTypeBeskrivelse = Statistikk.Behandling.BehandlingType.REVURDERING.beskrivelse,
             relatertBehandlingId = revurderingTilAttestering.tilRevurdering.id,
@@ -477,45 +362,7 @@ internal class StatistikkServiceImplTest {
     @Test
     fun `publiserer statistikk for iverksetting av revurdering på kafka`() {
         val kafkaPublisherMock: KafkaPublisher = mock()
-        val beregning = TestBeregning
-        val behandlingsperiode = Periode.create(1.januar(2021), 31.desember(2021))
-
-        val behandlingMock = mock<Behandling> {
-            on { sakId } doReturn UUID.randomUUID()
-            on { saksnummer } doReturn Saksnummer(2021)
-        }
-        val iverksattRevurdering = IverksattRevurdering.Innvilget(
-            id = UUID.randomUUID(),
-            periode = behandlingsperiode,
-            opprettet = LocalDate.now(clock).atStartOfDay().toTidspunkt(zoneIdOslo),
-            tilRevurdering = mock {
-                on { id } doReturn UUID.randomUUID()
-                on { behandling } doReturn behandlingMock
-            },
-            saksbehandler = NavIdentBruker.Saksbehandler("saksbehandler"),
-            oppgaveId = OppgaveId("55"),
-            beregning = beregning,
-            simulering = Simulering(
-                gjelderId = Fnr.generer(),
-                gjelderNavn = "Mr. Asd",
-                datoBeregnet = LocalDate.now(clock),
-                nettoBeløp = 100,
-                periodeList = listOf(),
-            ),
-            grunnlagsdata = Grunnlagsdata.IkkeVurdert,
-            attesteringer = Attesteringshistorikk.empty()
-                .leggTilNyAttestering(
-                    Attestering.Iverksatt(
-                        NavIdentBruker.Attestant("attestant"),
-                        Tidspunkt.now(clock),
-                    ),
-                ),
-            fritekstTilBrev = "",
-            revurderingsårsak = revurderingsårsak,
-            forhåndsvarsel = Forhåndsvarsel.IngenForhåndsvarsel,
-            vilkårsvurderinger = Vilkårsvurderinger.Revurdering.IkkeVurdert,
-            informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-        )
+        val iverksattRevurdering = iverksattRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak().second
 
         val expected = Statistikk.Behandling(
             funksjonellTid = Tidspunkt.now(clock),
@@ -527,15 +374,15 @@ internal class StatistikkServiceImplTest {
             saksnummer = iverksattRevurdering.saksnummer.nummer,
             behandlingStatus = "IVERKSATT_INNVILGET",
             behandlingStatusBeskrivelse = "Innvilget revurdering iverksatt",
-            behandlingYtelseDetaljer = emptyList(),
+            behandlingYtelseDetaljer = listOf(Statistikk.BehandlingYtelseDetaljer(Statistikk.Stønadsklassifisering.BOR_ALENE)),
             versjon = clock.millis(),
-            saksbehandler = "saksbehandler",
+            saksbehandler = iverksattRevurdering.saksbehandler.navIdent,
             behandlingType = Statistikk.Behandling.BehandlingType.REVURDERING,
             behandlingTypeBeskrivelse = Statistikk.Behandling.BehandlingType.REVURDERING.beskrivelse,
             relatertBehandlingId = iverksattRevurdering.tilRevurdering.id,
             resultat = "Innvilget",
             resultatBegrunnelse = null,
-            beslutter = "attestant",
+            beslutter = iverksattRevurdering.attestering.attestant.navIdent,
             avsluttet = true,
         )
 
@@ -553,12 +400,7 @@ internal class StatistikkServiceImplTest {
     fun `publiserer statistikk for mottat søknad på kafka`() {
         val kafkaPublisherMock: KafkaPublisher = mock()
         val saksnummer = Saksnummer(2049L)
-        val søknad = Søknad.Ny(
-            id = UUID.randomUUID(),
-            opprettet = Tidspunkt.now(clock),
-            sakId = UUID.randomUUID(),
-            søknadInnhold = SøknadInnholdTestdataBuilder.build(),
-        )
+        val søknad = nySakMedNySøknad().second
 
         val expected = Statistikk.Behandling(
             funksjonellTid = søknad.opprettet,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/lukk/LukkSøknadServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/lukk/LukkSøknadServiceImplTest.kt
@@ -51,9 +51,7 @@ import no.nav.su.se.bakover.test.søknadsbehandlingTilAttesteringInnvilget
 import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertUavklart
 import no.nav.su.se.bakover.test.trukketSøknad
 import org.junit.jupiter.api.Test
-import org.mockito.internal.verification.Times
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
@@ -304,28 +302,13 @@ internal class LukkSøknadServiceImplTest {
                 verify(oppgaveServiceMock).lukkOppgave(argThat { it shouldBe søknad.oppgaveId })
                 verify(sakServiceMock).hentSak(argThat<UUID> { it shouldBe søknad.sakId })
 
-                val events = argumentCaptor<Event>()
-                verify(serviceAndMocks.lukkSøknadServiceObserver, Times(2)).handle(
-                    events.capture()
-                ).also {
-                    events.firstValue shouldBe Event.Statistikk.SøknadStatistikk.SøknadLukket(
-                        Søknad.Journalført.MedOppgave.Lukket(
-                            id = søknad.id,
-                            opprettet = søknad.opprettet,
-                            sakId = søknad.sakId,
-                            søknadInnhold = søknad.søknadInnhold,
-                            journalpostId = søknad.journalpostId,
-                            oppgaveId = søknad.oppgaveId,
-                            lukketAv = saksbehandler,
-                            lukketType = AVVIST,
-                            lukketTidspunkt = fixedTidspunkt,
-                        ),
-                        sak.saksnummer,
-                    )
-                    events.secondValue shouldBe Event.Statistikk.SøknadsbehandlingStatistikk.SøknadsbehandlingLukket(
-                        søknadsbehandling = søknadsbehandling.lukkSøknadsbehandling().getOrFail()
-                    )
-                }
+                verify(serviceAndMocks.lukkSøknadServiceObserver).handle(
+                    argThat {
+                        it shouldBe Event.Statistikk.SøknadsbehandlingStatistikk.SøknadsbehandlingLukket(
+                            søknadsbehandling = søknadsbehandling.lukkSøknadsbehandling().getOrFail()
+                        )
+                    }
+                )
                 serviceAndMocks.verifyNoMoreInteractions()
             }
         }


### PR DESCRIPTION
I #605 byttet jeg ut noen mocks med testdata fra testdata-filene. Byttet ut alle mocks i de testene i de to filene nå når jeg først var i gang, så her er pr på de siste

Edit: La også ved at vi kun sender èn event ved lukking av saksbehandling