### PR TITLE
Fjern muligheten for å stanse utbetalinger ved opphør

### DIFF
--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/Application.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/Application.kt
@@ -248,11 +248,12 @@ fun Application.susebakover(
                     accessCheckProxy,
                 ) { accessProtectedServices ->
                     personRoutes(accessProtectedServices.person, clock)
-                    sakRoutes(accessProtectedServices.sak)
+                    sakRoutes(accessProtectedServices.sak, clock)
                     søknadRoutes(
                         søknadService = accessProtectedServices.søknad,
                         lukkSøknadService = accessProtectedServices.lukkSøknad,
                         avslåSøknadManglendeDokumentasjonService = accessProtectedServices.avslåSøknadManglendeDokumentasjonService,
+                        clock = clock,
                     )
                     overordnetSøknadsbehandligRoutes(accessProtectedServices.søknadsbehandling, clock)
                     avstemmingRoutes(accessProtectedServices.avstemming, clock)

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/sak/SakJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/sak/SakJson.kt
@@ -1,5 +1,6 @@
 package no.nav.su.se.bakover.web.routes.sak
 
+import no.nav.su.se.bakover.domain.KanStansesEllerGjenopptas
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppdrag.UtbetalingslinjePåTidslinje
@@ -15,6 +16,7 @@ import no.nav.su.se.bakover.web.routes.søknadsbehandling.beregning.PeriodeJson
 import no.nav.su.se.bakover.web.routes.søknadsbehandling.toJson
 import no.nav.su.se.bakover.web.routes.vedtak.VedtakJson
 import no.nav.su.se.bakover.web.routes.vedtak.toJson
+import java.time.Clock
 
 internal data class SakJson(
     val id: String,
@@ -26,16 +28,10 @@ internal data class SakJson(
     val utbetalingerKanStansesEllerGjenopptas: KanStansesEllerGjenopptas,
     val revurderinger: List<RevurderingJson>,
     val vedtak: List<VedtakJson>,
-    val klager: List<KlageJson>
+    val klager: List<KlageJson>,
 ) {
-    enum class KanStansesEllerGjenopptas {
-        STANS,
-        GJENOPPTA,
-        INGEN;
-    }
-
     companion object {
-        internal fun Sak.toJson() = SakJson(
+        internal fun Sak.toJson(clock: Clock) = SakJson(
             id = id.toString(),
             saksnummer = saksnummer.nummer,
             fnr = fnr.toString(),
@@ -54,16 +50,10 @@ internal data class SakJson(
                     }.toString(),
                 )
             },
-            utbetalingerKanStansesEllerGjenopptas = utbetalingstidslinje().tidslinje.let {
-                when {
-                    it.isEmpty() -> KanStansesEllerGjenopptas.INGEN
-                    it.last() is UtbetalingslinjePåTidslinje.Stans -> KanStansesEllerGjenopptas.GJENOPPTA
-                    else -> KanStansesEllerGjenopptas.STANS
-                }
-            },
+            utbetalingerKanStansesEllerGjenopptas = kanUtbetalingerStansesEllerGjenopptas(clock),
             revurderinger = revurderinger.map { it.toJson() },
             vedtak = vedtakListe.map { it.toJson() },
-            klager = klager.map { it.toJson() }
+            klager = klager.map { it.toJson() },
         )
     }
 }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/sak/SakRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/sak/SakRoutes.kt
@@ -29,11 +29,13 @@ import no.nav.su.se.bakover.web.routes.søknadsbehandling.beregning.PeriodeJson.
 import no.nav.su.se.bakover.web.svar
 import no.nav.su.se.bakover.web.withBody
 import no.nav.su.se.bakover.web.withSakId
+import java.time.Clock
 
 internal const val sakPath = "/saker"
 
 internal fun Route.sakRoutes(
     sakService: SakService,
+    clock: Clock,
 ) {
     authorize(Brukerrolle.Saksbehandler, Brukerrolle.Attestant) {
         post("$sakPath/søk") {
@@ -63,7 +65,7 @@ internal fun Route.sakRoutes(
                                     }
                                     .map {
                                         call.audit(fnr, AuditLogEvent.Action.ACCESS, null)
-                                        call.svar(Resultat.json(OK, serialize(it.toJson())))
+                                        call.svar(Resultat.json(OK, serialize(it.toJson(clock))))
                                     }
                             },
                         )
@@ -89,7 +91,7 @@ internal fun Route.sakRoutes(
                                         },
                                         {
                                             call.audit(it.fnr, AuditLogEvent.Action.ACCESS, null)
-                                            Resultat.json(OK, serialize((it.toJson())))
+                                            Resultat.json(OK, serialize((it.toJson(clock))))
                                         },
                                     ),
                                 )
@@ -148,7 +150,7 @@ internal fun Route.sakRoutes(
                         { NotFound.errorJson("Fant ikke sak med id: $sakId", "fant_ikke_sak") },
                         {
                             call.audit(it.fnr, AuditLogEvent.Action.ACCESS, null)
-                            Resultat.json(OK, serialize((it.toJson())))
+                            Resultat.json(OK, serialize((it.toJson(clock))))
                         },
                     ),
                 )

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutes.kt
@@ -43,6 +43,7 @@ import no.nav.su.se.bakover.web.sikkerlogg
 import no.nav.su.se.bakover.web.svar
 import no.nav.su.se.bakover.web.withBody
 import no.nav.su.se.bakover.web.withSøknadId
+import java.time.Clock
 
 internal const val søknadPath = "/soknad"
 
@@ -50,6 +51,7 @@ internal fun Route.søknadRoutes(
     søknadService: SøknadService,
     lukkSøknadService: LukkSøknadService,
     avslåSøknadManglendeDokumentasjonService: AvslåSøknadManglendeDokumentasjonService,
+    clock: Clock,
 ) {
     authorize(Brukerrolle.Veileder, Brukerrolle.Saksbehandler) {
         post(søknadPath) {
@@ -139,7 +141,7 @@ internal fun Route.søknadRoutes(
                         {
                             call.audit(it.fnr, AuditLogEvent.Action.UPDATE, null)
                             call.sikkerlogg("Lukket søknad for søknad: $søknadId")
-                            call.svar(Resultat.json(OK, serialize(it.toJson())))
+                            call.svar(Resultat.json(OK, serialize(it.toJson(clock))))
                         },
                     )
                 }
@@ -176,7 +178,7 @@ internal fun Route.søknadRoutes(
                             },
                         )
                     }.map {
-                        call.svar(Resultat.json(OK, serialize(it.toJson())))
+                        call.svar(Resultat.json(OK, serialize(it.toJson(clock))))
                     }
                 }
             }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/sak/SakJsonTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/sak/SakJsonTest.kt
@@ -16,6 +16,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.grunnlag.Uføregrad
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppdrag.Utbetalingslinje
+import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.web.routes.sak.SakJson.Companion.toJson
 import no.nav.su.se.bakover.web.routes.søknadsbehandling.UtbetalingJson
@@ -60,12 +61,12 @@ internal class SakJsonTest {
 
     @Test
     fun `should serialize to json string`() {
-        JSONAssert.assertEquals(sakJsonString, serialize(sak.toJson()), true)
+        JSONAssert.assertEquals(sakJsonString, serialize(sak.toJson(fixedClock)), true)
     }
 
     @Test
     fun `should deserialize json string`() {
-        deserialize<SakJson>(sakJsonString) shouldBe sak.toJson()
+        deserialize<SakJson>(sakJsonString) shouldBe sak.toJson(fixedClock)
     }
 
     @Nested
@@ -121,7 +122,7 @@ internal class SakJsonTest {
 
             val sak = sak.copy(utbetalinger = listOf(utbetaling1, utbetaling2, utbetaling3, utbetaling4))
 
-            val (actual1, actual2, actual3, actual4) = sak.toJson().utbetalinger
+            val (actual1, actual2, actual3, actual4) = sak.toJson(fixedClock).utbetalinger
             actual1 shouldBe UtbetalingJson(
                 fraOgMed = nyUtbetaling.fraOgMed,
                 tilOgMed = midlertidigStans.virkningstidspunkt.minusDays(1),

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutesKtTest.kt
@@ -451,7 +451,7 @@ internal class SøknadRoutesKtTest {
                     },
                 )
 
-                response.content shouldBe serialize(sak.toJson())
+                response.content shouldBe serialize(sak.toJson(fixedClock))
             }
         }
     }


### PR DESCRIPTION
Tillater heller ikke stans dersom det er opphold mellom stønadsperioder, uten at jeg er helt sikker på om dette er like problematisk. Vi plukker opp igjen problemstillingen dersom fag melder om behov for å stanse på en sak hvor vi har fjernet knappen. John Are er happy med dette.