### PR TITLE
Refaktorer klagevedtak til klageinstansvedtak

### DIFF
--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/klage/KlagePostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/klage/KlagePostgresRepo.kt
@@ -217,7 +217,7 @@ internal class KlagePostgresRepo(private val sessionFactory: PostgresSessionFact
     private fun hentProsesserteKlagevedtak(klageId: UUID): List<ProsessertKlageinstansvedtak> {
         return sessionFactory.withSession { session ->
             """
-            select * from klagevedtak where utlest_klageid = :klageid AND type = :type
+            select * from klageinstansvedtak where utlest_klageid = :klageid AND type = :type
             """.trimIndent().hentListe(
                 mapOf(
                     "klageid" to klageId,

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/klage/KlagevedtakPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/klage/KlagevedtakPostgresRepo.kt
@@ -29,7 +29,7 @@ internal class KlagevedtakPostgresRepo(private val sessionFactory: PostgresSessi
         Either.catch {
             return sessionFactory.withSession { session ->
                 """
-                insert into klagevedtak(id, opprettet, type, metadata)
+                insert into klageinstansvedtak(id, opprettet, type, metadata)
                 values(:id, :opprettet, :type, to_jsonb(:metadata::jsonb))
                 """.trimIndent()
                     .insert(
@@ -55,7 +55,7 @@ internal class KlagevedtakPostgresRepo(private val sessionFactory: PostgresSessi
     override fun lagre(klagevedtak: ProsessertKlageinstansvedtak, transactionContext: TransactionContext) {
         transactionContext.withTransaction { transaction ->
             """
-                update klagevedtak
+                update klageinstansvedtak
                     set type = :type,
                     oppgaveId = :oppgaveid,
                     utlest_utfall = :utlest_utfall,
@@ -80,7 +80,7 @@ internal class KlagevedtakPostgresRepo(private val sessionFactory: PostgresSessi
     override fun hentUbehandlaKlagevedtak(): List<UprosessertFattetKlageinstansvedtak> {
         return sessionFactory.withSession { session ->
             """
-                select * from klagevedtak where type = '${KlagevedtakType.UPROSESSERT}'
+                select * from klageinstansvedtak where type = '${KlagevedtakType.UPROSESSERT}'
             """.trimIndent().hentListe(
                 emptyMap(),
                 session,
@@ -91,7 +91,7 @@ internal class KlagevedtakPostgresRepo(private val sessionFactory: PostgresSessi
     override fun markerSomFeil(id: UUID) {
         sessionFactory.withSession { session ->
             """
-            update klagevedtak set type = '${KlagevedtakType.FEIL}' where id = :id
+            update klageinstansvedtak set type = '${KlagevedtakType.FEIL}' where id = :id
             """.trimIndent().oppdatering(mapOf("id" to id), session)
         }
     }

--- a/database/src/main/resources/db/migration/V119__klage_endringer_i_vedtak_og_constraints.sql
+++ b/database/src/main/resources/db/migration/V119__klage_endringer_i_vedtak_og_constraints.sql
@@ -1,0 +1,2 @@
+alter table klagevedtak rename to klageinstansvedtak;
+alter table klage add constraint unique_journalpostid unique (journalpostid);

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
@@ -1003,7 +1003,7 @@ internal class TestDataHelper(
             sakId = vedtak.behandling.sakId,
             saksnummer = vedtak.behandling.saksnummer,
             fnr = vedtak.behandling.fnr,
-            journalpostId = JournalpostId(value = "journalpostIdKlage"),
+            journalpostId = JournalpostId(value = UUID.randomUUID().toString()),
             oppgaveId = oppgaveId,
             saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "saksbehandlerNyKlage"),
             clock = fixedClock,

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/klage/KlagePostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/klage/KlagePostgresRepoTest.kt
@@ -1,6 +1,7 @@
 package no.nav.su.se.bakover.database.klage
 
 import arrow.core.right
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.database.TestDataHelper
@@ -14,9 +15,25 @@ import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.getOrFail
 import org.junit.jupiter.api.Test
+import org.postgresql.util.PSQLException
 import java.util.UUID
 
 internal class KlagePostgresRepoTest {
+
+    @Test
+    fun `kan ikke opprette klage på journalpost som allerede har en klage`() {
+        withMigratedDb { dataSource ->
+            val testDataHelper = TestDataHelper(dataSource)
+            val klageRepo = testDataHelper.klagePostgresRepo
+
+            val klage = testDataHelper.nyKlage()
+            val klageMedEksisterendeJournalpostId = klage.copy(id = UUID.randomUUID())
+
+            shouldThrow<PSQLException> {
+                klageRepo.lagre(klageMedEksisterendeJournalpostId)
+            }
+        }
+    }
 
     @Test
     fun `kan opprette og hente klager`() {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
@@ -150,8 +150,6 @@ data class Sak(
                     .reduser()
             }.reduser()
     }
-
-    fun hentKlager(): List<Klage> = klager
     fun hentÅpneKlager(): List<Klage> = klager.filter { it.erÅpen() }
 
     fun hentKlage(klageId: UUID): Klage? = klager.find { it.id == klageId }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
@@ -151,6 +151,7 @@ data class Sak(
             }.reduser()
     }
 
+    fun hentKlager(): List<Klage> = klager
     fun hentÅpneKlager(): List<Klage> = klager.filter { it.erÅpen() }
 
     fun hentKlage(klageId: UUID): Klage? = klager.find { it.id == klageId }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/Klage.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/Klage.kt
@@ -144,3 +144,5 @@ sealed class KunneIkkeBekrefteKlagesteg {
     data class UgyldigTilstand(val fra: KClass<out Klage>, val til: KClass<out Klage>) :
         KunneIkkeBekrefteKlagesteg()
 }
+
+fun List<Klage>.harEksisterendeJournalpostId(journalpostId: JournalpostId) = this.any { it.journalpostId == journalpostId }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/KlageRepo.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/KlageRepo.kt
@@ -13,3 +13,5 @@ interface KlageRepo {
     fun defaultSessionContext(): SessionContext
     fun defaultTransactionContext(): TransactionContext
 }
+
+object KlageHarAlleredeBehandling

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/OpprettetKlage.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/OpprettetKlage.kt
@@ -104,9 +104,10 @@ data class OpprettetKlage private constructor(
     }
 }
 
-sealed class KunneIkkeOppretteKlage {
-    object FantIkkeSak : KunneIkkeOppretteKlage()
-    object FinnesAlleredeEnÅpenKlage : KunneIkkeOppretteKlage()
-    object KunneIkkeOppretteOppgave : KunneIkkeOppretteKlage()
-    object UgyldigMottattDato : KunneIkkeOppretteKlage()
+sealed interface KunneIkkeOppretteKlage {
+    object FantIkkeSak : KunneIkkeOppretteKlage
+    object FinnesAlleredeEnÅpenKlage : KunneIkkeOppretteKlage
+    object KunneIkkeOppretteOppgave : KunneIkkeOppretteKlage
+    object UgyldigMottattDato : KunneIkkeOppretteKlage
+    object HarAlleredeEnKlageBehandling : KunneIkkeOppretteKlage
 }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/klage/KlageServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/klage/KlageServiceImpl.kt
@@ -31,6 +31,7 @@ import no.nav.su.se.bakover.domain.klage.OpprettetKlage
 import no.nav.su.se.bakover.domain.klage.OversendtKlage
 import no.nav.su.se.bakover.domain.klage.VilkårsvurdertKlage
 import no.nav.su.se.bakover.domain.klage.VurdertKlage
+import no.nav.su.se.bakover.domain.klage.harEksisterendeJournalpostId
 import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
 import no.nav.su.se.bakover.domain.sak.SakRepo
 import no.nav.su.se.bakover.domain.vedtak.VedtakRepo
@@ -67,7 +68,7 @@ class KlageServiceImpl(
             return KunneIkkeOppretteKlage.FinnesAlleredeEnÅpenKlage.left()
         }
 
-        if (sak.hentKlager().any { it.journalpostId == request.journalpostId }) {
+        if (sak.klager.harEksisterendeJournalpostId(request.journalpostId)) {
             return KunneIkkeOppretteKlage.HarAlleredeEnKlageBehandling.left()
         }
 

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/klage/KlageServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/klage/KlageServiceImpl.kt
@@ -66,6 +66,11 @@ class KlageServiceImpl(
             // TODO jah: Justere denne sjekken når vi har konseptet lukket klage.
             return KunneIkkeOppretteKlage.FinnesAlleredeEnÅpenKlage.left()
         }
+
+        if (sak.hentKlager().any { it.journalpostId == request.journalpostId }) {
+            return KunneIkkeOppretteKlage.HarAlleredeEnKlageBehandling.left()
+        }
+
         val aktørId = personService.hentAktørId(sak.fnr).getOrElse {
             return KunneIkkeOppretteKlage.KunneIkkeOppretteOppgave.left()
         }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/klage/KlageRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/klage/KlageRoutes.kt
@@ -100,6 +100,10 @@ internal fun Route.klageRoutes(
                                 "Mottatt dato kan ikke være frem i tid",
                                 "ugyldig_mottatt_dato",
                             )
+                            KunneIkkeOppretteKlage.HarAlleredeEnKlageBehandling -> BadRequest.errorJson(
+                                "Finnes allerede en klagebehandling med gitt journalpostId",
+                                "finnes_allerede_en_klagebehandling",
+                            )
                         }
                     }
                     call.svar(resultat)


### PR DESCRIPTION
Vi kommer trenge å lagre våre vedtak knyttet til klagen, så då er nyttigt å tydliggjøre att (de nåværande) klagevedtak er vedtaken fra klageinstans og ikke våre vedtak.

Har i tillegg lagt til en unique constraint på journalpostId sån att man ikke kan legge in 2 klagebehandlinger på de samme journalførte dokumentet.