### PR TITLE
Diverse utbedringer for avkorting + simulering.

### DIFF
--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/simulering/SimuleringRequestBuilderTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/simulering/SimuleringRequestBuilderTest.kt
@@ -5,8 +5,12 @@ import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.client.oppdrag.utbetaling.UtbetalingRequest
 import no.nav.su.se.bakover.client.oppdrag.utbetaling.UtbetalingRequestTest
 import no.nav.su.se.bakover.client.oppdrag.utbetaling.toUtbetalingRequest
+import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.februar
+import no.nav.su.se.bakover.common.januar
+import no.nav.su.se.bakover.common.mai
 import no.nav.su.se.bakover.common.oktober
+import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.common.september
 import no.nav.su.se.bakover.common.startOfDay
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
@@ -24,7 +28,13 @@ internal class SimuleringRequestBuilderTest {
     @Test
     fun `bygger simulering request til bruker uten eksisterende oppdragslinjer`() {
         val utbetalingsRequest = UtbetalingRequestTest.utbetalingRequestFørstegangsutbetaling.oppdragRequest
-        SimuleringRequestBuilder(utbetalingsRequest).build().request.also {
+        SimuleringRequestBuilder(
+            simuleringsperiode = Periode.create(
+                fraOgMed = 1.januar(2020),
+                tilOgMed = 31.desember(2020),
+            ),
+            mappedRequest = utbetalingsRequest,
+        ).build().request.also {
             it.oppdrag.let { oppdrag ->
                 oppdrag.assert(utbetalingsRequest)
                 oppdrag.oppdragslinje.forEachIndexed { index, oppdragslinje ->
@@ -54,7 +64,13 @@ internal class SimuleringRequestBuilderTest {
         )
 
         val utbetalingsRequest = toUtbetalingRequest(utbetalingMedEndring).oppdragRequest
-        SimuleringRequestBuilder(utbetalingsRequest).build().request.let {
+        SimuleringRequestBuilder(
+            simuleringsperiode = Periode.create(
+                fraOgMed = 1.februar(2020),
+                tilOgMed = 31.desember(2020),
+            ),
+            mappedRequest = utbetalingsRequest,
+        ).build().request.let {
             it.oppdrag.let { oppdrag ->
                 oppdrag.assert(utbetalingsRequest)
                 oppdrag.oppdragslinje.forEachIndexed { index, oppdragslinje ->
@@ -87,7 +103,13 @@ internal class SimuleringRequestBuilderTest {
         )
 
         val utbetalingsRequest = toUtbetalingRequest(utbetalingMedEndring).oppdragRequest
-        SimuleringRequestBuilder(utbetalingsRequest).build().request.let {
+        SimuleringRequestBuilder(
+            simuleringsperiode = Periode.create(
+                fraOgMed = 1.mai(2020),
+                tilOgMed = 31.desember(2020),
+            ),
+            mappedRequest = utbetalingsRequest,
+        ).build().request.let {
             it.oppdrag.let { oppdrag ->
                 oppdrag.assert(utbetalingsRequest)
                 oppdrag.oppdragslinje.forEachIndexed { index, oppdragslinje ->

--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/simulering/SimuleringRequestBuilderValidationTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/simulering/SimuleringRequestBuilderValidationTest.kt
@@ -5,12 +5,14 @@ import no.nav.su.se.bakover.client.oppdrag.avstemming.sakId
 import no.nav.su.se.bakover.client.oppdrag.avstemming.saksnummer
 import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.januar
+import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.grunnlag.Uføregrad
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppdrag.Utbetalingslinje
 import no.nav.su.se.bakover.domain.oppdrag.avstemming.Avstemmingsnøkkel
+import no.nav.su.se.bakover.domain.oppdrag.simulering.SimulerUtbetalingForPeriode
 import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.system.os.tjenester.simulerfpservice.simulerfpserviceservicetypes.SimulerBeregningRequest
 import org.junit.jupiter.api.Test
@@ -35,25 +37,31 @@ internal class SimuleringRequestBuilderValidationTest {
     fun `valider soap xml mot xsd skjema`() {
         val eksisterendeOppdragslinjeid = UUID30.randomUUID()
         val simuleringRequest = SimuleringRequestBuilder(
-            utbetaling = Utbetaling.UtbetalingForSimulering(
-                opprettet = fixedTidspunkt,
-                saksnummer = saksnummer,
-                sakId = sakId,
-                utbetalingslinjer = nonEmptyListOf(
-                    Utbetalingslinje.Ny(
-                        opprettet = fixedTidspunkt,
-                        fraOgMed = 1.januar(2020),
-                        tilOgMed = 31.januar(2020),
-                        beløp = 10,
-                        forrigeUtbetalingslinjeId = eksisterendeOppdragslinjeid,
-                        uføregrad = Uføregrad.parse(50),
+            request = SimulerUtbetalingForPeriode(
+                utbetaling = Utbetaling.UtbetalingForSimulering(
+                    opprettet = fixedTidspunkt,
+                    saksnummer = saksnummer,
+                    sakId = sakId,
+                    utbetalingslinjer = nonEmptyListOf(
+                        Utbetalingslinje.Ny(
+                            opprettet = fixedTidspunkt,
+                            fraOgMed = 1.januar(2020),
+                            tilOgMed = 31.januar(2020),
+                            beløp = 10,
+                            forrigeUtbetalingslinjeId = eksisterendeOppdragslinjeid,
+                            uføregrad = Uføregrad.parse(50),
+                        ),
                     ),
-                ),
-                fnr = Fnr("12345678910"),
-                type = Utbetaling.UtbetalingsType.NY,
+                    fnr = Fnr("12345678910"),
+                    type = Utbetaling.UtbetalingsType.NY,
 
-                behandler = NavIdentBruker.Saksbehandler("Z123"),
-                avstemmingsnøkkel = Avstemmingsnøkkel(opprettet = fixedTidspunkt),
+                    behandler = NavIdentBruker.Saksbehandler("Z123"),
+                    avstemmingsnøkkel = Avstemmingsnøkkel(opprettet = fixedTidspunkt),
+                ),
+                simuleringsperiode = Periode.create(
+                    fraOgMed = 1.januar(2020),
+                    tilOgMed = 31.januar(2020),
+                ),
             ),
         ).build().request
 
@@ -66,7 +74,7 @@ internal class SimuleringRequestBuilderValidationTest {
         marshaller.schema = s
         marshaller.marshal(
             JAXBElement(QName("", "request"), SimulerBeregningRequest::class.java, simuleringRequest),
-            DefaultHandler()
+            DefaultHandler(),
         )
     }
 }

--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/simulering/SimuleringSoapClientTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/simulering/SimuleringSoapClientTest.kt
@@ -10,12 +10,14 @@ import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.oktober
+import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.grunnlag.Uføregrad
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppdrag.Utbetalingslinje
 import no.nav.su.se.bakover.domain.oppdrag.avstemming.Avstemmingsnøkkel
+import no.nav.su.se.bakover.domain.oppdrag.simulering.SimulerUtbetalingForPeriode
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimuleringFeilet
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimulertPeriode
@@ -63,7 +65,15 @@ internal class SimuleringSoapClientTest {
             clock = fixedClock,
         )
 
-        simuleringService.simulerUtbetaling(nyUtbetaling) shouldBe SimuleringResponseMapper(
+        simuleringService.simulerUtbetaling(
+            request = SimulerUtbetalingForPeriode(
+                simuleringsperiode = Periode.create(
+                    fraOgMed = 1.januar(2020),
+                    tilOgMed = 31.desember(2020),
+                ),
+                utbetaling = nyUtbetaling,
+            ),
+        ) shouldBe SimuleringResponseMapper(
             okSimuleringResponse(),
             fixedClock,
         ).simulering.right()
@@ -93,7 +103,15 @@ internal class SimuleringSoapClientTest {
                 ),
             ),
         )
-        simuleringService.simulerUtbetaling(opphør) shouldBe Simulering(
+        simuleringService.simulerUtbetaling(
+            request = SimulerUtbetalingForPeriode(
+                simuleringsperiode = Periode.create(
+                    fraOgMed = 1.januar(2018),
+                    tilOgMed = 31.desember(2020),
+                ),
+                utbetaling = opphør,
+            ),
+        ) shouldBe Simulering(
             gjelderId = FNR,
             gjelderNavn = FNR.toString(),
             nettoBeløp = 0,
@@ -128,7 +146,15 @@ internal class SimuleringSoapClientTest {
             clock = fixedClock,
         )
 
-        simuleringService.simulerUtbetaling(nyUtbetaling) shouldBe SimuleringFeilet.FUNKSJONELL_FEIL.left()
+        simuleringService.simulerUtbetaling(
+            request = SimulerUtbetalingForPeriode(
+                simuleringsperiode = Periode.create(
+                    fraOgMed = 1.januar(2020),
+                    tilOgMed = 31.desember(2020),
+                ),
+                utbetaling = nyUtbetaling,
+            ),
+        ) shouldBe SimuleringFeilet.FUNKSJONELL_FEIL.left()
     }
 
     @Test
@@ -146,7 +172,15 @@ internal class SimuleringSoapClientTest {
             clock = fixedClock,
         )
 
-        simuleringService.simulerUtbetaling(nyUtbetaling) shouldBe SimuleringFeilet.OPPDRAG_UR_ER_STENGT.left()
+        simuleringService.simulerUtbetaling(
+            request = SimulerUtbetalingForPeriode(
+                simuleringsperiode = Periode.create(
+                    fraOgMed = 1.januar(2020),
+                    tilOgMed = 31.desember(2020),
+                ),
+                utbetaling = nyUtbetaling,
+            ),
+        ) shouldBe SimuleringFeilet.OPPDRAG_UR_ER_STENGT.left()
     }
 
     @Test
@@ -164,7 +198,15 @@ internal class SimuleringSoapClientTest {
             clock = fixedClock,
         )
 
-        val response = simuleringService.simulerUtbetaling(nyUtbetaling)
+        val response = simuleringService.simulerUtbetaling(
+            request = SimulerUtbetalingForPeriode(
+                simuleringsperiode = Periode.create(
+                    fraOgMed = 1.januar(2020),
+                    tilOgMed = 31.desember(2020),
+                ),
+                utbetaling = nyUtbetaling,
+            ),
+        )
 
         response shouldBe SimuleringFeilet.OPPDRAG_UR_ER_STENGT.left()
     }
@@ -184,7 +226,15 @@ internal class SimuleringSoapClientTest {
             clock = fixedClock,
         )
 
-        simuleringService.simulerUtbetaling(nyUtbetaling) shouldBe SimuleringFeilet.TEKNISK_FEIL.left()
+        simuleringService.simulerUtbetaling(
+            request = SimulerUtbetalingForPeriode(
+                simuleringsperiode = Periode.create(
+                    fraOgMed = 1.januar(2020),
+                    tilOgMed = 31.desember(2020),
+                ),
+                utbetaling = nyUtbetaling,
+            ),
+        ) shouldBe SimuleringFeilet.TEKNISK_FEIL.left()
     }
 
     @Test
@@ -223,7 +273,15 @@ internal class SimuleringSoapClientTest {
             avstemmingsnøkkel = Avstemmingsnøkkel(opprettet = fixedTidspunkt),
         )
 
-        simuleringService.simulerUtbetaling(utenBeløp) shouldBe Simulering(
+        simuleringService.simulerUtbetaling(
+            request = SimulerUtbetalingForPeriode(
+                simuleringsperiode = Periode.create(
+                    fraOgMed = 1.oktober(2020),
+                    tilOgMed = 31.desember(2020),
+                ),
+                utbetaling = utenBeløp,
+            ),
+        ) shouldBe Simulering(
             gjelderId = FNR,
             gjelderNavn = FNR.toString(),
             nettoBeløp = 0,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/SimulerUtbetalingRequest.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/SimulerUtbetalingRequest.kt
@@ -1,6 +1,7 @@
 package no.nav.su.se.bakover.domain.oppdrag
 
 import no.nav.su.se.bakover.domain.NavIdentBruker
+import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.beregning.Beregning
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
@@ -24,6 +25,10 @@ sealed interface SimulerUtbetalingRequest {
         val stansdato: LocalDate
     }
 
+    interface GjenopptakRequest : SimulerUtbetalingRequest {
+        val sak: Sak
+    }
+
     data class NyUtbetaling(
         override val sakId: UUID,
         override val saksbehandler: NavIdentBruker,
@@ -42,6 +47,13 @@ sealed interface SimulerUtbetalingRequest {
         override val saksbehandler: NavIdentBruker,
         override val stansdato: LocalDate,
     ) : StansRequest
+
+    data class Gjenopptak(
+        override val saksbehandler: NavIdentBruker,
+        override val sak: Sak,
+    ) : GjenopptakRequest {
+        override val sakId = sak.id
+    }
 }
 
 sealed interface UtbetalRequest : SimulerUtbetalingRequest {
@@ -64,4 +76,10 @@ sealed interface UtbetalRequest : SimulerUtbetalingRequest {
         override val simulering: Simulering,
     ) : UtbetalRequest,
         SimulerUtbetalingRequest.StansRequest by request
+
+    data class Gjenopptak(
+        override val sakId: UUID,
+        override val saksbehandler: NavIdentBruker,
+        override val simulering: Simulering,
+    ) : UtbetalRequest
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/SimulerUtbetalingRequest.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/SimulerUtbetalingRequest.kt
@@ -4,6 +4,7 @@ import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.beregning.Beregning
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
+import java.time.LocalDate
 import java.util.UUID
 
 sealed interface SimulerUtbetalingRequest {
@@ -15,12 +16,22 @@ sealed interface SimulerUtbetalingRequest {
         val uføregrunnlag: List<Grunnlag.Uføregrunnlag>
     }
 
+    interface OpphørRequest : SimulerUtbetalingRequest {
+        val opphørsdato: LocalDate
+    }
+
     data class NyUtbetaling(
         override val sakId: UUID,
         override val saksbehandler: NavIdentBruker,
         override val beregning: Beregning,
         override val uføregrunnlag: List<Grunnlag.Uføregrunnlag>,
     ) : NyUtbetalingRequest
+
+    data class Opphør(
+        override val sakId: UUID,
+        override val saksbehandler: NavIdentBruker,
+        override val opphørsdato: LocalDate,
+    ) : OpphørRequest
 }
 
 sealed interface UtbetalRequest : SimulerUtbetalingRequest {
@@ -31,4 +42,10 @@ sealed interface UtbetalRequest : SimulerUtbetalingRequest {
         override val simulering: Simulering,
     ) : UtbetalRequest,
         SimulerUtbetalingRequest.NyUtbetalingRequest by request
+
+    data class Opphør(
+        private val request: SimulerUtbetalingRequest.OpphørRequest,
+        override val simulering: Simulering,
+    ) : UtbetalRequest,
+        SimulerUtbetalingRequest.OpphørRequest by request
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/SimulerUtbetalingRequest.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/SimulerUtbetalingRequest.kt
@@ -20,6 +20,10 @@ sealed interface SimulerUtbetalingRequest {
         val opphørsdato: LocalDate
     }
 
+    interface StansRequest : SimulerUtbetalingRequest {
+        val stansdato: LocalDate
+    }
+
     data class NyUtbetaling(
         override val sakId: UUID,
         override val saksbehandler: NavIdentBruker,
@@ -32,6 +36,12 @@ sealed interface SimulerUtbetalingRequest {
         override val saksbehandler: NavIdentBruker,
         override val opphørsdato: LocalDate,
     ) : OpphørRequest
+
+    data class Stans(
+        override val sakId: UUID,
+        override val saksbehandler: NavIdentBruker,
+        override val stansdato: LocalDate,
+    ) : StansRequest
 }
 
 sealed interface UtbetalRequest : SimulerUtbetalingRequest {
@@ -48,4 +58,10 @@ sealed interface UtbetalRequest : SimulerUtbetalingRequest {
         override val simulering: Simulering,
     ) : UtbetalRequest,
         SimulerUtbetalingRequest.OpphørRequest by request
+
+    data class Stans(
+        private val request: SimulerUtbetalingRequest.Stans,
+        override val simulering: Simulering,
+    ) : UtbetalRequest,
+        SimulerUtbetalingRequest.StansRequest by request
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/SimulerUtbetalingRequest.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/SimulerUtbetalingRequest.kt
@@ -1,0 +1,34 @@
+package no.nav.su.se.bakover.domain.oppdrag
+
+import no.nav.su.se.bakover.domain.NavIdentBruker
+import no.nav.su.se.bakover.domain.beregning.Beregning
+import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
+import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
+import java.util.UUID
+
+sealed interface SimulerUtbetalingRequest {
+    val sakId: UUID
+    val saksbehandler: NavIdentBruker
+
+    interface NyUtbetalingRequest : SimulerUtbetalingRequest {
+        val beregning: Beregning
+        val uføregrunnlag: List<Grunnlag.Uføregrunnlag>
+    }
+
+    data class NyUtbetaling(
+        override val sakId: UUID,
+        override val saksbehandler: NavIdentBruker,
+        override val beregning: Beregning,
+        override val uføregrunnlag: List<Grunnlag.Uføregrunnlag>,
+    ) : NyUtbetalingRequest
+}
+
+sealed interface UtbetalRequest : SimulerUtbetalingRequest {
+    val simulering: Simulering
+
+    data class NyUtbetaling(
+        private val request: SimulerUtbetalingRequest.NyUtbetalingRequest,
+        override val simulering: Simulering,
+    ) : UtbetalRequest,
+        SimulerUtbetalingRequest.NyUtbetalingRequest by request
+}

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/SimulerUtbetalingRequest.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/SimulerUtbetalingRequest.kt
@@ -1,0 +1,14 @@
+package no.nav.su.se.bakover.domain.oppdrag.simulering
+
+import no.nav.su.se.bakover.common.periode.Periode
+import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
+
+sealed interface SimulerUtbetalingRequest {
+    val simuleringsperiode: Periode
+    val utbetaling: Utbetaling.UtbetalingForSimulering
+}
+
+data class SimulerUtbetalingForPeriode(
+    override val simuleringsperiode: Periode,
+    override val utbetaling: Utbetaling.UtbetalingForSimulering,
+) : SimulerUtbetalingRequest

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/SimuleringClient.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/SimuleringClient.kt
@@ -1,8 +1,7 @@
 package no.nav.su.se.bakover.domain.oppdrag.simulering
 
 import arrow.core.Either
-import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 
 interface SimuleringClient {
-    fun simulerUtbetaling(utbetaling: Utbetaling): Either<SimuleringFeilet, Simulering>
+    fun simulerUtbetaling(request: SimulerUtbetalingRequest): Either<SimuleringFeilet, Simulering>
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/TolketSimulering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/TolketSimulering.kt
@@ -41,7 +41,7 @@ data class TolketSimulering(
             simulertePerioder
                 .filter { periode inneholder it.periode }
                 .map { it.hentUtbetaltBeløp() }
-                .filter { it.sum() > 0 }
+                .filter { it.sum() > 0 },
         )
     }
 }
@@ -74,7 +74,11 @@ sealed class TolketUtbetaling {
                 val sum = tolketDetaljer.sumOf { it.beløp }
                 when {
                     sum > 0 -> Etterbetaling(tolketDetaljer + TolketDetalj.Etterbetaling(sum))
-                    sum == 0 -> UendretUtbetaling(tolketDetaljer + TolketDetalj.UendretUtbetaling(sum))
+                    sum == 0 -> UendretUtbetaling(
+                        tolketDetaljer + TolketDetalj.UendretUtbetaling(
+                            tolketDetaljer.filterIsInstance<TolketDetalj.Ordinær>().sumOf { it.beløp },
+                        ),
+                    )
                     else -> throw IndikererFeilutbetaling
                 }
             }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/TolketSimulering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/TolketSimulering.kt
@@ -32,11 +32,16 @@ data class TolketSimulering(
 
     fun harFeilutbetalinger() = simulertePerioder.any { it.harFeilutbetalinger() }
 
+    /**
+     * Identifiser eventuelle utbetalte beløp per periode.
+     * Inkluderer kun beløp som er større enn 0.
+     */
     fun hentUtbetalteBeløp(periode: Periode): Månedsbeløp {
         return Månedsbeløp(
             simulertePerioder
                 .filter { periode inneholder it.periode }
-                .map { it.hentUtbetaltBeløp() },
+                .map { it.hentUtbetaltBeløp() }
+                .filter { it.sum() > 0 }
         )
     }
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/beregning/BeregnRevurderingStrategy.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/beregning/BeregnRevurderingStrategy.kt
@@ -44,7 +44,7 @@ internal class VidereførAvkorting(
             return Revurdering.KunneIkkeBeregneRevurdering.AvkortingErUfullstendig.left()
         }
 
-        return utenAvkorting.oppdaterFradragOgMarkerSomVurdert(
+        return utenAvkorting.oppdaterFradrag(
             fradragsgrunnlag = utenAvkorting.grunnlagsdata.fradragsgrunnlag + fradragForAvkorting,
         ).getOrHandle {
             throw IllegalStateException(
@@ -66,7 +66,7 @@ internal class AnnullerAvkorting(
 }
 
 private fun beregnUtenAvkorting(revurdering: Revurdering, clock: Clock): Pair<OpprettetRevurdering, Beregning> {
-    return revurdering.oppdaterFradragOgMarkerSomVurdert(
+    return revurdering.oppdaterFradrag(
         fradragsgrunnlag = revurdering.grunnlagsdata.fradragsgrunnlag.filterNot { it.fradragstype == Fradragstype.AvkortingUtenlandsopphold },
     ).getOrHandle {
         throw IllegalStateException(Revurdering.KunneIkkeLeggeTilFradrag.UgyldigTilstand(revurdering::class).toString())

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/TolketSimuleringTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/TolketSimuleringTest.kt
@@ -300,17 +300,11 @@ internal class TolketSimuleringTest {
             it.hentUtbetalteBeløp(periode2021) shouldBe Månedsbeløp(
                 listOf(
                     MånedBeløp(februar(2021), Beløp(20779)),
-                    MånedBeløp(mars(2021), Beløp(0)),
                 ),
             )
             it.hentUtbetalteBeløp(februar(2021)) shouldBe Månedsbeløp(
                 listOf(
                     MånedBeløp(februar(2021), Beløp(20779)),
-                ),
-            )
-            it.hentUtbetalteBeløp(mars(2021)) shouldBe Månedsbeløp(
-                listOf(
-                    MånedBeløp(mars(2021), Beløp(0)),
                 ),
             )
         }
@@ -533,7 +527,6 @@ internal class TolketSimuleringTest {
             it.hentUtbetalteBeløp(periode2021) shouldBe Månedsbeløp(
                 listOf(
                     MånedBeløp(februar(2021), Beløp(20779)),
-                    MånedBeløp(mars(2021), Beløp(0)),
                 )
             )
         }
@@ -662,7 +655,6 @@ internal class TolketSimuleringTest {
             it.hentUtbetalteBeløp(periode2021) shouldBe Månedsbeløp(
                 listOf(
                     MånedBeløp(februar(2021), Beløp(20779)),
-                    MånedBeløp(mars(2021), Beløp(0)),
                 ),
             )
         }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/TolketSimuleringTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/TolketSimuleringTest.kt
@@ -631,7 +631,7 @@ internal class TolketSimuleringTest {
                                     beløp = -20779,
                                 ),
                                 TolketDetalj.UendretUtbetaling(
-                                    beløp = 0,
+                                    beløp = 20779,
                                 ),
                             ),
                         ),

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/RevurderingBeregnTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/RevurderingBeregnTest.kt
@@ -410,6 +410,7 @@ internal class RevurderingBeregnTest {
                         ),
                     ),
                 )
+                beregnet.informasjonSomRevurderes shouldBe revurdering.informasjonSomRevurderes
             }
         }
     }
@@ -534,6 +535,7 @@ internal class RevurderingBeregnTest {
                         ),
                     ),
                 )
+                beregnet.informasjonSomRevurderes shouldBe revurdering.informasjonSomRevurderes
             }
         }
     }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
@@ -222,13 +222,11 @@ open class AccessCheckProxy(
                 }
 
                 override fun simulerOpphør(
-                    sakId: UUID,
-                    saksbehandler: NavIdentBruker,
-                    opphørsdato: LocalDate,
+                    request: SimulerUtbetalingRequest.OpphørRequest,
                 ): Either<SimuleringFeilet, Utbetaling.SimulertUtbetaling> {
-                    assertHarTilgangTilSak(sakId)
+                    assertHarTilgangTilSak(request.sakId)
 
-                    return services.utbetaling.simulerOpphør(sakId, saksbehandler, opphørsdato)
+                    return services.utbetaling.simulerOpphør(request)
                 }
 
                 override fun utbetal(
@@ -283,13 +281,10 @@ open class AccessCheckProxy(
                 }
 
                 override fun opphør(
-                    sakId: UUID,
-                    attestant: NavIdentBruker,
-                    simulering: Simulering,
-                    opphørsdato: LocalDate,
+                    request: UtbetalRequest.Opphør,
                 ): Either<UtbetalingFeilet, Utbetaling.OversendtUtbetaling.UtenKvittering> {
-                    assertHarTilgangTilSak(sakId)
-                    return services.utbetaling.opphør(sakId, attestant, simulering, opphørsdato)
+                    assertHarTilgangTilSak(request.sakId)
+                    return services.utbetaling.opphør(request)
                 }
 
                 override fun hentGjeldendeUtbetaling(

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
@@ -19,7 +19,6 @@ import no.nav.su.se.bakover.domain.SøknadInnhold
 import no.nav.su.se.bakover.domain.behandling.Attestering
 import no.nav.su.se.bakover.domain.behandling.Behandling
 import no.nav.su.se.bakover.domain.behandling.avslag.AvslagManglendeDokumentasjon
-import no.nav.su.se.bakover.domain.beregning.Beregning
 import no.nav.su.se.bakover.domain.brev.LagBrevRequest
 import no.nav.su.se.bakover.domain.dokument.Dokument
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
@@ -47,6 +46,8 @@ import no.nav.su.se.bakover.domain.klage.VurdertKlage
 import no.nav.su.se.bakover.domain.kontrollsamtale.Kontrollsamtale
 import no.nav.su.se.bakover.domain.nøkkeltall.Nøkkeltall
 import no.nav.su.se.bakover.domain.oppdrag.Kvittering
+import no.nav.su.se.bakover.domain.oppdrag.SimulerUtbetalingRequest
+import no.nav.su.se.bakover.domain.oppdrag.UtbetalRequest
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppdrag.UtbetalingFeilet
 import no.nav.su.se.bakover.domain.oppdrag.UtbetalingslinjePåTidslinje
@@ -213,14 +214,11 @@ open class AccessCheckProxy(
                     kastKanKunKallesFraAnnenService()
 
                 override fun simulerUtbetaling(
-                    sakId: UUID,
-                    saksbehandler: NavIdentBruker,
-                    beregning: Beregning,
-                    uføregrunnlag: List<Grunnlag.Uføregrunnlag>,
+                    request: SimulerUtbetalingRequest.NyUtbetalingRequest,
                 ): Either<SimuleringFeilet, Utbetaling.SimulertUtbetaling> {
-                    assertHarTilgangTilSak(sakId)
+                    assertHarTilgangTilSak(request.sakId)
 
-                    return services.utbetaling.simulerUtbetaling(sakId, saksbehandler, beregning, uføregrunnlag)
+                    return services.utbetaling.simulerUtbetaling(request)
                 }
 
                 override fun simulerOpphør(
@@ -234,15 +232,11 @@ open class AccessCheckProxy(
                 }
 
                 override fun utbetal(
-                    sakId: UUID,
-                    attestant: NavIdentBruker,
-                    beregning: Beregning,
-                    simulering: Simulering,
-                    uføregrunnlag: List<Grunnlag.Uføregrunnlag>,
+                    request: UtbetalRequest.NyUtbetaling,
                 ): Either<UtbetalingFeilet, Utbetaling.OversendtUtbetaling.UtenKvittering> {
-                    assertHarTilgangTilSak(sakId)
+                    assertHarTilgangTilSak(request.sakId)
 
-                    return services.utbetaling.utbetal(sakId, attestant, beregning, simulering, uføregrunnlag)
+                    return services.utbetaling.utbetal(request)
                 }
 
                 override fun publiserUtbetaling(utbetaling: Utbetaling.SimulertUtbetaling): Either<UtbetalingFeilet, Utbetalingsrequest> = kastKanKunKallesFraAnnenService()
@@ -253,11 +247,7 @@ open class AccessCheckProxy(
                 ): Utbetaling.OversendtUtbetaling.UtenKvittering = kastKanKunKallesFraAnnenService()
 
                 override fun genererUtbetalingsRequest(
-                    sakId: UUID,
-                    attestant: NavIdentBruker,
-                    beregning: Beregning,
-                    simulering: Simulering,
-                    uføregrunnlag: List<Grunnlag.Uføregrunnlag>,
+                    request: UtbetalRequest.NyUtbetaling,
                 ): Either<UtbetalingFeilet, Utbetaling.SimulertUtbetaling> = kastKanKunKallesFraAnnenService()
 
                 override fun simulerStans(

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
@@ -249,18 +249,13 @@ open class AccessCheckProxy(
                 ): Either<UtbetalingFeilet, Utbetaling.SimulertUtbetaling> = kastKanKunKallesFraAnnenService()
 
                 override fun simulerStans(
-                    sakId: UUID,
-                    saksbehandler: NavIdentBruker,
-                    stansDato: LocalDate,
+                    request: SimulerUtbetalingRequest.StansRequest,
                 ): Either<SimulerStansFeilet, Utbetaling.SimulertUtbetaling> {
                     kastKanKunKallesFraAnnenService()
                 }
 
                 override fun stansUtbetalinger(
-                    sakId: UUID,
-                    attestant: NavIdentBruker,
-                    simulering: Simulering,
-                    stansDato: LocalDate,
+                    request: UtbetalRequest.Stans,
                 ): Either<UtbetalStansFeil, Utbetaling.OversendtUtbetaling.UtenKvittering> {
                     kastKanKunKallesFraAnnenService()
                 }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
@@ -54,7 +54,6 @@ import no.nav.su.se.bakover.domain.oppdrag.UtbetalingslinjePåTidslinje
 import no.nav.su.se.bakover.domain.oppdrag.Utbetalingsrequest
 import no.nav.su.se.bakover.domain.oppdrag.avstemming.Avstemming
 import no.nav.su.se.bakover.domain.oppdrag.avstemming.Avstemmingsnøkkel
-import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimuleringFeilet
 import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
 import no.nav.su.se.bakover.domain.oppgave.OppgaveFeil
@@ -261,16 +260,13 @@ open class AccessCheckProxy(
                 }
 
                 override fun simulerGjenopptak(
-                    sak: Sak,
-                    saksbehandler: NavIdentBruker,
+                    request: SimulerUtbetalingRequest.GjenopptakRequest,
                 ): Either<SimulerGjenopptakFeil, Utbetaling.SimulertUtbetaling> {
                     kastKanKunKallesFraAnnenService()
                 }
 
                 override fun gjenopptaUtbetalinger(
-                    sakId: UUID,
-                    attestant: NavIdentBruker,
-                    simulering: Simulering,
+                    request: UtbetalRequest.Gjenopptak,
                 ): Either<UtbetalGjenopptakFeil, Utbetaling.OversendtUtbetaling.UtenKvittering> {
                     kastKanKunKallesFraAnnenService()
                 }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -805,9 +805,11 @@ internal class RevurderingServiceImpl(
                         // TODO er tanken at vi skal oppdatere saksbehandler her? Det kan se ut som vi har tenkt det, men aldri fullført.
                         beregnetRevurdering.toSimulert { sakId, _, opphørsdato ->
                             utbetalingService.simulerOpphør(
-                                sakId = sakId,
-                                saksbehandler = saksbehandler,
-                                opphørsdato = opphørsdato,
+                                request = SimulerUtbetalingRequest.Opphør(
+                                    sakId = sakId,
+                                    saksbehandler = saksbehandler,
+                                    opphørsdato = opphørsdato,
+                                ),
                             )
                         }.mapLeft { KunneIkkeBeregneOgSimulereRevurdering.KunneIkkeSimulere(it) }
                             .map { simulert ->
@@ -1315,10 +1317,14 @@ internal class RevurderingServiceImpl(
                             clock = clock,
                             utbetal = { sakId: UUID, _: NavIdentBruker.Attestant, opphørsdato: LocalDate, simulering: Simulering ->
                                 utbetalingService.opphør(
-                                    sakId = sakId,
-                                    attestant = attestant,
-                                    opphørsdato = opphørsdato,
-                                    simulering = simulering,
+                                    request = UtbetalRequest.Opphør(
+                                        request = SimulerUtbetalingRequest.Opphør(
+                                            sakId = sakId,
+                                            saksbehandler = attestant,
+                                            opphørsdato = opphørsdato,
+                                        ),
+                                        simulering = simulering,
+                                    ),
                                 ).mapLeft {
                                     RevurderingTilAttestering.KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale(it)
                                 }.map {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingService.kt
@@ -3,8 +3,6 @@ package no.nav.su.se.bakover.service.utbetaling
 import arrow.core.Either
 import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.persistence.TransactionContext
-import no.nav.su.se.bakover.domain.NavIdentBruker
-import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.oppdrag.Kvittering
 import no.nav.su.se.bakover.domain.oppdrag.SimulerUtbetalingRequest
 import no.nav.su.se.bakover.domain.oppdrag.UtbetalRequest
@@ -14,7 +12,6 @@ import no.nav.su.se.bakover.domain.oppdrag.UtbetalingslinjePåTidslinje
 import no.nav.su.se.bakover.domain.oppdrag.Utbetalingsrequest
 import no.nav.su.se.bakover.domain.oppdrag.Utbetalingsstrategi
 import no.nav.su.se.bakover.domain.oppdrag.avstemming.Avstemmingsnøkkel
-import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimuleringFeilet
 import java.time.LocalDate
 import java.util.UUID
@@ -61,14 +58,11 @@ interface UtbetalingService {
     ): Either<UtbetalStansFeil, Utbetaling.OversendtUtbetaling.UtenKvittering>
 
     fun simulerGjenopptak(
-        sak: Sak,
-        saksbehandler: NavIdentBruker,
+        request: SimulerUtbetalingRequest.GjenopptakRequest,
     ): Either<SimulerGjenopptakFeil, Utbetaling.SimulertUtbetaling>
 
     fun gjenopptaUtbetalinger(
-        sakId: UUID,
-        attestant: NavIdentBruker,
-        simulering: Simulering,
+        request: UtbetalRequest.Gjenopptak,
     ): Either<UtbetalGjenopptakFeil, Utbetaling.OversendtUtbetaling.UtenKvittering>
 
     fun opphør(

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingService.kt
@@ -32,9 +32,7 @@ interface UtbetalingService {
     ): Either<SimuleringFeilet, Utbetaling.SimulertUtbetaling>
 
     fun simulerOpphør(
-        sakId: UUID,
-        saksbehandler: NavIdentBruker,
-        opphørsdato: LocalDate,
+        request: SimulerUtbetalingRequest.OpphørRequest,
     ): Either<SimuleringFeilet, Utbetaling.SimulertUtbetaling>
 
     fun utbetal(
@@ -79,10 +77,7 @@ interface UtbetalingService {
     ): Either<UtbetalGjenopptakFeil, Utbetaling.OversendtUtbetaling.UtenKvittering>
 
     fun opphør(
-        sakId: UUID,
-        attestant: NavIdentBruker,
-        simulering: Simulering,
-        opphørsdato: LocalDate,
+        request: UtbetalRequest.Opphør,
     ): Either<UtbetalingFeilet, Utbetaling.OversendtUtbetaling.UtenKvittering>
 
     fun hentGjeldendeUtbetaling(

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingService.kt
@@ -5,9 +5,9 @@ import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.persistence.TransactionContext
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Sak
-import no.nav.su.se.bakover.domain.beregning.Beregning
-import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
 import no.nav.su.se.bakover.domain.oppdrag.Kvittering
+import no.nav.su.se.bakover.domain.oppdrag.SimulerUtbetalingRequest
+import no.nav.su.se.bakover.domain.oppdrag.UtbetalRequest
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppdrag.UtbetalingFeilet
 import no.nav.su.se.bakover.domain.oppdrag.UtbetalingslinjePåTidslinje
@@ -28,10 +28,7 @@ interface UtbetalingService {
     ): Either<FantIkkeUtbetaling, Utbetaling.OversendtUtbetaling.MedKvittering>
 
     fun simulerUtbetaling(
-        sakId: UUID,
-        saksbehandler: NavIdentBruker,
-        beregning: Beregning,
-        uføregrunnlag: List<Grunnlag.Uføregrunnlag>,
+        request: SimulerUtbetalingRequest.NyUtbetalingRequest,
     ): Either<SimuleringFeilet, Utbetaling.SimulertUtbetaling>
 
     fun simulerOpphør(
@@ -41,11 +38,7 @@ interface UtbetalingService {
     ): Either<SimuleringFeilet, Utbetaling.SimulertUtbetaling>
 
     fun utbetal(
-        sakId: UUID,
-        attestant: NavIdentBruker,
-        beregning: Beregning,
-        simulering: Simulering,
-        uføregrunnlag: List<Grunnlag.Uføregrunnlag>,
+        request: UtbetalRequest.NyUtbetaling,
     ): Either<UtbetalingFeilet, Utbetaling.OversendtUtbetaling.UtenKvittering>
 
     fun publiserUtbetaling(
@@ -58,11 +51,7 @@ interface UtbetalingService {
     ): Utbetaling.OversendtUtbetaling.UtenKvittering
 
     fun genererUtbetalingsRequest(
-        sakId: UUID,
-        attestant: NavIdentBruker,
-        beregning: Beregning,
-        simulering: Simulering,
-        uføregrunnlag: List<Grunnlag.Uføregrunnlag>,
+        request: UtbetalRequest.NyUtbetaling,
     ): Either<UtbetalingFeilet, Utbetaling.SimulertUtbetaling>
 
     fun simulerStans(

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingService.kt
@@ -53,16 +53,11 @@ interface UtbetalingService {
     ): Either<UtbetalingFeilet, Utbetaling.SimulertUtbetaling>
 
     fun simulerStans(
-        sakId: UUID,
-        saksbehandler: NavIdentBruker,
-        stansDato: LocalDate,
+        request: SimulerUtbetalingRequest.StansRequest,
     ): Either<SimulerStansFeilet, Utbetaling.SimulertUtbetaling>
 
     fun stansUtbetalinger(
-        sakId: UUID,
-        attestant: NavIdentBruker,
-        simulering: Simulering,
-        stansDato: LocalDate,
+        request: UtbetalRequest.Stans,
     ): Either<UtbetalStansFeil, Utbetaling.OversendtUtbetaling.UtenKvittering>
 
     fun simulerGjenopptak(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/IverksettRevurderingTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/IverksettRevurderingTest.kt
@@ -170,7 +170,7 @@ internal class IverksettRevurderingTest {
                 on { hent(any()) } doReturn revurderingTilAttestering
             },
             utbetalingService = mock {
-                on { opphør(any(), any(), any(), any()) } doReturn utbetaling.right()
+                on { opphør(any()) } doReturn utbetaling.right()
             },
 
         )
@@ -181,10 +181,16 @@ internal class IverksettRevurderingTest {
 
         verify(mocks.revurderingRepo).hent(revurderingId)
         verify(mocks.utbetalingService).opphør(
-            sakId = argThat { it shouldBe sakId },
-            attestant = argThat { it shouldBe attestant },
-            simulering = argThat { it shouldBe revurderingTilAttestering.simulering },
-            opphørsdato = argThat { it shouldBe revurderingTilAttestering.periode.fraOgMed },
+            argThat {
+                it shouldBe UtbetalRequest.Opphør(
+                    request = SimulerUtbetalingRequest.Opphør(
+                        sakId = sakId,
+                        saksbehandler = attestant,
+                        opphørsdato = revurderingTilAttestering.periode.fraOgMed,
+                    ),
+                    simulering = revurderingTilAttestering.simulering,
+                )
+            },
         )
         verify(mocks.vedtakRepo).lagre(
             argThat {

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/IverksettRevurderingTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/IverksettRevurderingTest.kt
@@ -10,6 +10,8 @@ import no.nav.su.se.bakover.domain.avkorting.AvkortingVedRevurdering
 import no.nav.su.se.bakover.domain.behandling.Attestering
 import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
+import no.nav.su.se.bakover.domain.oppdrag.SimulerUtbetalingRequest
+import no.nav.su.se.bakover.domain.oppdrag.UtbetalRequest
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
@@ -78,7 +80,7 @@ internal class IverksettRevurderingTest {
             grunnlagsdata = Grunnlagsdata.IkkeVurdert,
             vilkårsvurderinger = Vilkårsvurderinger.Revurdering.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-            avkorting = AvkortingVedRevurdering.Iverksatt.IngenNyEllerUtestående
+            avkorting = AvkortingVedRevurdering.Iverksatt.IngenNyEllerUtestående,
         )
         val revurderingTilAttestering = RevurderingTilAttestering.Innvilget(
             id = revurderingId,
@@ -96,7 +98,7 @@ internal class IverksettRevurderingTest {
             vilkårsvurderinger = Vilkårsvurderinger.Revurdering.IkkeVurdert,
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
             attesteringer = Attesteringshistorikk.empty(),
-            avkorting = AvkortingVedRevurdering.Håndtert.IngenNyEllerUtestående
+            avkorting = AvkortingVedRevurdering.Håndtert.IngenNyEllerUtestående,
         )
 
         val revurderingRepoMock = mock<RevurderingRepo> {
@@ -107,7 +109,7 @@ internal class IverksettRevurderingTest {
             on { id } doReturn utbetalingId
         }
         val utbetalingServiceMock = mock<UtbetalingService> {
-            on { utbetal(any(), any(), any(), any(), any()) } doReturn utbetalingMock.right()
+            on { utbetal(any()) } doReturn utbetalingMock.right()
         }
         val vedtakRepoMock = mock<VedtakRepo>()
         val eventObserver: EventObserver = mock()
@@ -130,11 +132,17 @@ internal class IverksettRevurderingTest {
         ) {
             verify(revurderingRepoMock).hent(argThat { it shouldBe revurderingId })
             verify(utbetalingServiceMock).utbetal(
-                sakId = argThat { it shouldBe revurderingTilAttestering.sakId },
-                attestant = argThat { it shouldBe attestant },
-                beregning = argThat { it shouldBe revurderingTilAttestering.beregning },
-                simulering = argThat { it shouldBe revurderingTilAttestering.simulering },
-                uføregrunnlag = argThat { it shouldBe emptyList() },
+                request = argThat {
+                    it shouldBe UtbetalRequest.NyUtbetaling(
+                        request = SimulerUtbetalingRequest.NyUtbetaling(
+                            sakId = revurderingTilAttestering.sakId,
+                            saksbehandler = attestant,
+                            beregning = revurderingTilAttestering.beregning,
+                            uføregrunnlag = emptyList(),
+                        ),
+                        simulering = revurderingTilAttestering.simulering,
+                    )
+                },
             )
             verify(utbetalingMock, times(2)).id
             verify(vedtakRepoMock).lagre(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingBeregnOgSimulerTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingBeregnOgSimulerTest.kt
@@ -76,7 +76,7 @@ internal class RevurderingBeregnOgSimulerTest {
                 on { hent(any()) } doReturn opprettet
             },
             utbetalingService = mock {
-                on { simulerOpphør(any(), any(), any()) } doReturn opphørUtbetalingSimulert(
+                on { simulerOpphør(any()) } doReturn opphørUtbetalingSimulert(
                     sakOgBehandling = sak to opprettet,
                     opphørsdato = opprettet.periode.fraOgMed,
                     clock = fixedClock,
@@ -397,7 +397,7 @@ internal class RevurderingBeregnOgSimulerTest {
                 on { hent(any()) } doReturn opprettet
             },
             utbetalingService = mock {
-                on { simulerOpphør(any(), any(), any()) } doReturn opphørUtbetalingSimulert(
+                on { simulerOpphør(any()) } doReturn opphørUtbetalingSimulert(
                     sakOgBehandling = sak to opprettet,
                     opphørsdato = opprettet.periode.fraOgMed,
                     clock = fixedClock,
@@ -425,9 +425,13 @@ internal class RevurderingBeregnOgSimulerTest {
                 verify(serviceAndMocks.utbetalingService).hentUtbetalinger(sakId)
                 verify(serviceAndMocks.vedtakService).kopierGjeldendeVedtaksdata(sakId, opprettet.periode.fraOgMed)
                 verify(serviceAndMocks.utbetalingService).simulerOpphør(
-                    sakId = argThat { it shouldBe sakId },
-                    saksbehandler = argThat { it shouldBe NavIdentBruker.Saksbehandler("s1") },
-                    opphørsdato = argThat { it shouldBe opprettet.periode.fraOgMed },
+                    argThat {
+                        it shouldBe SimulerUtbetalingRequest.Opphør(
+                            sakId = sakId,
+                            saksbehandler = NavIdentBruker.Saksbehandler("s1"),
+                            opphørsdato = opprettet.periode.fraOgMed,
+                        )
+                    }
                 )
                 verify(serviceAndMocks.revurderingRepo).defaultTransactionContext()
                 verify(serviceAndMocks.revurderingRepo).lagre(argThat { it shouldBe actual }, anyOrNull())

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingBeregnOgSimulerTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingBeregnOgSimulerTest.kt
@@ -14,6 +14,7 @@ import no.nav.su.se.bakover.domain.avkorting.AvkortingVedRevurdering
 import no.nav.su.se.bakover.domain.avkorting.AvkortingVedSøknadsbehandling
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragTilhører
 import no.nav.su.se.bakover.domain.beregning.fradrag.Fradragstype
+import no.nav.su.se.bakover.domain.oppdrag.SimulerUtbetalingRequest
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimuleringFeilet
 import no.nav.su.se.bakover.domain.revurdering.RevurderingRepo
@@ -112,7 +113,7 @@ internal class RevurderingBeregnOgSimulerTest {
         }
 
         val utbetalingServiceMock = mock<UtbetalingService> {
-            on { simulerUtbetaling(any(), any(), any(), any()) } doReturn simulertUtbetaling.right()
+            on { simulerUtbetaling(any()) } doReturn simulertUtbetaling.right()
             on { hentUtbetalinger(any()) } doReturn sak.utbetalinger
         }
 
@@ -152,7 +153,7 @@ internal class RevurderingBeregnOgSimulerTest {
                 on { hent(any()) } doReturn opprettetRevurdering
             },
             utbetalingService = mock {
-                on { simulerUtbetaling(any(), any(), any(), any()) } doReturn nyUtbetalingSimulert(
+                on { simulerUtbetaling(any()) } doReturn nyUtbetalingSimulert(
                     sakOgBehandling = sak to opprettetRevurdering,
                     beregning = opprettetRevurdering.beregn(
                         eksisterendeUtbetalinger = sak.utbetalinger,
@@ -160,7 +161,7 @@ internal class RevurderingBeregnOgSimulerTest {
                         gjeldendeVedtaksdata = sak.kopierGjeldendeVedtaksdata(
                             fraOgMed = opprettetRevurdering.periode.fraOgMed,
                             clock = fixedClock,
-                        ).getOrFail()
+                        ).getOrFail(),
                     ).getOrFail().beregning,
                     clock = fixedClock,
                 ).right()
@@ -192,10 +193,14 @@ internal class RevurderingBeregnOgSimulerTest {
                     argThat { it shouldBe opprettetRevurdering.periode.fraOgMed },
                 )
                 verify(serviceAndMocks.utbetalingService).simulerUtbetaling(
-                    sakId = argThat { it shouldBe sakId },
-                    saksbehandler = argThat { it shouldBe saksbehandler },
-                    beregning = argThat { it shouldBe (actual.revurdering as SimulertRevurdering).beregning },
-                    uføregrunnlag = argThat { it shouldBe opprettetRevurdering.vilkårsvurderinger.uføre.grunnlag },
+                    request = argThat {
+                        it shouldBe SimulerUtbetalingRequest.NyUtbetaling(
+                            sakId = sakId,
+                            saksbehandler = saksbehandler,
+                            beregning = (actual.revurdering as SimulertRevurdering).beregning,
+                            uføregrunnlag = opprettetRevurdering.vilkårsvurderinger.uføre.grunnlag,
+                        )
+                    },
                 )
                 verify(serviceAndMocks.revurderingRepo).defaultTransactionContext()
                 verify(serviceAndMocks.revurderingRepo).lagre(argThat { it shouldBe actual.revurdering }, anyOrNull())
@@ -256,7 +261,7 @@ internal class RevurderingBeregnOgSimulerTest {
                 on { hent(any()) } doReturn beregnet
             },
             utbetalingService = mock {
-                on { simulerUtbetaling(any(), any(), any(), any()) } doReturn SimuleringFeilet.TEKNISK_FEIL.left()
+                on { simulerUtbetaling(any()) } doReturn SimuleringFeilet.TEKNISK_FEIL.left()
                 on { hentUtbetalinger(any()) } doReturn sak.utbetalinger
             },
             vedtakService = mock {
@@ -275,10 +280,14 @@ internal class RevurderingBeregnOgSimulerTest {
                 .left()
 
             verify(it.utbetalingService).simulerUtbetaling(
-                sakId = sakId,
-                saksbehandler = saksbehandler,
-                beregning = beregnet.beregning,
-                uføregrunnlag = beregnet.vilkårsvurderinger.uføre.grunnlag,
+                request = argThat {
+                    it shouldBe SimulerUtbetalingRequest.NyUtbetaling(
+                        sakId = sakId,
+                        saksbehandler = saksbehandler,
+                        beregning = beregnet.beregning,
+                        uføregrunnlag = beregnet.vilkårsvurderinger.uføre.grunnlag,
+                    )
+                },
             )
         }
     }
@@ -292,7 +301,7 @@ internal class RevurderingBeregnOgSimulerTest {
                 on { hent(any()) } doReturn underkjent
             },
             utbetalingService = mock {
-                on { simulerUtbetaling(any(), any(), any(), any()) } doReturn nyUtbetalingSimulert(
+                on { simulerUtbetaling(any()) } doReturn nyUtbetalingSimulert(
                     sakOgBehandling = sak to underkjent,
                     beregning = underkjent.beregning,
                     clock = fixedClock,
@@ -323,10 +332,14 @@ internal class RevurderingBeregnOgSimulerTest {
                 verify(serviceAndMocks.utbetalingService).hentUtbetalinger(sakId)
                 verify(serviceAndMocks.vedtakService).kopierGjeldendeVedtaksdata(sakId, underkjent.periode.fraOgMed)
                 verify(serviceAndMocks.utbetalingService).simulerUtbetaling(
-                    sakId = argThat { it shouldBe sakId },
-                    saksbehandler = argThat { it shouldBe saksbehandler },
-                    beregning = argThat { it shouldBe (actual.revurdering as SimulertRevurdering).beregning },
-                    uføregrunnlag = argThat { it shouldBe underkjent.vilkårsvurderinger.uføre.grunnlag },
+                    request = argThat {
+                        it shouldBe SimulerUtbetalingRequest.NyUtbetaling(
+                            sakId = sakId,
+                            saksbehandler = saksbehandler,
+                            beregning = (actual.revurdering as SimulertRevurdering).beregning,
+                            uføregrunnlag = underkjent.vilkårsvurderinger.uføre.grunnlag,
+                        )
+                    },
                 )
                 verify(serviceAndMocks.revurderingRepo).defaultTransactionContext()
                 verify(serviceAndMocks.revurderingRepo).lagre(argThat { it shouldBe actual.revurdering }, anyOrNull())
@@ -353,7 +366,7 @@ internal class RevurderingBeregnOgSimulerTest {
                     on { hent(any()) } doReturn opprettet
                 },
                 utbetalingService = mock {
-                    on { simulerUtbetaling(any(), any(), any(), any()) } doReturn simulertUtbetaling().right()
+                    on { simulerUtbetaling(any()) } doReturn simulertUtbetaling().right()
                     on { hentUtbetalinger(any()) } doReturn sak.utbetalinger
                 },
                 vedtakService = mock {
@@ -480,7 +493,7 @@ internal class RevurderingBeregnOgSimulerTest {
                 on { hent(any()) } doReturn revurdering2
             },
             utbetalingService = mock {
-                on { simulerUtbetaling(any(), any(), any(), any()) } doReturn simulertUtbetaling().right()
+                on { simulerUtbetaling(any()) } doReturn simulertUtbetaling().right()
                 on { hentUtbetalinger(any()) } doReturn sakEtterRevurdering2.utbetalinger
             },
             vedtakService = mock {

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/utbetaling/GjenopptaUtbetalingerServiceTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/utbetaling/GjenopptaUtbetalingerServiceTest.kt
@@ -11,6 +11,7 @@ import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.common.startOfMonth
 import no.nav.su.se.bakover.domain.Fnr
+import no.nav.su.se.bakover.domain.oppdrag.UtbetalRequest
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppdrag.UtbetalingFeilet
 import no.nav.su.se.bakover.domain.oppdrag.Utbetalingslinje
@@ -102,9 +103,11 @@ internal class GjenopptaUtbetalingerServiceTest {
             simuleringClient = simuleringClientMock,
             clock = klokke,
         ).gjenopptaUtbetalinger(
-            sakId = sak.id,
-            attestant = saksbehandler,
-            simulering = simulering,
+            request = UtbetalRequest.Gjenopptak(
+                sakId = sak.id,
+                saksbehandler = saksbehandler,
+                simulering = simulering,
+            ),
         ).getOrFail().let {
             verify(sakServiceMock).hentSak(
                 sakId = argThat { it shouldBe sak.id },
@@ -153,9 +156,11 @@ internal class GjenopptaUtbetalingerServiceTest {
         )
 
         service.gjenopptaUtbetalinger(
-            sakId = sakId,
-            attestant = saksbehandler,
-            simulering = simulering,
+            request = UtbetalRequest.Gjenopptak(
+                sakId = sakId,
+                saksbehandler = saksbehandler,
+                simulering = simulering,
+            ),
         ).let {
             it shouldBe UtbetalGjenopptakFeil.KunneIkkeUtbetale(UtbetalingFeilet.FantIkkeSak).left()
 
@@ -186,9 +191,11 @@ internal class GjenopptaUtbetalingerServiceTest {
             simuleringClient = simuleringClientMock,
             clock = fixedClock,
         ).gjenopptaUtbetalinger(
-            sakId = sak.id,
-            attestant = saksbehandler,
-            simulering = simulering,
+            request = UtbetalRequest.Gjenopptak(
+                sakId = sak.id,
+                saksbehandler = saksbehandler,
+                simulering = simulering,
+            ),
         ).let {
             it shouldBe UtbetalGjenopptakFeil.KunneIkkeSimulere(SimulerGjenopptakFeil.KunneIkkeSimulere(SimuleringFeilet.TEKNISK_FEIL))
                 .left()
@@ -242,9 +249,11 @@ internal class GjenopptaUtbetalingerServiceTest {
             simuleringClient = simuleringClientMock,
             clock = klokke,
         ).gjenopptaUtbetalinger(
-            sakId = sak.id,
-            attestant = saksbehandler,
-            simulering = simulering,
+            request = UtbetalRequest.Gjenopptak(
+                sakId = sak.id,
+                saksbehandler = saksbehandler,
+                simulering = simulering,
+            ),
         ).let {
             it shouldBe UtbetalGjenopptakFeil.KunneIkkeUtbetale(UtbetalingFeilet.Protokollfeil).left()
 
@@ -338,9 +347,11 @@ internal class GjenopptaUtbetalingerServiceTest {
             utbetalingPublisher = utbetalingPublisherMock,
             clock = fixedClock,
         ).gjenopptaUtbetalinger(
-            sakId = sak.id,
-            attestant = attestant,
-            simulering = simuleringMedFeil,
+            request = UtbetalRequest.Gjenopptak(
+                sakId = sak.id,
+                saksbehandler = attestant,
+                simulering = simuleringMedFeil,
+            ),
         ) shouldBe UtbetalGjenopptakFeil.KunneIkkeUtbetale(UtbetalingFeilet.KontrollAvSimuleringFeilet).left()
 
         verifyNoMoreInteractions(utbetalingRepoMock, utbetalingPublisherMock)

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/utbetaling/GjenopptaUtbetalingerServiceTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/utbetaling/GjenopptaUtbetalingerServiceTest.kt
@@ -12,11 +12,11 @@ import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.common.startOfMonth
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.oppdrag.UtbetalRequest
-import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppdrag.UtbetalingFeilet
 import no.nav.su.se.bakover.domain.oppdrag.Utbetalingslinje
 import no.nav.su.se.bakover.domain.oppdrag.simulering.KlasseKode
 import no.nav.su.se.bakover.domain.oppdrag.simulering.KlasseType
+import no.nav.su.se.bakover.domain.oppdrag.simulering.SimulerUtbetalingForPeriode
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimuleringClient
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimuleringFeilet
@@ -114,9 +114,9 @@ internal class GjenopptaUtbetalingerServiceTest {
             )
             verify(simuleringClientMock).simulerUtbetaling(
                 argThat {
-                    it.utbetalingslinjer shouldHaveSize 1
+                    it.utbetaling.utbetalingslinjer shouldHaveSize 1
                     val utbetalingslinjeForStans = sak.utbetalinger.first().sisteUtbetalingslinje()
-                    it.utbetalingslinjer.first().shouldBeEqualToIgnoringFields(
+                    it.utbetaling.utbetalingslinjer.first().shouldBeEqualToIgnoringFields(
                         Utbetalingslinje.Endring.Reaktivering(
                             utbetalingslinje = utbetalingslinjeForStans,
                             virkningstidspunkt = periode.fraOgMed,
@@ -203,7 +203,7 @@ internal class GjenopptaUtbetalingerServiceTest {
             inOrder(sakServiceMock, simuleringClientMock) {
                 verify(sakServiceMock).hentSak(sak.id)
                 verify(simuleringClientMock).simulerUtbetaling(
-                    argThat { it shouldBe beOfType<Utbetaling.UtbetalingForSimulering>() },
+                    argThat { it shouldBe beOfType<SimulerUtbetalingForPeriode>() },
                 )
             }
             verifyNoMoreInteractions(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/utbetaling/StansUtbetalingServiceTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/utbetaling/StansUtbetalingServiceTest.kt
@@ -12,6 +12,7 @@ import no.nav.su.se.bakover.common.februar
 import no.nav.su.se.bakover.common.idag
 import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.mars
+import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Sak
@@ -26,6 +27,7 @@ import no.nav.su.se.bakover.domain.oppdrag.Utbetalingsrequest
 import no.nav.su.se.bakover.domain.oppdrag.avstemming.Avstemmingsnøkkel
 import no.nav.su.se.bakover.domain.oppdrag.simulering.KlasseKode
 import no.nav.su.se.bakover.domain.oppdrag.simulering.KlasseType
+import no.nav.su.se.bakover.domain.oppdrag.simulering.SimulerUtbetalingForPeriode
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimuleringClient
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimuleringFeilet
@@ -181,12 +183,18 @@ internal class StansUtbetalingServiceTest {
             )
             verify(simuleringClientMock).simulerUtbetaling(
                 argThat {
-                    it shouldBe utbetalingForSimulering.copy(
-                        id = it.id,
-                        opprettet = it.opprettet,
-                        avstemmingsnøkkel = it.avstemmingsnøkkel,
-                        utbetalingslinjer = nonEmptyListOf(
-                            expectedUtbetalingslinje(it.utbetalingslinjer[0].opprettet),
+                    it shouldBe SimulerUtbetalingForPeriode(
+                        utbetaling = utbetalingForSimulering.copy(
+                            id = it.utbetaling.id,
+                            opprettet = it.utbetaling.opprettet,
+                            avstemmingsnøkkel = it.utbetaling.avstemmingsnøkkel,
+                            utbetalingslinjer = nonEmptyListOf(
+                                expectedUtbetalingslinje(it.utbetaling.utbetalingslinjer[0].opprettet),
+                            ),
+                        ),
+                        simuleringsperiode = Periode.create(
+                            fraOgMed = 1.februar(2021),
+                            tilOgMed = 31.desember(2021),
                         ),
                     )
                 },
@@ -267,12 +275,18 @@ internal class StansUtbetalingServiceTest {
 
             verify(simuleringClientMock).simulerUtbetaling(
                 argThat {
-                    it shouldBe utbetalingForSimulering.copy(
-                        id = it.id,
-                        opprettet = it.opprettet,
-                        avstemmingsnøkkel = it.avstemmingsnøkkel,
-                        utbetalingslinjer = nonEmptyListOf(
-                            expectedUtbetalingslinje(it.utbetalingslinjer[0].opprettet),
+                    it shouldBe SimulerUtbetalingForPeriode(
+                        utbetaling = utbetalingForSimulering.copy(
+                            id = it.utbetaling.id,
+                            opprettet = it.utbetaling.opprettet,
+                            avstemmingsnøkkel = it.utbetaling.avstemmingsnøkkel,
+                            utbetalingslinjer = nonEmptyListOf(
+                                expectedUtbetalingslinje(it.utbetaling.utbetalingslinjer[0].opprettet),
+                            ),
+                        ),
+                        simuleringsperiode = Periode.create(
+                            fraOgMed = 1.februar(2021),
+                            tilOgMed = 31.desember(2021),
                         ),
                     )
                 },
@@ -335,12 +349,18 @@ internal class StansUtbetalingServiceTest {
 
             verify(simuleringClientMock).simulerUtbetaling(
                 argThat {
-                    it shouldBe utbetalingForSimulering.copy(
-                        id = it.id,
-                        opprettet = it.opprettet,
-                        avstemmingsnøkkel = it.avstemmingsnøkkel,
-                        utbetalingslinjer = nonEmptyListOf(
-                            expectedUtbetalingslinje(it.utbetalingslinjer[0].opprettet),
+                    it shouldBe SimulerUtbetalingForPeriode(
+                        utbetaling = utbetalingForSimulering.copy(
+                            id = it.utbetaling.id,
+                            opprettet = it.utbetaling.opprettet,
+                            avstemmingsnøkkel = it.utbetaling.avstemmingsnøkkel,
+                            utbetalingslinjer = nonEmptyListOf(
+                                expectedUtbetalingslinje(it.utbetaling.utbetalingslinjer[0].opprettet),
+                            ),
+                        ),
+                        simuleringsperiode = Periode.create(
+                            fraOgMed = 1.februar(2021),
+                            tilOgMed = 31.desember(2021),
                         ),
                     )
                 },

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingServiceAndMocks.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingServiceAndMocks.kt
@@ -1,0 +1,25 @@
+package no.nav.su.se.bakover.service.utbetaling
+
+import no.nav.su.se.bakover.domain.oppdrag.simulering.SimuleringClient
+import no.nav.su.se.bakover.domain.oppdrag.utbetaling.UtbetalingPublisher
+import no.nav.su.se.bakover.domain.oppdrag.utbetaling.UtbetalingRepo
+import no.nav.su.se.bakover.service.sak.SakService
+import no.nav.su.se.bakover.test.fixedClock
+import org.mockito.kotlin.mock
+import java.time.Clock
+
+internal class UtbetalingServiceAndMocks(
+    val sakService: SakService = mock(),
+    val utbetalingRepo: UtbetalingRepo = mock(),
+    val simuleringClient: SimuleringClient = mock(),
+    val utbetalingPublisher: UtbetalingPublisher = mock(),
+    val clock: Clock = fixedClock,
+) {
+    val service = UtbetalingServiceImpl(
+        utbetalingRepo = utbetalingRepo,
+        sakService = sakService,
+        simuleringClient = simuleringClient,
+        utbetalingPublisher = utbetalingPublisher,
+        clock = clock,
+    )
+}

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingServiceImplTest.kt
@@ -18,6 +18,8 @@ import no.nav.su.se.bakover.domain.beregning.Beregning
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
 import no.nav.su.se.bakover.domain.grunnlag.Uføregrad
 import no.nav.su.se.bakover.domain.oppdrag.Kvittering
+import no.nav.su.se.bakover.domain.oppdrag.SimulerUtbetalingRequest
+import no.nav.su.se.bakover.domain.oppdrag.UtbetalRequest
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppdrag.UtbetalingFeilet
 import no.nav.su.se.bakover.domain.oppdrag.Utbetalingslinje
@@ -34,6 +36,7 @@ import no.nav.su.se.bakover.service.sak.SakService
 import no.nav.su.se.bakover.test.TestSessionFactory
 import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.fixedTidspunkt
+import no.nav.su.se.bakover.test.getOrFail
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.internal.verification.Times
@@ -351,12 +354,16 @@ internal class UtbetalingServiceImplTest {
             simuleringClient = simuleringClientMock,
             clock = fixedClock,
         ).utbetal(
-            sakId = sakId,
-            attestant = attestant,
-            beregning = beregning,
-            simulering = simulering,
-            listeMedUføregrunnlag,
-        ).orNull()!!
+            request = UtbetalRequest.NyUtbetaling(
+                request = SimulerUtbetalingRequest.NyUtbetaling(
+                    sakId = sakId,
+                    saksbehandler = attestant,
+                    beregning = beregning,
+                    uføregrunnlag = listeMedUføregrunnlag,
+                ),
+                simulering = simulering,
+            ),
+        ).getOrFail()
 
         actual shouldBe utbetalingForSimulering.copy(
             id = actual.id,
@@ -437,7 +444,7 @@ internal class UtbetalingServiceImplTest {
                     ),
                 ).toSimulertUtbetaling(simulering).toOversendtUtbetaling(oppdragsmelding)
             },
-            anyOrNull()
+            anyOrNull(),
         )
         verifyNoMoreInteractions(
             sakServiceMock,
@@ -470,11 +477,15 @@ internal class UtbetalingServiceImplTest {
             simuleringClient = simuleringClientMock,
             clock = fixedClock,
         ).utbetal(
-            sakId = sakId,
-            attestant = attestant,
-            beregning = beregning,
-            simulering = simulering,
-            uføregrunnlag = listeMedUføregrunnlag,
+            request = UtbetalRequest.NyUtbetaling(
+                request = SimulerUtbetalingRequest.NyUtbetaling(
+                    sakId = sakId,
+                    saksbehandler = attestant,
+                    beregning = beregning,
+                    uføregrunnlag = listeMedUføregrunnlag,
+                ),
+                simulering = simulering,
+            ),
         )
 
         response shouldBe UtbetalingFeilet.Protokollfeil.left()
@@ -551,11 +562,15 @@ internal class UtbetalingServiceImplTest {
             simuleringClient = simuleringClientMock,
             clock = fixedClock,
         ).utbetal(
-            sakId = sakId,
-            attestant = attestant,
-            beregning = beregning,
-            simulering = simulering,
-            listeMedUføregrunnlag,
+            request = UtbetalRequest.NyUtbetaling(
+                request = SimulerUtbetalingRequest.NyUtbetaling(
+                    sakId = sakId,
+                    saksbehandler = attestant,
+                    beregning = beregning,
+                    uføregrunnlag = listeMedUføregrunnlag,
+                ),
+                simulering = simulering,
+            ),
         )
 
         actual shouldBe UtbetalingFeilet.SimuleringHarBlittEndretSidenSaksbehandlerSimulerte.left()


### PR DESCRIPTION
Avkorting:

- Markerer ikke lenger fradrag som vurdert for tillegg/fratrekk av fradrag som ikke gjøres direkte av saksbehandler.

Simulering:

- Sender alltid med perioden som vi simulerer for, slik at denne bedre gjenspeiler revurderingene som gjøres. Ny utbetalinger simulerer for samme periode vi har beregnet for, mens endringer simulerer fra virkningstidspunkt og ut varigheten på utbetalingslinjen. 
- Endret "uendret" respons fra simulering til å vise faktisk beløp, og ikke 0,- kr mnd
- Endret simuleringstub til å gi en "tom respons" dersom ingen måneder er berørt ved stans/opphør fram i tid.