### PR TITLE
Legg på 5 min initiell delay på alla job:er som kjører ved oppstart

### DIFF
--- a/common/src/main/kotlin/no/nav/su/se/bakover/common/Config.kt
+++ b/common/src/main/kotlin/no/nav/su/se/bakover/common/Config.kt
@@ -543,14 +543,18 @@ data class ApplicationConfig(
             clientsConfig = ClientsConfig.createFromEnvironmentVariables(),
             kafkaConfig = KafkaConfig.createFromEnvironmentVariables(),
             unleash = UnleashConfig.createFromEnvironmentVariables(),
-            jobConfig = JobConfig(
-                personhendelse = JobConfig.Personhendelse(naisCluster()),
-                konsistensavstemming = when (naisCluster()) {
-                    NaisCluster.Dev -> JobConfig.Konsistensavstemming.Dev()
-                    NaisCluster.Prod -> JobConfig.Konsistensavstemming.Prod()
-                    null -> throw IllegalStateException("Kunne ikke identifsiere nais-cluster")
-                },
-            ),
+            jobConfig = naisCluster().let { cluster ->
+                if (cluster == null) throw IllegalStateException("Kunne ikke identifsiere nais-cluster")
+
+                JobConfig(
+                    personhendelse = JobConfig.Personhendelse(cluster),
+                    konsistensavstemming = when (cluster) {
+                        NaisCluster.Dev -> JobConfig.Konsistensavstemming.Dev()
+                        NaisCluster.Prod -> JobConfig.Konsistensavstemming.Prod()
+                    },
+                    initialDelay = Duration.of(5, ChronoUnit.MINUTES).toMillis()
+                )
+            },
             kabalKafkaConfig = KabalKafkaConfig.createFromEnvironmentVariables(),
         )
 
@@ -570,6 +574,7 @@ data class ApplicationConfig(
             jobConfig = JobConfig(
                 personhendelse = JobConfig.Personhendelse(naisCluster()),
                 konsistensavstemming = JobConfig.Konsistensavstemming.Local(),
+                initialDelay = 0
             ),
             kabalKafkaConfig = KabalKafkaConfig.createLocalConfig(),
         ).also {
@@ -593,6 +598,7 @@ data class ApplicationConfig(
     data class JobConfig(
         val personhendelse: Personhendelse,
         val konsistensavstemming: Konsistensavstemming,
+        val initialDelay: Long
     ) {
         data class Personhendelse(private val naisCluster: NaisCluster?) {
             private val PREPROD: Long = Duration.of(10, ChronoUnit.MINUTES).toMillis()

--- a/common/src/test/kotlin/no/nav/su/se/bakover/common/ApplicationConfigTest.kt
+++ b/common/src/test/kotlin/no/nav/su/se/bakover/common/ApplicationConfigTest.kt
@@ -127,6 +127,7 @@ internal class ApplicationConfigTest {
         jobConfig = ApplicationConfig.JobConfig(
             personhendelse = ApplicationConfig.JobConfig.Personhendelse(ApplicationConfig.NaisCluster.Prod),
             konsistensavstemming = ApplicationConfig.JobConfig.Konsistensavstemming.Prod(),
+            initialDelay = 300000
         ),
         kabalKafkaConfig = ApplicationConfig.KabalKafkaConfig(
             kafkaConfig = mapOf(
@@ -267,6 +268,7 @@ internal class ApplicationConfigTest {
                 jobConfig = ApplicationConfig.JobConfig(
                     personhendelse = ApplicationConfig.JobConfig.Personhendelse(null),
                     konsistensavstemming = ApplicationConfig.JobConfig.Konsistensavstemming.Local(),
+                    initialDelay = 0
                 ),
                 kabalKafkaConfig = ApplicationConfig.KabalKafkaConfig(emptyMap()),
             )

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/SharedRegressionTestData.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/SharedRegressionTestData.kt
@@ -123,6 +123,7 @@ object SharedRegressionTestData {
         jobConfig = ApplicationConfig.JobConfig(
             personhendelse = ApplicationConfig.JobConfig.Personhendelse(null),
             konsistensavstemming = ApplicationConfig.JobConfig.Konsistensavstemming.Local(),
+            initialDelay = 0
         ),
         kabalKafkaConfig = ApplicationConfig.KabalKafkaConfig(
             kafkaConfig = emptyMap(),

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/Application.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/Application.kt
@@ -312,18 +312,21 @@ fun Application.susebakover(
         DistribuerDokumentJob(
             brevService = services.brev,
             leaderPodLookup = clients.leaderPodLookup,
+            initialDelay = applicationConfig.jobConfig.initialDelay
         ).schedule()
 
         KonsistensavstemmingJob(
             avstemmingService = services.avstemming,
             leaderPodLookup = clients.leaderPodLookup,
             jobConfig = applicationConfig.jobConfig.konsistensavstemming,
+            initialDelay = applicationConfig.jobConfig.initialDelay,
             clock = clock,
         ).schedule()
 
         KlageinstansvedtakJob(
             klagevedtakService = services.klagevedtakService,
             leaderPodLookup = clients.leaderPodLookup,
+            initialDelay = applicationConfig.jobConfig.initialDelay,
         ).schedule()
     } else if (applicationConfig.runtimeEnvironment == ApplicationConfig.RuntimeEnvironment.Local) {
         LokalKvitteringJob(LokalKvitteringService(databaseRepos.utbetaling, utbetalingKvitteringConsumer)).schedule()
@@ -331,6 +334,7 @@ fun Application.susebakover(
         DistribuerDokumentJob(
             brevService = services.brev,
             leaderPodLookup = clients.leaderPodLookup,
+            initialDelay = applicationConfig.jobConfig.initialDelay,
         ).schedule()
 
         GrensesnittsavstemingJob(
@@ -342,11 +346,13 @@ fun Application.susebakover(
             avstemmingService = services.avstemming,
             leaderPodLookup = clients.leaderPodLookup,
             jobConfig = applicationConfig.jobConfig.konsistensavstemming,
+            initialDelay = applicationConfig.jobConfig.initialDelay,
             clock = clock,
         ).schedule()
         KlageinstansvedtakJob(
             klagevedtakService = services.klagevedtakService,
             leaderPodLookup = clients.leaderPodLookup,
+            initialDelay = applicationConfig.jobConfig.initialDelay,
         ).schedule()
     }
 
@@ -354,6 +360,7 @@ fun Application.susebakover(
         personhendelseService = personhendelseService,
         leaderPodLookup = clients.leaderPodLookup,
         intervall = applicationConfig.jobConfig.personhendelse.intervall,
+        initialDelay = applicationConfig.jobConfig.initialDelay,
     ).schedule()
 
     KontrollsamtaleinnkallingJob(

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/avstemming/KonsistensavstemmingJob.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/avstemming/KonsistensavstemmingJob.kt
@@ -20,6 +20,7 @@ internal class KonsistensavstemmingJob(
     private val avstemmingService: AvstemmingService,
     private val leaderPodLookup: LeaderPodLookup,
     private val jobConfig: ApplicationConfig.JobConfig.Konsistensavstemming,
+    private val initialDelay: Long,
     private val clock: Clock,
 ) {
     private val log = LoggerFactory.getLogger(this::class.java)
@@ -27,7 +28,6 @@ internal class KonsistensavstemmingJob(
 
     // Kjører hver fjerde time for å være rimelig sikker på at jobben faktisk blir kjørt
     private val periode = Duration.of(4, ChronoUnit.HOURS).toMillis()
-    private val initialDelay = Duration.of(5, ChronoUnit.MINUTES).toMillis()
 
     fun schedule() {
         log.info("Schedulerer jobb for konsistensavstemming med start om: $initialDelay ms, intervall: $periode ms")

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/dokument/DistribuerDokumentJob.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/dokument/DistribuerDokumentJob.kt
@@ -19,6 +19,7 @@ import kotlin.concurrent.fixedRateTimer
 class DistribuerDokumentJob(
     private val brevService: BrevService,
     private val leaderPodLookup: LeaderPodLookup,
+    private val initialDelay: Long,
 ) {
     private val log = LoggerFactory.getLogger(this::class.java)
     private val jobName = "Journalfør og bestill brevdistribusjon"
@@ -31,6 +32,7 @@ class DistribuerDokumentJob(
             name = jobName,
             daemon = true,
             period = periode,
+            initialDelay = initialDelay
         ) {
             Either.catch {
                 if (leaderPodLookup.erLeaderPod(hostname = hostName)) {

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/klage/KlageinstansvedtakJob.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/klage/KlageinstansvedtakJob.kt
@@ -23,6 +23,7 @@ import kotlin.concurrent.fixedRateTimer
 class KlageinstansvedtakJob(
     private val klagevedtakService: KlagevedtakService,
     private val leaderPodLookup: LeaderPodLookup,
+    private val initialDelay: Long,
 ) {
     private val log = LoggerFactory.getLogger(this::class.java)
     private val jobName = "Håndter utfall fra Klageinstans"
@@ -59,6 +60,7 @@ class KlageinstansvedtakJob(
             name = jobName,
             daemon = true,
             period = periode,
+            initialDelay = initialDelay
         ) {
             Either.catch {
                 if (leaderPodLookup.erLeaderPod(hostname = hostName)) {

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/personhendelser/PersonhendelseOppgaveJob.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/personhendelser/PersonhendelseOppgaveJob.kt
@@ -12,6 +12,7 @@ internal class PersonhendelseOppgaveJob(
     private val personhendelseService: PersonhendelseService,
     private val leaderPodLookup: LeaderPodLookup,
     private val intervall: Long,
+    private val initialDelay: Long,
 ) {
     private val log = LoggerFactory.getLogger(this::class.java)
     private val jobName = "Opprett personhendelse oppgaver"
@@ -26,6 +27,7 @@ internal class PersonhendelseOppgaveJob(
             name = jobName,
             daemon = true,
             period = intervall,
+            initialDelay = initialDelay
         ) {
             log.info("Kjører skeduleringsjobb '$jobName'")
             Either.catch {

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/TestEnvironment.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/TestEnvironment.kt
@@ -96,6 +96,7 @@ val applicationConfig = ApplicationConfig(
     jobConfig = ApplicationConfig.JobConfig(
         personhendelse = ApplicationConfig.JobConfig.Personhendelse(null),
         konsistensavstemming = ApplicationConfig.JobConfig.Konsistensavstemming.Local(),
+        initialDelay = 0
     ),
     kabalKafkaConfig = ApplicationConfig.KabalKafkaConfig(
         kafkaConfig = emptyMap(),


### PR DESCRIPTION
ref: https://trello.com/c/Dgfi22gW/1112-initiell-delay-p%C3%A5-jobbene-v%C3%A5re-for-%C3%A5-v%C3%A6re-sikre-p%C3%A5-at-leader-elector-er-oppe-etter-restart