### PR TITLE
Rydd opp klage

### DIFF
--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPostgresRepo.kt
@@ -141,7 +141,7 @@ internal class VedtakPostgresRepo(
         }
     }
 
-    internal fun hent(id: UUID, session: Session) =
+    internal fun hent(id: UUID, session: Session): Vedtak? =
         """
             select * from vedtak where id = :id
         """.trimIndent()

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
@@ -1257,10 +1257,10 @@ internal class TestDataHelper(
         return bekreftetVilkårsvurdertKlageTilVurdering(vedtak = vedtak).vurder(
             saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "saksbehandlerUtfyltVUrdertKlage"),
             vurderinger = VurderingerTilKlage.Påbegynt.create(
-                fritekstTilBrev = "Friteksten til brevet er som følge: ",
+                fritekstTilOversendelsesbrev = "Friteksten til brevet er som følge: ",
                 vedtaksvurdering = null,
             ),
-        ).getOrFail().let {
+        ).let {
             if (it !is VurdertKlage.Påbegynt) throw IllegalStateException("Forventet en Påbegynt vurdert klage. fikk ${it::class} ved opprettelse av test data")
             it
         }.also {
@@ -1274,14 +1274,14 @@ internal class TestDataHelper(
         return påbegyntVurdertKlage(vedtak = vedtak).vurder(
             saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "saksbehandlerUtfyltVUrdertKlage"),
             vurderinger = VurderingerTilKlage.Utfylt(
-                fritekstTilBrev = "Friteksten til brevet er som følge: ",
+                fritekstTilOversendelsesbrev = "Friteksten til brevet er som følge: ",
                 vedtaksvurdering = VurderingerTilKlage.Vedtaksvurdering.Utfylt.Oppretthold(
                     hjemler = Hjemler.Utfylt.create(
                         nonEmptyListOf(Hjemmel.SU_PARAGRAF_3, Hjemmel.SU_PARAGRAF_4),
                     ),
                 ),
             ),
-        ).getOrFail().let {
+        ).let {
             if (it !is VurdertKlage.Utfylt) throw IllegalStateException("Forventet en Påbegynt vurdert klage. fikk ${it::class} ved opprettelse av test data")
             it
         }.also {
@@ -1294,7 +1294,7 @@ internal class TestDataHelper(
     ): VurdertKlage.Bekreftet {
         return utfyltVurdertKlage(vedtak = vedtak).bekreftVurderinger(
             saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "saksbehandlerBekreftetVurdertKlage"),
-        ).orNull()!!.also {
+        ).also {
             klagePostgresRepo.lagre(it)
         }
     }
@@ -1318,10 +1318,10 @@ internal class TestDataHelper(
         saksbehandler: NavIdentBruker.Saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "saksbehandlerAvvistKlage"),
         fritekstTilBrev: String = "en god, og lang fritekst",
     ): AvvistKlage {
-        return bekreftetAvvistVilkårsvurdertKlage(vedtak).leggTilAvvistFritekstTilBrev(
+        return bekreftetAvvistVilkårsvurdertKlage(vedtak).leggTilFritekstTilAvvistVedtaksbrev(
             saksbehandler,
             fritekstTilBrev,
-        ).getOrFail().also {
+        ).also {
             klagePostgresRepo.lagre(it)
         }
     }
@@ -1366,10 +1366,7 @@ internal class TestDataHelper(
                 grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
                 kommentar = "underkjennelseskommentar",
             ),
-        ) { oppgaveId.right() }.orNull()!!.let {
-            if (it !is VurdertKlage.Bekreftet) throw IllegalStateException("Forventet VurdertKlage.Bekreftet ved opprettelse av test data. fikk ${it::class} ved opprettelse av test-data")
-            it
-        }.also {
+        ) { oppgaveId.right() }.orNull()!!.also {
             klagePostgresRepo.lagre(it)
         }
     }

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/klage/KlagePostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/klage/KlagePostgresRepoTest.kt
@@ -2,7 +2,6 @@ package no.nav.su.se.bakover.database.klage
 
 import arrow.core.right
 import io.kotest.matchers.collections.shouldBeEmpty
-import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeTypeOf
 import no.nav.su.se.bakover.database.TestDataHelper
 import no.nav.su.se.bakover.database.withMigratedDb
@@ -16,6 +15,7 @@ import no.nav.su.se.bakover.domain.klage.VurdertKlage
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.getOrFail
+import no.nav.su.se.bakover.test.klage.shouldBeEqualComparingPublicFieldsAndInterface
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
@@ -32,10 +32,10 @@ internal class KlagePostgresRepoTest {
             val klage = testDataHelper.nyKlage()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
-                klageRepo.hentKlager(klage.sakId, sessionContext) shouldBe listOf(klage)
+                klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
             }
-            klageRepo.hentKlage(klage.id) shouldBe klage
-            klageRepo.hentKlage(urelatertKlage.id) shouldBe urelatertKlage
+            klageRepo.hentKlage(klage.id).shouldBeEqualComparingPublicFieldsAndInterface(klage)
+            klageRepo.hentKlage(urelatertKlage.id).shouldBeEqualComparingPublicFieldsAndInterface(urelatertKlage)
         }
     }
 
@@ -55,10 +55,10 @@ internal class KlagePostgresRepoTest {
             }
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
-                klageRepo.hentKlager(klage.sakId, sessionContext) shouldBe listOf(klage)
+                klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
             }
-            klageRepo.hentKlage(klage.id) shouldBe klage
-            klageRepo.hentKlage(urelatertKlage.id) shouldBe urelatertKlage
+            klageRepo.hentKlage(klage.id).shouldBeEqualComparingPublicFieldsAndInterface(klage)
+            klageRepo.hentKlage(urelatertKlage.id).shouldBeEqualComparingPublicFieldsAndInterface(urelatertKlage)
         }
     }
 
@@ -73,10 +73,10 @@ internal class KlagePostgresRepoTest {
             val klage = testDataHelper.utfyltVilkårsvurdertKlageTilVurdering()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
-                klageRepo.hentKlager(klage.sakId, sessionContext) shouldBe listOf(klage)
+                klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
             }
-            klageRepo.hentKlage(klage.id) shouldBe klage
-            klageRepo.hentKlage(urelatertKlage.id) shouldBe urelatertKlage
+            klageRepo.hentKlage(klage.id).shouldBeEqualComparingPublicFieldsAndInterface(klage)
+            klageRepo.hentKlage(urelatertKlage.id).shouldBeEqualComparingPublicFieldsAndInterface(urelatertKlage)
         }
     }
 
@@ -91,10 +91,10 @@ internal class KlagePostgresRepoTest {
             val klage = testDataHelper.utfyltAvvistVilkårsvurdertKlage()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
-                klageRepo.hentKlager(klage.sakId, sessionContext) shouldBe listOf(klage)
+                klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
             }
-            klageRepo.hentKlage(klage.id) shouldBe klage
-            klageRepo.hentKlage(urelatertKlage.id) shouldBe urelatertKlage
+            klageRepo.hentKlage(klage.id).shouldBeEqualComparingPublicFieldsAndInterface(klage)
+            klageRepo.hentKlage(urelatertKlage.id).shouldBeEqualComparingPublicFieldsAndInterface(urelatertKlage)
         }
     }
 
@@ -109,10 +109,10 @@ internal class KlagePostgresRepoTest {
             val klage = testDataHelper.bekreftetVilkårsvurdertKlageTilVurdering()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
-                klageRepo.hentKlager(klage.sakId, sessionContext) shouldBe listOf(klage)
+                klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
             }
-            klageRepo.hentKlage(klage.id) shouldBe klage
-            klageRepo.hentKlage(urelatertKlage.id) shouldBe urelatertKlage
+            klageRepo.hentKlage(klage.id).shouldBeEqualComparingPublicFieldsAndInterface(klage)
+            klageRepo.hentKlage(urelatertKlage.id).shouldBeEqualComparingPublicFieldsAndInterface(urelatertKlage)
         }
     }
 
@@ -127,10 +127,10 @@ internal class KlagePostgresRepoTest {
             val klage = testDataHelper.bekreftetAvvistVilkårsvurdertKlage()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
-                klageRepo.hentKlager(klage.sakId, sessionContext) shouldBe listOf(klage)
+                klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
             }
-            klageRepo.hentKlage(klage.id) shouldBe klage
-            klageRepo.hentKlage(urelatertKlage.id) shouldBe urelatertKlage
+            klageRepo.hentKlage(klage.id).shouldBeEqualComparingPublicFieldsAndInterface(klage)
+            klageRepo.hentKlage(urelatertKlage.id).shouldBeEqualComparingPublicFieldsAndInterface(urelatertKlage)
         }
     }
 
@@ -150,10 +150,10 @@ internal class KlagePostgresRepoTest {
             }
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
-                klageRepo.hentKlager(klage.sakId, sessionContext) shouldBe listOf(klage)
+                klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
             }
-            klageRepo.hentKlage(klage.id) shouldBe klage
-            klageRepo.hentKlage(urelatertKlage.id) shouldBe urelatertKlage
+            klageRepo.hentKlage(klage.id).shouldBeEqualComparingPublicFieldsAndInterface(klage)
+            klageRepo.hentKlage(urelatertKlage.id).shouldBeEqualComparingPublicFieldsAndInterface(urelatertKlage)
         }
     }
 
@@ -168,10 +168,10 @@ internal class KlagePostgresRepoTest {
             val klage = testDataHelper.utfyltVurdertKlage()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
-                klageRepo.hentKlager(klage.sakId, sessionContext) shouldBe listOf(klage)
+                klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
             }
-            klageRepo.hentKlage(klage.id) shouldBe klage
-            klageRepo.hentKlage(urelatertKlage.id) shouldBe urelatertKlage
+            klageRepo.hentKlage(klage.id).shouldBeEqualComparingPublicFieldsAndInterface(klage)
+            klageRepo.hentKlage(urelatertKlage.id).shouldBeEqualComparingPublicFieldsAndInterface(urelatertKlage)
         }
     }
 
@@ -185,10 +185,10 @@ internal class KlagePostgresRepoTest {
             val klage = testDataHelper.avvistKlage()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
-                klageRepo.hentKlager(klage.sakId, sessionContext) shouldBe listOf(klage)
+                klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
             }
-            klageRepo.hentKlage(klage.id) shouldBe klage
-            klageRepo.hentKlage(urelatertKlage.id) shouldBe urelatertKlage
+            klageRepo.hentKlage(klage.id).shouldBeEqualComparingPublicFieldsAndInterface(klage)
+            klageRepo.hentKlage(urelatertKlage.id).shouldBeEqualComparingPublicFieldsAndInterface(urelatertKlage)
         }
     }
 
@@ -203,10 +203,10 @@ internal class KlagePostgresRepoTest {
             val klage = testDataHelper.klageTilAttesteringTilVurdering()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
-                klageRepo.hentKlager(klage.sakId, sessionContext) shouldBe listOf(klage)
+                klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
             }
-            klageRepo.hentKlage(klage.id) shouldBe klage
-            klageRepo.hentKlage(urelatertKlage.id) shouldBe urelatertKlage
+            klageRepo.hentKlage(klage.id).shouldBeEqualComparingPublicFieldsAndInterface(klage)
+            klageRepo.hentKlage(urelatertKlage.id).shouldBeEqualComparingPublicFieldsAndInterface(urelatertKlage)
         }
     }
 
@@ -221,10 +221,10 @@ internal class KlagePostgresRepoTest {
             val klage = testDataHelper.avvistKlageTilAttestering()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
-                klageRepo.hentKlager(klage.sakId, sessionContext) shouldBe listOf(klage)
+                klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
             }
-            klageRepo.hentKlage(klage.id) shouldBe klage
-            klageRepo.hentKlage(urelatertKlage.id) shouldBe urelatertKlage
+            klageRepo.hentKlage(klage.id).shouldBeEqualComparingPublicFieldsAndInterface(klage)
+            klageRepo.hentKlage(urelatertKlage.id).shouldBeEqualComparingPublicFieldsAndInterface(urelatertKlage)
         }
     }
 
@@ -239,10 +239,10 @@ internal class KlagePostgresRepoTest {
             val klage = testDataHelper.underkjentKlageTilVurdering()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
-                klageRepo.hentKlager(klage.sakId, sessionContext) shouldBe listOf(klage)
+                klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
             }
-            klageRepo.hentKlage(klage.id) shouldBe klage
-            klageRepo.hentKlage(urelatertKlage.id) shouldBe urelatertKlage
+            klageRepo.hentKlage(klage.id).shouldBeEqualComparingPublicFieldsAndInterface(klage)
+            klageRepo.hentKlage(urelatertKlage.id).shouldBeEqualComparingPublicFieldsAndInterface(urelatertKlage)
         }
     }
 
@@ -257,10 +257,10 @@ internal class KlagePostgresRepoTest {
             val klage = testDataHelper.underkjentAvvistKlage()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
-                klageRepo.hentKlager(klage.sakId, sessionContext) shouldBe listOf(klage)
+                klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
             }
-            klageRepo.hentKlage(klage.id) shouldBe klage
-            klageRepo.hentKlage(urelatertKlage.id) shouldBe urelatertKlage
+            klageRepo.hentKlage(klage.id).shouldBeEqualComparingPublicFieldsAndInterface(klage)
+            klageRepo.hentKlage(urelatertKlage.id).shouldBeEqualComparingPublicFieldsAndInterface(urelatertKlage)
         }
     }
 
@@ -275,10 +275,10 @@ internal class KlagePostgresRepoTest {
             val klage = testDataHelper.oversendtKlage()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
-                klageRepo.hentKlager(klage.sakId, sessionContext) shouldBe listOf(klage)
+                klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
             }
-            klageRepo.hentKlage(klage.id) shouldBe klage
-            klageRepo.hentKlage(urelatertKlage.id) shouldBe urelatertKlage
+            klageRepo.hentKlage(klage.id).shouldBeEqualComparingPublicFieldsAndInterface(klage)
+            klageRepo.hentKlage(urelatertKlage.id).shouldBeEqualComparingPublicFieldsAndInterface(urelatertKlage)
         }
     }
 
@@ -293,10 +293,10 @@ internal class KlagePostgresRepoTest {
             val klage = testDataHelper.iverksattAvvistKlage()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
-                klageRepo.hentKlager(klage.sakId, sessionContext) shouldBe listOf(klage)
+                klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
             }
-            klageRepo.hentKlage(klage.id) shouldBe klage
-            klageRepo.hentKlage(urelatertKlage.id) shouldBe urelatertKlage
+            klageRepo.hentKlage(klage.id).shouldBeEqualComparingPublicFieldsAndInterface(klage)
+            klageRepo.hentKlage(urelatertKlage.id).shouldBeEqualComparingPublicFieldsAndInterface(urelatertKlage)
         }
     }
 
@@ -309,18 +309,12 @@ internal class KlagePostgresRepoTest {
             val urelatertKlage = testDataHelper.nyKlage()
 
             val klage = testDataHelper.avsluttetKlage()
-            val expectedKlage = klage.copy(
-                forrigeSteg = (klage.forrigeSteg as VurdertKlage.Bekreftet).copy(
-                    // Det finnes bare et felt for saksbehandler i databasetabellen og den blir overskrevet når vi lagrer en avsluttet klage.
-                    saksbehandler = klage.saksbehandler,
-                ),
-            )
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
-                klageRepo.hentKlager(klage.sakId, sessionContext) shouldBe listOf(expectedKlage)
+                klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
             }
-            klageRepo.hentKlage(klage.id) shouldBe expectedKlage
-            klageRepo.hentKlage(urelatertKlage.id) shouldBe urelatertKlage
+            klageRepo.hentKlage(klage.id).shouldBeEqualComparingPublicFieldsAndInterface(klage)
+            klageRepo.hentKlage(urelatertKlage.id).shouldBeEqualComparingPublicFieldsAndInterface(urelatertKlage)
         }
     }
 
@@ -343,14 +337,18 @@ internal class KlagePostgresRepoTest {
             )
 
             val nyOppgave = OppgaveId("123")
-            val nyKlage = klage.leggTilNyKlageinstanshendelse(tolketKlageinstanshendelse) { nyOppgave.right() }.getOrFail()
+            val nyKlage =
+                klage.leggTilNyKlageinstanshendelse(tolketKlageinstanshendelse) { nyOppgave.right() }.getOrFail()
 
             testDataHelper.sessionFactory.withTransactionContext { tx ->
                 klageRepo.lagre(nyKlage, tx)
-                testDataHelper.klageinstanshendelsePostgresRepo.lagre(tolketKlageinstanshendelse.tilProsessert(nyOppgave), tx)
+                testDataHelper.klageinstanshendelsePostgresRepo.lagre(
+                    tolketKlageinstanshendelse.tilProsessert(nyOppgave),
+                    tx,
+                )
             }
-            klageRepo.hentKlage(klage.id) shouldBe nyKlage
-            klageRepo.hentKlager(klage.sakId) shouldBe listOf(nyKlage)
+            klageRepo.hentKlage(klage.id).shouldBeEqualComparingPublicFieldsAndInterface(nyKlage)
+            klageRepo.hentKlager(klage.sakId).shouldBeEqualComparingPublicFieldsAndInterface(listOf(nyKlage))
         }
     }
 

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/vedtak/LagreOgHentKlagevedtakTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/vedtak/LagreOgHentKlagevedtakTest.kt
@@ -1,9 +1,10 @@
 package no.nav.su.se.bakover.database.vedtak
 
-import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.database.TestDataHelper
 import no.nav.su.se.bakover.database.withMigratedDb
 import no.nav.su.se.bakover.database.withSession
+import no.nav.su.se.bakover.domain.vedtak.Klagevedtak
+import no.nav.su.se.bakover.test.klage.shouldBeEqualComparingPublicFieldsAndInterface
 import org.junit.jupiter.api.Test
 
 internal class LagreOgHentKlagevedtakTest {
@@ -15,7 +16,7 @@ internal class LagreOgHentKlagevedtakTest {
             val vedtak = testDataHelper.vedtakForIverksattAvvistKlage()
 
             dataSource.withSession {
-                vedtakRepo.hent(vedtak.id, it) shouldBe vedtak
+                (vedtakRepo.hent(vedtak.id, it) as Klagevedtak.Avvist).shouldBeEqualComparingPublicFieldsAndInterface(vedtak)
             }
         }
     }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
@@ -149,7 +149,8 @@ data class Sak(
             periode = månedsperiode,
             vedtakListe = NonEmptyList.fromListUnsafe(
                 vedtakListe.filterIsInstance<VedtakSomKanRevurderes>()
-                    .filterNot { it is VedtakSomKanRevurderes.EndringIYtelse.GjenopptakAvYtelse || it is VedtakSomKanRevurderes.EndringIYtelse.StansAvYtelse || it is VedtakSomKanRevurderes.IngenEndringIYtelse }.ifEmpty {
+                    .filterNot { it is VedtakSomKanRevurderes.EndringIYtelse.GjenopptakAvYtelse || it is VedtakSomKanRevurderes.EndringIYtelse.StansAvYtelse || it is VedtakSomKanRevurderes.IngenEndringIYtelse }
+                    .ifEmpty {
                         return null
                     },
             ),
@@ -200,7 +201,9 @@ data class Sak(
                     .reduser()
             }.reduser()
     }
-    fun hentÅpneKlager(): List<Klage> = klager.filter { it.erÅpen() }
+
+    /** Skal ikke kunne ha mer enn én åpen klage av gangen. */
+    fun kanOppretteKlage(): Boolean = klager.none { it.erÅpen() }
 
     fun hentKlage(klageId: UUID): Klage? = klager.find { it.id == klageId }
 
@@ -223,7 +226,10 @@ data class Sak(
      * problematisk hvis man stanser og gjenopptar på tvers av disse. Ta opp igjen problemstillingen dersom
      * fag trenger å stanse i et slikt tilfelle.
      */
-    private fun ingenKommendeOpphørEllerHull(utbetalingslinjer: List<UtbetalingslinjePåTidslinje>, clock: Clock): Boolean {
+    private fun ingenKommendeOpphørEllerHull(
+        utbetalingslinjer: List<UtbetalingslinjePåTidslinje>,
+        clock: Clock,
+    ): Boolean {
         val kommendeUtbetalingslinjer = utbetalingslinjer.filter { it.periode.tilOgMed.isAfter(LocalDate.now(clock)) }
 
         if (kommendeUtbetalingslinjer.any { it is UtbetalingslinjePåTidslinje.Opphør }) {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Attestering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Attestering.kt
@@ -24,6 +24,7 @@ data class Attesteringshistorikk private constructor(
         fun create(
             attesteringer: List<Attestering>,
         ): Attesteringshistorikk {
+            // TODO jah: Denne vil feile for Klage dersom en oversendt klage kommer i retur vil vi "iverksette" to ganger. Selv om det ikke kan kalles en iverksetting.
             assert(attesteringer.filterIsInstance<Attestering.Iverksatt>().size <= 1) {
                 "Attesteringshistorikk kan maks inneholde en iverksetting, men var: $attesteringer"
             }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/AvsluttetKlage.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/AvsluttetKlage.kt
@@ -1,18 +1,8 @@
 package no.nav.su.se.bakover.domain.klage
 
-import arrow.core.Either
 import arrow.core.left
 import no.nav.su.se.bakover.common.Tidspunkt
-import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NavIdentBruker
-import no.nav.su.se.bakover.domain.Person
-import no.nav.su.se.bakover.domain.behandling.Attestering
-import no.nav.su.se.bakover.domain.oppgave.OppgaveId
-import no.nav.su.se.bakover.domain.person.KunneIkkeHenteNavnForNavIdent
-import no.nav.su.se.bakover.domain.person.KunneIkkeHentePerson
-import java.time.Clock
-import java.time.LocalDate
-import java.util.UUID
 
 /**
  * Representerer en feilregistrert klage. Eksempler kan være:
@@ -22,11 +12,18 @@ import java.util.UUID
  * - Klagen ble håndtert på annet vis. F.eks. manuelt via Gosys.
  */
 data class AvsluttetKlage(
-    val forrigeSteg: Klage,
+    // Ønsker å skille oss fra konseptet forrigeSteg her, siden vi støtter veldig mange forskjellige steg og ikke bare ett som i de andre tilfellene for klage.
+    private val underliggendeKlage: Klage,
     override val saksbehandler: NavIdentBruker.Saksbehandler,
     val begrunnelse: String,
     val tidspunktAvsluttet: Tidspunkt,
-) : Klage by forrigeSteg {
+) : Klage by underliggendeKlage {
+
+    /**
+     * Skal kun kalles av intergrasjonslagene for å avgjøre typen (og tester for å forenkle).
+     * Egentlig ønsker vi ikke eksponere selve feltet, men vi trenger å avgjøre den underliggende typen for å instansiere/serialisere den.
+     * */
+    fun hentUnderliggendeKlage() = underliggendeKlage
 
     override fun erÅpen() = false
 
@@ -37,55 +34,4 @@ data class AvsluttetKlage(
         begrunnelse: String,
         tidspunktAvsluttet: Tidspunkt,
     ) = KunneIkkeAvslutteKlage.UgyldigTilstand(this::class).left()
-
-    override fun getFritekstTilBrev() = KunneIkkeHenteFritekstTilBrev.UgyldigTilstand(this::class).left()
-
-    override fun lagBrevRequest(
-        hentNavnForNavIdent: (saksbehandler: NavIdentBruker.Saksbehandler) -> Either<KunneIkkeHenteNavnForNavIdent, String>,
-        hentVedtakDato: (klageId: UUID) -> LocalDate?,
-        hentPerson: (fnr: Fnr) -> Either<KunneIkkeHentePerson, Person>,
-        clock: Clock,
-    ) = KunneIkkeLageBrevRequest.UgyldigTilstand(this::class).left()
-
-    override fun vilkårsvurder(
-        saksbehandler: NavIdentBruker.Saksbehandler,
-        vilkårsvurderinger: VilkårsvurderingerTilKlage,
-    ) = KunneIkkeVilkårsvurdereKlage.UgyldigTilstand(this::class, VilkårsvurdertKlage::class).left()
-
-    override fun bekreftVilkårsvurderinger(
-        saksbehandler: NavIdentBruker.Saksbehandler,
-    ) = KunneIkkeBekrefteKlagesteg.UgyldigTilstand(this::class, VilkårsvurdertKlage.Bekreftet::class).left()
-
-    override fun vurder(
-        saksbehandler: NavIdentBruker.Saksbehandler,
-        vurderinger: VurderingerTilKlage,
-    ) = KunneIkkeVurdereKlage.UgyldigTilstand(this::class, VurdertKlage::class).left()
-
-    override fun bekreftVurderinger(
-        saksbehandler: NavIdentBruker.Saksbehandler,
-    ) = KunneIkkeBekrefteKlagesteg.UgyldigTilstand(this::class, VurdertKlage.Bekreftet::class).left()
-
-    override fun leggTilAvvistFritekstTilBrev(
-        saksbehandler: NavIdentBruker.Saksbehandler,
-        fritekst: String,
-    ) = KunneIkkeLeggeTilFritekstForAvvist.UgyldigTilstand(this::class, AvvistKlage::class).left()
-
-    override fun sendTilAttestering(
-        saksbehandler: NavIdentBruker.Saksbehandler,
-        opprettOppgave: () -> Either<KunneIkkeSendeTilAttestering.KunneIkkeOppretteOppgave, OppgaveId>,
-    ) = KunneIkkeSendeTilAttestering.UgyldigTilstand(this::class, KlageTilAttestering::class).left()
-
-    override fun underkjenn(
-        underkjentAttestering: Attestering.Underkjent,
-        opprettOppgave: () -> Either<KunneIkkeUnderkjenne.KunneIkkeOppretteOppgave, OppgaveId>,
-    ) = KunneIkkeUnderkjenne.UgyldigTilstand(this::class, VurdertKlage.Bekreftet::class).left()
-
-    override fun oversend(
-        iverksattAttestering: Attestering.Iverksatt,
-    ) = KunneIkkeOversendeKlage.UgyldigTilstand(this::class, OversendtKlage::class).left()
-
-    override fun leggTilNyKlageinstanshendelse(
-        tolketKlageinstanshendelse: TolketKlageinstanshendelse,
-        lagOppgaveCallback: () -> Either<Klage.KunneIkkeLeggeTilNyKlageinstansHendelse, OppgaveId>,
-    ) = Klage.KunneIkkeLeggeTilNyKlageinstansHendelse.MåVæreEnOversendtKlage(menVar = this::class).left()
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/Hjemler.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/Hjemler.kt
@@ -6,9 +6,7 @@ import arrow.core.getOrHandle
 import arrow.core.left
 import arrow.core.right
 
-sealed class Hjemler : List<Hjemmel> {
-
-    protected abstract val hjemler: List<Hjemmel>
+sealed interface Hjemler : List<Hjemmel> {
 
     companion object {
         fun empty(): IkkeUtfylt {
@@ -25,8 +23,8 @@ sealed class Hjemler : List<Hjemmel> {
     }
 
     data class IkkeUtfylt private constructor(
-        override val hjemler: List<Hjemmel> = emptyList(),
-    ) : Hjemler(), List<Hjemmel> by hjemler {
+        private val hjemler: List<Hjemmel> = emptyList(),
+    ) : Hjemler, List<Hjemmel> by hjemler {
         companion object {
             fun create(): IkkeUtfylt {
                 return IkkeUtfylt()
@@ -38,8 +36,8 @@ sealed class Hjemler : List<Hjemmel> {
      * Hjemlene blir sortert alfabetisk.
      */
     data class Utfylt private constructor(
-        override val hjemler: NonEmptyList<Hjemmel>,
-    ) : Hjemler(), List<Hjemmel> by hjemler {
+        private val hjemler: NonEmptyList<Hjemmel>,
+    ) : Hjemler, List<Hjemmel> by hjemler {
         companion object {
             /**
              * Kun ment å brukes fra databaselaget og tester

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/OpprettetKlage.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/OpprettetKlage.kt
@@ -13,7 +13,7 @@ import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import java.time.LocalDate
 import java.util.UUID
 
-data class OpprettetKlage private constructor(
+data class OpprettetKlage(
     override val id: UUID,
     override val opprettet: Tidspunkt,
     override val sakId: UUID,
@@ -25,30 +25,6 @@ data class OpprettetKlage private constructor(
     override val saksbehandler: NavIdentBruker.Saksbehandler,
 ) : Klage {
 
-    companion object {
-        fun create(
-            id: UUID,
-            opprettet: Tidspunkt,
-            sakId: UUID,
-            saksnummer: Saksnummer,
-            fnr: Fnr,
-            journalpostId: JournalpostId,
-            oppgaveId: OppgaveId,
-            datoKlageMottatt: LocalDate,
-            saksbehandler: NavIdentBruker.Saksbehandler,
-        ): OpprettetKlage = OpprettetKlage(
-            id = id,
-            opprettet = opprettet,
-            sakId = sakId,
-            saksnummer = saksnummer,
-            fnr = fnr,
-            journalpostId = journalpostId,
-            oppgaveId = oppgaveId,
-            datoKlageMottatt = datoKlageMottatt,
-            saksbehandler = saksbehandler,
-        )
-    }
-
     override fun erÅpen() = true
 
     override fun kanAvsluttes() = true
@@ -58,7 +34,7 @@ data class OpprettetKlage private constructor(
         begrunnelse: String,
         tidspunktAvsluttet: Tidspunkt,
     ) = AvsluttetKlage(
-        forrigeSteg = this,
+        underliggendeKlage = this,
         saksbehandler = saksbehandler,
         begrunnelse = begrunnelse,
         tidspunktAvsluttet = tidspunktAvsluttet,
@@ -67,7 +43,7 @@ data class OpprettetKlage private constructor(
     override fun vilkårsvurder(
         saksbehandler: NavIdentBruker.Saksbehandler,
         vilkårsvurderinger: VilkårsvurderingerTilKlage,
-    ): Either<KunneIkkeVilkårsvurdereKlage, VilkårsvurdertKlage> {
+    ): Either<Nothing, VilkårsvurdertKlage> {
         return when (vilkårsvurderinger) {
             is VilkårsvurderingerTilKlage.Utfylt -> vilkårsvurder(saksbehandler, vilkårsvurderinger)
             is VilkårsvurderingerTilKlage.Påbegynt -> vilkårsvurder(saksbehandler, vilkårsvurderinger)
@@ -78,7 +54,7 @@ data class OpprettetKlage private constructor(
         saksbehandler: NavIdentBruker.Saksbehandler,
         vilkårsvurderinger: VilkårsvurderingerTilKlage.Påbegynt,
     ): VilkårsvurdertKlage.Påbegynt {
-        return VilkårsvurdertKlage.Påbegynt.create(
+        return VilkårsvurdertKlage.Påbegynt(
             id = id,
             opprettet = opprettet,
             sakId = sakId,
@@ -111,6 +87,7 @@ data class OpprettetKlage private constructor(
             attesteringer = Attesteringshistorikk.empty(),
             datoKlageMottatt = datoKlageMottatt,
             klageinstanshendelser = Klageinstanshendelser.empty(),
+            fritekstTilAvvistVedtaksbrev = null,
         )
     }
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/OversendtKlage.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/OversendtKlage.kt
@@ -8,10 +8,8 @@ import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Person
-import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.brev.LagBrevRequest
-import no.nav.su.se.bakover.domain.journal.JournalpostId
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.person.KunneIkkeHenteNavnForNavIdent
 import no.nav.su.se.bakover.domain.person.KunneIkkeHentePerson
@@ -20,26 +18,16 @@ import java.time.LocalDate
 import java.util.UUID
 import kotlin.reflect.KClass
 
-data class OversendtKlage private constructor(
-    override val id: UUID,
-    override val opprettet: Tidspunkt,
-    override val sakId: UUID,
-    override val saksnummer: Saksnummer,
-    override val fnr: Fnr,
-    override val journalpostId: JournalpostId,
-    override val oppgaveId: OppgaveId,
-    override val saksbehandler: NavIdentBruker.Saksbehandler,
-    override val datoKlageMottatt: LocalDate,
-    val klageinstanshendelser: Klageinstanshendelser,
-    val vilkårsvurderinger: VilkårsvurderingerTilKlage.Utfylt,
-    val vurderinger: VurderingerTilKlage.Utfylt,
-    val attesteringer: Attesteringshistorikk,
-) : Klage {
+data class OversendtKlage(
+    private val forrigeSteg: KlageTilAttestering.Vurdert,
+    override val klageinstanshendelser: Klageinstanshendelser,
+    override val attesteringer: Attesteringshistorikk,
+) : Klage, VurdertKlage.UtfyltFelter by forrigeSteg {
 
     override fun erÅpen() = false
 
     override fun getFritekstTilBrev(): Either<KunneIkkeHenteFritekstTilBrev.UgyldigTilstand, String> {
-        return vurderinger.fritekstTilBrev.right()
+        return vurderinger.fritekstTilOversendelsesbrev.right()
     }
 
     override fun lagBrevRequest(
@@ -56,7 +44,7 @@ data class OversendtKlage private constructor(
             saksbehandlerNavn = hentNavnForNavIdent(this.saksbehandler).getOrHandle {
                 return KunneIkkeLageBrevRequest.FeilVedHentingAvSaksbehandlernavn(it).left()
             },
-            fritekst = this.vurderinger.fritekstTilBrev,
+            fritekst = this.vurderinger.fritekstTilOversendelsesbrev,
             saksnummer = this.saksnummer,
             klageDato = this.datoKlageMottatt,
             vedtakDato = hentVedtakDato(this.id)
@@ -71,46 +59,13 @@ data class OversendtKlage private constructor(
         tidspunktAvsluttet: Tidspunkt,
     ) = KunneIkkeAvslutteKlage.UgyldigTilstand(this::class).left()
 
-    companion object {
-        fun create(
-            id: UUID,
-            opprettet: Tidspunkt,
-            sakId: UUID,
-            saksnummer: Saksnummer,
-            fnr: Fnr,
-            journalpostId: JournalpostId,
-            oppgaveId: OppgaveId,
-            saksbehandler: NavIdentBruker.Saksbehandler,
-            vilkårsvurderinger: VilkårsvurderingerTilKlage.Utfylt,
-            vurderinger: VurderingerTilKlage.Utfylt,
-            attesteringer: Attesteringshistorikk,
-            datoKlageMottatt: LocalDate,
-            klageinstanshendelser: Klageinstanshendelser,
-        ): OversendtKlage {
-            return OversendtKlage(
-                id = id,
-                opprettet = opprettet,
-                sakId = sakId,
-                saksnummer = saksnummer,
-                fnr = fnr,
-                journalpostId = journalpostId,
-                oppgaveId = oppgaveId,
-                saksbehandler = saksbehandler,
-                vilkårsvurderinger = vilkårsvurderinger,
-                vurderinger = vurderinger,
-                attesteringer = attesteringer,
-                datoKlageMottatt = datoKlageMottatt,
-                klageinstanshendelser = klageinstanshendelser,
-            )
-        }
-    }
-
-    override fun leggTilNyKlageinstanshendelse(
+    fun leggTilNyKlageinstanshendelse(
         tolketKlageinstanshendelse: TolketKlageinstanshendelse,
         lagOppgaveCallback: () -> Either<Klage.KunneIkkeLeggeTilNyKlageinstansHendelse, OppgaveId>,
     ): Either<Klage.KunneIkkeLeggeTilNyKlageinstansHendelse, Klage> {
         return lagOppgaveCallback().map { oppgaveId ->
-            val oppdatertKlage = leggTilProsessertKlageinstanshendelse(tolketKlageinstanshendelse.tilProsessert(oppgaveId))
+            val oppdatertKlageinstanshendelser =
+                this.klageinstanshendelser.leggTilNyttVedtak(tolketKlageinstanshendelse.tilProsessert(oppgaveId))
 
             when (tolketKlageinstanshendelse.utfall) {
                 KlageinstansUtfall.TRUKKET,
@@ -120,42 +75,27 @@ data class OversendtKlage private constructor(
                 KlageinstansUtfall.STADFESTELSE,
                 KlageinstansUtfall.UGUNST,
                 KlageinstansUtfall.AVVIST,
-                -> oppdatertKlage
-                KlageinstansUtfall.RETUR -> oppdatertKlage.toBekreftet(oppgaveId)
+                -> this.copy(klageinstanshendelser = oppdatertKlageinstanshendelser)
+                KlageinstansUtfall.RETUR -> this.forrigeSteg.returFraKlageinstans(
+                    oppgaveId = oppgaveId,
+                    klageinstanshendelser = oppdatertKlageinstanshendelser,
+                )
             }
         }
     }
-
-    private fun toBekreftet(oppgaveId: OppgaveId) =
-        VurdertKlage.Bekreftet.create(
-            id = id,
-            opprettet = opprettet,
-            sakId = sakId,
-            saksnummer = saksnummer,
-            fnr = fnr,
-            journalpostId = journalpostId,
-            oppgaveId = oppgaveId,
-            saksbehandler = saksbehandler,
-            vilkårsvurderinger = vilkårsvurderinger,
-            vurderinger = vurderinger,
-            attesteringer = attesteringer,
-            datoKlageMottatt = datoKlageMottatt,
-            klageinstanshendelser = klageinstanshendelser,
-        )
-
-    private fun leggTilProsessertKlageinstanshendelse(hendelse: ProsessertKlageinstanshendelse): OversendtKlage =
-        this.copy(klageinstanshendelser = this.klageinstanshendelser.leggTilNyttVedtak(hendelse))
 }
 
-sealed class KunneIkkeOversendeKlage {
-    object FantIkkeKlage : KunneIkkeOversendeKlage()
-    data class UgyldigTilstand(val fra: KClass<out Klage>, val til: KClass<out Klage>) :
-        KunneIkkeOversendeKlage()
+sealed interface KunneIkkeOversendeKlage {
+    object FantIkkeKlage : KunneIkkeOversendeKlage
+    data class UgyldigTilstand(val fra: KClass<out Klage>) : KunneIkkeOversendeKlage {
+        val til = OversendtKlage::class
+    }
 
-    object AttestantOgSaksbehandlerKanIkkeVæreSammePerson : KunneIkkeOversendeKlage()
-    data class KunneIkkeLageBrev(val feil: KunneIkkeLageBrevForKlage) : KunneIkkeOversendeKlage()
-    object FantIkkeJournalpostIdKnyttetTilVedtaket : KunneIkkeOversendeKlage()
-    object KunneIkkeOversendeTilKlageinstans : KunneIkkeOversendeKlage()
-    data class KunneIkkeLageBrevRequest(val feil: no.nav.su.se.bakover.domain.klage.KunneIkkeLageBrevRequest) :
-        KunneIkkeOversendeKlage()
+    object AttestantOgSaksbehandlerKanIkkeVæreSammePerson : KunneIkkeOversendeKlage
+    data class KunneIkkeLageBrev(val feil: KunneIkkeLageBrevForKlage) : KunneIkkeOversendeKlage
+    object FantIkkeJournalpostIdKnyttetTilVedtaket : KunneIkkeOversendeKlage
+    object KunneIkkeOversendeTilKlageinstans : KunneIkkeOversendeKlage
+    data class KunneIkkeLageBrevRequest(
+        val feil: no.nav.su.se.bakover.domain.klage.KunneIkkeLageBrevRequest,
+    ) : KunneIkkeOversendeKlage
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/VilkårsvurderingerTilKlage.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/VilkårsvurderingerTilKlage.kt
@@ -6,18 +6,24 @@ import java.util.UUID
  * Inneholder kun selve vilkårsvurderingene som er gjort i forbindelse med en klage.
  * For selve klagen se [VilkårsvurdertKlage]
  */
-sealed class VilkårsvurderingerTilKlage {
+sealed interface VilkårsvurderingerTilKlage {
 
-    abstract val vedtakId: UUID?
-    abstract val innenforFristen: Svarord?
-    abstract val klagesDetPåKonkreteElementerIVedtaket: Boolean?
-    abstract val erUnderskrevet: Svarord?
-    abstract val begrunnelse: String?
+    val vedtakId: UUID?
+    val innenforFristen: Svarord?
+    val klagesDetPåKonkreteElementerIVedtaket: Boolean?
+    val erUnderskrevet: Svarord?
+    val begrunnelse: String?
 
     enum class Svarord {
         JA,
         NEI_MEN_SKAL_VURDERES,
         NEI,
+    }
+
+    fun erAvvist(): Boolean {
+        return this.klagesDetPåKonkreteElementerIVedtaket == false ||
+            this.innenforFristen == Svarord.NEI ||
+            this.erUnderskrevet == Svarord.NEI
     }
 
     /**
@@ -29,7 +35,7 @@ sealed class VilkårsvurderingerTilKlage {
         override val klagesDetPåKonkreteElementerIVedtaket: Boolean?,
         override val erUnderskrevet: Svarord?,
         override val begrunnelse: String?,
-    ) : VilkårsvurderingerTilKlage() {
+    ) : VilkårsvurderingerTilKlage {
         companion object {
 
             fun empty(): Påbegynt {
@@ -85,11 +91,11 @@ sealed class VilkårsvurderingerTilKlage {
 
     data class Utfylt(
         override val vedtakId: UUID,
-        override val innenforFristen: Svarord?,
+        override val innenforFristen: Svarord,
         override val klagesDetPåKonkreteElementerIVedtaket: Boolean,
-        override val erUnderskrevet: Svarord?,
+        override val erUnderskrevet: Svarord,
         override val begrunnelse: String,
-    ) : VilkårsvurderingerTilKlage()
+    ) : VilkårsvurderingerTilKlage
 
     companion object {
 

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/VurderingerTilKlage.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/VurderingerTilKlage.kt
@@ -6,24 +6,24 @@ import arrow.core.Either
  * Støtter kun opprettholdelse i MVP, men vi har støtte for å lagre alle feltene.
  * Validerer at vi kan bekrefte eller sende til attestering.
  */
-sealed class VurderingerTilKlage {
+sealed interface VurderingerTilKlage {
 
-    abstract val fritekstTilBrev: String?
-    abstract val vedtaksvurdering: Vedtaksvurdering?
+    val fritekstTilOversendelsesbrev: String?
+    val vedtaksvurdering: Vedtaksvurdering?
 
     companion object {
 
         fun empty(): Påbegynt {
             // Går via create for å verifisere at vi bruker de samme reglene.
             return create(
-                fritekstTilBrev = null,
+                fritekstTilOversendelsesbrev = null,
                 vedtaksvurdering = null,
             ) as Påbegynt
         }
 
         /**
          * [VurderingerTilKlage.Påbegynt] dersom minst en av disse er oppfylt:
-         * 1. fritekstTilBrev er null
+         * 1. fritekstTilOversendelsesbrev er null
          * 2. vedtaksvurdering er null
          * 3. vedtaksvurdering er [Vedtaksvurdering.Påbegynt]
          *
@@ -32,11 +32,11 @@ sealed class VurderingerTilKlage {
          * @param vedtaksvurdering En [VurderingerTilKlage.Påbegynt] kan inneholde enten en [Vedtaksvurdering.Påbegynt] eller [Vedtaksvurdering.Utfylt]
          * */
         fun create(
-            fritekstTilBrev: String?,
+            fritekstTilOversendelsesbrev: String?,
             vedtaksvurdering: Vedtaksvurdering?,
         ): VurderingerTilKlage {
             return Påbegynt.create(
-                fritekstTilBrev = fritekstTilBrev,
+                fritekstTilOversendelsesbrev = fritekstTilOversendelsesbrev,
                 vedtaksvurdering = vedtaksvurdering,
             )
         }
@@ -44,19 +44,19 @@ sealed class VurderingerTilKlage {
 
     /**
      * Påbegynt dersom en av disse er oppfylt:
-     * 1. fritekstTilBrev er null
+     * 1. fritekstTilOversendelsesbrev er null
      * 2. vedtaksvurdering er null
      * 3. vedtaksvurdering er [Vedtaksvurdering.Påbegynt]
      */
     data class Påbegynt private constructor(
-        override val fritekstTilBrev: String?,
+        override val fritekstTilOversendelsesbrev: String?,
         override val vedtaksvurdering: Vedtaksvurdering?,
-    ) : VurderingerTilKlage() {
+    ) : VurderingerTilKlage {
 
         companion object {
             /**
              * [VurderingerTilKlage.Påbegynt] dersom minst en av disse er oppfylt:
-             * 1. fritekstTilBrev er null
+             * 1. fritekstTilOversendelsesbrev er null
              * 2. vedtaksvurdering er null
              * 3. vedtaksvurdering er [Vedtaksvurdering.Påbegynt]
              *
@@ -65,19 +65,19 @@ sealed class VurderingerTilKlage {
              * @param vedtaksvurdering En [VurderingerTilKlage.Påbegynt] kan inneholde enten en [Vedtaksvurdering.Påbegynt] eller [Vedtaksvurdering.Utfylt]
              * */
             fun create(
-                fritekstTilBrev: String?,
+                fritekstTilOversendelsesbrev: String?,
                 vedtaksvurdering: Vedtaksvurdering?,
             ): VurderingerTilKlage {
                 val erUtfylt =
-                    fritekstTilBrev != null && vedtaksvurdering != null && vedtaksvurdering is Vedtaksvurdering.Utfylt
+                    fritekstTilOversendelsesbrev != null && vedtaksvurdering != null && vedtaksvurdering is Vedtaksvurdering.Utfylt
                 return if (erUtfylt) {
                     Utfylt(
-                        fritekstTilBrev = fritekstTilBrev!!,
+                        fritekstTilOversendelsesbrev = fritekstTilOversendelsesbrev!!,
                         vedtaksvurdering = vedtaksvurdering!! as Vedtaksvurdering.Utfylt,
                     )
                 } else {
                     Påbegynt(
-                        fritekstTilBrev = fritekstTilBrev,
+                        fritekstTilOversendelsesbrev = fritekstTilOversendelsesbrev,
                         vedtaksvurdering = vedtaksvurdering,
                     )
                 }
@@ -86,11 +86,11 @@ sealed class VurderingerTilKlage {
     }
 
     data class Utfylt(
-        override val fritekstTilBrev: String,
+        override val fritekstTilOversendelsesbrev: String,
         override val vedtaksvurdering: Vedtaksvurdering.Utfylt,
-    ) : VurderingerTilKlage()
+    ) : VurderingerTilKlage
 
-    sealed class Vedtaksvurdering {
+    sealed interface Vedtaksvurdering {
 
         companion object {
 
@@ -114,8 +114,8 @@ sealed class VurderingerTilKlage {
             }
         }
 
-        sealed class Påbegynt : Vedtaksvurdering() {
-            data class Omgjør private constructor(val årsak: Årsak?, val utfall: Utfall?) : Påbegynt() {
+        sealed interface Påbegynt : Vedtaksvurdering {
+            data class Omgjør private constructor(val årsak: Årsak?, val utfall: Utfall?) : Påbegynt {
 
                 companion object {
                     /**
@@ -142,12 +142,12 @@ sealed class VurderingerTilKlage {
                 }
             }
 
-            data class Oppretthold(val hjemler: Hjemler.IkkeUtfylt) : Påbegynt()
+            data class Oppretthold(val hjemler: Hjemler.IkkeUtfylt) : Påbegynt
         }
 
-        sealed class Utfylt : Vedtaksvurdering() {
-            data class Omgjør(val årsak: Årsak, val utfall: Utfall) : Utfylt()
-            data class Oppretthold(val hjemler: Hjemler.Utfylt) : Utfylt()
+        sealed interface Utfylt : Vedtaksvurdering {
+            data class Omgjør(val årsak: Årsak, val utfall: Utfall) : Utfylt
+            data class Oppretthold(val hjemler: Hjemler.Utfylt) : Utfylt
         }
 
         enum class Årsak {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/klage/KlageServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/klage/KlageServiceImpl.kt
@@ -6,6 +6,7 @@ import arrow.core.getOrElse
 import arrow.core.getOrHandle
 import arrow.core.left
 import arrow.core.right
+import arrow.core.rightIfNotNull
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.persistence.SessionFactory
 import no.nav.su.se.bakover.domain.NavIdentBruker
@@ -16,9 +17,12 @@ import no.nav.su.se.bakover.domain.journalpost.JournalpostClient
 import no.nav.su.se.bakover.domain.klage.AvsluttetKlage
 import no.nav.su.se.bakover.domain.klage.AvvistKlage
 import no.nav.su.se.bakover.domain.klage.IverksattAvvistKlage
+import no.nav.su.se.bakover.domain.klage.KanBekrefteKlagevurdering
+import no.nav.su.se.bakover.domain.klage.KanLeggeTilFritekstTilAvvistBrev
 import no.nav.su.se.bakover.domain.klage.Klage
 import no.nav.su.se.bakover.domain.klage.KlageClient
 import no.nav.su.se.bakover.domain.klage.KlageRepo
+import no.nav.su.se.bakover.domain.klage.KlageSomKanVurderes
 import no.nav.su.se.bakover.domain.klage.KlageTilAttestering
 import no.nav.su.se.bakover.domain.klage.KunneIkkeAvslutteKlage
 import no.nav.su.se.bakover.domain.klage.KunneIkkeBekrefteKlagesteg
@@ -44,7 +48,6 @@ import no.nav.su.se.bakover.service.brev.BrevService
 import no.nav.su.se.bakover.service.oppgave.OppgaveService
 import no.nav.su.se.bakover.service.person.PersonService
 import no.nav.su.se.bakover.service.vedtak.VedtakService
-import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 import org.slf4j.LoggerFactory
 import java.time.Clock
 import java.util.UUID
@@ -69,15 +72,12 @@ class KlageServiceImpl(
         request.validate().getOrHandle { return it.left() }
         val sak = sakRepo.hentSak(request.sakId) ?: return KunneIkkeOppretteKlage.FantIkkeSak.left()
 
-        sak.hentÅpneKlager().ifNotEmpty {
-            // TODO jah: Justere denne sjekken når vi har konseptet lukket klage.
+        if (!sak.kanOppretteKlage()) {
             return KunneIkkeOppretteKlage.FinnesAlleredeEnÅpenKlage.left()
         }
-
         if (sak.klager.harEksisterendeJournalpostId(request.journalpostId)) {
             return KunneIkkeOppretteKlage.HarAlleredeEnKlageBehandling.left()
         }
-
         journalpostClient.hentFerdigstiltJournalpost(sak.saksnummer, request.journalpostId).mapLeft {
             return KunneIkkeOppretteKlage.FeilVedHentingAvJournalpost(it).left()
         }
@@ -138,15 +138,21 @@ class KlageServiceImpl(
     }
 
     override fun vurder(request: KlageVurderingerRequest): Either<KunneIkkeVurdereKlage, VurdertKlage> {
-        return request.toDomain().flatMap {
-            val klage = klageRepo.hentKlage(it.klageId) ?: return KunneIkkeVurdereKlage.FantIkkeKlage.left()
-
-            klage.vurder(
-                saksbehandler = it.saksbehandler,
-                vurderinger = it.vurderinger,
-            ).tap { vurdertKlage ->
-                klageRepo.lagre(vurdertKlage)
-            }
+        return request.toDomain().flatMap { r ->
+            klageRepo.hentKlage(r.klageId)
+                .rightIfNotNull { KunneIkkeVurdereKlage.FantIkkeKlage }
+                .flatMap {
+                    (it as? KlageSomKanVurderes)
+                        ?.right()
+                        ?: KunneIkkeVurdereKlage.UgyldigTilstand(it::class).left()
+                }.map {
+                    it.vurder(
+                        saksbehandler = r.saksbehandler,
+                        vurderinger = r.vurderinger,
+                    ).also { vurdertKlage ->
+                        klageRepo.lagre(vurdertKlage)
+                    }
+                }
         }
     }
 
@@ -154,11 +160,19 @@ class KlageServiceImpl(
         klageId: UUID,
         saksbehandler: NavIdentBruker.Saksbehandler,
     ): Either<KunneIkkeBekrefteKlagesteg, VurdertKlage.Bekreftet> {
-        val klage = klageRepo.hentKlage(klageId) ?: return KunneIkkeBekrefteKlagesteg.FantIkkeKlage.left()
-
-        return klage.bekreftVurderinger(saksbehandler = saksbehandler).tap {
-            klageRepo.lagre(it)
-        }
+        return klageRepo.hentKlage(klageId)
+            .rightIfNotNull { KunneIkkeBekrefteKlagesteg.FantIkkeKlage }
+            .flatMap {
+                (it as? KanBekrefteKlagevurdering)
+                    ?.right()
+                    ?: KunneIkkeBekrefteKlagesteg.UgyldigTilstand(it::class, VurdertKlage.Bekreftet::class).left()
+            }.map {
+                it.bekreftVurderinger(
+                    saksbehandler = saksbehandler,
+                ).also { bekreftetVurdertKlage ->
+                    klageRepo.lagre(bekreftetVurdertKlage)
+                }
+            }
     }
 
     override fun leggTilAvvistFritekstTilBrev(
@@ -166,11 +180,20 @@ class KlageServiceImpl(
         saksbehandler: NavIdentBruker.Saksbehandler,
         fritekst: String,
     ): Either<KunneIkkeLeggeTilFritekstForAvvist, AvvistKlage> {
-        val klage = klageRepo.hentKlage(klageId) ?: return KunneIkkeLeggeTilFritekstForAvvist.FantIkkeKlage.left()
-
-        return klage.leggTilAvvistFritekstTilBrev(saksbehandler = saksbehandler, fritekst = fritekst).tap {
-            klageRepo.lagre(it)
-        }
+        return klageRepo.hentKlage(klageId)
+            .rightIfNotNull { KunneIkkeLeggeTilFritekstForAvvist.FantIkkeKlage }
+            .flatMap {
+                (it as? KanLeggeTilFritekstTilAvvistBrev)
+                    ?.right()
+                    ?: KunneIkkeLeggeTilFritekstForAvvist.UgyldigTilstand(it::class).left()
+            }.map {
+                it.leggTilFritekstTilAvvistVedtaksbrev(
+                    saksbehandler = saksbehandler,
+                    fritekstTilAvvistVedtaksbrev = fritekst,
+                ).also { avvistKlage ->
+                    klageRepo.lagre(avvistKlage)
+                }
+            }
     }
 
     override fun sendTilAttestering(
@@ -239,7 +262,10 @@ class KlageServiceImpl(
         klageId: UUID,
         attestant: NavIdentBruker.Attestant,
     ): Either<KunneIkkeOversendeKlage, OversendtKlage> {
-        val klage = klageRepo.hentKlage(klageId) ?: return KunneIkkeOversendeKlage.FantIkkeKlage.left()
+        val klage = (klageRepo.hentKlage(klageId) ?: return KunneIkkeOversendeKlage.FantIkkeKlage.left()).let {
+            it as? KlageTilAttestering.Vurdert ?: return KunneIkkeOversendeKlage.UgyldigTilstand(it::class)
+                .left()
+        }
 
         val oversendtKlage = klage.oversend(
             Attestering.Iverksatt(
@@ -306,7 +332,6 @@ class KlageServiceImpl(
 
         if (klage !is KlageTilAttestering.Avvist) return KunneIkkeIverksetteAvvistKlage.UgyldigTilstand(
             klage::class,
-            IverksattAvvistKlage::class,
         ).left()
 
         val avvistKlage = klage.iverksett(

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/klage/KlageVurderingerRequest.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/klage/KlageVurderingerRequest.kt
@@ -110,7 +110,7 @@ data class KlageVurderingerRequest(
         return Domain(
             klageId = klageId,
             vurderinger = VurderingerTilKlage.create(
-                fritekstTilBrev = fritekstTilBrev,
+                fritekstTilOversendelsesbrev = fritekstTilBrev,
                 vedtaksvurdering = toVedtaksvurdering().getOrHandle { return it.left() },
             ),
             saksbehandler = saksbehandler,

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/klage/KlageinstanshendelseServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/klage/KlageinstanshendelseServiceImpl.kt
@@ -8,6 +8,7 @@ import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.journal.JournalpostId
 import no.nav.su.se.bakover.domain.klage.AvsluttetKlage
+import no.nav.su.se.bakover.domain.klage.AvvistKlage
 import no.nav.su.se.bakover.domain.klage.IverksattAvvistKlage
 import no.nav.su.se.bakover.domain.klage.Klage
 import no.nav.su.se.bakover.domain.klage.KlageRepo
@@ -64,7 +65,9 @@ class KlageinstanshendelseServiceImpl(
     }
 
     private fun prosesserTolketKlageinstanshendelse(hendelse: TolketKlageinstanshendelse) {
-        val klage = klageRepo.hentKlage(hendelse.klageId)
+        // TODO jah: Vi har ikke håndtert muligheten for at det kan komme en oversendelse fra klageinstansen mens vi er i en annen tilstand enn [OversendtKlage]
+        //  Vi kan løse problemet dersom det dukker opp.
+        val klage = klageRepo.hentKlage(hendelse.klageId) as? OversendtKlage
 
         if (klage == null) {
             log.error("Kunne ikke prosessere melding fra Klageinstans. Fant ikke klage med klageId: ${hendelse.klageId}")
@@ -96,6 +99,7 @@ class KlageinstanshendelseServiceImpl(
                 when (it) {
                     is OpprettetKlage,
                     is VilkårsvurdertKlage,
+                    is AvvistKlage,
                     is KlageTilAttestering,
                     is IverksattAvvistKlage,
                     is AvsluttetKlage,

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/klage/NyKlageRequest.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/klage/NyKlageRequest.kt
@@ -20,7 +20,7 @@ data class NyKlageRequest(
     private val saksbehandler: NavIdentBruker.Saksbehandler,
     val journalpostId: JournalpostId,
     private val datoKlageMottatt: LocalDate,
-    private val clock: Clock = Clock.systemUTC(),
+    private val clock: Clock,
 ) {
     fun toKlage(
         saksnummer: Saksnummer,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/AvsluttKlageTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/AvsluttKlageTest.kt
@@ -178,7 +178,7 @@ internal class AvsluttKlageTest {
         verify(mocks.klageRepoMock).lagre(
             argThat {
                 it shouldBe AvsluttetKlage(
-                    forrigeSteg = klage,
+                    underliggendeKlage = klage,
                     saksbehandler = saksbehandler,
                     begrunnelse = begrunnelse,
                     tidspunktAvsluttet = fixedTidspunkt,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/BekreftVilkårsvurdertKlageTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/BekreftVilkårsvurdertKlageTest.kt
@@ -19,6 +19,7 @@ import no.nav.su.se.bakover.test.avvistKlage
 import no.nav.su.se.bakover.test.bekreftetAvvistVilkårsvurdertKlage
 import no.nav.su.se.bakover.test.bekreftetVilkårsvurdertKlageTilVurdering
 import no.nav.su.se.bakover.test.bekreftetVurdertKlage
+import no.nav.su.se.bakover.test.createBekreftetVilkårsvurdertKlage
 import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.getOrFail
 import no.nav.su.se.bakover.test.iverksattAvvistKlage
@@ -250,7 +251,7 @@ internal class BekreftVilkårsvurdertKlageTest {
             klageId = klage.id,
             saksbehandler = NavIdentBruker.Saksbehandler("bekreftetVilkårsvurderingene"),
         ).orNull()!!.also {
-            expectedKlage = VilkårsvurdertKlage.Bekreftet.create(
+            expectedKlage = createBekreftetVilkårsvurdertKlage(
                 id = it.id,
                 opprettet = fixedTidspunkt,
                 sakId = klage.sakId,
@@ -263,7 +264,8 @@ internal class BekreftVilkårsvurdertKlageTest {
                 vurderinger = vurderingerTilKlage,
                 attesteringer = attesteringer,
                 datoKlageMottatt = 1.desember(2021),
-                klageinstanshendelser = Klageinstanshendelser.empty()
+                klageinstanshendelser = Klageinstanshendelser.empty(),
+                fritekstTilBrev = klage.getFritekstTilBrev().orNull(),
             )
             it shouldBe expectedKlage
         }
@@ -276,7 +278,7 @@ internal class BekreftVilkårsvurdertKlageTest {
             },
             argThat {
                 it shouldBe TestSessionFactory.transactionContext
-            }
+            },
         )
         mocks.verifyNoMoreInteractions()
     }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/IverksettAvvistKlageTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/IverksettAvvistKlageTest.kt
@@ -215,7 +215,7 @@ internal class IverksettAvvistKlageTest {
         mocks.service.iverksettAvvistKlage(
             klageId = klage.id,
             attestant = NavIdentBruker.Attestant("attestant"),
-        ) shouldBe KunneIkkeIverksetteAvvistKlage.UgyldigTilstand(klage::class, IverksattAvvistKlage::class).left()
+        ) shouldBe KunneIkkeIverksetteAvvistKlage.UgyldigTilstand(klage::class).left()
 
         Mockito.verify(mocks.klageRepoMock).hentKlage(argThat { it shouldBe klage.id })
         mocks.verifyNoMoreInteractions()
@@ -253,16 +253,8 @@ internal class IverksettAvvistKlageTest {
 
         val actual = mocks.service.iverksettAvvistKlage(klage.id, attestant).getOrFail()
 
-        val expected = IverksattAvvistKlage.create(
-            id = klage.id,
-            opprettet = klage.opprettet,
-            sakId = klage.sakId,
-            saksnummer = klage.saksnummer,
-            fnr = klage.fnr,
-            journalpostId = klage.journalpostId,
-            oppgaveId = klage.oppgaveId,
-            saksbehandler = klage.saksbehandler,
-            vilkårsvurderinger = klage.vilkårsvurderinger,
+        val expected = IverksattAvvistKlage(
+            forrigeSteg = klage,
             attesteringer = Attesteringshistorikk.create(
                 listOf(
                     Attestering.Iverksatt(
@@ -271,8 +263,6 @@ internal class IverksettAvvistKlageTest {
                     ),
                 ),
             ),
-            datoKlageMottatt = klage.datoKlageMottatt,
-            fritekstTilBrev = klage.fritekstTilBrev,
         )
 
         actual shouldBe expected

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/OpprettKlageTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/OpprettKlageTest.kt
@@ -4,7 +4,7 @@ import arrow.core.left
 import arrow.core.right
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeTypeOf
-import no.nav.su.se.bakover.common.desember
+import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.domain.AktørId
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.journal.JournalpostId
@@ -46,7 +46,8 @@ internal class OpprettKlageTest {
             sakId = UUID.randomUUID(),
             journalpostId = JournalpostId("j2"),
             saksbehandler = NavIdentBruker.Saksbehandler("s2"),
-            datoKlageMottatt = 1.desember(2021),
+            datoKlageMottatt = 1.januar(2021),
+            clock = fixedClock,
         )
         mocks.service.opprett(request) shouldBe KunneIkkeOppretteKlage.FantIkkeSak.left()
 
@@ -72,7 +73,8 @@ internal class OpprettKlageTest {
             sakId = UUID.randomUUID(),
             journalpostId = alleredeEksisterendeKlagebehandling.journalpostId,
             saksbehandler = NavIdentBruker.Saksbehandler("s2"),
-            datoKlageMottatt = 1.desember(2021),
+            datoKlageMottatt = 1.januar(2021),
+            clock = fixedClock,
         )
         mocks.service.opprett(request) shouldBe KunneIkkeOppretteKlage.HarAlleredeEnKlageBehandling.left()
 
@@ -109,7 +111,8 @@ internal class OpprettKlageTest {
             sakId = UUID.randomUUID(),
             journalpostId = avsluttetKlage.journalpostId,
             saksbehandler = NavIdentBruker.Saksbehandler("s2"),
-            datoKlageMottatt = 1.desember(2021),
+            datoKlageMottatt = 1.januar(2021),
+            clock = fixedClock,
         )
 
         val nyKlage = mocks.service.opprett(request).getOrFail()
@@ -135,7 +138,8 @@ internal class OpprettKlageTest {
             sakId = sakId,
             journalpostId = JournalpostId("j2"),
             saksbehandler = NavIdentBruker.Saksbehandler("s2"),
-            datoKlageMottatt = 1.desember(2021),
+            datoKlageMottatt = 1.januar(2021),
+            clock = fixedClock,
         )
         mocks.service.opprett(request) shouldBe KunneIkkeOppretteKlage.FinnesAlleredeEnÅpenKlage.left()
 
@@ -168,7 +172,8 @@ internal class OpprettKlageTest {
             sakId = sakId,
             journalpostId = JournalpostId("j2"),
             saksbehandler = NavIdentBruker.Saksbehandler("s2"),
-            datoKlageMottatt = 1.desember(2021),
+            datoKlageMottatt = 1.januar(2021),
+            clock = fixedClock,
         )
         mocks.service.opprett(request) shouldBe KunneIkkeOppretteKlage.KunneIkkeOppretteOppgave.left()
 
@@ -212,7 +217,8 @@ internal class OpprettKlageTest {
             sakId = sakId,
             journalpostId = JournalpostId("j2"),
             saksbehandler = NavIdentBruker.Saksbehandler("s2"),
-            datoKlageMottatt = 1.desember(2021),
+            datoKlageMottatt = 1.januar(2021),
+            clock = fixedClock,
         )
         mocks.service.opprett(request) shouldBe KunneIkkeOppretteKlage.KunneIkkeOppretteOppgave.left()
 
@@ -274,11 +280,12 @@ internal class OpprettKlageTest {
             sakId = sak.id,
             journalpostId = JournalpostId("1"),
             saksbehandler = NavIdentBruker.Saksbehandler("2"),
-            datoKlageMottatt = 1.desember(2021),
+            datoKlageMottatt = 1.januar(2021),
+            clock = fixedClock,
         )
         var expectedKlage: OpprettetKlage?
         mocks.service.opprett(request).orNull()!!.also {
-            expectedKlage = OpprettetKlage.create(
+            expectedKlage = OpprettetKlage(
                 id = it.id,
                 opprettet = fixedTidspunkt,
                 sakId = sak.id,
@@ -289,7 +296,7 @@ internal class OpprettKlageTest {
                 saksbehandler = NavIdentBruker.Saksbehandler(
                     navIdent = "2",
                 ),
-                datoKlageMottatt = 1.desember(2021),
+                datoKlageMottatt = 1.januar(2021),
             )
             it shouldBe expectedKlage
         }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/OversendKlageTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/OversendKlageTest.kt
@@ -163,7 +163,7 @@ internal class OversendKlageTest {
                     person = person,
                     dagensDato = fixedLocalDate,
                     saksbehandlerNavn = "Some name",
-                    fritekst = klage.vurderinger.fritekstTilBrev,
+                    fritekst = klage.vurderinger.fritekstTilOversendelsesbrev,
                     klageDato = 1.desember(2021),
                     vedtakDato = 1.januar(2021),
                     saksnummer = Saksnummer(12345676),
@@ -211,7 +211,7 @@ internal class OversendKlageTest {
                     person = person,
                     dagensDato = fixedLocalDate,
                     saksbehandlerNavn = "Some name",
-                    fritekst = klage.vurderinger.fritekstTilBrev,
+                    fritekst = klage.vurderinger.fritekstTilOversendelsesbrev,
                     klageDato = 1.desember(2021),
                     vedtakDato = 1.januar(2021),
                     saksnummer = Saksnummer(12345676),
@@ -265,7 +265,7 @@ internal class OversendKlageTest {
                     person = person,
                     dagensDato = fixedLocalDate,
                     saksbehandlerNavn = "Some name",
-                    fritekst = klage.vurderinger.fritekstTilBrev,
+                    fritekst = klage.vurderinger.fritekstTilOversendelsesbrev,
                     klageDato = 1.desember(2021),
                     vedtakDato = 1.januar(2021),
                     saksnummer = sak.saksnummer,
@@ -273,17 +273,8 @@ internal class OversendKlageTest {
             },
         )
         verify(mocks.vedtakServiceMock).hentJournalpostId(argThat { it shouldBe klage.vilkårsvurderinger.vedtakId })
-        val expectedKlage = OversendtKlage.create(
-            id = klage.id,
-            opprettet = klage.opprettet,
-            sakId = klage.sakId,
-            saksnummer = klage.saksnummer,
-            fnr = klage.fnr,
-            journalpostId = klage.journalpostId,
-            oppgaveId = klage.oppgaveId,
-            saksbehandler = NavIdentBruker.Saksbehandler("saksbehandler"),
-            vilkårsvurderinger = klage.vilkårsvurderinger,
-            vurderinger = klage.vurderinger,
+        val expectedKlage = OversendtKlage(
+            forrigeSteg = klage,
             attesteringer = Attesteringshistorikk.create(
                 listOf(
                     Attestering.Iverksatt(
@@ -292,7 +283,6 @@ internal class OversendKlageTest {
                     ),
                 ),
             ),
-            datoKlageMottatt = 1.desember(2021),
             klageinstanshendelser = Klageinstanshendelser.empty(),
         )
         verify(mocks.klageClient).sendTilKlageinstans(
@@ -453,7 +443,7 @@ internal class OversendKlageTest {
         mocks.service.oversend(
             klageId = klage.id,
             attestant = NavIdentBruker.Attestant("attestant"),
-        ) shouldBe KunneIkkeOversendeKlage.UgyldigTilstand(klage::class, OversendtKlage::class).left()
+        ) shouldBe KunneIkkeOversendeKlage.UgyldigTilstand(klage::class).left()
 
         verify(mocks.klageRepoMock).hentKlage(argThat { it shouldBe klage.id })
         mocks.verifyNoMoreInteractions()
@@ -497,17 +487,8 @@ internal class OversendKlageTest {
             klageId = klage.id,
             attestant = attestant,
         ).getOrHandle { fail(it.toString()) }.also {
-            expectedKlage = OversendtKlage.create(
-                id = it.id,
-                opprettet = fixedTidspunkt,
-                sakId = klage.sakId,
-                saksnummer = klage.saksnummer,
-                fnr = klage.fnr,
-                journalpostId = klage.journalpostId,
-                oppgaveId = klage.oppgaveId,
-                saksbehandler = NavIdentBruker.Saksbehandler("saksbehandler"),
-                vilkårsvurderinger = klage.vilkårsvurderinger,
-                vurderinger = klage.vurderinger,
+            expectedKlage = OversendtKlage(
+                forrigeSteg = klage,
                 attesteringer = Attesteringshistorikk.create(
                     listOf(
                         Attestering.Iverksatt(
@@ -516,7 +497,6 @@ internal class OversendKlageTest {
                         ),
                     ),
                 ),
-                datoKlageMottatt = 1.desember(2021),
                 klageinstanshendelser = Klageinstanshendelser.empty(),
             )
             it shouldBe expectedKlage
@@ -532,7 +512,7 @@ internal class OversendKlageTest {
                     person = person,
                     dagensDato = fixedLocalDate,
                     saksbehandlerNavn = "Some name",
-                    fritekst = klage.vurderinger.fritekstTilBrev,
+                    fritekst = klage.vurderinger.fritekstTilOversendelsesbrev,
                     klageDato = 1.desember(2021),
                     vedtakDato = 1.januar(2021),
                     saksnummer = klage.saksnummer,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/SendKlageTilAttesteringTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/SendKlageTilAttesteringTest.kt
@@ -3,14 +3,11 @@ package no.nav.su.se.bakover.service.klage
 import arrow.core.left
 import arrow.core.right
 import io.kotest.matchers.shouldBe
-import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.domain.AktørId
 import no.nav.su.se.bakover.domain.NavIdentBruker
-import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.klage.AvvistKlage
 import no.nav.su.se.bakover.domain.klage.Klage
 import no.nav.su.se.bakover.domain.klage.KlageTilAttestering
-import no.nav.su.se.bakover.domain.klage.Klageinstanshendelser
 import no.nav.su.se.bakover.domain.klage.KunneIkkeSendeTilAttestering
 import no.nav.su.se.bakover.domain.klage.VurdertKlage
 import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
@@ -25,7 +22,6 @@ import no.nav.su.se.bakover.test.bekreftetAvvistVilkårsvurdertKlage
 import no.nav.su.se.bakover.test.bekreftetVilkårsvurdertKlageTilVurdering
 import no.nav.su.se.bakover.test.bekreftetVurdertKlage
 import no.nav.su.se.bakover.test.fixedClock
-import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.iverksattAvvistKlage
 import no.nav.su.se.bakover.test.opprettetKlage
 import no.nav.su.se.bakover.test.oversendtKlage
@@ -217,7 +213,7 @@ internal class SendKlageTilAttesteringTest {
         mocks.service.sendTilAttestering(
             klageId = klage.id,
             saksbehandler = klage.saksbehandler,
-        ) shouldBe KunneIkkeSendeTilAttestering.UgyldigTilstand(klage::class, KlageTilAttestering::class).left()
+        ) shouldBe KunneIkkeSendeTilAttestering.UgyldigTilstand(klage::class).left()
 
         verify(mocks.klageRepoMock).hentKlage(argThat { it shouldBe klage.id })
         mocks.verifyNoMoreInteractions()
@@ -239,7 +235,6 @@ internal class SendKlageTilAttesteringTest {
             verifiserGyldigStatusovergang(
                 vedtak = it.first.vedtakListe.first(),
                 klage = it.second,
-                attesteringer = it.second.attesteringer,
                 tilordnetRessurs = it.second.attesteringer.let {
                     assert(it.size == 1)
                     it.first().attestant
@@ -249,17 +244,15 @@ internal class SendKlageTilAttesteringTest {
     }
 
     @Test
-    fun `skal kunne sende en underkjent avvist klage klage til attestering`() {
+    fun `skal kunne sende en underkjent avvist klage til attestering`() {
         underkjentAvvistKlage().let {
             verifiserGyldigStatusovergang(
                 vedtak = it.first.vedtakListe.first(),
                 klage = it.second,
-                attesteringer = it.second.attesteringer,
                 tilordnetRessurs = it.second.attesteringer.let {
                     assert(it.size == 1)
                     it.first().attestant
                 },
-                fritekstTilBrev = it.second.fritekstTilBrev,
             )
         }
     }
@@ -267,84 +260,60 @@ internal class SendKlageTilAttesteringTest {
     private fun verifiserGyldigStatusovergang(
         vedtak: Vedtak,
         klage: Klage,
-        attesteringer: Attesteringshistorikk = Attesteringshistorikk.empty(),
         tilordnetRessurs: NavIdentBruker.Attestant? = null,
-        fritekstTilBrev: String = "attesterings fritekst for brevet",
     ) {
-        val session = TestSessionFactory()
+        val mocks = KlageServiceMocks(
+            klageRepoMock = mock {
+                on { hentKlage(any()) } doReturn klage
+                on { defaultTransactionContext() } doReturn TestSessionFactory.transactionContext
+            },
+            vedtakServiceMock = mock {
+                on { hentForVedtakId(any()) } doReturn vedtak
+            },
+            personServiceMock = mock {
+                on { hentAktørId(any()) } doReturn AktørId("aktørId").right()
+            },
+            oppgaveService = mock {
+                on { opprettOppgave(any()) } doReturn OppgaveId("oppgaveIdTilAttestering").right()
+            },
+        )
 
-        session.withTransactionContext { transactionContext ->
-
-            val mocks = KlageServiceMocks(
-                klageRepoMock = mock {
-                    on { hentKlage(any()) } doReturn klage
-                    on { defaultTransactionContext() } doReturn transactionContext
-                },
-                vedtakServiceMock = mock {
-                    on { hentForVedtakId(any()) } doReturn vedtak
-                },
-                personServiceMock = mock {
-                    on { hentAktørId(any()) } doReturn AktørId("aktørId").right()
-                },
-                oppgaveService = mock {
-                    on { opprettOppgave(any()) } doReturn OppgaveId("nyOppgaveId").right()
-                },
+        var expectedKlage: KlageTilAttestering?
+        mocks.service.sendTilAttestering(
+            klageId = klage.id,
+            saksbehandler = NavIdentBruker.Saksbehandler("saksbehandlerSomSendteTilAttestering"),
+        ).orNull()!!.also {
+            expectedKlage = if (klage is AvvistKlage) KlageTilAttestering.Avvist(
+                forrigeSteg = klage,
+                oppgaveId = OppgaveId("oppgaveIdTilAttestering"),
+                saksbehandler = NavIdentBruker.Saksbehandler("saksbehandlerSomSendteTilAttestering"),
+            ) else KlageTilAttestering.Vurdert(
+                forrigeSteg = klage as VurdertKlage.Bekreftet,
+                oppgaveId = OppgaveId("oppgaveIdTilAttestering"),
+                saksbehandler = NavIdentBruker.Saksbehandler("saksbehandlerSomSendteTilAttestering"),
             )
-
-            var expectedKlage: KlageTilAttestering?
-            mocks.service.sendTilAttestering(
-                klageId = klage.id,
-                saksbehandler = NavIdentBruker.Saksbehandler("bekreftetVilkårsvurderingene"),
-            ).orNull()!!.also {
-                expectedKlage = KlageTilAttestering.create(
-                    id = it.id,
-                    opprettet = fixedTidspunkt,
-                    sakId = klage.sakId,
-                    saksnummer = klage.saksnummer,
-                    fnr = klage.fnr,
-                    journalpostId = klage.journalpostId,
-                    oppgaveId = OppgaveId("nyOppgaveId"),
-                    saksbehandler = NavIdentBruker.Saksbehandler("bekreftetVilkårsvurderingene"),
-                    vilkårsvurderinger = when (klage) {
-                        is AvvistKlage -> klage.vilkårsvurderinger
-                        is VurdertKlage.Bekreftet -> klage.vilkårsvurderinger
-                        else -> throw IllegalStateException("Bare VilkårsvurdertKlage.Bekreftet(Avvist), og VurdertKlage.Bekreftet kan sendes til attestering")
-                    },
-                    vurderinger = when (klage) {
-                        is AvvistKlage -> null
-                        is VurdertKlage.Bekreftet -> klage.vurderinger
-                        else -> throw IllegalStateException("Bare VilkårsvurdertKlage.Bekreftet(Avvist), og VurdertKlage.Bekreftet kan sendes til attestering")
-                    },
-                    attesteringer = attesteringer,
-                    datoKlageMottatt = 1.desember(2021),
-                    fritekstTilBrev = fritekstTilBrev,
-                    klageinstanshendelser = Klageinstanshendelser.empty()
-                )
-                it shouldBe expectedKlage
-            }
-
-            verify(mocks.klageRepoMock).hentKlage(argThat { it shouldBe klage.id })
-            verify(mocks.klageRepoMock).lagre(
-                argThat {
-                    it shouldBe expectedKlage
-                },
-                argThat { it shouldBe transactionContext },
-            )
-            verify(mocks.klageRepoMock).defaultTransactionContext()
-            verify(mocks.oppgaveService).opprettOppgave(
-                argThat {
-                    it shouldBe OppgaveConfig.Klage.Saksbehandler(
-                        saksnummer = klage.saksnummer,
-                        aktørId = AktørId("aktørId"),
-                        journalpostId = klage.journalpostId,
-                        tilordnetRessurs = tilordnetRessurs,
-                        clock = fixedClock,
-                    )
-                },
-            )
-            verify(mocks.personServiceMock).hentAktørId(argThat { it shouldBe klage.fnr })
-            verify(mocks.oppgaveService).lukkOppgave(klage.oppgaveId)
-            mocks.verifyNoMoreInteractions()
+            it shouldBe expectedKlage!!
         }
+
+        verify(mocks.klageRepoMock).hentKlage(argThat { it shouldBe klage.id })
+        verify(mocks.klageRepoMock).lagre(
+            argThat { it shouldBe expectedKlage },
+            argThat { it shouldBe TestSessionFactory.transactionContext },
+        )
+        verify(mocks.klageRepoMock).defaultTransactionContext()
+        verify(mocks.oppgaveService).opprettOppgave(
+            argThat {
+                it shouldBe OppgaveConfig.Klage.Saksbehandler(
+                    saksnummer = klage.saksnummer,
+                    aktørId = AktørId("aktørId"),
+                    journalpostId = klage.journalpostId,
+                    tilordnetRessurs = tilordnetRessurs,
+                    clock = fixedClock,
+                )
+            },
+        )
+        verify(mocks.personServiceMock).hentAktørId(argThat { it shouldBe klage.fnr })
+        verify(mocks.oppgaveService).lukkOppgave(klage.oppgaveId)
+        mocks.verifyNoMoreInteractions()
     }
 }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/VilkårsvurderKlageTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/VilkårsvurderKlageTest.kt
@@ -205,7 +205,6 @@ internal class VilkårsvurderKlageTest {
         )
         mocks.service.vilkårsvurder(request) shouldBe KunneIkkeVilkårsvurdereKlage.UgyldigTilstand(
             klage::class,
-            VilkårsvurdertKlage::class,
         ).left()
 
         verify(mocks.klageRepoMock).hentKlage(argThat { it shouldBe klage.id })
@@ -425,7 +424,7 @@ internal class VilkårsvurderKlageTest {
 
         var expectedKlage: VilkårsvurdertKlage.Påbegynt?
         mocks.service.vilkårsvurder(request).getOrFail().also {
-            expectedKlage = VilkårsvurdertKlage.Påbegynt.create(
+            expectedKlage = VilkårsvurdertKlage.Påbegynt(
                 id = it.id,
                 opprettet = fixedTidspunkt,
                 sakId = klage.sakId,
@@ -499,7 +498,8 @@ internal class VilkårsvurderKlageTest {
                 vurderinger = vurderingerTilKlage,
                 attesteringer = attesteringer,
                 datoKlageMottatt = 1.desember(2021),
-                klageinstanshendelser = Klageinstanshendelser.empty()
+                klageinstanshendelser = Klageinstanshendelser.empty(),
+                fritekstTilAvvistVedtaksbrev = null,
             )
             it shouldBe expectedKlage
         }

--- a/test-common/src/main/kotlin/GenerelleTestData.kt
+++ b/test-common/src/main/kotlin/GenerelleTestData.kt
@@ -80,7 +80,7 @@ val stønadsperiode2021 = Stønadsperiode.create(periode2021, "stønadsperiode20
 val attestant = NavIdentBruker.Attestant("attestant")
 const val attestantNavn = "Att E. Stant"
 
-fun attesteringIverksatt(clock: Clock) = Attestering.Iverksatt(
+fun attesteringIverksatt(clock: Clock = fixedClock) = Attestering.Iverksatt(
     attestant = attestant,
     opprettet = Tidspunkt.now(clock),
 )

--- a/test-common/src/main/kotlin/KlageTestData.kt
+++ b/test-common/src/main/kotlin/KlageTestData.kt
@@ -6,9 +6,12 @@ import arrow.core.right
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.mapSecond
+import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Sak
+import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.journal.JournalpostId
 import no.nav.su.se.bakover.domain.klage.AvsluttetKlage
 import no.nav.su.se.bakover.domain.klage.AvvistKlage
@@ -16,6 +19,7 @@ import no.nav.su.se.bakover.domain.klage.Hjemler
 import no.nav.su.se.bakover.domain.klage.Hjemmel
 import no.nav.su.se.bakover.domain.klage.IverksattAvvistKlage
 import no.nav.su.se.bakover.domain.klage.KlageTilAttestering
+import no.nav.su.se.bakover.domain.klage.Klageinstanshendelser
 import no.nav.su.se.bakover.domain.klage.OpprettetKlage
 import no.nav.su.se.bakover.domain.klage.OversendtKlage
 import no.nav.su.se.bakover.domain.klage.VilkårsvurderingerTilKlage
@@ -37,7 +41,7 @@ fun opprettetKlage(
     sakMedVedtak: Sak = vedtakSøknadsbehandlingIverksattInnvilget().first,
 ): Pair<Sak, OpprettetKlage> {
     assert(sakMedVedtak.vedtakListe.isNotEmpty())
-    val klage = OpprettetKlage.create(
+    val klage = OpprettetKlage(
         id = id,
         opprettet = opprettet,
         sakId = sakId,
@@ -312,7 +316,7 @@ fun påbegyntVurdertKlage(
         val klage = it.second.vurder(
             saksbehandler = saksbehandler,
             vurderinger = VurderingerTilKlage.create(
-                fritekstTilBrev = fritekstTilBrev,
+                fritekstTilOversendelsesbrev = fritekstTilBrev,
                 vedtaksvurdering = vedtaksvurdering,
             ) as VurderingerTilKlage.Påbegynt,
         )
@@ -360,7 +364,7 @@ fun utfyltVurdertKlage(
         val klage = it.second.vurder(
             saksbehandler = saksbehandler,
             vurderinger = VurderingerTilKlage.create(
-                fritekstTilBrev = fritekstTilBrev,
+                fritekstTilOversendelsesbrev = fritekstTilBrev,
                 vedtaksvurdering = vedtaksvurdering,
             ) as VurderingerTilKlage.Utfylt,
         )
@@ -409,7 +413,7 @@ fun bekreftetVurdertKlage(
     ).let {
         val klage = it.second.bekreftVurderinger(
             saksbehandler = saksbehandler,
-        ).orNull()!!
+        )
         Pair(
             it.first.copy(klager = it.first.klager.filterNot { it.id == klage.id } + klage),
             klage,
@@ -448,9 +452,9 @@ fun avvistKlage(
         begrunnelse = begrunnelse,
         sakMedVedtak = sakMedVedtak,
     ).let {
-        val klage = it.second.leggTilAvvistFritekstTilBrev(
+        val klage = it.second.leggTilFritekstTilAvvistVedtaksbrev(
             saksbehandler, fritekstTilBrev,
-        ).getOrFail()
+        )
 
         Pair(
             it.first.copy(klager = it.first.klager.filterNot { it.id == klage.id } + klage),
@@ -614,9 +618,6 @@ fun underkjentKlageTilVurdering(
                 kommentar = attesteringskommentar,
             ),
         ) { underkjentKlageOppgaveId.right() }.orNull()!!
-
-        if (klage !is VurdertKlage.Bekreftet) throw IllegalStateException("Forventet en VurdertKlage.Bekreftet. Fikk ${klage::class} ved opprettelse av test-data.")
-
         Pair(
             it.first.copy(klager = it.first.klager.filterNot { it.id == klage.id } + klage),
             klage,
@@ -814,4 +815,50 @@ fun iverksattAvvistKlage(
             klage,
         )
     }
+}
+
+fun createBekreftetVilkårsvurdertKlage(
+    id: UUID,
+    opprettet: Tidspunkt,
+    sakId: UUID,
+    saksnummer: Saksnummer,
+    fnr: Fnr,
+    journalpostId: JournalpostId,
+    oppgaveId: OppgaveId,
+    saksbehandler: NavIdentBruker.Saksbehandler,
+    vilkårsvurderinger: VilkårsvurderingerTilKlage.Utfylt,
+    attesteringer: Attesteringshistorikk,
+    datoKlageMottatt: LocalDate,
+    vurderinger: VurderingerTilKlage? = null,
+    fritekstTilBrev: String? = null,
+    klageinstanshendelser: Klageinstanshendelser = Klageinstanshendelser.empty(),
+): VilkårsvurdertKlage.Bekreftet {
+    return if (vilkårsvurderinger.erAvvist()) VilkårsvurdertKlage.Bekreftet.Avvist(
+        id = id,
+        opprettet = opprettet,
+        sakId = sakId,
+        saksnummer = saksnummer,
+        fnr = fnr,
+        journalpostId = journalpostId,
+        oppgaveId = oppgaveId,
+        saksbehandler = saksbehandler,
+        vilkårsvurderinger = vilkårsvurderinger,
+        attesteringer = attesteringer,
+        datoKlageMottatt = datoKlageMottatt,
+        fritekstTilAvvistVedtaksbrev = fritekstTilBrev,
+    ) else VilkårsvurdertKlage.Bekreftet.TilVurdering(
+        id = id,
+        opprettet = opprettet,
+        sakId = sakId,
+        saksnummer = saksnummer,
+        fnr = fnr,
+        journalpostId = journalpostId,
+        oppgaveId = oppgaveId,
+        saksbehandler = saksbehandler,
+        vilkårsvurderinger = vilkårsvurderinger,
+        vurderinger = vurderinger,
+        attesteringer = attesteringer,
+        datoKlageMottatt = datoKlageMottatt,
+        klageinstanshendelser = klageinstanshendelser,
+    )
 }

--- a/test-common/src/main/kotlin/klage/KlageMatchers.kt
+++ b/test-common/src/main/kotlin/klage/KlageMatchers.kt
@@ -1,0 +1,81 @@
+package no.nav.su.se.bakover.test.klage
+
+import io.kotest.assertions.eq.actualIsNull
+import io.kotest.assertions.eq.expectedIsNull
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
+import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.domain.klage.AvsluttetKlage
+import no.nav.su.se.bakover.domain.klage.AvvistKlage
+import no.nav.su.se.bakover.domain.klage.AvvistKlageFelter
+import no.nav.su.se.bakover.domain.klage.IverksattAvvistKlage
+import no.nav.su.se.bakover.domain.klage.Klage
+import no.nav.su.se.bakover.domain.klage.KlageTilAttestering
+import no.nav.su.se.bakover.domain.klage.OpprettetKlage
+import no.nav.su.se.bakover.domain.klage.OversendtKlage
+import no.nav.su.se.bakover.domain.klage.VilkårsvurdertKlage
+import no.nav.su.se.bakover.domain.klage.VurdertKlage
+import no.nav.su.se.bakover.domain.klage.VurdertKlageFelter
+import no.nav.su.se.bakover.domain.vedtak.Klagevedtak
+import kotlin.reflect.KProperty
+
+fun Klagevedtak.Avvist.shouldBeEqualComparingPublicFieldsAndInterface(expected: Klagevedtak.Avvist) {
+    this.shouldBeEqualToIgnoringFields(expected, Klagevedtak.Avvist::klage)
+    this.klage.shouldBeEqualComparingPublicFieldsAndInterface(expected.klage)
+}
+
+fun List<Klage?>.shouldBeEqualComparingPublicFieldsAndInterface(expected: List<Klage?>) {
+    this.zip(expected).forEach {
+        it.first.shouldBeEqualComparingPublicFieldsAndInterface(it.second)
+    }
+}
+
+fun Klage?.shouldBeEqualComparingPublicFieldsAndInterface(expected: Klage?, ignoreProperty: KProperty<*>? = null) {
+    if (this == null) {
+        if (expected == null) return
+        else actualIsNull(expected)
+    }
+    if (expected == null) expectedIsNull(this!!)
+
+    if (ignoreProperty != null) {
+        this!!.shouldBeEqualToIgnoringFields(expected!!, true, ignoreProperty)
+    } else {
+        this!!.shouldBeEqualToComparingFields(other = expected!!, ignorePrivateFields = true)
+    }
+    when (this) {
+        is OpprettetKlage -> this.shouldBe(expected)
+        is VilkårsvurdertKlage.Påbegynt -> this.shouldBe(expected)
+        is VilkårsvurdertKlage.Utfylt.Avvist -> this.shouldBe(expected)
+        is VilkårsvurdertKlage.Utfylt.TilVurdering -> this.shouldBe(expected)
+        is VilkårsvurdertKlage.Bekreftet.Avvist -> this.shouldBe(expected)
+        is VilkårsvurdertKlage.Bekreftet.TilVurdering -> this.shouldBe(expected)
+        // Vi gjør en cast til delegate by interfacet før vi sammenligner resten av feltene
+        is AvvistKlage -> this.castAndCompare<VilkårsvurdertKlage.BekreftetFelter>(expected, ignoreProperty)
+        is VurdertKlage.Påbegynt -> this.castAndCompare<VilkårsvurdertKlage.Bekreftet.TilVurderingFelter>(
+            expected,
+            ignoreProperty,
+        )
+        is VurdertKlage.Utfylt -> this.castAndCompare<VurdertKlageFelter>(expected, ignoreProperty)
+        is VurdertKlage.Bekreftet -> this.castAndCompare<VurdertKlage.UtfyltFelter>(expected, ignoreProperty)
+        is KlageTilAttestering.Avvist -> this.castAndCompare<AvvistKlageFelter>(expected, ignoreProperty)
+        is KlageTilAttestering.Vurdert -> this.castAndCompare<VurdertKlage.UtfyltFelter>(expected, ignoreProperty)
+        is AvsluttetKlage -> {
+            this.castAndCompare<Klage>(expected, ignoreProperty)
+            // Gjør en spesialsjekk på den underliggende typen som kan variere.
+            // Den brukes både ved instansiering fra databasen og serialisering til json.
+            this.hentUnderliggendeKlage()
+                .shouldBeEqualComparingPublicFieldsAndInterface((expected as AvsluttetKlage).hentUnderliggendeKlage(), Klage::saksbehandler)
+        }
+        is OversendtKlage -> this.castAndCompare<VurdertKlage.UtfyltFelter>(expected)
+        is IverksattAvvistKlage -> this.castAndCompare<AvvistKlageFelter>(expected)
+    }
+}
+
+private fun <T> Klage.castAndCompare(expected: Klage, ignoreProperty: KProperty<*>? = null) {
+    @Suppress("UNCHECKED_CAST")
+    if (ignoreProperty != null) {
+        (this as T)!!.shouldBeEqualToIgnoringFields((expected as T)!!, ignoreProperty)
+    } else {
+        (this as T)!!.shouldBeEqualToComparingFields((expected as T)!!)
+    }
+}

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/Application.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/Application.kt
@@ -249,7 +249,7 @@ fun Application.susebakover(
                     avstemmingRoutes(accessProtectedServices.avstemming, clock)
                     driftRoutes(accessProtectedServices.søknad)
                     revurderingRoutes(accessProtectedServices.revurdering, accessProtectedServices.vedtakService, clock)
-                    klageRoutes(accessProtectedServices.klageService)
+                    klageRoutes(accessProtectedServices.klageService, clock)
                     dokumentRoutes(accessProtectedServices.brev)
                     nøkkeltallRoutes(accessProtectedServices.nøkkeltallService)
                     kontrollsamtaleRoutes(accessProtectedServices.kontrollsamtale)

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/klage/KlageJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/klage/KlageJson.kt
@@ -190,7 +190,7 @@ internal fun Klage.toJson(): KlageJson {
             klagesDetPåKonkreteElementerIVedtaket = this.vilkårsvurderinger.klagesDetPåKonkreteElementerIVedtaket,
             erUnderskrevet = this.vilkårsvurderinger.erUnderskrevet.toString(),
             begrunnelse = this.vilkårsvurderinger.begrunnelse,
-            fritekstTilBrev = this.vurderinger.fritekstTilBrev,
+            fritekstTilBrev = this.vurderinger.fritekstTilOversendelsesbrev,
             vedtaksvurdering = this.vurderinger.vedtaksvurdering?.toJson(),
             attesteringer = this.attesteringer.toJson(),
             klagevedtakshistorikk = klageinstanshendelser.map { it.toJson() },
@@ -211,11 +211,11 @@ internal fun Klage.toJson(): KlageJson {
             datoKlageMottatt = this.datoKlageMottatt.toString(),
             status = Typer.TIL_ATTESTERING_TIL_VURDERING.toString(),
             vedtakId = this.vilkårsvurderinger.vedtakId.toString(),
-            innenforFristen = this.vilkårsvurderinger.innenforFristen?.toString(),
+            innenforFristen = this.vilkårsvurderinger.innenforFristen.toString(),
             klagesDetPåKonkreteElementerIVedtaket = this.vilkårsvurderinger.klagesDetPåKonkreteElementerIVedtaket,
-            erUnderskrevet = this.vilkårsvurderinger.erUnderskrevet?.toString(),
+            erUnderskrevet = this.vilkårsvurderinger.erUnderskrevet.toString(),
             begrunnelse = this.vilkårsvurderinger.begrunnelse,
-            fritekstTilBrev = this.vurderinger.fritekstTilBrev,
+            fritekstTilBrev = this.vurderinger.fritekstTilOversendelsesbrev,
             vedtaksvurdering = this.vurderinger.vedtaksvurdering.toJson(),
             attesteringer = this.attesteringer.toJson(),
             klagevedtakshistorikk = klageinstanshendelser.map { it.toJson() },
@@ -230,11 +230,11 @@ internal fun Klage.toJson(): KlageJson {
             datoKlageMottatt = this.datoKlageMottatt.toString(),
             status = Typer.TIL_ATTESTERING_AVVIST.toString(),
             vedtakId = this.vilkårsvurderinger.vedtakId.toString(),
-            innenforFristen = this.vilkårsvurderinger.innenforFristen?.toString(),
+            innenforFristen = this.vilkårsvurderinger.innenforFristen.toString(),
             klagesDetPåKonkreteElementerIVedtaket = this.vilkårsvurderinger.klagesDetPåKonkreteElementerIVedtaket,
-            erUnderskrevet = this.vilkårsvurderinger.erUnderskrevet?.toString(),
+            erUnderskrevet = this.vilkårsvurderinger.erUnderskrevet.toString(),
             begrunnelse = this.vilkårsvurderinger.begrunnelse,
-            fritekstTilBrev = this.fritekstTilBrev,
+            fritekstTilBrev = this.fritekstTilVedtaksbrev,
             vedtaksvurdering = null,
             attesteringer = this.attesteringer.toJson(),
             klagevedtakshistorikk = emptyList(),
@@ -249,11 +249,12 @@ internal fun Klage.toJson(): KlageJson {
             datoKlageMottatt = this.datoKlageMottatt.toString(),
             status = Typer.OVERSENDT.toString(),
             vedtakId = this.vilkårsvurderinger.vedtakId.toString(),
-            innenforFristen = this.vilkårsvurderinger.innenforFristen?.toString(),
+            innenforFristen = this.vilkårsvurderinger.innenforFristen
+                .toString(),
             klagesDetPåKonkreteElementerIVedtaket = this.vilkårsvurderinger.klagesDetPåKonkreteElementerIVedtaket,
-            erUnderskrevet = this.vilkårsvurderinger.erUnderskrevet?.toString(),
+            erUnderskrevet = this.vilkårsvurderinger.erUnderskrevet.toString(),
             begrunnelse = this.vilkårsvurderinger.begrunnelse,
-            fritekstTilBrev = this.vurderinger.fritekstTilBrev,
+            fritekstTilBrev = this.vurderinger.fritekstTilOversendelsesbrev,
             vedtaksvurdering = this.vurderinger.vedtaksvurdering.toJson(),
             attesteringer = this.attesteringer.toJson(),
             klagevedtakshistorikk = klageinstanshendelser.map { it.toJson() },
@@ -268,17 +269,17 @@ internal fun Klage.toJson(): KlageJson {
             datoKlageMottatt = this.datoKlageMottatt.toString(),
             status = Typer.IVERKSATT_AVVIST.toString(),
             vedtakId = this.vilkårsvurderinger.vedtakId.toString(),
-            innenforFristen = this.vilkårsvurderinger.innenforFristen?.toString(),
+            innenforFristen = this.vilkårsvurderinger.innenforFristen.toString(),
             klagesDetPåKonkreteElementerIVedtaket = this.vilkårsvurderinger.klagesDetPåKonkreteElementerIVedtaket,
-            erUnderskrevet = this.vilkårsvurderinger.erUnderskrevet?.toString(),
+            erUnderskrevet = this.vilkårsvurderinger.erUnderskrevet.toString(),
             begrunnelse = this.vilkårsvurderinger.begrunnelse,
-            fritekstTilBrev = this.fritekstTilBrev,
+            fritekstTilBrev = this.fritekstTilVedtaksbrev,
             vedtaksvurdering = null,
             attesteringer = this.attesteringer.toJson(),
             klagevedtakshistorikk = emptyList(),
             avsluttet = avsluttet,
         )
-        is AvsluttetKlage -> this.forrigeSteg.toJson().copy(
+        is AvsluttetKlage -> this.hentUnderliggendeKlage().toJson().copy(
             avsluttet = KlageJson.Avsluttet.ER_AVSLUTTET,
         )
     }
@@ -444,8 +445,20 @@ private fun VilkårsvurdertKlage.mapUtfyltOgBekreftetTilKlageJson(
         klagesDetPåKonkreteElementerIVedtaket = this.vilkårsvurderinger.klagesDetPåKonkreteElementerIVedtaket,
         erUnderskrevet = this.vilkårsvurderinger.erUnderskrevet.toString(),
         begrunnelse = this.vilkårsvurderinger.begrunnelse,
-        fritekstTilBrev = null,
-        vedtaksvurdering = null,
+        fritekstTilBrev = when (this) {
+            is VilkårsvurdertKlage.Påbegynt -> null
+            is VilkårsvurdertKlage.Bekreftet.Avvist -> this.fritekstTilAvvistVedtaksbrev
+            is VilkårsvurdertKlage.Bekreftet.TilVurdering -> this.vurderinger?.fritekstTilOversendelsesbrev
+            is VilkårsvurdertKlage.Utfylt.Avvist -> this.fritekstTilVedtaksbrev
+            is VilkårsvurdertKlage.Utfylt.TilVurdering -> this.vurderinger?.fritekstTilOversendelsesbrev
+        },
+        vedtaksvurdering = when (this) {
+            is VilkårsvurdertKlage.Påbegynt -> null
+            is VilkårsvurdertKlage.Bekreftet.Avvist -> null
+            is VilkårsvurdertKlage.Bekreftet.TilVurdering -> this.vurderinger?.vedtaksvurdering?.toJson()
+            is VilkårsvurdertKlage.Utfylt.Avvist -> null
+            is VilkårsvurdertKlage.Utfylt.TilVurdering -> this.vurderinger?.vedtaksvurdering?.toJson()
+        },
         attesteringer = this.attesteringer.toJson(),
         klagevedtakshistorikk = klagevedtakshistorikk,
         avsluttet = avsluttet,
@@ -472,7 +485,7 @@ private fun VurdertKlage.mapUtfyltOgBekreftetTilKlageJson(
         klagesDetPåKonkreteElementerIVedtaket = this.vilkårsvurderinger.klagesDetPåKonkreteElementerIVedtaket,
         erUnderskrevet = this.vilkårsvurderinger.erUnderskrevet.toString(),
         begrunnelse = this.vilkårsvurderinger.begrunnelse,
-        fritekstTilBrev = this.vurderinger.fritekstTilBrev,
+        fritekstTilBrev = this.vurderinger.fritekstTilOversendelsesbrev,
         // Vedtaksvurderingen kan ikke være null dersom klagen er utfylt / bekreftet
         vedtaksvurdering = this.vurderinger.vedtaksvurdering!!.toJson(),
         attesteringer = this.attesteringer.toJson(),
@@ -498,7 +511,7 @@ private fun AvvistKlage.mapPåbegyntOgBekreftetTilKlageJson(
         klagesDetPåKonkreteElementerIVedtaket = this.vilkårsvurderinger.klagesDetPåKonkreteElementerIVedtaket,
         erUnderskrevet = this.vilkårsvurderinger.erUnderskrevet.toString(),
         begrunnelse = this.vilkårsvurderinger.begrunnelse,
-        fritekstTilBrev = this.fritekstTilBrev,
+        fritekstTilBrev = this.fritekstTilVedtaksbrev,
         vedtaksvurdering = null,
         attesteringer = this.attesteringer.toJson(),
         klagevedtakshistorikk = emptyList(),

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/klage/KlageRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/klage/KlageRoutes.kt
@@ -61,6 +61,7 @@ import no.nav.su.se.bakover.web.svar
 import no.nav.su.se.bakover.web.withBody
 import no.nav.su.se.bakover.web.withKlageId
 import no.nav.su.se.bakover.web.withSakId
+import java.time.Clock
 import java.time.LocalDate
 import java.util.UUID
 
@@ -82,6 +83,7 @@ private enum class Svarord {
 
 internal fun Route.klageRoutes(
     klageService: KlageService,
+    clock: Clock,
 ) {
     authorize(Brukerrolle.Saksbehandler) {
         post(klagePath) {
@@ -94,6 +96,7 @@ internal fun Route.klageRoutes(
                             saksbehandler = call.suUserContext.saksbehandler,
                             journalpostId = JournalpostId(body.journalpostId),
                             datoKlageMottatt = body.datoKlageMottatt,
+                            clock = clock,
                         ),
                     ).map {
                         Resultat.json(HttpStatusCode.Created, serialize(it.toJson()))

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/klage/AvsluttKlageTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/klage/AvsluttKlageTest.kt
@@ -161,7 +161,7 @@ internal class AvsluttKlageTest {
                   "saksbehandler":"saksbehandler",
                   "datoKlageMottatt":"2021-12-01",
                   "status":"VURDERT_BEKREFTET",
-                  "vedtakId":"${(klage.forrigeSteg as VurdertKlage.Bekreftet).vilkårsvurderinger.vedtakId}",
+                  "vedtakId":"${(klage.hentUnderliggendeKlage() as VurdertKlage.Bekreftet).vilkårsvurderinger.vedtakId}",
                   "innenforFristen":"JA",
                   "klagesDetPåKonkreteElementerIVedtaket":true,
                   "erUnderskrevet":"JA",

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/klage/AvvistKlageTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/klage/AvvistKlageTest.kt
@@ -10,7 +10,6 @@ import io.ktor.server.testing.contentType
 import io.ktor.server.testing.setBody
 import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.domain.Brukerrolle
-import no.nav.su.se.bakover.domain.klage.AvvistKlage
 import no.nav.su.se.bakover.domain.klage.KunneIkkeLeggeTilFritekstForAvvist
 import no.nav.su.se.bakover.domain.klage.OpprettetKlage
 import no.nav.su.se.bakover.service.klage.KlageService
@@ -93,7 +92,7 @@ internal class AvvistKlageTest {
     @Test
     fun `ugyldig tilstand`() {
         verifiserFeilkode(
-            feilkode = KunneIkkeLeggeTilFritekstForAvvist.UgyldigTilstand(OpprettetKlage::class, AvvistKlage::class),
+            feilkode = KunneIkkeLeggeTilFritekstForAvvist.UgyldigTilstand(OpprettetKlage::class),
             status = HttpStatusCode.BadRequest,
             body = "{\"message\":\"Kan ikke gå fra tilstanden OpprettetKlage til tilstanden AvvistKlage\",\"code\":\"ugyldig_tilstand\"}",
         )

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/klage/OversendKlageTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/klage/OversendKlageTest.kt
@@ -13,7 +13,6 @@ import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.klage.KunneIkkeLageBrevForKlage
 import no.nav.su.se.bakover.domain.klage.KunneIkkeOversendeKlage
 import no.nav.su.se.bakover.domain.klage.OpprettetKlage
-import no.nav.su.se.bakover.domain.klage.OversendtKlage
 import no.nav.su.se.bakover.service.klage.KlageService
 import no.nav.su.se.bakover.test.oversendtKlage
 import no.nav.su.se.bakover.web.TestServicesBuilder
@@ -94,7 +93,7 @@ internal class OversendKlageTest {
     @Test
     fun `ugyldig tilstand`() {
         verifiserFeilkode(
-            feilkode = KunneIkkeOversendeKlage.UgyldigTilstand(OpprettetKlage::class, OversendtKlage::class),
+            feilkode = KunneIkkeOversendeKlage.UgyldigTilstand(OpprettetKlage::class),
             status = HttpStatusCode.BadRequest,
             body = "{\"message\":\"Kan ikke gå fra tilstanden OpprettetKlage til tilstanden OversendtKlage\",\"code\":\"ugyldig_tilstand\"}",
         )

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/klage/SendKlageTilAttesteringTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/klage/SendKlageTilAttesteringTest.kt
@@ -11,7 +11,6 @@ import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.klage.KunneIkkeSendeTilAttestering
 import no.nav.su.se.bakover.domain.klage.OpprettetKlage
-import no.nav.su.se.bakover.domain.klage.OversendtKlage
 import no.nav.su.se.bakover.service.klage.KlageService
 import no.nav.su.se.bakover.test.vurdertKlageTilAttestering
 import no.nav.su.se.bakover.web.TestServicesBuilder
@@ -85,9 +84,9 @@ internal class SendKlageTilAttesteringTest {
     @Test
     fun `ugyldig tilstand`() {
         verifiserFeilkode(
-            feilkode = KunneIkkeSendeTilAttestering.UgyldigTilstand(OpprettetKlage::class, OversendtKlage::class),
+            feilkode = KunneIkkeSendeTilAttestering.UgyldigTilstand(OpprettetKlage::class),
             status = HttpStatusCode.BadRequest,
-            body = "{\"message\":\"Kan ikke gå fra tilstanden OpprettetKlage til tilstanden OversendtKlage\",\"code\":\"ugyldig_tilstand\"}",
+            body = "{\"message\":\"Kan ikke gå fra tilstanden OpprettetKlage til tilstanden KlageTilAttestering\",\"code\":\"ugyldig_tilstand\"}",
         )
     }
 

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/klage/VilkårsvurderKlageTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/klage/VilkårsvurderKlageTest.kt
@@ -12,7 +12,6 @@ import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.klage.KunneIkkeVilkårsvurdereKlage
 import no.nav.su.se.bakover.domain.klage.OpprettetKlage
-import no.nav.su.se.bakover.domain.klage.OversendtKlage
 import no.nav.su.se.bakover.service.klage.KlageService
 import no.nav.su.se.bakover.test.påbegyntVilkårsvurdertKlage
 import no.nav.su.se.bakover.web.TestServicesBuilder
@@ -106,9 +105,9 @@ internal class VilkårsvurderKlageTest {
     @Test
     fun `ugyldig tilstand`() {
         verifiserFeilkode(
-            feilkode = KunneIkkeVilkårsvurdereKlage.UgyldigTilstand(OpprettetKlage::class, OversendtKlage::class),
+            feilkode = KunneIkkeVilkårsvurdereKlage.UgyldigTilstand(OpprettetKlage::class),
             status = HttpStatusCode.BadRequest,
-            body = "{\"message\":\"Kan ikke gå fra tilstanden OpprettetKlage til tilstanden OversendtKlage\",\"code\":\"ugyldig_tilstand\"}",
+            body = "{\"message\":\"Kan ikke gå fra tilstanden OpprettetKlage til tilstanden VilkårsvurdertKlage\",\"code\":\"ugyldig_tilstand\"}",
         )
     }
 

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/klage/VurderKlageTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/klage/VurderKlageTest.kt
@@ -12,7 +12,6 @@ import io.ktor.server.testing.withTestApplication
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.klage.KunneIkkeVurdereKlage
 import no.nav.su.se.bakover.domain.klage.OpprettetKlage
-import no.nav.su.se.bakover.domain.klage.OversendtKlage
 import no.nav.su.se.bakover.service.klage.KlageService
 import no.nav.su.se.bakover.test.påbegyntVurdertKlage
 import no.nav.su.se.bakover.web.TestServicesBuilder
@@ -129,9 +128,9 @@ internal class VurderKlageTest {
     @Test
     fun `ugyldig tilstand`() {
         verifiserFeilkode(
-            feilkode = KunneIkkeVurdereKlage.UgyldigTilstand(OpprettetKlage::class, OversendtKlage::class),
+            feilkode = KunneIkkeVurdereKlage.UgyldigTilstand(OpprettetKlage::class),
             status = HttpStatusCode.BadRequest,
-            body = "{\"message\":\"Kan ikke gå fra tilstanden OpprettetKlage til tilstanden OversendtKlage\",\"code\":\"ugyldig_tilstand\"}",
+            body = "{\"message\":\"Kan ikke gå fra tilstanden OpprettetKlage til tilstanden VurdertKlage\",\"code\":\"ugyldig_tilstand\"}",
         )
     }
 


### PR DESCRIPTION
Jacob kom med en Idé akkurat i det vi skulle merge den store KlagePRen (tm). Det innebærte å bruke en kombinasjon av sealed interfaces og by delegation. Siden jeg uansett satt og fiklet en del på klage-pakken, tenkte jeg å teste det. Det var en del arbeid å skrive om, og jeg er ikke helt ferdig. Men dersom folk liker det bedre enn slik det var, kan jeg fullføre jobben i en annen PR.

En ting som er verdt å merke seg her, er at når man bygger opp domenemodellen, så vil forrigeSteg oppdatere seg når man går framover. Det betyr at forrigeSteg kan inneholde en annen saksbehandler enn nåværende steg (det stemmer bedre med virkeligheten). Men når vi persisterer den vil vi kun lagre hvert felt en gang, så forrigeSteg vil arve fra nåværende steg ved henting fra databasen. Dette førte til at veldig mange databasetester feilet. Løsningen min ble å lage egne matchers for Klage. Som ekskluderte forrigeSteg, men heller sammenlignet på det interfacet vi arvet fra by delegation.

En annen ting Jacob og jeg diskuterte var alle funksjonene som ligger på Klage.kt (toppnivået). Der man uavhengig av klagetypen man har, kan f.eks. prøve å iverksette. Det er i dag løst ved arv, slik at de som støtter operasjonene må override. Det føles litt rart i de tilfellene man har en spesifikk type og VET at operasjonen er lovlig, men få en Either alikevel. Jeg har fjernet noen av disse funksjonene fra Klage.kt og heller laget et interface av typen KanVurdereKlage som servicen sjekker på. Det gjør at vi får noen ekstra linjer kode i service-laget. Dere får si hva dere foretrekker.