### PR TITLE
Fix bug ved annullering av kontrollsamtale-innkallinger

### DIFF
--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/kontrollsamtale/Kontrollsamtale.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/kontrollsamtale/Kontrollsamtale.kt
@@ -26,18 +26,23 @@ data class Kontrollsamtale(
     val dokumentId: UUID?,
 ) {
 
-    fun settInnkalt(): Either<UgyldigStatusovergang, Kontrollsamtale> {
-        if (this.status !== Kontrollsamtalestatus.PLANLAGT_INNKALLING) return UgyldigStatusovergang.left()
-        return this.copy(status = Kontrollsamtalestatus.INNKALT).right()
+    fun settInnkalt(dokumentId: UUID): Either<UgyldigStatusovergang, Kontrollsamtale> {
+        if (this.status != Kontrollsamtalestatus.PLANLAGT_INNKALLING) return UgyldigStatusovergang.left()
+        return this.copy(
+            status = Kontrollsamtalestatus.INNKALT,
+            dokumentId = dokumentId
+        ).right()
     }
 
-    fun annuller(): Either<UgyldigStatusovergang, Kontrollsamtale> {
-        if (this.status !== Kontrollsamtalestatus.PLANLAGT_INNKALLING || this.status !== Kontrollsamtalestatus.INNKALT) return UgyldigStatusovergang.left()
-        return this.copy(status = Kontrollsamtalestatus.ANNULLERT).right()
-    }
+    fun annuller(): Either<UgyldigStatusovergang, Kontrollsamtale> =
+        if (this.status == Kontrollsamtalestatus.PLANLAGT_INNKALLING || this.status == Kontrollsamtalestatus.INNKALT) {
+            this.copy(status = Kontrollsamtalestatus.ANNULLERT).right()
+        } else {
+            UgyldigStatusovergang.left()
+        }
 
     fun endreDato(innkallingsdato: LocalDate): Either<UgyldigStatusovergang, Kontrollsamtale> {
-        if (this.status !== Kontrollsamtalestatus.PLANLAGT_INNKALLING) return UgyldigStatusovergang.left()
+        if (this.status != Kontrollsamtalestatus.PLANLAGT_INNKALLING) return UgyldigStatusovergang.left()
         return this.copy(innkallingsdato = innkallingsdato).right()
     }
 

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/kontrollsamtale/KontrollsamtaleTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/kontrollsamtale/KontrollsamtaleTest.kt
@@ -1,5 +1,6 @@
 package no.nav.su.se.bakover.domain.kontrollsamtale
 
+import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.periode.Periode
@@ -7,6 +8,7 @@ import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.LocalDate
 import java.time.ZoneOffset
+import java.util.UUID
 
 class KontrollsamtaleTest {
     private val todayClock = Clock.fixed(20.desember(2021).atStartOfDay().toInstant(ZoneOffset.UTC), ZoneOffset.UTC)
@@ -65,5 +67,11 @@ class KontrollsamtaleTest {
         val periode = Periode.create(LocalDate.of(2021, 9, 1), LocalDate.of(2022, 2, 28))
 
         regnUtInnkallingsdato(periode, vedtaksdato, todayClock) shouldBe null
+    }
+
+    @Test
+    fun `annullering av en planlagt kontrollsamtale er mulig`() {
+        val kontrollsamtale = Kontrollsamtale.opprettNyKontrollsamtale(UUID.randomUUID(), LocalDate.of(2022, 1, 1))
+        kontrollsamtale.annuller() shouldBeRight kontrollsamtale.copy(status = Kontrollsamtalestatus.ANNULLERT)
     }
 }


### PR DESCRIPTION
Vi hadde en feilaktig satt opp if-sjekk som gjorde at kontrollsamtale-innkallinger ikke ble annullert i `annuller`-kallet. Setter samtidig dokument-id på innkalte, som feilaktig forsvant i en refaktorering.