### PR TITLE
Flytt statistikk ut av transaksjon og logg iverksett-feil

### DIFF
--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/Utbetaling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/Utbetaling.kt
@@ -164,5 +164,3 @@ sealed class UtbetalingFeilet {
     object KontrollAvSimuleringFeilet : UtbetalingFeilet()
     object FantIkkeSak : UtbetalingFeilet()
 }
-
-class UtbetalingFeiletException(val feil: UtbetalingFeilet) : Exception(feil.toString())

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Søknadsbehandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/Søknadsbehandling.kt
@@ -2111,16 +2111,16 @@ enum class BehandlingsStatus {
     IVERKSATT_AVSLAG,
 }
 
-sealed class KunneIkkeIverksette {
-    object AttestantOgSaksbehandlerKanIkkeVæreSammePerson : KunneIkkeIverksette()
-    data class KunneIkkeUtbetale(val utbetalingFeilet: UtbetalingFeilet) : KunneIkkeIverksette()
-    object FantIkkeBehandling : KunneIkkeIverksette()
-    object FantIkkePerson : KunneIkkeIverksette()
-    object FikkIkkeHentetSaksbehandlerEllerAttestant : KunneIkkeIverksette()
-    object KunneIkkeGenerereVedtaksbrev : KunneIkkeIverksette()
-    object AvkortingErUfullstendig : KunneIkkeIverksette()
-    object HarBlittAnnullertAvEnAnnen : KunneIkkeIverksette()
-    object HarAlleredeBlittAvkortetAvEnAnnen : KunneIkkeIverksette()
+sealed interface KunneIkkeIverksette {
+    object AttestantOgSaksbehandlerKanIkkeVæreSammePerson : KunneIkkeIverksette
+    data class KunneIkkeUtbetale(val utbetalingFeilet: UtbetalingFeilet) : KunneIkkeIverksette
+    object FantIkkeBehandling : KunneIkkeIverksette
+    object KunneIkkeGenerereVedtaksbrev : KunneIkkeIverksette
+    object AvkortingErUfullstendig : KunneIkkeIverksette
+    object HarBlittAnnullertAvEnAnnen : KunneIkkeIverksette
+    object HarAlleredeBlittAvkortetAvEnAnnen : KunneIkkeIverksette
+    object KunneIkkeOpprettePlanlagtKontrollsamtale : KunneIkkeIverksette
+    object LagringFeilet : KunneIkkeIverksette
 }
 
 // Her trikses det litt for å få til at funksjonen returnerer den samme konkrete typen som den kalles på.

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
@@ -253,22 +253,19 @@ sealed class KunneIkkeSendeRevurderingTilAttestering {
         KunneIkkeSendeRevurderingTilAttestering()
 }
 
-sealed class KunneIkkeIverksetteRevurdering {
-    object AttestantOgSaksbehandlerKanIkkeVæreSammePerson : KunneIkkeIverksetteRevurdering()
-    data class KunneIkkeUtbetale(val utbetalingFeilet: UtbetalingFeilet) : KunneIkkeIverksetteRevurdering()
-    object KunneIkkeGenerereBrev : KunneIkkeIverksetteRevurdering()
-    object FantIkkePerson : KunneIkkeIverksetteRevurdering()
-    object KunneIkkeHenteNavnForSaksbehandlerEllerAttestant : KunneIkkeIverksetteRevurdering()
-    object KunneIkkeFinneGjeldendeUtbetaling : KunneIkkeIverksetteRevurdering()
-    object IngenEndringErIkkeGyldig : KunneIkkeIverksetteRevurdering()
-    object FantIkkeRevurdering : KunneIkkeIverksetteRevurdering()
-    object LagringFeilet : KunneIkkeIverksetteRevurdering()
-    object HarAlleredeBlittAvkortetAvEnAnnen : KunneIkkeIverksetteRevurdering()
-    object HarAlleredeBlittAnnullertAvEnAnnen : KunneIkkeIverksetteRevurdering()
+sealed interface KunneIkkeIverksetteRevurdering {
+    object AttestantOgSaksbehandlerKanIkkeVæreSammePerson : KunneIkkeIverksetteRevurdering
+    data class KunneIkkeUtbetale(val utbetalingFeilet: UtbetalingFeilet) : KunneIkkeIverksetteRevurdering
+    object IngenEndringErIkkeGyldig : KunneIkkeIverksetteRevurdering
+    object FantIkkeRevurdering : KunneIkkeIverksetteRevurdering
+    object LagringFeilet : KunneIkkeIverksetteRevurdering
+    object HarAlleredeBlittAvkortetAvEnAnnen : KunneIkkeIverksetteRevurdering
+    object KunneIkkeAnnulereKontrollsamtale : KunneIkkeIverksetteRevurdering
+
     data class UgyldigTilstand(
         val fra: KClass<out AbstraktRevurdering>,
         val til: KClass<out AbstraktRevurdering>,
-    ) : KunneIkkeIverksetteRevurdering()
+    ) : KunneIkkeIverksetteRevurdering
 }
 
 sealed class KunneIkkeLageBrevutkastForRevurdering {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -32,7 +32,6 @@ import no.nav.su.se.bakover.domain.grunnlag.harFlerEnnEnBosituasjonsperiode
 import no.nav.su.se.bakover.domain.grunnlag.singleFullstendigOrThrow
 import no.nav.su.se.bakover.domain.oppdrag.SimulerUtbetalingRequest
 import no.nav.su.se.bakover.domain.oppdrag.UtbetalRequest
-import no.nav.su.se.bakover.domain.oppdrag.UtbetalingFeiletException
 import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
 import no.nav.su.se.bakover.domain.oppgave.OppgaveFeil
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
@@ -1228,28 +1227,29 @@ internal class RevurderingServiceImpl(
                         ),
                     ).mapLeft { KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale(it) }
                         .flatMap { utbetaling ->
+                            val vedtak = VedtakSomKanRevurderes.from(iverksattRevurdering, utbetaling.id, clock)
                             Either.catch {
                                 sessionFactory.withTransactionContext { tx ->
-                                    val vedtak = VedtakSomKanRevurderes.from(iverksattRevurdering, utbetaling.id, clock)
+                                    // OBS: Det er kun exceptions som vil føre til at transaksjonen ruller tilbake. Hvis funksjonene returnerer Left/null o.l. vil transaksjonen gå igjennom. De tilfellene må håndteres eksplisitt per funksjon.
+                                    // Det er også viktig at publiseringen av utbetalingen er det siste som skjer i blokka. Alt som ikke skal påvirke utfallet av iverksettingen skal flyttes ut av blokka. E.g. statistikk.
                                     utbetalingService.lagreUtbetaling(utbetaling, tx)
                                     vedtakRepo.lagre(vedtak, tx)
                                     revurderingRepo.lagre(iverksattRevurdering, tx)
                                     utbetalingService.publiserUtbetaling(utbetaling).mapLeft { feil ->
-                                        log.error(
-                                            "Kunne ikke publisere revurderingsutbetaling på køen. Ruller tilbake. SakId: ${iverksattRevurdering.sakId}",
-                                            feil,
+                                        throw IverksettTransactionException(
+                                            "Kunne ikke publisere utbetaling på køen. Underliggende feil: $feil.",
+                                            KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale(feil),
                                         )
-                                        throw UtbetalingFeiletException(feil)
                                     }
+                                    vedtak
                                 }
                             }.mapLeft {
                                 when (it) {
-                                    is UtbetalingFeiletException -> KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale(it.feil)
+                                    is IverksettTransactionException -> it.feil
                                     else -> KunneIkkeIverksetteRevurdering.LagringFeilet
                                 }
                             }
-                        }
-                        .map { iverksattRevurdering }
+                        }.map { Pair(iverksattRevurdering, it) }
                 }
             is RevurderingTilAttestering.Opphørt ->
                 revurdering.tilIverksatt(
@@ -1278,46 +1278,66 @@ internal class RevurderingServiceImpl(
                     ).mapLeft {
                         KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale(it)
                     }.flatMap { utbetaling ->
+                        val opphørtVedtak = VedtakSomKanRevurderes.from(
+                            revurdering = iverksattRevurdering, utbetalingId = utbetaling.id,
+                            clock = clock,
+                        )
                         Either.catch {
                             sessionFactory.withTransactionContext { tx ->
-                                val opphørtVedtak =
-                                    VedtakSomKanRevurderes.from(iverksattRevurdering, utbetaling.id, clock)
+                                // OBS: Det er kun exceptions som vil føre til at transaksjonen ruller tilbake. Hvis funksjonene returnerer Left/null o.l. vil transaksjonen gå igjennom. De tilfellene må håndteres eksplisitt per funksjon.
+                                // Det er også viktig at publiseringen av utbetalingen er det siste som skjer i blokka. Alt som ikke skal påvirke utfallet av iverksettingen skal flyttes ut av blokka. E.g. statistikk.
                                 utbetalingService.lagreUtbetaling(utbetaling, tx)
                                 vedtakRepo.lagre(opphørtVedtak, tx)
                                 kontrollsamtaleService.annullerKontrollsamtale(opphørtVedtak.behandling.sakId, tx)
+                                    .mapLeft { feil ->
+                                        throw IverksettTransactionException(
+                                            "Kunne ikke annullere kontrollsamtale. Underliggende feil: $feil.",
+                                            KunneIkkeIverksetteRevurdering.KunneIkkeAnnulereKontrollsamtale,
+                                        )
+                                    }
                                 revurderingRepo.lagre(iverksattRevurdering, tx)
                                 utbetalingService.publiserUtbetaling(utbetaling).mapLeft { feil ->
-                                    log.error(
-                                        "Kunne ikke publisere revurdering-opphør på køen. Ruller tilbake. SakId: ${iverksattRevurdering.sakId}",
-                                        feil,
-                                    )
-                                    throw UtbetalingFeiletException(feil)
-                                }
-                                observers.forEach { observer ->
-                                    observer.handle(
-                                        Event.Statistikk.Vedtaksstatistikk(opphørtVedtak),
+                                    throw IverksettTransactionException(
+                                        "Kunne ikke publisere utbetaling på køen. Underliggende feil: $feil.",
+                                        KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale(feil),
                                     )
                                 }
+                                opphørtVedtak
                             }
                         }.mapLeft {
+                            log.error(
+                                "Kunne ikke iverksette revurdering for sak ${iverksattRevurdering.sakId} og søknadsbehandling ${iverksattRevurdering.id}.",
+                                it,
+                            )
                             when (it) {
-                                is UtbetalingFeiletException -> KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale(it.feil)
+                                is IverksettTransactionException -> it.feil
                                 else -> KunneIkkeIverksetteRevurdering.LagringFeilet
                             }
                         }
                     }.map {
-                        iverksattRevurdering
+                        Pair(iverksattRevurdering, it)
                     }
                 }
         }.map {
-            observers.forEach { observer ->
-                observer.handle(
-                    Event.Statistikk.RevurderingStatistikk.RevurderingIverksatt(it),
+            Either.catch {
+                observers.forEach { observer ->
+                    observer.handle(Event.Statistikk.RevurderingStatistikk.RevurderingIverksatt(it.first))
+                    observer.handle(Event.Statistikk.Vedtaksstatistikk(it.second))
+                }
+            }.mapLeft { e ->
+                log.error(
+                    "Kunne ikke sende statistikk etter vi iverksatte revurdering. Dette er kun en sideeffekt og påvirker ikke saksbehandlingen.",
+                    e,
                 )
             }
-            it
+            it.first
         }
     }
+
+    private data class IverksettTransactionException(
+        override val message: String,
+        val feil: KunneIkkeIverksetteRevurdering,
+    ) : RuntimeException(message)
 
     override fun underkjenn(
         revurderingId: UUID,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/IverksettRevurderingTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/IverksettRevurderingTest.kt
@@ -13,6 +13,7 @@ import no.nav.su.se.bakover.domain.revurdering.IverksattRevurdering
 import no.nav.su.se.bakover.domain.revurdering.RevurderingTilAttestering
 import no.nav.su.se.bakover.domain.vedtak.VedtakSomKanRevurderes
 import no.nav.su.se.bakover.service.argThat
+import no.nav.su.se.bakover.service.kontrollsamtale.KunneIkkeKalleInnTilKontrollsamtale
 import no.nav.su.se.bakover.test.attestant
 import no.nav.su.se.bakover.test.getOrFail
 import no.nav.su.se.bakover.test.grunnlagsdataEnsligMedFradrag
@@ -314,6 +315,33 @@ internal class IverksettRevurderingTest {
     }
 
     @Test
+    fun `skal ikke opphøre dersom annulering av kontrollsamtale feiler`() {
+        val sakOgRevurdering = tilAttesteringRevurderingOpphørtUføreFraInnvilgetSøknadsbehandlingsVedtak()
+        val revurderingTilAttestering = sakOgRevurdering.second
+        val simulertOpphør = simulertUtbetalingOpphør(eksisterendeUtbetalinger = sakOgRevurdering.first.utbetalinger).getOrFail()
+        val serviceAndMocks = RevurderingServiceMocks(
+            revurderingRepo = mock {
+                on { hent(any()) } doReturn revurderingTilAttestering
+            },
+            utbetalingService = mock {
+                on { verifiserOgSimulerOpphør(any()) } doReturn simulertOpphør.right()
+                on { verifiserOgSimulerUtbetaling(any()) } doReturn simulertUtbetaling().right()
+            },
+            vedtakRepo = mock {
+                doNothing().whenever(it).lagre(any(), anyOrNull())
+            },
+            kontrollsamtaleService = mock {
+                on { annullerKontrollsamtale(any(), anyOrNull()) } doReturn KunneIkkeKalleInnTilKontrollsamtale.FantIkkeKontrollsamtale.left()
+            }
+        )
+
+        serviceAndMocks.revurderingService.iverksett(
+            revurderingId = revurderingId,
+            attestant = attestant,
+        ) shouldBe KunneIkkeIverksetteRevurdering.KunneIkkeAnnulereKontrollsamtale.left()
+    }
+
+    @Test
     fun `skal returnere left dersom utbetaling feiler for iverksett`() {
         val serviceAndMocks = RevurderingServiceMocks(
             revurderingRepo = mock {
@@ -336,7 +364,6 @@ internal class IverksettRevurderingTest {
             revurderingId = revurderingId,
             attestant = attestant,
         )
-
         response shouldBe KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale(UtbetalingFeilet.FantIkkeSak).left()
     }
 }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingIngenEndringTest.kt
@@ -1,6 +1,5 @@
 package no.nav.su.se.bakover.service.revurdering
 
-import arrow.core.left
 import arrow.core.right
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -15,7 +14,6 @@ import no.nav.su.se.bakover.domain.revurdering.RevurderingTilAttestering
 import no.nav.su.se.bakover.domain.revurdering.UnderkjentRevurdering
 import no.nav.su.se.bakover.domain.vedtak.VedtakSomKanRevurderes
 import no.nav.su.se.bakover.service.argThat
-import no.nav.su.se.bakover.service.brev.KunneIkkeLageDokument
 import no.nav.su.se.bakover.test.aktørId
 import no.nav.su.se.bakover.test.attestant
 import no.nav.su.se.bakover.test.attesteringUnderkjent
@@ -285,96 +283,6 @@ internal class RevurderingIngenEndringTest {
             verify(revurderingRepoMock).defaultTransactionContext()
             verify(revurderingRepoMock).lagre(any(), anyOrNull())
             verifyNoMoreInteractions()
-        }
-    }
-
-    @Test
-    @Disabled("https://trello.com/c/5iblmYP9/1090-endre-sperre-for-10-endring-til-%C3%A5-v%C3%A6re-en-advarsel")
-    fun `iverksetter revurdering som ikke fører til endring i ytelse svarer med feil hvis vi ikke kan hente person`() {
-        val (_, revurderingTilAttestering) = tilAttesteringRevurderingIngenEndringFraInnvilgetSøknadsbehandlingsVedtak(
-            skalFøreTilBrevutsending = true,
-        )
-
-        RevurderingServiceMocks(
-            revurderingRepo = mock {
-                on { hent(any()) } doReturn revurderingTilAttestering
-            },
-            brevService = mock {
-                on { lagDokument(any()) } doReturn KunneIkkeLageDokument.KunneIkkeHentePerson.left()
-            },
-        ).let {
-
-            it.revurderingService.iverksett(
-                revurderingId,
-                attestant,
-            ) shouldBe KunneIkkeIverksetteRevurdering.FantIkkePerson.left()
-
-            inOrder(
-                *it.all(),
-            ) {
-                verify(it.revurderingRepo).hent(revurderingTilAttestering.id)
-                verify(it.brevService).lagDokument(any())
-                verifyNoMoreInteractions()
-            }
-        }
-    }
-
-    @Test
-    @Disabled("https://trello.com/c/5iblmYP9/1090-endre-sperre-for-10-endring-til-%C3%A5-v%C3%A6re-en-advarsel")
-    fun `iverksetter revurdering som ikke fører til endring i ytelse svarer med feil hvis vi ikke kan hente gjeldende utbetaling`() {
-        val (_, revurderingTilAttestering) = tilAttesteringRevurderingIngenEndringFraInnvilgetSøknadsbehandlingsVedtak(
-            skalFøreTilBrevutsending = true,
-        )
-
-        RevurderingServiceMocks(
-            revurderingRepo = mock {
-                on { hent(any()) } doReturn revurderingTilAttestering
-            },
-            brevService = mock {
-                on { lagDokument(any()) } doReturn KunneIkkeLageDokument.KunneIkkeFinneGjeldendeUtbetaling.left()
-            },
-        ).let {
-            it.revurderingService.iverksett(
-                revurderingId,
-                attestant,
-            ) shouldBe KunneIkkeIverksetteRevurdering.KunneIkkeFinneGjeldendeUtbetaling.left()
-
-            inOrder(
-                *it.all(),
-            ) {
-                verify(it.revurderingRepo).hent(revurderingTilAttestering.id)
-                verify(it.brevService).lagDokument(argThat { it shouldBe beOfType<VedtakSomKanRevurderes.IngenEndringIYtelse>() })
-                verifyNoMoreInteractions()
-            }
-        }
-    }
-
-    @Test
-    fun `iverksetter revurdering som ikke fører til endring i ytelse svarer med feil hvis generering av brev feiler`() {
-        val (_, revurderingTilAttestering) = tilAttesteringRevurderingIngenEndringFraInnvilgetSøknadsbehandlingsVedtak(
-            skalFøreTilBrevutsending = true,
-        )
-
-        RevurderingServiceMocks(
-            revurderingRepo = mock {
-                on { hent(any()) } doReturn revurderingTilAttestering
-            },
-            brevService = mock {
-                on { lagDokument(any()) } doReturn KunneIkkeLageDokument.KunneIkkeGenererePDF.left()
-            },
-        ).let {
-            it.revurderingService.iverksett(
-                revurderingId,
-                attestant,
-            ) shouldBe KunneIkkeIverksetteRevurdering.KunneIkkeGenerereBrev.left()
-
-            inOrder(
-                *it.all(),
-            ) {
-                verify(it.revurderingRepo).hent(revurderingTilAttestering.id)
-                verify(it.brevService).lagDokument(argThat { it shouldBe beOfType<VedtakSomKanRevurderes.IngenEndringIYtelse>() })
-                verifyNoMoreInteractions()
-            }
         }
     }
 }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/IverksettRevurderingRoute.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/IverksettRevurderingRoute.kt
@@ -15,14 +15,12 @@ import no.nav.su.se.bakover.service.revurdering.RevurderingService
 import no.nav.su.se.bakover.web.AuditLogEvent
 import no.nav.su.se.bakover.web.Resultat
 import no.nav.su.se.bakover.web.audit
+import no.nav.su.se.bakover.web.errorJson
 import no.nav.su.se.bakover.web.features.authorize
 import no.nav.su.se.bakover.web.features.suUserContext
 import no.nav.su.se.bakover.web.metrics.SuMetrics
-import no.nav.su.se.bakover.web.routes.Feilresponser.Brev.kunneIkkeGenerereBrev
 import no.nav.su.se.bakover.web.routes.Feilresponser.attestantOgSaksbehandlerKanIkkeVæreSammePerson
-import no.nav.su.se.bakover.web.routes.Feilresponser.avkortingErAlleredeAnnullert
 import no.nav.su.se.bakover.web.routes.Feilresponser.avkortingErAlleredeAvkortet
-import no.nav.su.se.bakover.web.routes.Feilresponser.fantIkkePerson
 import no.nav.su.se.bakover.web.routes.Feilresponser.ingenEndringUgyldig
 import no.nav.su.se.bakover.web.routes.Feilresponser.lagringFeilet
 import no.nav.su.se.bakover.web.routes.Feilresponser.tilResultat
@@ -62,12 +60,11 @@ private fun KunneIkkeIverksetteRevurdering.tilResultat() = when (this) {
     is UgyldigTilstand -> ugyldigTilstand(this.fra, this.til)
     is AttestantOgSaksbehandlerKanIkkeVæreSammePerson -> attestantOgSaksbehandlerKanIkkeVæreSammePerson
     is KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale -> this.utbetalingFeilet.tilResultat()
-    KunneIkkeIverksetteRevurdering.FantIkkePerson -> fantIkkePerson
-    KunneIkkeIverksetteRevurdering.KunneIkkeFinneGjeldendeUtbetaling -> Revurderingsfeilresponser.Brev.fantIkkeGjeldendeUtbetaling
-    KunneIkkeIverksetteRevurdering.KunneIkkeGenerereBrev -> kunneIkkeGenerereBrev
-    KunneIkkeIverksetteRevurdering.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant -> Revurderingsfeilresponser.Brev.navneoppslagSaksbehandlerAttesttantFeilet
-    KunneIkkeIverksetteRevurdering.HarAlleredeBlittAnnullertAvEnAnnen -> avkortingErAlleredeAnnullert
     KunneIkkeIverksetteRevurdering.HarAlleredeBlittAvkortetAvEnAnnen -> avkortingErAlleredeAvkortet
     KunneIkkeIverksetteRevurdering.IngenEndringErIkkeGyldig -> ingenEndringUgyldig
     KunneIkkeIverksetteRevurdering.LagringFeilet -> lagringFeilet
+    KunneIkkeIverksetteRevurdering.KunneIkkeAnnulereKontrollsamtale -> HttpStatusCode.InternalServerError.errorJson(
+        "Kunne ikke annulere kontrollsamtale",
+        "kunne_ikke_annulere_kontrollsamtale",
+    )
 }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutes.kt
@@ -60,6 +60,7 @@ import no.nav.su.se.bakover.web.routes.Feilresponser.fantIkkePerson
 import no.nav.su.se.bakover.web.routes.Feilresponser.fantIkkeSak
 import no.nav.su.se.bakover.web.routes.Feilresponser.harIkkeEktefelle
 import no.nav.su.se.bakover.web.routes.Feilresponser.kunneIkkeSimulere
+import no.nav.su.se.bakover.web.routes.Feilresponser.lagringFeilet
 import no.nav.su.se.bakover.web.routes.Feilresponser.tilResultat
 import no.nav.su.se.bakover.web.routes.Feilresponser.ugyldigTilstand
 import no.nav.su.se.bakover.web.routes.sak.sakPath
@@ -438,11 +439,14 @@ internal fun Route.søknadsbehandlingRoutes(
                 is KunneIkkeIverksette.KunneIkkeUtbetale -> value.utbetalingFeilet.tilResultat()
                 is KunneIkkeIverksette.KunneIkkeGenerereVedtaksbrev -> kunneIkkeGenerereBrev
                 is KunneIkkeIverksette.FantIkkeBehandling -> fantIkkeBehandling
-                is KunneIkkeIverksette.FantIkkePerson -> fantIkkePerson
-                is KunneIkkeIverksette.FikkIkkeHentetSaksbehandlerEllerAttestant -> feilVedHentingAvSaksbehandlerEllerAttestant
                 KunneIkkeIverksette.AvkortingErUfullstendig -> avkortingErUfullstendig
                 KunneIkkeIverksette.HarAlleredeBlittAvkortetAvEnAnnen -> avkortingErAlleredeAvkortet
                 KunneIkkeIverksette.HarBlittAnnullertAvEnAnnen -> avkortingErAlleredeAnnullert
+                KunneIkkeIverksette.KunneIkkeOpprettePlanlagtKontrollsamtale -> InternalServerError.errorJson(
+                    "Kunne ikke opprette kontrollsamtale",
+                    "kunne_ikke_opprette_kontrollsamtale",
+                )
+                KunneIkkeIverksette.LagringFeilet -> lagringFeilet
             }
         }
 


### PR DESCRIPTION
Iverksetting av søknadsbehandling og revurderinger kjøres som en transaksjon. Der har vi noen bugs og mangler i dag. Dersom kontrollsamtale feiler, ignorerer vi dette. Vi logger ikke feil. Og dersom statistikk feiler vil vi sende en utbetaling uten å persistere.

Denne PR prøver å løse dette. En TODO i framtiden vil være å gjøre om den withTransaction til å ha et sterkere grensesnitt for å hjelpe på slike feil i fremtiden. withTransaction kan f.eks. ta inn et vararg antall funksjoner som hver må returnere en spesifikk type, f.eks. TransactionFunctionResponse også kan selve withtransaction returnere TransactionReponse. Da slipper vi ha en exception-flyt og det vil bli enklere å skrive tester. 