### PR TITLE
Ack kvitteringer fra oppdrag manuelt

### DIFF
--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/utbetaling/kvittering/UtbetalingKvitteringIbmMqConsumer.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/utbetaling/kvittering/UtbetalingKvitteringIbmMqConsumer.kt
@@ -13,7 +13,7 @@ class UtbetalingKvitteringIbmMqConsumer(
     private val kvitteringConsumer: UtbetalingKvitteringConsumer,
 ) {
     private val log = LoggerFactory.getLogger(this::class.java)
-    private val jmsContext = globalJmsContext.createContext(Session.AUTO_ACKNOWLEDGE)
+    private val jmsContext = globalJmsContext.createContext(Session.CLIENT_ACKNOWLEDGE)
     private val consumer = jmsContext.createConsumer(jmsContext.createQueue(kvitteringQueueName))
 
     // TODO: Vurder å gjøre om dette til en jobb som poller med receive, i stedet for asynkron messageListener
@@ -28,9 +28,9 @@ class UtbetalingKvitteringIbmMqConsumer(
                     sikkerLogg.info("Kvittering lest fra $kvitteringQueueName, innhold:$it")
                     kvitteringConsumer.onMessage(it)
                 }
+                message.acknowledge()
             } catch (ex: Exception) {
                 log.error("Feil ved prossessering av melding fra: $kvitteringQueueName", ex)
-                throw ex
             }
         }
 


### PR DESCRIPTION
For å slippe å boble opp en exception i tilfellene vi ikke ønsker å acke, som da logger stack trace rått til logg. Implementasjonen skal være helt analog til hvordan det var tidligere med auto, bare nå med eksplisitt acking (og fjerning av den implisitte no-ack throwen).

Dokumentasjonen var litt tvetydig, mulig dette kunne vært løst med `AUTO_ACKNOWLEDGE` også, bare ved å unngå å rethrowe. Docen sier noe sånt som at ack skjer automatisk rett etter at `onMessage` returnerer suksessfullt, men det er litt uklart hva dette egentlig betyr og litt kinkig å teste.