### PR TITLE
Rydd opp testdata for databasetestene

### DIFF
--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/søknadsbehandling/SøknadsbehandlingPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/søknadsbehandling/SøknadsbehandlingPostgresRepo.kt
@@ -29,7 +29,6 @@ import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.avkorting.AvkortingVedSøknadsbehandling
-import no.nav.su.se.bakover.domain.behandling.Attestering
 import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.avslag.AvslagManglendeDokumentasjon
@@ -155,21 +154,6 @@ internal class SøknadsbehandlingPostgresRepo(
                     },
                     session = tx,
                 )
-            }
-        }
-    }
-
-    override fun hentEventuellTidligereAttestering(id: UUID): Attestering? {
-        // henter ut siste elementet (seneste attestering) i attesteringslisten
-        return dbMetrics.timeQuery("hentEventuellTidligereAttestering") {
-            sessionFactory.withSession { session ->
-                "select b.attestering from behandling b where b.id=:id"
-                    .hent(mapOf("id" to id), session) { row ->
-                        row.stringOrNull("attestering")?.let {
-                            val attesteringer = Attesteringshistorikk.create(objectMapper.readValue(it))
-                            attesteringer.lastOrNull()
-                        }
-                    }
             }
         }
     }

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/DomeneTilPersistert.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/DomeneTilPersistert.kt
@@ -3,6 +3,7 @@ package no.nav.su.se.bakover.database
 import no.nav.su.se.bakover.database.beregning.PersistertBeregning
 import no.nav.su.se.bakover.database.beregning.toSnapshot
 import no.nav.su.se.bakover.domain.beregning.Beregning
+import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.revurdering.AbstraktRevurdering
 import no.nav.su.se.bakover.domain.revurdering.AvsluttetRevurdering
 import no.nav.su.se.bakover.domain.revurdering.BeregnetRevurdering
@@ -25,52 +26,52 @@ import no.nav.su.se.bakover.domain.vedtak.VedtakSomKanRevurderes
 internal inline fun <reified T : Søknadsbehandling> T.persistertVariant(): T {
     return when (this) {
         is Søknadsbehandling.Beregnet.Avslag -> {
-            copy(beregning = beregning.persistertVariant())
+            copy(beregning = beregning.persistertVariant(), grunnlagsdata = grunnlagsdata.persistertVariant())
         }
         is Søknadsbehandling.Beregnet.Innvilget -> {
-            copy(beregning = beregning.persistertVariant())
+            copy(beregning = beregning.persistertVariant(), grunnlagsdata = grunnlagsdata.persistertVariant())
         }
         is Søknadsbehandling.Iverksatt.Avslag.MedBeregning -> {
-            copy(beregning = beregning.persistertVariant())
+            copy(beregning = beregning.persistertVariant(), grunnlagsdata = grunnlagsdata.persistertVariant())
         }
         is Søknadsbehandling.Iverksatt.Avslag.UtenBeregning -> {
-            this
+            this.copy(grunnlagsdata = grunnlagsdata.persistertVariant())
         }
         is Søknadsbehandling.Iverksatt.Innvilget -> {
-            copy(beregning = beregning.persistertVariant())
+            copy(beregning = beregning.persistertVariant(), grunnlagsdata = grunnlagsdata.persistertVariant())
         }
         is LukketSøknadsbehandling -> {
             this
         }
         is Søknadsbehandling.Simulert -> {
-            copy(beregning = beregning.persistertVariant())
+            copy(beregning = beregning.persistertVariant(), grunnlagsdata = grunnlagsdata.persistertVariant())
         }
         is Søknadsbehandling.TilAttestering.Avslag.MedBeregning -> {
-            copy(beregning = beregning.persistertVariant())
+            copy(beregning = beregning.persistertVariant(), grunnlagsdata = grunnlagsdata.persistertVariant())
         }
         is Søknadsbehandling.TilAttestering.Avslag.UtenBeregning -> {
-            this
+            this.copy(grunnlagsdata = grunnlagsdata.persistertVariant())
         }
         is Søknadsbehandling.TilAttestering.Innvilget -> {
-            copy(beregning = beregning.persistertVariant())
+            copy(beregning = beregning.persistertVariant(), grunnlagsdata = grunnlagsdata.persistertVariant())
         }
         is Søknadsbehandling.Underkjent.Avslag.MedBeregning -> {
-            copy(beregning = beregning.persistertVariant())
+            copy(beregning = beregning.persistertVariant(), grunnlagsdata = grunnlagsdata.persistertVariant())
         }
         is Søknadsbehandling.Underkjent.Avslag.UtenBeregning -> {
-            this
+            this.copy(grunnlagsdata = grunnlagsdata.persistertVariant())
         }
         is Søknadsbehandling.Underkjent.Innvilget -> {
-            copy(beregning = beregning.persistertVariant())
+            copy(beregning = beregning.persistertVariant(), grunnlagsdata = grunnlagsdata.persistertVariant())
         }
         is Søknadsbehandling.Vilkårsvurdert.Avslag -> {
-            this
+            this.copy(grunnlagsdata = grunnlagsdata.persistertVariant())
         }
         is Søknadsbehandling.Vilkårsvurdert.Innvilget -> {
-            this
+            this.copy(grunnlagsdata = grunnlagsdata.persistertVariant())
         }
         is Søknadsbehandling.Vilkårsvurdert.Uavklart -> {
-            this
+            this.copy(grunnlagsdata = grunnlagsdata.persistertVariant())
         }
         else -> null
     } as T
@@ -85,109 +86,128 @@ internal inline fun <reified T : AbstraktRevurdering> T.persistertVariant(): T {
             copy(
                 tilRevurdering = tilRevurdering.persistertVariant(),
                 beregning = beregning.persistertVariant(),
+                grunnlagsdata = grunnlagsdata.persistertVariant(),
             )
         }
         is BeregnetRevurdering.Innvilget -> {
             copy(
                 tilRevurdering = tilRevurdering.persistertVariant(),
                 beregning = beregning.persistertVariant(),
+                grunnlagsdata = grunnlagsdata.persistertVariant(),
             )
         }
         is BeregnetRevurdering.Opphørt -> {
             copy(
                 tilRevurdering = tilRevurdering.persistertVariant(),
                 beregning = beregning.persistertVariant(),
+                grunnlagsdata = grunnlagsdata.persistertVariant(),
             )
         }
         is IverksattRevurdering.IngenEndring -> {
             copy(
                 tilRevurdering = tilRevurdering.persistertVariant(),
                 beregning = beregning.persistertVariant(),
+                grunnlagsdata = grunnlagsdata.persistertVariant(),
             )
         }
         is IverksattRevurdering.Innvilget -> {
             copy(
                 tilRevurdering = tilRevurdering.persistertVariant(),
                 beregning = beregning.persistertVariant(),
+                grunnlagsdata = grunnlagsdata.persistertVariant(),
             )
         }
         is IverksattRevurdering.Opphørt -> {
             copy(
                 tilRevurdering = tilRevurdering.persistertVariant(),
                 beregning = beregning.persistertVariant(),
+                grunnlagsdata = grunnlagsdata.persistertVariant(),
             )
         }
         is OpprettetRevurdering -> {
             copy(
                 tilRevurdering = tilRevurdering.persistertVariant(),
+                grunnlagsdata = grunnlagsdata.persistertVariant(),
             )
         }
         is RevurderingTilAttestering.IngenEndring -> {
             copy(
                 tilRevurdering = tilRevurdering.persistertVariant(),
                 beregning = beregning.persistertVariant(),
+                grunnlagsdata = grunnlagsdata.persistertVariant(),
             )
         }
         is RevurderingTilAttestering.Innvilget -> {
             copy(
                 tilRevurdering = tilRevurdering.persistertVariant(),
                 beregning = beregning.persistertVariant(),
+                grunnlagsdata = grunnlagsdata.persistertVariant(),
             )
         }
         is RevurderingTilAttestering.Opphørt -> {
             copy(
                 tilRevurdering = tilRevurdering.persistertVariant(),
                 beregning = beregning.persistertVariant(),
+                grunnlagsdata = grunnlagsdata.persistertVariant(),
             )
         }
         is SimulertRevurdering.Innvilget -> {
             copy(
                 tilRevurdering = tilRevurdering.persistertVariant(),
                 beregning = beregning.persistertVariant(),
+                grunnlagsdata = grunnlagsdata.persistertVariant(),
             )
         }
         is SimulertRevurdering.Opphørt -> {
             copy(
                 tilRevurdering = tilRevurdering.persistertVariant(),
                 beregning = beregning.persistertVariant(),
+                grunnlagsdata = grunnlagsdata.persistertVariant(),
             )
         }
         is UnderkjentRevurdering.IngenEndring -> {
             copy(
                 tilRevurdering = tilRevurdering.persistertVariant(),
                 beregning = beregning.persistertVariant(),
+                grunnlagsdata = grunnlagsdata.persistertVariant(),
             )
         }
         is UnderkjentRevurdering.Innvilget -> {
             copy(
                 tilRevurdering = tilRevurdering.persistertVariant(),
                 beregning = beregning.persistertVariant(),
+                grunnlagsdata = grunnlagsdata.persistertVariant(),
             )
         }
         is UnderkjentRevurdering.Opphørt -> {
             copy(
                 tilRevurdering = tilRevurdering.persistertVariant(),
                 beregning = beregning.persistertVariant(),
+                grunnlagsdata = grunnlagsdata.persistertVariant(),
             )
         }
         is StansAvYtelseRevurdering.SimulertStansAvYtelse -> {
             copy(
                 tilRevurdering = tilRevurdering.persistertVariant(),
+                grunnlagsdata = grunnlagsdata.persistertVariant(),
             )
         }
         is StansAvYtelseRevurdering.IverksattStansAvYtelse -> {
             copy(
                 tilRevurdering = tilRevurdering.persistertVariant(),
+                grunnlagsdata = grunnlagsdata.persistertVariant(),
             )
         }
         is GjenopptaYtelseRevurdering.SimulertGjenopptakAvYtelse -> {
             copy(
                 tilRevurdering = tilRevurdering.persistertVariant(),
+                grunnlagsdata = grunnlagsdata.persistertVariant(),
             )
         }
         is GjenopptaYtelseRevurdering.IverksattGjenopptakAvYtelse -> {
             copy(
                 tilRevurdering = tilRevurdering.persistertVariant(),
+                grunnlagsdata = grunnlagsdata.persistertVariant(),
             )
         }
         else -> null
@@ -251,4 +271,14 @@ internal fun Avslagsvedtak.persistertVariant(): Avslagsvedtak {
 
 internal fun Beregning.persistertVariant(): PersistertBeregning {
     return this.toSnapshot()
+}
+
+internal fun Grunnlagsdata.persistertVariant(): Grunnlagsdata {
+    return this.copy(
+        fradragsgrunnlag = this.fradragsgrunnlag.map {
+            it.copy(
+                fradrag = it.fradrag.toSnapshot(),
+            )
+        },
+    )
 }

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/MigrationsPostgresTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/MigrationsPostgresTest.kt
@@ -8,7 +8,7 @@ internal class MigrationsPostgresTest {
     @Test
     fun `rader skal ikke lekke ut av withMigratedDb`() {
         withMigratedDb { dataSource ->
-            TestDataHelper(dataSource).nySakMedJournalførtSøknadOgOppgave()
+            TestDataHelper(dataSource).persisterJournalførtSøknadMedOppgave()
             dataSource.withSession { session ->
                 "select count(1) from sak".antall(session = session) shouldBe 1
             }

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/PostgresTransactionContextTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/PostgresTransactionContextTest.kt
@@ -13,8 +13,7 @@ internal class PostgresTransactionContextTest {
     @Test
     fun `commits transaction and Starts and closes only one connection`() {
         withMigratedDb { dataSource ->
-            val sak = TestDataHelper(dataSource).nySakMedJournalførtSøknadOgOppgave()
-            val søknad = sak.søknader.first() as Søknad.Journalført.MedOppgave.IkkeLukket
+            val (_, søknad) = TestDataHelper(dataSource).persisterJournalførtSøknadMedOppgave()
             withTestContext(dataSource, 1) { spiedDataSource ->
                 val testDataHelper = TestDataHelper(spiedDataSource)
                 testDataHelper.sessionFactory.withTransactionContext { context ->
@@ -47,8 +46,7 @@ internal class PostgresTransactionContextTest {
     @Test
     fun `throw should rollback`() {
         withMigratedDb { dataSource ->
-            val sak = TestDataHelper(dataSource).nySakMedJournalførtSøknadOgOppgave()
-            val søknad = sak.søknader.first() as Søknad.Journalført.MedOppgave.IkkeLukket
+            val (_, søknad) = TestDataHelper(dataSource).persisterJournalførtSøknadMedOppgave()
 
             withTestContext(dataSource, 1) { spiedDataSource ->
                 val testDataHelper = TestDataHelper(spiedDataSource)

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
@@ -8,8 +8,7 @@ import io.kotest.assertions.fail
 import kotliquery.using
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.UUID30
-import no.nav.su.se.bakover.common.desember
-import no.nav.su.se.bakover.common.januar
+import no.nav.su.se.bakover.common.UUIDFactory
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.database.avkorting.AvkortingsvarselPostgresRepo
 import no.nav.su.se.bakover.database.avstemming.AvstemmingPostgresRepo
@@ -49,10 +48,8 @@ import no.nav.su.se.bakover.domain.avkorting.AvkortingVedSøknadsbehandling
 import no.nav.su.se.bakover.domain.behandling.Attestering
 import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
-import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.behandling.withAvslåttFlyktning
 import no.nav.su.se.bakover.domain.beregning.Beregning
-import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.grunnlag.Uføregrad
 import no.nav.su.se.bakover.domain.journal.JournalpostId
@@ -94,16 +91,13 @@ import no.nav.su.se.bakover.domain.søknadsbehandling.LukketSøknadsbehandling
 import no.nav.su.se.bakover.domain.søknadsbehandling.NySøknadsbehandling
 import no.nav.su.se.bakover.domain.søknadsbehandling.Stønadsperiode
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
-import no.nav.su.se.bakover.domain.vedtak.GjeldendeVedtaksdata
+import no.nav.su.se.bakover.domain.vedtak.Avslagsvedtak
 import no.nav.su.se.bakover.domain.vedtak.Klagevedtak
 import no.nav.su.se.bakover.domain.vedtak.VedtakSomKanRevurderes
-import no.nav.su.se.bakover.domain.vilkår.UtenlandsoppholdVilkår
-import no.nav.su.se.bakover.domain.vilkår.Vilkår
 import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
+import no.nav.su.se.bakover.test.attestant
 import no.nav.su.se.bakover.test.behandlingsinformasjonAlleVilkårInnvilget
-import no.nav.su.se.bakover.test.beregningAvslagForHøyInntekt
 import no.nav.su.se.bakover.test.bosituasjongrunnlagEnslig
-import no.nav.su.se.bakover.test.bosituasjongrunnlagEpsUførFlyktning
 import no.nav.su.se.bakover.test.enUkeEtterFixedTidspunkt
 import no.nav.su.se.bakover.test.epsFnr
 import no.nav.su.se.bakover.test.fixedClock
@@ -111,31 +105,32 @@ import no.nav.su.se.bakover.test.fixedLocalDate
 import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.generer
 import no.nav.su.se.bakover.test.getOrFail
+import no.nav.su.se.bakover.test.gjeldendeVedtaksdata
+import no.nav.su.se.bakover.test.grunnlagsdataEnsligMedFradrag
+import no.nav.su.se.bakover.test.grunnlagsdataMedEpsMedFradrag
 import no.nav.su.se.bakover.test.innvilgetUførevilkår
 import no.nav.su.se.bakover.test.innvilgetUførevilkårForventetInntekt0
+import no.nav.su.se.bakover.test.periode2021
+import no.nav.su.se.bakover.test.stønadsperiode2021
 import no.nav.su.se.bakover.test.uføregrunnlagForventetInntekt
-import no.nav.su.se.bakover.test.uføregrunnlagForventetInntekt0
-import no.nav.su.se.bakover.test.utlandsoppholdInnvilget
 import no.nav.su.se.bakover.test.vilkårsvurderingerAvslåttUføreOgAndreInnvilget
-import no.nav.su.se.bakover.test.vilkårsvurderingerInnvilget
+import no.nav.su.se.bakover.test.vilkårsvurderingerSøknadsbehandlingInnvilget
 import java.time.Clock
+import java.util.LinkedList
 import java.util.UUID
 import javax.sql.DataSource
 
-internal val stønadsperiode = Stønadsperiode.create(Periode.create(1.januar(2021), 31.desember(2021)))
-internal val tomBehandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon()
-internal val behandlingsinformasjonMedAlleVilkårOppfylt =
-    Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt()
 internal val behandlingsinformasjonMedAvslag =
     Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAvslåttFlyktning()
 
 internal val oppgaveId = OppgaveId("oppgaveId")
 internal val journalpostId = JournalpostId("journalpostId")
 
-internal fun innvilgetBeregning(periode: Periode = stønadsperiode.periode) =
-    no.nav.su.se.bakover.test.beregning(periode)
-
-internal val avslåttBeregning: Beregning = beregningAvslagForHøyInntekt()
+internal fun innvilgetBeregning(
+    periode: Periode = periode2021,
+): Beregning {
+    return no.nav.su.se.bakover.test.beregning(periode)
+}
 
 internal fun simulering(fnr: Fnr) = Simulering(
     gjelderId = fnr,
@@ -146,7 +141,6 @@ internal fun simulering(fnr: Fnr) = Simulering(
 )
 
 internal val saksbehandler = NavIdentBruker.Saksbehandler("saksbehandler")
-internal val attestant = NavIdentBruker.Attestant("attestant")
 internal val underkjentAttestering =
     Attestering.Underkjent(
         attestant = attestant,
@@ -156,8 +150,9 @@ internal val underkjentAttestering =
     )
 internal val iverksattAttestering = Attestering.Iverksatt(attestant, enUkeEtterFixedTidspunkt)
 internal val avstemmingsnøkkel = Avstemmingsnøkkel(fixedTidspunkt)
-internal fun utbetalingslinje(periode: Periode = stønadsperiode.periode) =
-    Utbetalingslinje.Ny(
+
+internal fun utbetalingslinje(periode: Periode = stønadsperiode2021.periode): Utbetalingslinje.Ny {
+    return Utbetalingslinje.Ny(
         opprettet = fixedTidspunkt,
         fraOgMed = periode.fraOgMed,
         tilOgMed = periode.tilOgMed,
@@ -165,50 +160,62 @@ internal fun utbetalingslinje(periode: Periode = stønadsperiode.periode) =
         beløp = 25000,
         uføregrad = Uføregrad.parse(50),
     )
+}
 
 internal fun oversendtUtbetalingUtenKvittering(
+    id: UUID30 = UUID30.randomUUID(),
     søknadsbehandling: Søknadsbehandling.Iverksatt.Innvilget,
     avstemmingsnøkkel: Avstemmingsnøkkel = no.nav.su.se.bakover.database.avstemmingsnøkkel,
     utbetalingslinjer: NonEmptyList<Utbetalingslinje> = nonEmptyListOf(utbetalingslinje(søknadsbehandling.periode)),
-) = oversendtUtbetalingUtenKvittering(
-    søknadsbehandling.fnr,
-    søknadsbehandling.sakId,
-    søknadsbehandling.saksnummer,
-    utbetalingslinjer,
-    avstemmingsnøkkel,
-)
+): Utbetaling.OversendtUtbetaling.UtenKvittering {
+    return oversendtUtbetalingUtenKvittering(
+        id = id,
+        fnr = søknadsbehandling.fnr,
+        sakId = søknadsbehandling.sakId,
+        saksnummer = søknadsbehandling.saksnummer,
+        utbetalingslinjer = utbetalingslinjer,
+        avstemmingsnøkkel = avstemmingsnøkkel,
+    )
+}
 
 internal fun oversendtUtbetalingUtenKvittering(
+    id: UUID30 = UUID30.randomUUID(),
     revurdering: RevurderingTilAttestering,
     avstemmingsnøkkel: Avstemmingsnøkkel = no.nav.su.se.bakover.database.avstemmingsnøkkel,
     utbetalingslinjer: NonEmptyList<Utbetalingslinje> = nonEmptyListOf(utbetalingslinje(revurdering.periode)),
-) = oversendtUtbetalingUtenKvittering(
-    revurdering.fnr,
-    revurdering.sakId,
-    revurdering.saksnummer,
-    utbetalingslinjer,
-    avstemmingsnøkkel,
-)
+): Utbetaling.OversendtUtbetaling.UtenKvittering {
+    return oversendtUtbetalingUtenKvittering(
+        id = id,
+        fnr = revurdering.fnr,
+        sakId = revurdering.sakId,
+        saksnummer = revurdering.saksnummer,
+        utbetalingslinjer = utbetalingslinjer,
+        avstemmingsnøkkel = avstemmingsnøkkel,
+    )
+}
 
 internal fun oversendtUtbetalingUtenKvittering(
+    id: UUID30 = UUID30.randomUUID(),
     fnr: Fnr,
     sakId: UUID,
     saksnummer: Saksnummer,
     utbetalingslinjer: NonEmptyList<Utbetalingslinje> = nonEmptyListOf(utbetalingslinje()),
     avstemmingsnøkkel: Avstemmingsnøkkel = no.nav.su.se.bakover.database.avstemmingsnøkkel,
-) = Utbetaling.OversendtUtbetaling.UtenKvittering(
-    id = UUID30.randomUUID(),
-    opprettet = fixedTidspunkt,
-    sakId = sakId,
-    saksnummer = saksnummer,
-    fnr = fnr,
-    utbetalingslinjer = utbetalingslinjer,
-    type = Utbetaling.UtbetalingsType.NY,
-    behandler = attestant,
-    avstemmingsnøkkel = avstemmingsnøkkel,
-    simulering = simulering(fnr),
-    utbetalingsrequest = Utbetalingsrequest("<xml></xml>"),
-)
+): Utbetaling.OversendtUtbetaling.UtenKvittering {
+    return Utbetaling.OversendtUtbetaling.UtenKvittering(
+        id = id,
+        opprettet = fixedTidspunkt,
+        sakId = sakId,
+        saksnummer = saksnummer,
+        fnr = fnr,
+        utbetalingslinjer = utbetalingslinjer,
+        type = Utbetaling.UtbetalingsType.NY,
+        behandler = attestant,
+        avstemmingsnøkkel = avstemmingsnøkkel,
+        simulering = simulering(fnr),
+        utbetalingsrequest = Utbetalingsrequest("<xml></xml>"),
+    )
+}
 
 internal val kvitteringOk = Kvittering(
     utbetalingsstatus = Kvittering.Utbetalingsstatus.OK,
@@ -231,7 +238,8 @@ internal class TestDataHelper(
     internal val dbMetrics: DbMetrics = dbMetricsStub,
     private val clock: Clock = fixedClock,
 ) {
-    internal val sessionFactory = PostgresSessionFactory(dataSource, dbMetricsStub, sessionCounterStub)
+    internal val sessionFactory: PostgresSessionFactory =
+        PostgresSessionFactory(dataSource, dbMetricsStub, sessionCounterStub)
     internal val utbetalingRepo = UtbetalingPostgresRepo(
         sessionFactory = sessionFactory,
         dbMetrics = dbMetrics,
@@ -321,41 +329,64 @@ internal class TestDataHelper(
         dbMetrics,
     )
 
-    fun nySakMedNySøknad(
+    /**
+     * Oppretter og persisterer en ny sak (dersom den ikke finnes fra før) med søknad med tomt søknadsinnhold.
+     * Søknaden er uten journalføring og oppgave.
+     */
+    fun persisterSakMedSøknadUtenJournalføringOgOppgave(
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
         fnr: Fnr = Fnr.generer(),
         søknadInnhold: SøknadInnhold = SøknadInnholdTestdataBuilder.build(),
     ): NySak {
-        return SakFactory(clock = clock).nySakMedNySøknad(fnr, søknadInnhold).also {
+        return SakFactory(
+            clock = clock,
+            uuidFactory = object : UUIDFactory() {
+                val ids = LinkedList(listOf(sakId, søknadId))
+                override fun newUUID(): UUID {
+                    return ids.pop()
+                }
+            },
+        ).nySakMedNySøknad(fnr, søknadInnhold).also {
             sakRepo.opprettSak(it)
         }
     }
 
     /**
-     * Ny søknad som _ikke_ er journalført eller har oppgave
+     * Oppretter og persisterer en ny søknad på en eksisterende sak med tomt søknadsinnhold.
+     * Søknaden er uten journalføring og oppgave.
      */
-    fun nySøknadForEksisterendeSak(
+    fun persisterSøknadUtenJournalføringOgOppgavePåEksisterendeSak(
         sakId: UUID,
+        søknadId: UUID = UUID.randomUUID(),
         søknadInnhold: SøknadInnhold = SøknadInnholdTestdataBuilder.build(),
     ): Søknad.Ny {
         return Søknad.Ny(
             sakId = sakId,
-            id = UUID.randomUUID(),
+            id = søknadId,
             søknadInnhold = søknadInnhold,
             opprettet = fixedTidspunkt,
         ).also { søknadRepo.opprettSøknad(it) }
     }
 
-    fun nyLukketSøknadForEksisterendeSak(
-        sakId: UUID,
+    /**
+     * Oppretter og persisterer en ny lukket søknad på en eksisterende sak med tomt søknadsinnhold.
+     * Søknaden er journalført og har oppgave (vi skal ikke kunne lukke en søknad før den har blitt journalført med oppgave).
+     */
+    fun persisterLukketJournalførtSøknadMedOppgave(
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
+        fnr: Fnr = Fnr.generer(),
+        journalpostId: JournalpostId = no.nav.su.se.bakover.database.journalpostId,
         søknadInnhold: SøknadInnhold = SøknadInnholdTestdataBuilder.build(),
     ): Søknad.Journalført.MedOppgave.Lukket {
-        return nySøknadForEksisterendeSak(sakId = sakId, søknadInnhold = søknadInnhold)
-            .journalfør(journalpostId).also {
-                søknadRepo.oppdaterjournalpostId(it)
-            }
-            .medOppgave(oppgaveId).also {
-                søknadRepo.oppdaterOppgaveId(it)
-            }
+        return persisterJournalførtSøknadMedOppgave(
+            sakId = sakId,
+            søknadId = søknadId,
+            fnr = fnr,
+            journalpostId = journalpostId,
+            søknadInnhold = søknadInnhold,
+        ).second
             .let {
                 it.lukk(
                     lukketAv = NavIdentBruker.Saksbehandler("saksbehandler"),
@@ -367,107 +398,231 @@ internal class TestDataHelper(
             }
     }
 
-    fun nyLukketSøknadsbehandlingOgSøknadForEksisterendeSak(sak: Sak): LukketSøknadsbehandling {
-        return nySøknadsbehandling(
-            sak = sak,
-            søknad = nyLukketSøknadForEksisterendeSak(sakId = sak.id),
-        ).let {
-            it.lukkSøknadsbehandling().orNull()!!.also {
-                søknadsbehandlingRepo.lagre(it)
-            }
-        }
-    }
-
-    fun nySakMedJournalførtSøknad(
+    fun persisterSakOgJournalførtSøknadUtenOppgave(
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
         fnr: Fnr = Fnr.generer(),
         journalpostId: JournalpostId = no.nav.su.se.bakover.database.journalpostId,
-    ): Sak {
-        val nySak: NySak = nySakMedNySøknad(fnr)
-        nySak.søknad.journalfør(journalpostId).also { journalførtSøknad ->
+        søknadInnhold: SøknadInnhold = SøknadInnholdTestdataBuilder.build(),
+    ): Pair<Sak, Søknad.Journalført.UtenOppgave> {
+        val nySak: NySak = persisterSakMedSøknadUtenJournalføringOgOppgave(
+            fnr = fnr,
+            sakId = sakId,
+            søknadId = søknadId,
+            søknadInnhold = søknadInnhold,
+        )
+        val journalførtSøknad = nySak.søknad.journalfør(journalpostId).also { journalførtSøknad ->
             søknadRepo.oppdaterjournalpostId(journalførtSøknad)
         }
-        return sakRepo.hentSak(nySak.id)
-            ?: throw IllegalStateException("Fant ikke sak rett etter vi opprettet den.")
+        return Pair(
+            sakRepo.hentSak(nySak.id) ?: throw IllegalStateException("Fant ikke sak rett etter vi opprettet den."),
+            journalførtSøknad,
+        )
     }
 
-    fun journalførtSøknadForEksisterendeSak(
+    fun persisterJournalførtSøknadUtenOppgaveForEksisterendeSak(
         sakId: UUID,
+        søknadId: UUID = UUID.randomUUID(),
         journalpostId: JournalpostId = no.nav.su.se.bakover.database.journalpostId,
+        søknadInnhold: SøknadInnhold = SøknadInnholdTestdataBuilder.build(),
     ): Søknad.Journalført.UtenOppgave {
-        return nySøknadForEksisterendeSak(sakId).journalfør(journalpostId).also {
-            søknadRepo.oppdaterjournalpostId(it)
-        }
+        return persisterSøknadUtenJournalføringOgOppgavePåEksisterendeSak(
+            sakId = sakId,
+            søknadId = søknadId,
+            søknadInnhold = søknadInnhold,
+        ).journalfør(journalpostId)
+            .also {
+                søknadRepo.oppdaterjournalpostId(it)
+            }
     }
 
-    fun nySakMedJournalførtSøknadOgOppgave(
+    /**
+     * Oppretter ikke ny sak dersom den finnes fra før.
+     */
+    fun persisterJournalførtSøknadMedOppgave(
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
         fnr: Fnr = Fnr.generer(),
         oppgaveId: OppgaveId = no.nav.su.se.bakover.database.oppgaveId,
         journalpostId: JournalpostId = no.nav.su.se.bakover.database.journalpostId,
-    ): Sak {
-        val sak: Sak = nySakMedJournalførtSøknad(fnr, journalpostId)
-        sak.journalførtSøknad().medOppgave(oppgaveId).also {
-            søknadRepo.oppdaterOppgaveId(it)
+        søknadInnhold: SøknadInnhold = SøknadInnholdTestdataBuilder.build(),
+    ): Pair<Sak, Søknad.Journalført.MedOppgave.IkkeLukket> {
+        return sakRepo.hentSak(sakId).let {
+            if (it == null) {
+                persisterSakOgJournalførtSøknadUtenOppgave(
+                    sakId = sakId,
+                    søknadId = søknadId,
+                    fnr = fnr,
+                    journalpostId = journalpostId,
+                    søknadInnhold = søknadInnhold,
+                )
+            } else {
+                Pair(
+                    it,
+                    persisterJournalførtSøknadUtenOppgaveForEksisterendeSak(
+                        sakId = sakId,
+                        søknadId = søknadId,
+                        journalpostId = journalpostId,
+                        søknadInnhold = søknadInnhold,
+                    ),
+                )
+            }
+        }.let {
+            val medOppgave = it.second.medOppgave(oppgaveId).also { søknad ->
+                søknadRepo.oppdaterOppgaveId(søknad)
+            }
+            Pair(
+                sakRepo.hentSak(it.first.id)
+                    ?: throw IllegalStateException("Fant ikke sak rett etter vi opprettet den."),
+                medOppgave,
+            )
         }
-        return sakRepo.hentSak(sak.id)
-            ?: throw IllegalStateException("Fant ikke sak rett etter vi opprettet den.")
     }
 
-    fun journalførtSøknadMedOppgaveForEksisterendeSak(
-        sakId: UUID,
-        journalpostId: JournalpostId = no.nav.su.se.bakover.database.journalpostId,
-        oppgaveId: OppgaveId = no.nav.su.se.bakover.database.oppgaveId,
-    ): Søknad.Journalført.MedOppgave.IkkeLukket {
-        return journalførtSøknadForEksisterendeSak(sakId, journalpostId).medOppgave(oppgaveId).also {
-            søknadRepo.oppdaterOppgaveId(it)
-        }
-    }
-
-    fun nyOversendtUtbetalingMedKvittering(
-        periode: Periode = stønadsperiode.periode,
+    /**
+     * Persisterer:
+     * 1. [Søknadsbehandling.Iverksatt.Innvilget]
+     * 1. [Utbetaling.OversendtUtbetaling]:
+     *    1. [Utbetaling.OversendtUtbetaling.UtenKvittering]
+     *    1. [Utbetaling.OversendtUtbetaling.MedKvittering]
+     * 1. [VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling]
+     */
+    fun persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering(
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
+        stønadsperiode: Stønadsperiode = stønadsperiode2021,
         avstemmingsnøkkel: Avstemmingsnøkkel = no.nav.su.se.bakover.database.avstemmingsnøkkel,
-        utbetalingslinjer: NonEmptyList<Utbetalingslinje> = nonEmptyListOf(utbetalingslinje(periode)),
-    ): Pair<Søknadsbehandling.Iverksatt.Innvilget, Utbetaling.OversendtUtbetaling.MedKvittering> {
-        val utenKvittering = nyIverksattInnvilget(
-            periode = periode,
+        utbetalingslinjer: NonEmptyList<Utbetalingslinje> = nonEmptyListOf(utbetalingslinje(stønadsperiode.periode)),
+        utbetalingId: UUID30 = UUID30.randomUUID(),
+        epsFnr: Fnr? = null,
+        vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerSøknadsbehandlingInnvilget(
+            stønadsperiode.periode,
+        ),
+        grunnlagsdata: Grunnlagsdata = if (epsFnr != null) grunnlagsdataMedEpsMedFradrag(
+            periode = stønadsperiode.periode,
+            epsFnr = epsFnr,
+        ) else grunnlagsdataEnsligMedFradrag(stønadsperiode.periode),
+        søknadsbehandling: Søknadsbehandling.Iverksatt.Innvilget = persisterSøknadsbehandlingIverksattInnvilget(
+            sakId = sakId,
+            søknadId = søknadId,
+            epsFnr = epsFnr,
+            stønadsperiode = stønadsperiode,
+            vilkårsvurderinger = vilkårsvurderinger,
+            grunnlagsdata = grunnlagsdata,
+        ).second,
+    ): Triple<Sak, VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling, Utbetaling.OversendtUtbetaling.MedKvittering> {
+        assert(søknadsbehandling.sakId == sakId && søknadsbehandling.søknad.sakId == sakId && søknadsbehandling.søknad.id == søknadId)
+
+        val utbetalingMedKvittering: Utbetaling.OversendtUtbetaling.MedKvittering = oversendtUtbetalingUtenKvittering(
+            id = utbetalingId,
+            søknadsbehandling = søknadsbehandling,
             avstemmingsnøkkel = avstemmingsnøkkel,
             utbetalingslinjer = utbetalingslinjer,
-        )
-        return utenKvittering.first to utenKvittering.second.toKvittertUtbetaling(kvitteringOk).also {
-            utbetalingRepo.oppdaterMedKvittering(it)
+        ).let {
+            utbetalingRepo.opprettUtbetaling(it, sessionFactory.newTransactionContext())
+            it.toKvittertUtbetaling(kvitteringOk).also { utbetalingMedKvittering ->
+                utbetalingRepo.oppdaterMedKvittering(utbetalingMedKvittering)
+            }
         }
-    }
-
-    fun vedtakForSøknadsbehandlingOgUtbetalingId(
-        søknadsbehandling: Søknadsbehandling.Iverksatt.Innvilget,
-        utbetalingId: UUID30,
-    ) =
-        VedtakSomKanRevurderes.fromSøknadsbehandling(søknadsbehandling, utbetalingId, fixedClock).also {
+        val vedtak = VedtakSomKanRevurderes.fromSøknadsbehandling(
+            søknadsbehandling = søknadsbehandling,
+            utbetalingId = utbetalingMedKvittering.id,
+            clock = fixedClock,
+        ).also {
             vedtakRepo.lagre(it)
         }
-
-    fun vedtakMedInnvilgetSøknadsbehandling(
-        periode: Periode = stønadsperiode.periode,
-    ): Pair<VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling, Utbetaling> {
-        val (søknadsbehandling, utbetaling) = nyOversendtUtbetalingMedKvittering(periode)
-        return Pair(
-            VedtakSomKanRevurderes.fromSøknadsbehandling(søknadsbehandling, utbetaling.id, fixedClock).also {
-                vedtakRepo.lagre(it)
-            },
-            utbetaling,
+        return Triple(
+            sakRepo.hentSak(sakId)!!,
+            vedtak,
+            utbetalingMedKvittering,
         )
     }
 
-    fun vedtakForRevurdering(revurdering: RevurderingTilAttestering.Innvilget): Pair<VedtakSomKanRevurderes.EndringIYtelse, Utbetaling> {
-        val utbetalingId = UUID30.randomUUID()
+    /**
+     * Persisterer:
+     * 1. [Søknadsbehandling.Iverksatt.Innvilget]
+     * 1. [Utbetaling.OversendtUtbetaling.UtenKvittering]
+     * 1. [VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling]
+     */
+    fun persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingUtenKvittering(
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
+        stønadsperiode: Stønadsperiode = stønadsperiode2021,
+        avstemmingsnøkkel: Avstemmingsnøkkel = no.nav.su.se.bakover.database.avstemmingsnøkkel,
+        utbetalingslinjer: NonEmptyList<Utbetalingslinje> = nonEmptyListOf(utbetalingslinje(stønadsperiode.periode)),
+        utbetalingId: UUID30 = UUID30.randomUUID(),
+        søknadsbehandling: Søknadsbehandling.Iverksatt.Innvilget = persisterSøknadsbehandlingIverksattInnvilget(
+            sakId = sakId,
+            søknadId = søknadId,
+            stønadsperiode = stønadsperiode,
+        ).second,
+    ): Pair<VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling, Utbetaling.OversendtUtbetaling.UtenKvittering> {
+        assert(søknadsbehandling.sakId == sakId && søknadsbehandling.søknad.sakId == sakId && søknadsbehandling.søknad.id == søknadId)
+
+        val utbetalingUtenKvittering: Utbetaling.OversendtUtbetaling.UtenKvittering = oversendtUtbetalingUtenKvittering(
+            id = utbetalingId,
+            søknadsbehandling = søknadsbehandling,
+            avstemmingsnøkkel = avstemmingsnøkkel,
+            utbetalingslinjer = utbetalingslinjer,
+        ).also {
+            utbetalingRepo.opprettUtbetaling(it, sessionFactory.newTransactionContext())
+        }
+        return Pair(
+            VedtakSomKanRevurderes.fromSøknadsbehandling(
+                søknadsbehandling,
+                utbetalingUtenKvittering.id,
+                fixedClock,
+            ).also {
+                vedtakRepo.lagre(it)
+            },
+            utbetalingUtenKvittering,
+        )
+    }
+
+    fun persisterVedtakMedAvslåttSøknadsbehandlingUtenBeregning(
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
+        stønadsperiode: Stønadsperiode = stønadsperiode2021,
+        søknadsbehandling: Søknadsbehandling.Iverksatt.Avslag.UtenBeregning = persisterSøknadsbehandlingIverksattAvslagUtenBeregning(
+            sakId = sakId,
+            søknadId = søknadId,
+            stønadsperiode = stønadsperiode,
+        ).second,
+    ): Triple<Sak, Avslagsvedtak.AvslagVilkår, Søknadsbehandling.Iverksatt.Avslag.UtenBeregning> {
+        assert(sakId == søknadsbehandling.sakId && søknadId == søknadsbehandling.søknad.id && søknadsbehandling.stønadsperiode == stønadsperiode)
+        val vedtak = Avslagsvedtak.fromSøknadsbehandlingUtenBeregning(
+            avslag = søknadsbehandling,
+            clock = fixedClock,
+        )
+        return Triple(sakRepo.hentSak(sakId)!!, vedtak, søknadsbehandling)
+    }
+
+    /**
+     * Persisterer:
+     * 1. [Utbetaling.OversendtUtbetaling]:
+     *    1. [Utbetaling.OversendtUtbetaling.UtenKvittering]
+     *    1. [Utbetaling.OversendtUtbetaling.MedKvittering]
+     * 1. [VedtakSomKanRevurderes.EndringIYtelse.InnvilgetRevurdering]
+     */
+    fun persisterVedtakMedInnvilgetRevurderingOgOversendtUtbetalingMedKvittering(
+        revurdering: RevurderingTilAttestering.Innvilget,
+        periode: Periode = stønadsperiode2021.periode,
+        avstemmingsnøkkel: Avstemmingsnøkkel = no.nav.su.se.bakover.database.avstemmingsnøkkel,
+        utbetalingslinjer: NonEmptyList<Utbetalingslinje> = nonEmptyListOf(utbetalingslinje(periode)),
+        utbetalingId: UUID30 = UUID30.randomUUID(),
+    ): Pair<VedtakSomKanRevurderes.EndringIYtelse.InnvilgetRevurdering, Utbetaling.OversendtUtbetaling.MedKvittering> {
 
         val utbetaling = oversendtUtbetalingUtenKvittering(
+            id = utbetalingId,
             revurdering = revurdering,
             avstemmingsnøkkel = avstemmingsnøkkel,
-            utbetalingslinjer = nonEmptyListOf(utbetalingslinje()),
-        ).copy(id = utbetalingId)
-
-        utbetalingRepo.opprettUtbetaling(utbetaling, sessionFactory.newTransactionContext())
-
+            utbetalingslinjer = utbetalingslinjer,
+        ).let {
+            utbetalingRepo.opprettUtbetaling(it, sessionFactory.newTransactionContext())
+            it.toKvittertUtbetaling(kvitteringOk).also { utbetalingMedKvittering ->
+                utbetalingRepo.oppdaterMedKvittering(utbetalingMedKvittering)
+            }
+        }
         return Pair(
             VedtakSomKanRevurderes.from(
                 revurdering = revurdering.tilIverksatt(
@@ -486,18 +641,77 @@ internal class TestDataHelper(
         )
     }
 
-    fun vedtakForIverksattAvvistKlage(klage: IverksattAvvistKlage = iverksattAvvistKlage()): Klagevedtak.Avvist {
+    fun persisterVedtakForKlageIverksattAvvist(
+        klage: IverksattAvvistKlage = persisterKlageIverksattAvvist(),
+    ): Klagevedtak.Avvist {
+
         return Klagevedtak.Avvist.fromIverksattAvvistKlage(klage, fixedClock).also {
             vedtakRepo.lagre(it)
         }
     }
 
-    fun nyRevurdering(
+    fun persisterVedtakForStans(
+        stans: StansAvYtelseRevurdering.IverksattStansAvYtelse = persisterStansAvYtelseIverksatt(),
+        periode: Periode = stønadsperiode2021.periode,
+        avstemmingsnøkkel: Avstemmingsnøkkel = no.nav.su.se.bakover.database.avstemmingsnøkkel,
+        utbetalingslinjer: NonEmptyList<Utbetalingslinje> = nonEmptyListOf(utbetalingslinje(periode)),
+        utbetalingId: UUID30 = UUID30.randomUUID(),
+    ): VedtakSomKanRevurderes.EndringIYtelse.StansAvYtelse {
+        oversendtUtbetalingUtenKvittering(
+            id = utbetalingId,
+            fnr = stans.fnr,
+            sakId = stans.sakId,
+            saksnummer = stans.saksnummer,
+            avstemmingsnøkkel = avstemmingsnøkkel,
+            utbetalingslinjer = utbetalingslinjer,
+        ).let {
+            utbetalingRepo.opprettUtbetaling(it, sessionFactory.newTransactionContext())
+            it.toKvittertUtbetaling(kvitteringOk).also { utbetalingMedKvittering ->
+                utbetalingRepo.oppdaterMedKvittering(utbetalingMedKvittering)
+            }
+        }
+        return VedtakSomKanRevurderes.from(stans, utbetalingId, fixedClock).also {
+            vedtakRepo.lagre(it)
+        }
+    }
+
+    /**
+     * TODO jah: På sikt burde denne muligens først persistere en stans, men føler det er litt out of scope for denne PR.
+     */
+    fun persisterVedtakForGjenopptak(
+        stans: GjenopptaYtelseRevurdering.IverksattGjenopptakAvYtelse = persisterGjenopptakAvYtelseIverksatt(),
+        periode: Periode = stønadsperiode2021.periode,
+        avstemmingsnøkkel: Avstemmingsnøkkel = no.nav.su.se.bakover.database.avstemmingsnøkkel,
+        utbetalingslinjer: NonEmptyList<Utbetalingslinje> = nonEmptyListOf(utbetalingslinje(periode)),
+        utbetalingId: UUID30 = UUID30.randomUUID(),
+    ): VedtakSomKanRevurderes.EndringIYtelse.GjenopptakAvYtelse {
+        oversendtUtbetalingUtenKvittering(
+            id = utbetalingId,
+            fnr = stans.fnr,
+            sakId = stans.sakId,
+            saksnummer = stans.saksnummer,
+            avstemmingsnøkkel = avstemmingsnøkkel,
+            utbetalingslinjer = utbetalingslinjer,
+        ).let {
+            utbetalingRepo.opprettUtbetaling(it, sessionFactory.newTransactionContext())
+            it.toKvittertUtbetaling(kvitteringOk).also { utbetalingMedKvittering ->
+                utbetalingRepo.oppdaterMedKvittering(utbetalingMedKvittering)
+            }
+        }
+        return VedtakSomKanRevurderes.from(stans, utbetalingId, fixedClock).also {
+            vedtakRepo.lagre(it)
+        }
+    }
+
+    fun persisterRevurderingOpprettet(
         innvilget: VedtakSomKanRevurderes.EndringIYtelse,
         periode: Periode,
         epsFnr: Fnr? = null,
-        grunnlagsdata: Grunnlagsdata = innvilgetGrunnlagsdataRevurdering(periode, epsFnr),
-        vilkårsvurderinger: Vilkårsvurderinger.Revurdering = innvilgetVilkårsvurderingerSøknadsbehandling(periode = periode)
+        grunnlagsdata: Grunnlagsdata = if (epsFnr != null) grunnlagsdataMedEpsMedFradrag(
+            periode,
+            epsFnr,
+        ) else grunnlagsdataEnsligMedFradrag(periode),
+        vilkårsvurderinger: Vilkårsvurderinger.Revurdering = vilkårsvurderingerSøknadsbehandlingInnvilget(periode = periode)
             .tilVilkårsvurderingerRevurdering(),
     ): OpprettetRevurdering {
         return OpprettetRevurdering(
@@ -523,40 +737,17 @@ internal class TestDataHelper(
         }
     }
 
-    private fun beregnetRevurdering(): BeregnetRevurdering.Innvilget {
-        val vedtak = vedtakMedInnvilgetSøknadsbehandling()
-        return nyRevurdering(
-            innvilget = vedtak.first,
-            periode = stønadsperiode.periode,
+    fun persisterRevurderingBeregnetInnvilget(): BeregnetRevurdering.Innvilget {
+        val (sak, vedtak, _) = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering()
+        return persisterRevurderingOpprettet(
+            innvilget = vedtak,
+            periode = stønadsperiode2021.periode,
             epsFnr = null,
         ).beregn(
-            eksisterendeUtbetalinger = listOf(vedtak.second),
+            eksisterendeUtbetalinger = sak.utbetalinger,
             clock = clock,
-            gjeldendeVedtaksdata = GjeldendeVedtaksdata(
-                periode = stønadsperiode.periode,
-                vedtakListe = nonEmptyListOf(vedtak.first),
-                clock = clock,
-            ),
-        ).getOrFail().let {
-            revurderingRepo.lagre(it)
-            it as BeregnetRevurdering.Innvilget
-        }
-    }
 
-    fun beregnetInnvilgetRevurdering(): BeregnetRevurdering.Innvilget {
-        val vedtak = vedtakMedInnvilgetSøknadsbehandling()
-        return nyRevurdering(
-            innvilget = vedtak.first,
-            periode = stønadsperiode.periode,
-            epsFnr = null,
-        ).beregn(
-            eksisterendeUtbetalinger = listOf(vedtak.second),
-            clock = clock,
-            gjeldendeVedtaksdata = GjeldendeVedtaksdata(
-                periode = stønadsperiode.periode,
-                vedtakListe = nonEmptyListOf(vedtak.first),
-                clock = clock,
-            ),
+            gjeldendeVedtaksdata = sak.gjeldendeVedtaksdata(stønadsperiode2021),
         ).getOrHandle {
             throw IllegalStateException("Her skal vi ha en beregnet revurdering")
         }.also {
@@ -564,23 +755,19 @@ internal class TestDataHelper(
         } as BeregnetRevurdering.Innvilget
     }
 
-    fun beregnetOpphørtRevurdering(): BeregnetRevurdering.Opphørt {
-        val vedtak = vedtakMedInnvilgetSøknadsbehandling()
-        return nyRevurdering(
-            innvilget = vedtak.first,
-            periode = stønadsperiode.periode,
+    fun persisterRevurderingBeregnetOpphørt(): BeregnetRevurdering.Opphørt {
+        val (sak, vedtak, _) = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering()
+        return persisterRevurderingOpprettet(
+            innvilget = vedtak,
+            periode = stønadsperiode2021.periode,
             epsFnr = null,
             vilkårsvurderinger = vilkårsvurderingerAvslåttUføreOgAndreInnvilget(
-                periode = stønadsperiode.periode,
+                periode = stønadsperiode2021.periode,
             ),
         ).beregn(
-            eksisterendeUtbetalinger = listOf(vedtak.second),
+            eksisterendeUtbetalinger = sak.utbetalinger,
             clock = clock,
-            gjeldendeVedtaksdata = GjeldendeVedtaksdata(
-                periode = stønadsperiode.periode,
-                vedtakListe = nonEmptyListOf(vedtak.first),
-                clock = clock,
-            ),
+            gjeldendeVedtaksdata = sak.gjeldendeVedtaksdata(stønadsperiode2021),
         ).getOrHandle {
             throw IllegalStateException("Her skal vi ha en beregnet revurdering")
         }.also {
@@ -588,25 +775,21 @@ internal class TestDataHelper(
         } as BeregnetRevurdering.Opphørt
     }
 
-    fun beregnetIngenEndringRevurdering(): BeregnetRevurdering.IngenEndring {
-        val vedtak = vedtakMedInnvilgetSøknadsbehandling(
-            stønadsperiode.periode,
+    fun persisterRevurderingBeregningIngenEndring(): BeregnetRevurdering.IngenEndring {
+        val (sak, vedtak, _) = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering(
+            stønadsperiode = stønadsperiode2021,
         )
-        val gjeldende = GjeldendeVedtaksdata(
-            periode = stønadsperiode.periode,
-            vedtakListe = nonEmptyListOf(vedtak.first),
-            clock = fixedClock,
-        )
-        return nyRevurdering(
-            innvilget = vedtak.first,
-            periode = stønadsperiode.periode,
+        val gjeldende = sak.gjeldendeVedtaksdata(stønadsperiode2021)
+        return persisterRevurderingOpprettet(
+            innvilget = vedtak,
+            periode = stønadsperiode2021.periode,
             epsFnr = null,
             grunnlagsdata = gjeldende.grunnlagsdata,
             vilkårsvurderinger = gjeldende.vilkårsvurderinger,
         ).beregn(
-            eksisterendeUtbetalinger = listOf(vedtak.second),
+            eksisterendeUtbetalinger = sak.utbetalinger,
             clock = clock,
-            gjeldendeVedtaksdata = gjeldende,
+            gjeldendeVedtaksdata = sak.gjeldendeVedtaksdata(stønadsperiode2021),
         ).getOrHandle {
             throw IllegalStateException("Her skal vi ha en beregnet revurdering")
         }.also {
@@ -614,14 +797,14 @@ internal class TestDataHelper(
         } as BeregnetRevurdering.IngenEndring
     }
 
-    fun simulertInnvilgetRevurdering(): SimulertRevurdering.Innvilget {
-        return beregnetInnvilgetRevurdering().toSimulert(simulering(Fnr.generer())).also {
+    fun persisterRevurderingSimulertInnvilget(): SimulertRevurdering.Innvilget {
+        return persisterRevurderingBeregnetInnvilget().toSimulert(simulering(Fnr.generer())).also {
             revurderingRepo.lagre(it)
         }
     }
 
-    fun simulertOpphørtRevurdering(): SimulertRevurdering.Opphørt {
-        return beregnetOpphørtRevurdering().toSimulert { _, _, _ ->
+    private fun persisterRevurderingSimulertOpphørt(): SimulertRevurdering.Opphørt {
+        return persisterRevurderingBeregnetOpphørt().toSimulert { _, _, _ ->
             Utbetaling.SimulertUtbetaling(
                 id = UUID30.randomUUID(),
                 opprettet = fixedTidspunkt,
@@ -642,8 +825,8 @@ internal class TestDataHelper(
     /**
      * Setter forhåndsvarsel til SkalIkkeForhåndsvarsel dersom den ikke er satt på dette tidspunktet.
      */
-    fun revurderingTilAttesteringInnvilget(): RevurderingTilAttestering.Innvilget {
-        val simulert: SimulertRevurdering.Innvilget = simulertInnvilgetRevurdering().let {
+    fun persisterRevurderingTilAttesteringInnvilget(): RevurderingTilAttestering.Innvilget {
+        val simulert: SimulertRevurdering.Innvilget = persisterRevurderingSimulertInnvilget().let {
             if (it.forhåndsvarsel == null) it.prøvOvergangTilSkalIkkeForhåndsvarsles().orNull()!! else it
         }
         return simulert.tilAttestering(
@@ -661,8 +844,8 @@ internal class TestDataHelper(
      * Setter forhåndsvarsel til SkalIkkeForhåndsvarsel dersom den ikke er satt på dette tidspunktet.
      */
     @Suppress("unused")
-    fun revurderingTilAttesteringIngenEndring(): RevurderingTilAttestering.IngenEndring {
-        val beregnet: BeregnetRevurdering.IngenEndring = beregnetIngenEndringRevurdering()
+    fun persisterRevurderingTilAttesteringIngenEndring(): RevurderingTilAttestering.IngenEndring {
+        val beregnet: BeregnetRevurdering.IngenEndring = persisterRevurderingBeregningIngenEndring()
         return beregnet.tilAttestering(
             attesteringsoppgaveId = oppgaveId,
             saksbehandler = saksbehandler,
@@ -676,16 +859,16 @@ internal class TestDataHelper(
     /**
      * Setter forhåndsvarsel til SkalIkkeForhåndsvarsel.
      */
-    fun revurderingTilAttesteringOpphørt(): RevurderingTilAttestering.Opphørt {
-        return simulertOpphørtRevurdering().prøvOvergangTilSkalIkkeForhåndsvarsles().getOrFail().tilAttestering(
+    private fun persisterRevurderingTilAttesteringOpphørt(): RevurderingTilAttestering.Opphørt {
+        return persisterRevurderingSimulertOpphørt().prøvOvergangTilSkalIkkeForhåndsvarsles().getOrFail().tilAttestering(
             attesteringsoppgaveId = oppgaveId,
             saksbehandler = saksbehandler,
             fritekstTilBrev = "",
         ).getOrFail().also { revurderingRepo.lagre(it) }
     }
 
-    fun iverksattRevurderingInnvilget(): IverksattRevurdering.Innvilget {
-        return revurderingTilAttesteringInnvilget().tilIverksatt(
+    fun persisterRevurderingIverksattInnvilget(): IverksattRevurdering.Innvilget {
+        return persisterRevurderingTilAttesteringInnvilget().tilIverksatt(
             attestant = attestant,
             clock = fixedClock,
             hentOpprinneligAvkorting = { null },
@@ -697,8 +880,8 @@ internal class TestDataHelper(
     }
 
     @Suppress("unused")
-    fun iverksattRevurderingIngenEndring(): IverksattRevurdering.IngenEndring {
-        return revurderingTilAttesteringIngenEndring().tilIverksatt(
+    fun persisterRevurderingIverksattIngenEndring(): IverksattRevurdering.IngenEndring {
+        return persisterRevurderingTilAttesteringIngenEndring().tilIverksatt(
             attestant,
         ).getOrHandle {
             throw IllegalStateException("Her skulle vi ha hatt en iverksatt revurdering")
@@ -707,8 +890,8 @@ internal class TestDataHelper(
         }
     }
 
-    fun iverksattRevurderingOpphørt(): IverksattRevurdering.Opphørt {
-        return revurderingTilAttesteringOpphørt().tilIverksatt(
+    fun persisterRevurderingIverksattOpphørt(): IverksattRevurdering.Opphørt {
+        return persisterRevurderingTilAttesteringOpphørt().tilIverksatt(
             attestant,
             { null },
             fixedClock,
@@ -717,17 +900,22 @@ internal class TestDataHelper(
         }
     }
 
-    fun underkjentRevurderingFraInnvilget(): UnderkjentRevurdering.Innvilget {
-        return revurderingTilAttesteringInnvilget().underkjenn(underkjentAttestering, OppgaveId("oppgaveid")).also {
+    fun persisterRevurderingUnderkjentInnvilget(): UnderkjentRevurdering.Innvilget {
+        return persisterRevurderingTilAttesteringInnvilget().underkjenn(underkjentAttestering, OppgaveId("oppgaveid")).also {
             revurderingRepo.lagre(it)
         } as UnderkjentRevurdering.Innvilget
     }
 
-    fun avsluttetRevurdering(): AvsluttetRevurdering {
-        val vedtak = vedtakMedInnvilgetSøknadsbehandling()
-        return nyRevurdering(
-            innvilget = vedtak.first,
-            periode = stønadsperiode.periode,
+    /**
+     * Baseres på [persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering] og [persisterRevurderingOpprettet]
+     */
+    fun persisterRevurderingAvsluttet(
+        sakId: UUID = UUID.randomUUID(),
+    ): AvsluttetRevurdering {
+        val (_, vedtak, _) = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering(sakId = sakId)
+        return persisterRevurderingOpprettet(
+            innvilget = vedtak,
+            periode = stønadsperiode2021.periode,
         ).avslutt(
             begrunnelse = "",
             fritekst = null,
@@ -735,19 +923,19 @@ internal class TestDataHelper(
         ).getOrFail().also { revurderingRepo.lagre(it) }
     }
 
-    fun simulertStans(
+    private fun persisterStansAvYtelseSimulert(
         id: UUID = UUID.randomUUID(),
         opprettet: Tidspunkt = fixedTidspunkt,
         periode: Periode = Periode.create(
-            stønadsperiode.periode.fraOgMed.plusMonths(1),
-            stønadsperiode.periode.tilOgMed,
+            stønadsperiode2021.periode.fraOgMed.plusMonths(1),
+            stønadsperiode2021.periode.tilOgMed,
         ),
-        grunnlagsdata: Grunnlagsdata = innvilgetGrunnlagsdataRevurdering(periode, epsFnr),
-        vilkårsvurderinger: Vilkårsvurderinger.Revurdering = innvilgetVilkårsvurderingerSøknadsbehandling(periode = periode)
+        grunnlagsdata: Grunnlagsdata = grunnlagsdataMedEpsMedFradrag(periode, epsFnr),
+        vilkårsvurderinger: Vilkårsvurderinger.Revurdering = vilkårsvurderingerSøknadsbehandlingInnvilget(periode = periode)
             .tilVilkårsvurderingerRevurdering(),
-        tilRevurdering: VedtakSomKanRevurderes = vedtakMedInnvilgetSøknadsbehandling(
-            stønadsperiode.periode,
-        ).first,
+        tilRevurdering: VedtakSomKanRevurderes = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering(
+            stønadsperiode = stønadsperiode2021,
+        ).second,
         simulering: Simulering = simulering(Fnr.generer()),
         revurderingsårsak: Revurderingsårsak = Revurderingsårsak(
             Revurderingsårsak.Årsak.DØDSFALL,
@@ -769,26 +957,26 @@ internal class TestDataHelper(
         }
     }
 
-    fun iverksattStans(
+    fun persisterStansAvYtelseIverksatt(
         id: UUID = UUID.randomUUID(),
         opprettet: Tidspunkt = fixedTidspunkt,
         periode: Periode = Periode.create(
-            stønadsperiode.periode.fraOgMed.plusMonths(1),
-            stønadsperiode.periode.tilOgMed,
+            stønadsperiode2021.periode.fraOgMed.plusMonths(1),
+            stønadsperiode2021.periode.tilOgMed,
         ),
-        grunnlagsdata: Grunnlagsdata = innvilgetGrunnlagsdataRevurdering(periode, epsFnr),
-        vilkårsvurderinger: Vilkårsvurderinger.Revurdering = innvilgetVilkårsvurderingerSøknadsbehandling(periode = periode)
+        grunnlagsdata: Grunnlagsdata = grunnlagsdataMedEpsMedFradrag(periode, epsFnr),
+        vilkårsvurderinger: Vilkårsvurderinger.Revurdering = vilkårsvurderingerSøknadsbehandlingInnvilget(periode = periode)
             .tilVilkårsvurderingerRevurdering(),
-        tilRevurdering: VedtakSomKanRevurderes = vedtakMedInnvilgetSøknadsbehandling(
-            stønadsperiode.periode,
-        ).first,
+        tilRevurdering: VedtakSomKanRevurderes = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering(
+            stønadsperiode = stønadsperiode2021,
+        ).second,
         simulering: Simulering = simulering(Fnr.generer()),
         revurderingsårsak: Revurderingsårsak = Revurderingsårsak(
             Revurderingsårsak.Årsak.DØDSFALL,
             Revurderingsårsak.Begrunnelse.create("begrunnelse"),
         ),
     ): StansAvYtelseRevurdering.IverksattStansAvYtelse {
-        return simulertStans(
+        return persisterStansAvYtelseSimulert(
             id,
             opprettet,
             periode,
@@ -802,19 +990,19 @@ internal class TestDataHelper(
         }
     }
 
-    fun simulertGjenopptak(
+    private fun persisterGjenopptakAvYtelseSimulert(
         id: UUID = UUID.randomUUID(),
         opprettet: Tidspunkt = fixedTidspunkt,
         periode: Periode = Periode.create(
-            stønadsperiode.periode.fraOgMed.plusMonths(1),
-            stønadsperiode.periode.tilOgMed,
+            stønadsperiode2021.periode.fraOgMed.plusMonths(1),
+            stønadsperiode2021.periode.tilOgMed,
         ),
-        grunnlagsdata: Grunnlagsdata = innvilgetGrunnlagsdataRevurdering(periode, epsFnr),
-        vilkårsvurderinger: Vilkårsvurderinger.Revurdering = innvilgetVilkårsvurderingerSøknadsbehandling(periode = periode)
+        grunnlagsdata: Grunnlagsdata = grunnlagsdataMedEpsMedFradrag(periode, epsFnr),
+        vilkårsvurderinger: Vilkårsvurderinger.Revurdering = vilkårsvurderingerSøknadsbehandlingInnvilget(periode = periode)
             .tilVilkårsvurderingerRevurdering(),
-        tilRevurdering: VedtakSomKanRevurderes = vedtakMedInnvilgetSøknadsbehandling(
-            stønadsperiode.periode,
-        ).first,
+        tilRevurdering: VedtakSomKanRevurderes = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering(
+            stønadsperiode = stønadsperiode2021,
+        ).second,
         simulering: Simulering = simulering(Fnr.generer()),
         revurderingsårsak: Revurderingsårsak = Revurderingsårsak(
             Revurderingsårsak.Årsak.DØDSFALL,
@@ -836,26 +1024,29 @@ internal class TestDataHelper(
         }
     }
 
-    fun iverksettGjenopptak(
+    /**
+     * @param tilRevurdering default: [persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering]
+     */
+    fun persisterGjenopptakAvYtelseIverksatt(
         id: UUID = UUID.randomUUID(),
         opprettet: Tidspunkt = fixedTidspunkt,
         periode: Periode = Periode.create(
-            stønadsperiode.periode.fraOgMed.plusMonths(1),
-            stønadsperiode.periode.tilOgMed,
+            stønadsperiode2021.periode.fraOgMed.plusMonths(1),
+            stønadsperiode2021.periode.tilOgMed,
         ),
-        grunnlagsdata: Grunnlagsdata = innvilgetGrunnlagsdataRevurdering(periode, epsFnr),
-        vilkårsvurderinger: Vilkårsvurderinger.Revurdering = innvilgetVilkårsvurderingerSøknadsbehandling(periode = periode)
+        grunnlagsdata: Grunnlagsdata = grunnlagsdataMedEpsMedFradrag(periode, epsFnr),
+        vilkårsvurderinger: Vilkårsvurderinger.Revurdering = vilkårsvurderingerSøknadsbehandlingInnvilget(periode = periode)
             .tilVilkårsvurderingerRevurdering(),
-        tilRevurdering: VedtakSomKanRevurderes = vedtakMedInnvilgetSøknadsbehandling(
-            stønadsperiode.periode,
-        ).first,
+        tilRevurdering: VedtakSomKanRevurderes = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering(
+            stønadsperiode = stønadsperiode2021,
+        ).second,
         simulering: Simulering = simulering(Fnr.generer()),
         revurderingsårsak: Revurderingsårsak = Revurderingsårsak(
             Revurderingsårsak.Årsak.DØDSFALL,
             Revurderingsårsak.Begrunnelse.create("begrunnelse"),
         ),
     ): GjenopptaYtelseRevurdering.IverksattGjenopptakAvYtelse {
-        return simulertGjenopptak(
+        return persisterGjenopptakAvYtelseSimulert(
             id,
             opprettet,
             periode,
@@ -869,144 +1060,159 @@ internal class TestDataHelper(
         }
     }
 
-    /* Kaller lagreNySøknadsbehandling (insert) */
-    fun nySøknadsbehandling(
-        sak: Sak = nySakMedJournalførtSøknadOgOppgave(),
-        søknad: Søknad.Journalført.MedOppgave = sak.journalførtSøknadMedOppgave(),
-        behandlingsinformasjon: Behandlingsinformasjon = tomBehandlingsinformasjon,
-        stønadsperiode: Stønadsperiode? = no.nav.su.se.bakover.database.stønadsperiode,
-    ): Søknadsbehandling.Vilkårsvurdert.Uavklart {
-        return NySøknadsbehandling(
-            id = UUID.randomUUID(),
-            opprettet = fixedTidspunkt,
-            sakId = sak.id,
-            søknad = søknad,
-            oppgaveId = søknad.oppgaveId,
-            behandlingsinformasjon = behandlingsinformasjon,
-            fnr = sak.fnr,
-            avkorting = AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående.kanIkke(),
-        ).let {
-            søknadsbehandlingRepo.lagreNySøknadsbehandling(it)
-            (søknadsbehandlingRepo.hent(it.id)!! as Søknadsbehandling.Vilkårsvurdert.Uavklart).copy(
-                stønadsperiode = stønadsperiode,
-            ).also {
-                søknadsbehandlingRepo.lagre(it)
+    /**
+     * Underliggende søknadsbehahandling: [Søknadsbehandling.Vilkårsvurdert.Uavklart]
+     */
+    fun persisterSøknadsbehandlingAvsluttet(
+        id: UUID = UUID.randomUUID(),
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
+        stønadsperiode: Stønadsperiode = stønadsperiode2021,
+    ): Pair<Sak, LukketSøknadsbehandling> {
+        return persisterSøknadsbehandlingVilkårsvurdertUavklart(
+            id = id,
+            sakId = sakId,
+            søknadId = søknadId,
+            stønadsperiode = stønadsperiode,
+        ).second.let {
+            it.lukkSøknadsbehandling().orNull()!!.let { lukketSøknadsbehandling ->
+                søknadsbehandlingRepo.lagre(lukketSøknadsbehandling)
+                søknadRepo.lukkSøknad(
+                    (it.søknad as Søknad.Journalført.MedOppgave.IkkeLukket).lukk(
+                        lukketAv = NavIdentBruker.Saksbehandler("saksbehandler"),
+                        type = Søknad.Journalført.MedOppgave.Lukket.LukketType.TRUKKET,
+                        lukketTidspunkt = fixedTidspunkt,
+                    ),
+                )
+                Pair(sakRepo.hentSak(sakId)!!, lukketSøknadsbehandling)
             }
         }
     }
 
-    private fun innvilgetGrunnlagsdataSøknadsbehandling(
-        periode: Periode = stønadsperiode.periode,
-        epsFnr: Fnr? = null,
-    ) = Grunnlagsdata.create(
-        bosituasjon = listOf(
-            when (epsFnr == null) {
-                true -> bosituasjongrunnlagEnslig(id = UUID.randomUUID(), periode = periode)
-                false -> bosituasjongrunnlagEpsUførFlyktning(id = UUID.randomUUID(), periode = periode, epsFnr = epsFnr)
-            },
+    /**
+     * 1) persisterer en [NySøknadsbehandling]
+     * 2) legger stønadsperiode og persisterer
+     */
+    fun persisterSøknadsbehandlingVilkårsvurdertUavklart(
+        id: UUID = UUID.randomUUID(),
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
+        stønadsperiode: Stønadsperiode = stønadsperiode2021,
+    ): Pair<Sak, Søknadsbehandling.Vilkårsvurdert.Uavklart> {
+        val (sak, søknad) = persisterJournalførtSøknadMedOppgave(sakId = sakId, søknadId = søknadId)
+        assert(sak.id == sakId && sak.søknader.count { it.sakId == sakId && it.id == søknadId } == 1)
+        return NySøknadsbehandling(
+            id = id,
+            opprettet = fixedTidspunkt,
+            sakId = sak.id,
+            søknad = søknad,
+            oppgaveId = søknad.oppgaveId,
+            fnr = sak.fnr,
+            avkorting = AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående.kanIkke(),
+        ).let { nySøknadsbehandling ->
+            søknadsbehandlingRepo.lagreNySøknadsbehandling(nySøknadsbehandling)
+            sakRepo.hentSak(sakId)!!.oppdaterStønadsperiodeForSøknadsbehandling(
+                søknadsbehandlingId = nySøknadsbehandling.id,
+                stønadsperiode = stønadsperiode,
+                clock = fixedClock,
+            ).getOrFail().let {
+                søknadsbehandlingRepo.lagre(it)
+                assert(it.fnr == sak.fnr && it.sakId == sakId)
+                Pair(sakRepo.hentSak(sakId)!!, it as Søknadsbehandling.Vilkårsvurdert.Uavklart)
+            }
+        }
+    }
+
+    internal fun persisterSøknadsbehandlingVilkårsvurdertInnvilget(
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
+        stønadsperiode: Stønadsperiode = stønadsperiode2021,
+        behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,
+        vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerSøknadsbehandlingInnvilget(
+            periode = stønadsperiode.periode,
         ),
-        fradragsgrunnlag = emptyList(),
-    )
-
-    private fun innvilgetGrunnlagsdataRevurdering(
-        periode: Periode = stønadsperiode.periode,
-        epsFnr: Fnr? = null,
-    ) =
-        innvilgetGrunnlagsdataSøknadsbehandling(periode, epsFnr)
-
-    internal fun nyInnvilgetVilkårsvurdering(
-        periode: Periode = stønadsperiode.periode,
-        behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonMedAlleVilkårOppfylt,
-        vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = innvilgetVilkårsvurderingerSøknadsbehandling(periode = periode),
-        grunnlagsdata: Grunnlagsdata = innvilgetGrunnlagsdataSøknadsbehandling(periode = periode),
-    ): Søknadsbehandling.Vilkårsvurdert.Innvilget {
-        return nySøknadsbehandling(
-            stønadsperiode = Stønadsperiode.create(periode),
-            behandlingsinformasjon = behandlingsinformasjon,
-        ).copy(
+        grunnlagsdata: Grunnlagsdata = grunnlagsdataEnsligMedFradrag(periode = stønadsperiode.periode),
+    ): Pair<Sak, Søknadsbehandling.Vilkårsvurdert.Innvilget> {
+        return persisterSøknadsbehandlingVilkårsvurdertUavklart(
+            sakId = sakId,
+            søknadId = søknadId,
+            stønadsperiode = stønadsperiode,
+        ).second.copy(
             vilkårsvurderinger = vilkårsvurderinger,
             grunnlagsdata = grunnlagsdata,
         ).tilVilkårsvurdert(
-            behandlingsinformasjon,
-            clock = fixedClock,
-        ).also {
-            søknadsbehandlingRepo.lagre(it)
-        } as Søknadsbehandling.Vilkårsvurdert.Innvilget
-    }
-
-    fun innvilgetVilkårsvurderingerSøknadsbehandling(
-        periode: Periode = stønadsperiode.periode,
-        uføre: Vilkår.Uførhet = innvilgetUførevilkårForventetInntekt0(
-            id = UUID.randomUUID(),
-            periode = periode,
-            uføregrunnlag = uføregrunnlagForventetInntekt0(
-                id = UUID.randomUUID(),
-                opprettet = fixedTidspunkt,
-                periode = periode,
-            ),
-        ),
-        bosituasjon: Grunnlag.Bosituasjon.Fullstendig = bosituasjongrunnlagEnslig(
-            id = UUID.randomUUID(),
-            periode = periode,
-        ),
-        behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,
-        utenlandsopphold: UtenlandsoppholdVilkår = utlandsoppholdInnvilget(
-            id = UUID.randomUUID(),
-            periode = periode,
-        ),
-    ): Vilkårsvurderinger.Søknadsbehandling {
-        return vilkårsvurderingerInnvilget(
-            periode = periode,
-            uføre = uføre,
-            bosituasjon = bosituasjon,
             behandlingsinformasjon = behandlingsinformasjon,
-            utenlandsopphold = utenlandsopphold,
-        )
+            clock = fixedClock,
+        ).let {
+            søknadsbehandlingRepo.lagre(it)
+            Pair(sakRepo.hentSak(sakId)!!, it as Søknadsbehandling.Vilkårsvurdert.Innvilget)
+        }
     }
 
-    internal fun nyAvslåttVilkårsvurdering(
+    internal fun persisterSøknadsbehandlingVilkårsvurdertAvslag(
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
         grunnlagsdata: Grunnlagsdata = Grunnlagsdata.create(
-            bosituasjon = listOf(bosituasjongrunnlagEnslig(periode = stønadsperiode.periode)),
+            bosituasjon = listOf(bosituasjongrunnlagEnslig(periode = stønadsperiode2021.periode)),
         ),
         vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = Vilkårsvurderinger.Søknadsbehandling(
-            uføre = innvilgetUførevilkår(periode = stønadsperiode.periode),
+            uføre = innvilgetUførevilkår(periode = stønadsperiode2021.periode),
         ),
-    ): Søknadsbehandling.Vilkårsvurdert.Avslag {
-        return nySøknadsbehandling()
-            .copy(
-                grunnlagsdata = grunnlagsdata,
-                vilkårsvurderinger = vilkårsvurderinger,
-            ).tilVilkårsvurdert(
-                behandlingsinformasjon = behandlingsinformasjonMedAvslag,
-                clock = fixedClock,
-            )
-            .also {
+        stønadsperiode: Stønadsperiode = stønadsperiode2021,
+    ): Pair<Sak, Søknadsbehandling.Vilkårsvurdert.Avslag> {
+        return persisterSøknadsbehandlingVilkårsvurdertUavklart(
+            sakId = sakId,
+            søknadId = søknadId,
+            stønadsperiode = stønadsperiode,
+        ).second.copy(
+            grunnlagsdata = grunnlagsdata,
+            vilkårsvurderinger = vilkårsvurderinger,
+        ).tilVilkårsvurdert(
+            behandlingsinformasjon = behandlingsinformasjonMedAvslag,
+            clock = fixedClock,
+        )
+            .let {
                 søknadsbehandlingRepo.lagre(it)
-            } as Søknadsbehandling.Vilkårsvurdert.Avslag
+                Pair(sakRepo.hentSak(sakId)!!, it as Søknadsbehandling.Vilkårsvurdert.Avslag)
+            }
     }
 
-    private fun nyInnvilgetBeregning(
-        periode: Periode = stønadsperiode.periode,
-        behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonMedAlleVilkårOppfylt,
-        vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = innvilgetVilkårsvurderingerSøknadsbehandling(periode),
-        grunnlagsdata: Grunnlagsdata = innvilgetGrunnlagsdataSøknadsbehandling(periode),
-    ): Søknadsbehandling.Beregnet.Innvilget {
-        return nyInnvilgetVilkårsvurdering(
-            periode,
-            behandlingsinformasjon,
-            vilkårsvurderinger,
-            grunnlagsdata,
-        ).beregn(
+    private fun persisterSøknadsbehandlingBeregnetInnvilget(
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
+        stønadsperiode: Stønadsperiode = stønadsperiode2021,
+        behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,
+        vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerSøknadsbehandlingInnvilget(
+            stønadsperiode.periode,
+        ),
+        grunnlagsdata: Grunnlagsdata = grunnlagsdataEnsligMedFradrag(stønadsperiode.periode),
+    ): Pair<Sak, Søknadsbehandling.Beregnet.Innvilget> {
+        return persisterSøknadsbehandlingVilkårsvurdertInnvilget(
+            sakId = sakId,
+            søknadId = søknadId,
+            stønadsperiode = stønadsperiode,
+            behandlingsinformasjon = behandlingsinformasjon,
+            vilkårsvurderinger = vilkårsvurderinger,
+            grunnlagsdata = grunnlagsdata,
+        ).second.beregn(
             begrunnelse = null,
             clock = fixedClock,
-        ).getOrFail().also {
+        ).getOrFail().let {
             søknadsbehandlingRepo.lagre(it)
-        } as Søknadsbehandling.Beregnet.Innvilget
+            Pair(sakRepo.hentSak(sakId)!!, it as Søknadsbehandling.Beregnet.Innvilget)
+        }
     }
 
-    internal fun nyAvslåttBeregning(): Søknadsbehandling.Beregnet.Avslag {
-        return nyInnvilgetVilkårsvurdering(
-            vilkårsvurderinger = innvilgetVilkårsvurderingerSøknadsbehandling(
+    internal fun persisterSøknadsbehandlingBeregnetAvslag(
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
+        stønadsperiode: Stønadsperiode = stønadsperiode2021,
+    ): Pair<Sak, Søknadsbehandling.Beregnet.Avslag> {
+        return persisterSøknadsbehandlingVilkårsvurdertInnvilget(
+            sakId = sakId,
+            søknadId = søknadId,
+            stønadsperiode = stønadsperiode,
+            vilkårsvurderinger = vilkårsvurderingerSøknadsbehandlingInnvilget(
                 periode = stønadsperiode.periode,
                 uføre = innvilgetUførevilkårForventetInntekt0(
                     id = UUID.randomUUID(),
@@ -1018,162 +1224,223 @@ internal class TestDataHelper(
                     ),
                 ),
             ),
-        ).beregn(
+        ).second.beregn(
             begrunnelse = null,
             clock = fixedClock,
-        ).getOrFail().also {
+        ).getOrFail().let {
             søknadsbehandlingRepo.lagre(it)
-        } as Søknadsbehandling.Beregnet.Avslag
+            Pair(sakRepo.hentSak(sakId)!!, it as Søknadsbehandling.Beregnet.Avslag)
+        }
     }
 
-    private fun nySimulering(
-        periode: Periode = stønadsperiode.periode,
-        behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonMedAlleVilkårOppfylt,
-        vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = innvilgetVilkårsvurderingerSøknadsbehandling(periode),
-        grunnlagsdata: Grunnlagsdata = innvilgetGrunnlagsdataSøknadsbehandling(periode),
-    ): Søknadsbehandling.Simulert {
-        return nyInnvilgetBeregning(
-            periode,
-            behandlingsinformasjon,
-            vilkårsvurderinger,
-            grunnlagsdata,
+    private fun persisterSøknadsbehandlingSimulert(
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
+        stønadsperiode: Stønadsperiode = stønadsperiode2021,
+        behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,
+        vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerSøknadsbehandlingInnvilget(
+            stønadsperiode.periode,
+        ),
+        grunnlagsdata: Grunnlagsdata = grunnlagsdataEnsligMedFradrag(stønadsperiode.periode),
+    ): Pair<Sak, Søknadsbehandling.Simulert> {
+        return persisterSøknadsbehandlingBeregnetInnvilget(
+            sakId = sakId,
+            søknadId = søknadId,
+            stønadsperiode = stønadsperiode,
+            behandlingsinformasjon = behandlingsinformasjon,
+            vilkårsvurderinger = vilkårsvurderinger,
+            grunnlagsdata = grunnlagsdata,
         ).let {
-            it.tilSimulert(simulering(it.fnr))
-        }.also {
+            it.second.tilSimulert(simulering(it.second.fnr))
+        }.let {
             søknadsbehandlingRepo.lagre(it)
+            Pair(sakRepo.hentSak(sakId)!!, it)
         }
     }
 
-    internal fun nyTilInnvilgetAttestering(
-        periode: Periode = stønadsperiode.periode,
-        behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonMedAlleVilkårOppfylt,
-        vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = innvilgetVilkårsvurderingerSøknadsbehandling(periode),
-        grunnlagsdata: Grunnlagsdata = innvilgetGrunnlagsdataSøknadsbehandling(periode),
+    internal fun persisterSøknadsbehandlingTilAttesteringInnvilget(
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
+        stønadsperiode: Stønadsperiode = stønadsperiode2021,
+        behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,
+        vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerSøknadsbehandlingInnvilget(
+            stønadsperiode.periode,
+        ),
+        grunnlagsdata: Grunnlagsdata = grunnlagsdataEnsligMedFradrag(stønadsperiode.periode),
         fritekstTilBrev: String = "",
-    ): Søknadsbehandling.TilAttestering.Innvilget {
-        return nySimulering(
-            periode,
-            behandlingsinformasjon,
-            vilkårsvurderinger,
-            grunnlagsdata,
-        ).tilAttestering(
-            saksbehandler,
-            fritekstTilBrev,
-        ).also {
+    ): Pair<Sak, Søknadsbehandling.TilAttestering.Innvilget> {
+        return persisterSøknadsbehandlingSimulert(
+            sakId = sakId,
+            søknadId = søknadId,
+            stønadsperiode = stønadsperiode,
+            behandlingsinformasjon = behandlingsinformasjon,
+            vilkårsvurderinger = vilkårsvurderinger,
+            grunnlagsdata = grunnlagsdata,
+        ).second.tilAttestering(
+            saksbehandler = saksbehandler,
+            fritekstTilBrev = fritekstTilBrev,
+        ).let {
             søknadsbehandlingRepo.lagre(it)
+            Pair(sakRepo.hentSak(sakId)!!, it)
         }
     }
 
-    internal fun tilAvslåttAttesteringMedBeregning(fritekstTilBrev: String = ""): Søknadsbehandling.TilAttestering.Avslag.MedBeregning {
-        return nyAvslåttBeregning().tilAttestering(
-            saksbehandler,
-            fritekstTilBrev,
-        ).also {
-            søknadsbehandlingRepo.lagre(it)
-        }
-    }
-
-    internal fun nyTilAvslåttAttesteringUtenBeregning(
+    internal fun persisterSøknadsbehandlingTilAttesteringAvslagMedBeregning(
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
         fritekstTilBrev: String = "",
-    ): Søknadsbehandling.TilAttestering.Avslag.UtenBeregning {
-        return nyAvslåttVilkårsvurdering().tilAttestering(
+        stønadsperiode: Stønadsperiode = stønadsperiode2021,
+    ): Pair<Sak, Søknadsbehandling.TilAttestering.Avslag.MedBeregning> {
+        return persisterSøknadsbehandlingBeregnetAvslag(
+            sakId = sakId,
+            søknadId = søknadId,
+            stønadsperiode = stønadsperiode,
+        ).second.tilAttestering(
+            saksbehandler = saksbehandler,
+            fritekstTilBrev = fritekstTilBrev,
+        ).let {
+            søknadsbehandlingRepo.lagre(it)
+            Pair(sakRepo.hentSak(sakId)!!, it)
+        }
+    }
+
+    internal fun persisterSøknadsbehandlingTilAttesteringAvslagUtenBeregning(
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
+        fritekstTilBrev: String = "",
+        stønadsperiode: Stønadsperiode = stønadsperiode2021,
+    ): Pair<Sak, Søknadsbehandling.TilAttestering.Avslag.UtenBeregning> {
+        return persisterSøknadsbehandlingVilkårsvurdertAvslag(
+            sakId = sakId,
+            søknadId = søknadId,
+            stønadsperiode = stønadsperiode,
+        ).second.tilAttestering(
             saksbehandler,
             fritekstTilBrev = fritekstTilBrev,
-        ).also {
+        ).let {
             søknadsbehandlingRepo.lagre(it)
+            Pair(sakRepo.hentSak(sakId)!!, it)
         }
     }
 
-    internal fun nyInnvilgetUnderkjenning(): Søknadsbehandling.Underkjent.Innvilget {
-        return nyTilInnvilgetAttestering().tilUnderkjent(
+    internal fun persisterSøknadsbehandlingUnderkjentInnvilget(
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
+        stønadsperiode: Stønadsperiode = stønadsperiode2021,
+    ): Pair<Sak, Søknadsbehandling.Underkjent.Innvilget> {
+        return persisterSøknadsbehandlingTilAttesteringInnvilget(
+            sakId = sakId,
+            søknadId = søknadId,
+            stønadsperiode = stønadsperiode,
+        ).second.tilUnderkjent(
             underkjentAttestering,
-        ).also {
+        ).let {
             søknadsbehandlingRepo.lagre(it)
+            Pair(sakRepo.hentSak(sakId)!!, it)
         }
     }
 
-    internal fun nyUnderkjenningUtenBeregning(): Søknadsbehandling.Underkjent.Avslag.UtenBeregning {
-        return nyTilAvslåttAttesteringUtenBeregning().tilUnderkjent(
+    internal fun persisterSøknadsbehandlingUnderkjentAvslagUtenBeregning(
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
+        stønadsperiode: Stønadsperiode = stønadsperiode2021,
+    ): Pair<Sak, Søknadsbehandling.Underkjent.Avslag.UtenBeregning> {
+        return persisterSøknadsbehandlingTilAttesteringAvslagUtenBeregning(
+            sakId = sakId,
+            søknadId = søknadId,
+            stønadsperiode = stønadsperiode,
+        ).second.tilUnderkjent(
             underkjentAttestering,
-        ).also {
+        ).let {
             søknadsbehandlingRepo.lagre(it)
+            Pair(sakRepo.hentSak(sakId)!!, it)
         }
     }
 
-    internal fun nyUnderkjenningMedBeregning(): Søknadsbehandling.Underkjent.Avslag.MedBeregning {
-        return tilAvslåttAttesteringMedBeregning().tilUnderkjent(
+    internal fun persisterSøknadsbehandlingUnderkjentAvslagMedBeregning(
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
+        stønadsperiode: Stønadsperiode = stønadsperiode2021,
+    ): Pair<Sak, Søknadsbehandling.Underkjent.Avslag.MedBeregning> {
+        return persisterSøknadsbehandlingTilAttesteringAvslagMedBeregning(
+            sakId = sakId,
+            søknadId = søknadId,
+            stønadsperiode = stønadsperiode,
+        ).second.tilUnderkjent(
             underkjentAttestering,
-        ).also {
+        ).let {
             søknadsbehandlingRepo.lagre(it)
+            Pair(sakRepo.hentSak(sakId)!!, it)
         }
     }
 
-    internal fun nyIverksattInnvilget(
-        periode: Periode = stønadsperiode.periode,
-        behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonMedAlleVilkårOppfylt,
-        vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = innvilgetVilkårsvurderingerSøknadsbehandling(periode),
+    internal fun persisterSøknadsbehandlingIverksattInnvilget(
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
+        stønadsperiode: Stønadsperiode = stønadsperiode2021,
+        behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,
+        vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerSøknadsbehandlingInnvilget(
+            stønadsperiode.periode,
+        ),
         epsFnr: Fnr? = null,
-        grunnlagsdata: Grunnlagsdata = innvilgetGrunnlagsdataSøknadsbehandling(periode, epsFnr),
-        avstemmingsnøkkel: Avstemmingsnøkkel = no.nav.su.se.bakover.database.avstemmingsnøkkel,
-        utbetalingslinjer: NonEmptyList<Utbetalingslinje> = nonEmptyListOf(utbetalingslinje(periode)),
-    ): Pair<Søknadsbehandling.Iverksatt.Innvilget, Utbetaling.OversendtUtbetaling.UtenKvittering> {
-        val utbetalingId = UUID30.randomUUID()
-        val innvilget =
-            nyTilInnvilgetAttestering(
-                periode = periode,
-                behandlingsinformasjon,
-                vilkårsvurderinger,
-                grunnlagsdata,
-            ).tilIverksatt(
-                iverksattAttestering,
-            )
-        val utbetaling = oversendtUtbetalingUtenKvittering(
-            søknadsbehandling = innvilget,
-            avstemmingsnøkkel = avstemmingsnøkkel,
-            utbetalingslinjer = utbetalingslinjer,
-        ).copy(id = utbetalingId)
-        utbetalingRepo.opprettUtbetaling(utbetaling, sessionFactory.newTransactionContext())
-        søknadsbehandlingRepo.lagre(innvilget)
-        vedtakRepo.lagre(VedtakSomKanRevurderes.fromSøknadsbehandling(innvilget, utbetalingId, fixedClock))
-        return innvilget to utbetaling
+        grunnlagsdata: Grunnlagsdata = if (epsFnr != null) grunnlagsdataMedEpsMedFradrag(
+            periode = stønadsperiode.periode,
+            epsFnr = epsFnr,
+        ) else grunnlagsdataEnsligMedFradrag(stønadsperiode.periode),
+    ): Pair<Sak, Søknadsbehandling.Iverksatt.Innvilget> {
+        return persisterSøknadsbehandlingTilAttesteringInnvilget(
+            sakId = sakId,
+            søknadId = søknadId,
+            stønadsperiode = stønadsperiode,
+            behandlingsinformasjon = behandlingsinformasjon,
+            vilkårsvurderinger = vilkårsvurderinger,
+            grunnlagsdata = grunnlagsdata,
+        ).second.tilIverksatt(
+            attestering = iverksattAttestering,
+        ).let {
+            søknadsbehandlingRepo.lagre(it)
+            Pair(sakRepo.hentSak(sakId)!!, it)
+        }
     }
 
-    @Suppress("unused")
-    internal fun nyUtbetalingUtenKvittering(
-        revurderingTilAttestering: RevurderingTilAttestering,
-    ): Utbetaling.OversendtUtbetaling.UtenKvittering {
-        val utbetaling = oversendtUtbetalingUtenKvittering(
-            revurdering = revurderingTilAttestering,
-            avstemmingsnøkkel = avstemmingsnøkkel,
-            utbetalingslinjer = nonEmptyListOf(utbetalingslinje()),
-        ).copy(id = UUID30.randomUUID())
-
-        utbetalingRepo.opprettUtbetaling(utbetaling, sessionFactory.newTransactionContext())
-        return utbetaling
-    }
-
-    internal fun nyIverksattAvslagUtenBeregning(
+    internal fun persisterSøknadsbehandlingIverksattAvslagUtenBeregning(
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
         fritekstTilBrev: String = "",
-    ): Søknadsbehandling.Iverksatt.Avslag.UtenBeregning {
-        return nyTilAvslåttAttesteringUtenBeregning(
+        stønadsperiode: Stønadsperiode = stønadsperiode2021,
+    ): Pair<Sak, Søknadsbehandling.Iverksatt.Avslag.UtenBeregning> {
+        return persisterSøknadsbehandlingTilAttesteringAvslagUtenBeregning(
+            sakId = sakId,
+            søknadId = søknadId,
             fritekstTilBrev = fritekstTilBrev,
-        ).tilIverksatt(
+            stønadsperiode = stønadsperiode,
+        ).second.tilIverksatt(
             iverksattAttestering,
-        ).also {
+        ).let {
             søknadsbehandlingRepo.lagre(it)
+            Pair(sakRepo.hentSak(sakId)!!, it)
         }
     }
 
-    internal fun nyIverksattAvslagMedBeregning(): Søknadsbehandling.Iverksatt.Avslag.MedBeregning {
-        return tilAvslåttAttesteringMedBeregning().tilIverksatt(
+    internal fun persisterSøknadsbehandlingIverksattAvslagMedBeregning(
+        sakId: UUID = UUID.randomUUID(),
+        søknadId: UUID = UUID.randomUUID(),
+        stønadsperiode: Stønadsperiode = stønadsperiode2021,
+    ): Pair<Sak, Søknadsbehandling.Iverksatt.Avslag.MedBeregning> {
+        return persisterSøknadsbehandlingTilAttesteringAvslagMedBeregning(
+            sakId = sakId,
+            søknadId = søknadId,
+            stønadsperiode = stønadsperiode,
+        ).second.tilIverksatt(
             iverksattAttestering,
-        ).also {
+        ).let {
             søknadsbehandlingRepo.lagre(it)
+            Pair(sakRepo.hentSak(sakId)!!, it)
         }
     }
 
-    fun nyKlage(
-        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = vedtakMedInnvilgetSøknadsbehandling().first,
+    fun persisterKlageOpprettet(
+        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second,
     ): OpprettetKlage {
         return Klage.ny(
             sakId = vedtak.behandling.sakId,
@@ -1189,10 +1456,10 @@ internal class TestDataHelper(
         }
     }
 
-    fun utfyltVilkårsvurdertKlageTilVurdering(
-        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = vedtakMedInnvilgetSøknadsbehandling().first,
+    fun persisterKlageVilkårsvurdertUtfyltTilVurdering(
+        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second,
     ): VilkårsvurdertKlage.Utfylt.TilVurdering {
-        return nyKlage(vedtak = vedtak).vilkårsvurder(
+        return persisterKlageOpprettet(vedtak = vedtak).vilkårsvurder(
             saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "saksbehandlerUtfyltVilkårsvurdertKlage"),
             vilkårsvurderinger = VilkårsvurderingerTilKlage.Utfylt(
                 vedtakId = vedtak.id,
@@ -1209,10 +1476,10 @@ internal class TestDataHelper(
         }
     }
 
-    fun utfyltAvvistVilkårsvurdertKlage(
-        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = vedtakMedInnvilgetSøknadsbehandling().first,
+    fun persisterKlageVilkårsvurdertUtfyltAvvist(
+        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second,
     ): VilkårsvurdertKlage.Utfylt.Avvist {
-        return nyKlage(vedtak).vilkårsvurder(
+        return persisterKlageOpprettet(vedtak).vilkårsvurder(
             saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "saksbehandlerUtfyltAvvistVilkårsvurdertKlage"),
             vilkårsvurderinger = VilkårsvurderingerTilKlage.Utfylt(
                 vedtakId = vedtak.id,
@@ -1229,10 +1496,10 @@ internal class TestDataHelper(
         }
     }
 
-    fun bekreftetVilkårsvurdertKlageTilVurdering(
-        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = vedtakMedInnvilgetSøknadsbehandling().first,
+    fun persisterKlageVilkårsvurdertBekreftetTilVurdering(
+        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second,
     ): VilkårsvurdertKlage.Bekreftet.TilVurdering {
-        return utfyltVilkårsvurdertKlageTilVurdering(vedtak = vedtak).bekreftVilkårsvurderinger(
+        return persisterKlageVilkårsvurdertUtfyltTilVurdering(vedtak = vedtak).bekreftVilkårsvurderinger(
             saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "saksbehandlerBekreftetVilkårsvurdertKlage"),
         ).orNull()!!.let {
             if (it !is VilkårsvurdertKlage.Bekreftet.TilVurdering) throw IllegalStateException("Forventet en Bekreftet(TilVurdering) vilkårsvurdert klage. fikk ${it::class} ved opprettelse av test-data")
@@ -1242,10 +1509,10 @@ internal class TestDataHelper(
         }
     }
 
-    fun bekreftetAvvistVilkårsvurdertKlage(
-        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = vedtakMedInnvilgetSøknadsbehandling().first,
+    fun persisterKlageVilkårsvurdertBekreftetAvvist(
+        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second,
     ): VilkårsvurdertKlage.Bekreftet.Avvist {
-        return utfyltAvvistVilkårsvurdertKlage(vedtak).bekreftVilkårsvurderinger(
+        return persisterKlageVilkårsvurdertUtfyltAvvist(vedtak).bekreftVilkårsvurderinger(
             saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "saksbehandlerBekreftetAvvistVilkårsvurdertKlage"),
         ).getOrFail().let {
             if (it !is VilkårsvurdertKlage.Bekreftet.Avvist) throw IllegalStateException("Forventet en Bekreftet(Avvist) vilkårsvurdert klage. fikk ${it::class} ved opprettelse av test-data")
@@ -1255,10 +1522,10 @@ internal class TestDataHelper(
         }
     }
 
-    fun påbegyntVurdertKlage(
-        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = vedtakMedInnvilgetSøknadsbehandling().first,
+    fun persisterKlageVurdertPåbegynt(
+        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second,
     ): VurdertKlage.Påbegynt {
-        return bekreftetVilkårsvurdertKlageTilVurdering(vedtak = vedtak).vurder(
+        return persisterKlageVilkårsvurdertBekreftetTilVurdering(vedtak = vedtak).vurder(
             saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "saksbehandlerUtfyltVUrdertKlage"),
             vurderinger = VurderingerTilKlage.Påbegynt.create(
                 fritekstTilOversendelsesbrev = "Friteksten til brevet er som følge: ",
@@ -1272,10 +1539,10 @@ internal class TestDataHelper(
         }
     }
 
-    fun utfyltVurdertKlage(
-        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = vedtakMedInnvilgetSøknadsbehandling().first,
+    fun persisterKlageVurdertUtfylt(
+        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second,
     ): VurdertKlage.Utfylt {
-        return påbegyntVurdertKlage(vedtak = vedtak).vurder(
+        return persisterKlageVurdertPåbegynt(vedtak = vedtak).vurder(
             saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "saksbehandlerUtfyltVUrdertKlage"),
             vurderinger = VurderingerTilKlage.Utfylt(
                 fritekstTilOversendelsesbrev = "Friteksten til brevet er som følge: ",
@@ -1293,22 +1560,28 @@ internal class TestDataHelper(
         }
     }
 
-    fun bekreftetVurdertKlage(
-        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = vedtakMedInnvilgetSøknadsbehandling().first,
+    fun persisterKlageVurdertBekreftet(
+        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second,
     ): VurdertKlage.Bekreftet {
-        return utfyltVurdertKlage(vedtak = vedtak).bekreftVurderinger(
+        return persisterKlageVurdertUtfylt(vedtak = vedtak).bekreftVurderinger(
             saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "saksbehandlerBekreftetVurdertKlage"),
         ).also {
             klagePostgresRepo.lagre(it)
         }
     }
 
-    fun avsluttetKlage(
-        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = vedtakMedInnvilgetSøknadsbehandling().first,
+    /**
+     * underliggende klage: [persisterKlageVurdertBekreftet]
+     */
+    fun persisterKlageAvsluttet(
+        sakId: UUID = UUID.randomUUID(),
+        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering(
+            sakId = sakId,
+        ).second,
         begrunnelse: String = "Begrunnelse for å avslutte klagen.",
         tidspunktAvsluttet: Tidspunkt = fixedTidspunkt,
     ): AvsluttetKlage {
-        return bekreftetVurdertKlage(vedtak = vedtak).avslutt(
+        return persisterKlageVurdertBekreftet(vedtak = vedtak).avslutt(
             saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "saksbehandlerSomAvsluttetKlagen"),
             begrunnelse = begrunnelse,
             tidspunktAvsluttet = tidspunktAvsluttet,
@@ -1317,12 +1590,12 @@ internal class TestDataHelper(
         }
     }
 
-    fun avvistKlage(
-        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = vedtakMedInnvilgetSøknadsbehandling().first,
+    fun persisterKlageAvvist(
+        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second,
         saksbehandler: NavIdentBruker.Saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "saksbehandlerAvvistKlage"),
         fritekstTilBrev: String = "en god, og lang fritekst",
     ): AvvistKlage {
-        return bekreftetAvvistVilkårsvurdertKlage(vedtak).leggTilFritekstTilAvvistVedtaksbrev(
+        return persisterKlageVilkårsvurdertBekreftetAvvist(vedtak).leggTilFritekstTilAvvistVedtaksbrev(
             saksbehandler,
             fritekstTilBrev,
         ).also {
@@ -1330,11 +1603,11 @@ internal class TestDataHelper(
         }
     }
 
-    fun klageTilAttesteringTilVurdering(
-        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = vedtakMedInnvilgetSøknadsbehandling().first,
+    fun persisterKlageTilAttesteringVurdert(
+        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second,
         oppgaveId: OppgaveId = OppgaveId("klageTilAttesteringOppgaveId"),
     ): KlageTilAttestering.Vurdert {
-        return bekreftetVurdertKlage(vedtak = vedtak).sendTilAttestering(
+        return persisterKlageVurdertBekreftet(vedtak = vedtak).sendTilAttestering(
             saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "saksbehandlerKlageTilAttestering"),
             opprettOppgave = { oppgaveId.right() },
         ).orNull()!!.let {
@@ -1345,13 +1618,13 @@ internal class TestDataHelper(
         }
     }
 
-    fun avvistKlageTilAttestering(
-        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = vedtakMedInnvilgetSøknadsbehandling().first,
+    fun persisterKlageTilAttesteringAvvist(
+        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second,
         oppgaveId: OppgaveId = OppgaveId("klageTilAttesteringOppgaveId"),
         saksbehandler: NavIdentBruker.Saksbehandler = NavIdentBruker.Saksbehandler("saksbehandlerAvvistKlageTilAttestering"),
         fritekstTilBrev: String = "en god, og lang fritekst",
     ): KlageTilAttestering.Avvist {
-        return avvistKlage(vedtak, saksbehandler, fritekstTilBrev).sendTilAttestering(
+        return persisterKlageAvvist(vedtak, saksbehandler, fritekstTilBrev).sendTilAttestering(
             saksbehandler = saksbehandler,
             opprettOppgave = { oppgaveId.right() },
         ).getOrFail().also {
@@ -1359,11 +1632,11 @@ internal class TestDataHelper(
         }
     }
 
-    fun underkjentKlageTilVurdering(
-        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = vedtakMedInnvilgetSøknadsbehandling().first,
+    fun persisterKlageUnderkjentVurdert(
+        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second,
         oppgaveId: OppgaveId = OppgaveId("underkjentKlageOppgaveId"),
     ): VurdertKlage.Bekreftet {
-        return klageTilAttesteringTilVurdering(vedtak = vedtak, oppgaveId = oppgaveId).underkjenn(
+        return persisterKlageTilAttesteringVurdert(vedtak = vedtak, oppgaveId = oppgaveId).underkjenn(
             underkjentAttestering = Attestering.Underkjent(
                 attestant = NavIdentBruker.Attestant(navIdent = "saksbehandlerUnderkjentKlage"),
                 opprettet = fixedTidspunkt,
@@ -1375,11 +1648,11 @@ internal class TestDataHelper(
         }
     }
 
-    fun underkjentAvvistKlage(
-        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = vedtakMedInnvilgetSøknadsbehandling().first,
+    fun persisterKlageUnderkjentAvvist(
+        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second,
         oppgaveId: OppgaveId = OppgaveId("underkjentKlageOppgaveId"),
     ): AvvistKlage {
-        return avvistKlageTilAttestering(vedtak, oppgaveId).underkjenn(
+        return persisterKlageTilAttesteringAvvist(vedtak, oppgaveId).underkjenn(
             underkjentAttestering = Attestering.Underkjent(
                 attestant = NavIdentBruker.Attestant(navIdent = "saksbehandlerUnderkjentKlage"),
                 opprettet = fixedTidspunkt,
@@ -1391,11 +1664,11 @@ internal class TestDataHelper(
         }
     }
 
-    fun oversendtKlage(
-        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = vedtakMedInnvilgetSøknadsbehandling().first,
+    fun persisterKlageOversendt(
+        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second,
         oppgaveId: OppgaveId = OppgaveId("klageTilAttesteringOppgaveId"),
     ): OversendtKlage {
-        return klageTilAttesteringTilVurdering(vedtak = vedtak, oppgaveId = oppgaveId).oversend(
+        return persisterKlageTilAttesteringVurdert(vedtak = vedtak, oppgaveId = oppgaveId).oversend(
             iverksattAttestering = Attestering.Iverksatt(
                 attestant = NavIdentBruker.Attestant(navIdent = "saksbehandlerOversendtKlage"),
                 opprettet = fixedTidspunkt,
@@ -1405,11 +1678,11 @@ internal class TestDataHelper(
         }
     }
 
-    fun iverksattAvvistKlage(
-        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = vedtakMedInnvilgetSøknadsbehandling().first,
+    fun persisterKlageIverksattAvvist(
+        vedtak: VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling = persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second,
         oppgaveId: OppgaveId = OppgaveId("klageTilAttesteringOppgaveId"),
     ): IverksattAvvistKlage {
-        return avvistKlageTilAttestering(vedtak, oppgaveId).iverksett(
+        return persisterKlageTilAttesteringAvvist(vedtak, oppgaveId).iverksett(
             iverksattAttestering = Attestering.Iverksatt(
                 attestant = NavIdentBruker.Attestant(navIdent = "saksbehandlerIverksattAvvistKlage"),
                 opprettet = fixedTidspunkt,
@@ -1417,7 +1690,7 @@ internal class TestDataHelper(
         ).getOrFail().also { klagePostgresRepo.lagre(it) }
     }
 
-    fun uprosessertKlageinstanshendelse(
+    fun persisterUprosessertKlageinstanshendelse(
         id: UUID = UUID.randomUUID(),
         klageId: UUID = UUID.randomUUID(),
         utfall: KlageinstansUtfall = KlageinstansUtfall.STADFESTELSE,

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/grunnlag/FormueVilkårsvurderingPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/grunnlag/FormueVilkårsvurderingPostgresRepoTest.kt
@@ -213,7 +213,7 @@ internal class FormueVilkårsvurderingPostgresRepoTest {
     fun `sletter grunnlag hvis vurdering går fra vurdert til ikke vurdert`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val søknadsbehandling = testDataHelper.nySøknadsbehandling()
+            val søknadsbehandling = testDataHelper.persisterSøknadsbehandlingVilkårsvurdertUavklart().second
             val (vilkår, grunnlag) = formuevilkårUtenEps0Innvilget(
                 bosituasjon = bosituasjongrunnlagEnslig(periode = periode2021),
             ).let { it to it.grunnlag }

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/grunnlag/FradragsgrunnlagPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/grunnlag/FradragsgrunnlagPostgresRepoTest.kt
@@ -21,7 +21,7 @@ internal class FradragsgrunnlagPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val grunnlagRepo = testDataHelper.fradragsgrunnlagPostgresRepo
-            val behandling = testDataHelper.nySøknadsbehandling()
+            val behandling = testDataHelper.persisterSøknadsbehandlingVilkårsvurdertUavklart().second
 
             val fradragsgrunnlag1 = lagFradragsgrunnlag(
                 type = Fradragstype.Arbeidsinntekt,

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/grunnlag/UføreVilkårsvurderingPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/grunnlag/UføreVilkårsvurderingPostgresRepoTest.kt
@@ -25,7 +25,7 @@ internal class UføreVilkårsvurderingPostgresRepoTest {
     fun `lagrer og henter vilkårsvurdering uten grunnlag`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val søknadsbehandling = testDataHelper.nySøknadsbehandling()
+            val søknadsbehandling = testDataHelper.persisterSøknadsbehandlingVilkårsvurdertUavklart().second
             val vurderingUførhet = Vilkår.Uførhet.Vurdert.create(
                 vurderingsperioder = nonEmptyListOf(
                     Vurderingsperiode.Uføre.create(
@@ -50,7 +50,7 @@ internal class UføreVilkårsvurderingPostgresRepoTest {
     fun `lagrer og henter vilkårsvurdering med grunnlag`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val søknadsbehandling = testDataHelper.nySøknadsbehandling()
+            val søknadsbehandling = testDataHelper.persisterSøknadsbehandlingVilkårsvurdertUavklart().second
             val uføregrunnlag = Grunnlag.Uføregrunnlag(
                 id = UUID.randomUUID(),
                 opprettet = fixedTidspunkt,
@@ -83,7 +83,7 @@ internal class UføreVilkårsvurderingPostgresRepoTest {
     fun `kan erstatte eksisterende vilkårsvurderinger med grunnlag`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val søknadsbehandling = testDataHelper.nySøknadsbehandling()
+            val søknadsbehandling = testDataHelper.persisterSøknadsbehandlingVilkårsvurdertUavklart().second
             val uføregrunnlag = Grunnlag.Uføregrunnlag(
                 id = UUID.randomUUID(),
                 opprettet = fixedTidspunkt,
@@ -118,7 +118,7 @@ internal class UføreVilkårsvurderingPostgresRepoTest {
     fun `sletter grunnlag hvis vurdering går fra vurdert til ikke vurdert`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val søknadsbehandling = testDataHelper.nySøknadsbehandling()
+            val søknadsbehandling = testDataHelper.persisterSøknadsbehandlingVilkårsvurdertUavklart().second
             val (vilkår, grunnlag) = innvilgetUførevilkår().let { it to it.grunnlag }
 
             dataSource.withTransaction { session ->

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/grunnlag/UføregrunnlagPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/grunnlag/UføregrunnlagPostgresRepoTest.kt
@@ -22,7 +22,7 @@ internal class UføregrunnlagPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val grunnlagRepo = UføregrunnlagPostgresRepo(testDataHelper.dbMetrics)
-            val behandling = testDataHelper.nySøknadsbehandling()
+            val behandling = testDataHelper.persisterSøknadsbehandlingVilkårsvurdertUavklart().second
 
             val uføregrunnlag1 = Uføregrunnlag(
                 periode = Periode.create(fraOgMed = 1.januar(2021), tilOgMed = 30.april(2021)),

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/grunnlag/UtenlandsoppholdVilkårsvurderingPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/grunnlag/UtenlandsoppholdVilkårsvurderingPostgresRepoTest.kt
@@ -26,7 +26,7 @@ internal class UtenlandsoppholdVilkårsvurderingPostgresRepoTest {
     fun `lagrer og henter vilkårsvurdering uten grunnlag`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val søknadsbehandling = testDataHelper.nySøknadsbehandling()
+            val søknadsbehandling = testDataHelper.persisterSøknadsbehandlingVilkårsvurdertUavklart().second
             val vilkår = UtenlandsoppholdVilkår.Vurdert.tryCreate(
                 vurderingsperioder = nonEmptyListOf(
                     VurderingsperiodeUtenlandsopphold.create(
@@ -54,7 +54,7 @@ internal class UtenlandsoppholdVilkårsvurderingPostgresRepoTest {
     fun `lagrer og henter vilkårsvurdering med grunnlag`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val søknadsbehandling = testDataHelper.nySøknadsbehandling()
+            val søknadsbehandling = testDataHelper.persisterSøknadsbehandlingVilkårsvurdertUavklart().second
             val vilkår = UtenlandsoppholdVilkår.Vurdert.tryCreate(
                 vurderingsperioder = nonEmptyListOf(
                     VurderingsperiodeUtenlandsopphold.create(
@@ -98,7 +98,7 @@ internal class UtenlandsoppholdVilkårsvurderingPostgresRepoTest {
     fun `kan erstatte eksisterende vilkårsvurderinger med grunnlag`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val søknadsbehandling = testDataHelper.nySøknadsbehandling()
+            val søknadsbehandling = testDataHelper.persisterSøknadsbehandlingVilkårsvurdertUavklart().second
             val gammel = UtenlandsoppholdVilkår.Vurdert.tryCreate(
                 vurderingsperioder = nonEmptyListOf(
                     VurderingsperiodeUtenlandsopphold.create(
@@ -155,7 +155,7 @@ internal class UtenlandsoppholdVilkårsvurderingPostgresRepoTest {
     fun `sletter grunnlag hvis vurdering går fra vurdert til ikke vurdert`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val søknadsbehandling = testDataHelper.nySøknadsbehandling()
+            val søknadsbehandling = testDataHelper.persisterSøknadsbehandlingVilkårsvurdertUavklart().second
             val (vilkår, grunnlag) = utlandsoppholdInnvilget(
                 grunnlag = Utenlandsoppholdgrunnlag(
                     id = UUID.randomUUID(),

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/klage/KlagePostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/klage/KlagePostgresRepoTest.kt
@@ -27,9 +27,9 @@ internal class KlagePostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val klageRepo = testDataHelper.klagePostgresRepo
 
-            val urelatertKlage = testDataHelper.nyKlage()
+            val urelatertKlage = testDataHelper.persisterKlageOpprettet()
 
-            val klage = testDataHelper.nyKlage()
+            val klage = testDataHelper.persisterKlageOpprettet()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
                 klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
@@ -45,9 +45,9 @@ internal class KlagePostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val klageRepo = testDataHelper.klagePostgresRepo
 
-            val urelatertKlage = testDataHelper.nyKlage()
+            val urelatertKlage = testDataHelper.persisterKlageOpprettet()
 
-            val klage = testDataHelper.nyKlage().vilkårsvurder(
+            val klage = testDataHelper.persisterKlageOpprettet().vilkårsvurder(
                 saksbehandler = NavIdentBruker.Saksbehandler("saksbehandlerPåbegyntVilkårsvurderinger"),
                 vilkårsvurderinger = VilkårsvurderingerTilKlage.empty(),
             ).getOrFail().also {
@@ -68,9 +68,9 @@ internal class KlagePostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val klageRepo = testDataHelper.klagePostgresRepo
 
-            val urelatertKlage = testDataHelper.nyKlage()
+            val urelatertKlage = testDataHelper.persisterKlageOpprettet()
 
-            val klage = testDataHelper.utfyltVilkårsvurdertKlageTilVurdering()
+            val klage = testDataHelper.persisterKlageVilkårsvurdertUtfyltTilVurdering()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
                 klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
@@ -86,9 +86,9 @@ internal class KlagePostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val klageRepo = testDataHelper.klagePostgresRepo
 
-            val urelatertKlage = testDataHelper.nyKlage()
+            val urelatertKlage = testDataHelper.persisterKlageOpprettet()
 
-            val klage = testDataHelper.utfyltAvvistVilkårsvurdertKlage()
+            val klage = testDataHelper.persisterKlageVilkårsvurdertUtfyltAvvist()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
                 klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
@@ -104,9 +104,9 @@ internal class KlagePostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val klageRepo = testDataHelper.klagePostgresRepo
 
-            val urelatertKlage = testDataHelper.nyKlage()
+            val urelatertKlage = testDataHelper.persisterKlageOpprettet()
 
-            val klage = testDataHelper.bekreftetVilkårsvurdertKlageTilVurdering()
+            val klage = testDataHelper.persisterKlageVilkårsvurdertBekreftetTilVurdering()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
                 klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
@@ -122,9 +122,9 @@ internal class KlagePostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val klageRepo = testDataHelper.klagePostgresRepo
 
-            val urelatertKlage = testDataHelper.nyKlage()
+            val urelatertKlage = testDataHelper.persisterKlageOpprettet()
 
-            val klage = testDataHelper.bekreftetAvvistVilkårsvurdertKlage()
+            val klage = testDataHelper.persisterKlageVilkårsvurdertBekreftetAvvist()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
                 klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
@@ -140,9 +140,9 @@ internal class KlagePostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val klageRepo = testDataHelper.klagePostgresRepo
 
-            val urelatertKlage = testDataHelper.nyKlage()
+            val urelatertKlage = testDataHelper.persisterKlageOpprettet()
 
-            val klage = testDataHelper.bekreftetVilkårsvurdertKlageTilVurdering().vurder(
+            val klage = testDataHelper.persisterKlageVilkårsvurdertBekreftetTilVurdering().vurder(
                 saksbehandler = NavIdentBruker.Saksbehandler("saksbehandlerPåbegyntVurderinger"),
                 vurderinger = VurderingerTilKlage.empty(),
             ).also {
@@ -163,9 +163,9 @@ internal class KlagePostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val klageRepo = testDataHelper.klagePostgresRepo
 
-            val urelatertKlage = testDataHelper.nyKlage()
+            val urelatertKlage = testDataHelper.persisterKlageOpprettet()
 
-            val klage = testDataHelper.utfyltVurdertKlage()
+            val klage = testDataHelper.persisterKlageVurdertUtfylt()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
                 klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
@@ -181,8 +181,8 @@ internal class KlagePostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val klageRepo = testDataHelper.klagePostgresRepo
 
-            val urelatertKlage = testDataHelper.nyKlage()
-            val klage = testDataHelper.avvistKlage()
+            val urelatertKlage = testDataHelper.persisterKlageOpprettet()
+            val klage = testDataHelper.persisterKlageAvvist()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
                 klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
@@ -198,9 +198,9 @@ internal class KlagePostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val klageRepo = testDataHelper.klagePostgresRepo
 
-            val urelatertKlage = testDataHelper.nyKlage()
+            val urelatertKlage = testDataHelper.persisterKlageOpprettet()
 
-            val klage = testDataHelper.klageTilAttesteringTilVurdering()
+            val klage = testDataHelper.persisterKlageTilAttesteringVurdert()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
                 klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
@@ -216,9 +216,9 @@ internal class KlagePostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val klageRepo = testDataHelper.klagePostgresRepo
 
-            val urelatertKlage = testDataHelper.nyKlage()
+            val urelatertKlage = testDataHelper.persisterKlageOpprettet()
 
-            val klage = testDataHelper.avvistKlageTilAttestering()
+            val klage = testDataHelper.persisterKlageTilAttesteringAvvist()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
                 klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
@@ -234,9 +234,9 @@ internal class KlagePostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val klageRepo = testDataHelper.klagePostgresRepo
 
-            val urelatertKlage = testDataHelper.nyKlage()
+            val urelatertKlage = testDataHelper.persisterKlageOpprettet()
 
-            val klage = testDataHelper.underkjentKlageTilVurdering()
+            val klage = testDataHelper.persisterKlageUnderkjentVurdert()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
                 klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
@@ -252,9 +252,9 @@ internal class KlagePostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val klageRepo = testDataHelper.klagePostgresRepo
 
-            val urelatertKlage = testDataHelper.nyKlage()
+            val urelatertKlage = testDataHelper.persisterKlageOpprettet()
 
-            val klage = testDataHelper.underkjentAvvistKlage()
+            val klage = testDataHelper.persisterKlageUnderkjentAvvist()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
                 klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
@@ -270,9 +270,9 @@ internal class KlagePostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val klageRepo = testDataHelper.klagePostgresRepo
 
-            val urelatertKlage = testDataHelper.nyKlage()
+            val urelatertKlage = testDataHelper.persisterKlageOpprettet()
 
-            val klage = testDataHelper.oversendtKlage()
+            val klage = testDataHelper.persisterKlageOversendt()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
                 klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
@@ -288,9 +288,9 @@ internal class KlagePostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val klageRepo = testDataHelper.klagePostgresRepo
 
-            val urelatertKlage = testDataHelper.nyKlage()
+            val urelatertKlage = testDataHelper.persisterKlageOpprettet()
 
-            val klage = testDataHelper.iverksattAvvistKlage()
+            val klage = testDataHelper.persisterKlageIverksattAvvist()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
                 klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
@@ -306,9 +306,9 @@ internal class KlagePostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val klageRepo = testDataHelper.klagePostgresRepo
 
-            val urelatertKlage = testDataHelper.nyKlage()
+            val urelatertKlage = testDataHelper.persisterKlageOpprettet()
 
-            val klage = testDataHelper.avsluttetKlage()
+            val klage = testDataHelper.persisterKlageAvsluttet()
 
             testDataHelper.sessionFactory.withSessionContext { sessionContext ->
                 klageRepo.hentKlager(klage.sakId, sessionContext).shouldBeEqualComparingPublicFieldsAndInterface(listOf(klage))
@@ -324,8 +324,8 @@ internal class KlagePostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val klageRepo = testDataHelper.klagePostgresRepo
 
-            val klage = testDataHelper.oversendtKlage()
-            val (klageinstanshendelseId, _) = testDataHelper.uprosessertKlageinstanshendelse(klageId = klage.id)
+            val klage = testDataHelper.persisterKlageOversendt()
+            val (klageinstanshendelseId, _) = testDataHelper.persisterUprosessertKlageinstanshendelse(klageId = klage.id)
 
             val tolketKlageinstanshendelse = TolketKlageinstanshendelse(
                 id = klageinstanshendelseId,
@@ -358,8 +358,8 @@ internal class KlagePostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val klageRepo = testDataHelper.klagePostgresRepo
 
-            val klage = testDataHelper.oversendtKlage()
-            val (klageinstanshendelseId, _) = testDataHelper.uprosessertKlageinstanshendelse(klageId = klage.id)
+            val klage = testDataHelper.persisterKlageOversendt()
+            val (klageinstanshendelseId, _) = testDataHelper.persisterUprosessertKlageinstanshendelse(klageId = klage.id)
 
             val tolketKlageinstanshendelse = TolketKlageinstanshendelse(
                 id = klageinstanshendelseId,

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/klage/KlageinstanshendelsePostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/klage/KlageinstanshendelsePostgresRepoTest.kt
@@ -94,7 +94,7 @@ internal class KlageinstanshendelsePostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val klageinstanshendelsePostgresRepo = testDataHelper.klageinstanshendelsePostgresRepo
             val id = UUID.randomUUID()
-            val klage = testDataHelper.oversendtKlage()
+            val klage = testDataHelper.persisterKlageOversendt()
 
             UprosessertKlageinstanshendelse(
                 id = id,

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/nøkkeltall/NøkkeltallPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/nøkkeltall/NøkkeltallPostgresRepoTest.kt
@@ -36,8 +36,8 @@ internal class NøkkeltallPostgresRepoTest {
     fun `to søknader knyttet til en sak`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val nySak = testDataHelper.nySakMedNySøknad()
-            testDataHelper.nySøknadForEksisterendeSak(nySak.id)
+            val nySak = testDataHelper.persisterSakMedSøknadUtenJournalføringOgOppgave()
+            testDataHelper.persisterSøknadUtenJournalføringOgOppgavePåEksisterendeSak(nySak.id)
 
             val nøkkeltallRepo = testDataHelper.nøkkeltallRepo
             nøkkeltallRepo.hentNøkkeltall() shouldBe Nøkkeltall(
@@ -61,8 +61,8 @@ internal class NøkkeltallPostgresRepoTest {
     fun `en avslått og en innvilget søknad i to forskjellige saker`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            testDataHelper.nyIverksattAvslagUtenBeregning()
-            testDataHelper.nyIverksattInnvilget()
+            testDataHelper.persisterVedtakMedAvslåttSøknadsbehandlingUtenBeregning()
+            testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering()
             val nøkkeltallRepo = testDataHelper.nøkkeltallRepo
             nøkkeltallRepo.hentNøkkeltall() shouldBe Nøkkeltall(
                 søknader = Nøkkeltall.Søknader(
@@ -86,10 +86,10 @@ internal class NøkkeltallPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val nøkkeltallRepo = testDataHelper.nøkkeltallRepo
-            val nySak = testDataHelper.nySakMedNySøknad()
-            testDataHelper.nyLukketSøknadForEksisterendeSak(nySak.id)
-            testDataHelper.nyLukketSøknadForEksisterendeSak(nySak.id)
-            testDataHelper.nyLukketSøknadForEksisterendeSak(nySak.id)
+            val nySak = testDataHelper.persisterSakMedSøknadUtenJournalføringOgOppgave()
+            testDataHelper.persisterLukketJournalførtSøknadMedOppgave(nySak.id)
+            testDataHelper.persisterLukketJournalførtSøknadMedOppgave(nySak.id)
+            testDataHelper.persisterLukketJournalførtSøknadMedOppgave(nySak.id)
 
             nøkkeltallRepo.hentNøkkeltall() shouldBe Nøkkeltall(
                 søknader = Nøkkeltall.Søknader(
@@ -113,7 +113,7 @@ internal class NøkkeltallPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val nøkkeltallRepo = testDataHelper.nøkkeltallRepo
-            testDataHelper.nySakMedNySøknad(
+            testDataHelper.persisterSakMedSøknadUtenJournalføringOgOppgave(
                 søknadInnhold = SøknadInnholdTestdataBuilder.build(
                     forNav = ForNav.Papirsøknad(
                         mottaksdatoForSøknad = fixedLocalDate,
@@ -145,20 +145,17 @@ internal class NøkkeltallPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val nøkkeltallRepo = testDataHelper.nøkkeltallRepo
-            val sakId = testDataHelper.nySakMedNySøknad().id
-            val sak = testDataHelper.sakRepo.hentSak(sakId)!!
-
-            testDataHelper.nyLukketSøknadsbehandlingOgSøknadForEksisterendeSak(sak)
+            testDataHelper.persisterSøknadsbehandlingAvsluttet()
 
             nøkkeltallRepo.hentNøkkeltall() shouldBe Nøkkeltall(
                 søknader = Nøkkeltall.Søknader(
-                    totaltAntall = 2,
+                    totaltAntall = 1,
                     iverksatteAvslag = 0,
                     iverksatteInnvilget = 0,
-                    ikkePåbegynt = 1,
+                    ikkePåbegynt = 0,
                     påbegynt = 0,
                     lukket = 1,
-                    digitalsøknader = 2,
+                    digitalsøknader = 1,
                     papirsøknader = 0,
                 ),
                 antallUnikePersoner = 1,

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/person/PersonPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/person/PersonPostgresRepoTest.kt
@@ -164,11 +164,15 @@ internal class PersonPostgresRepoTest {
     ) {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val (innvilget, utbetaling) = testDataHelper.nyIverksattInnvilget(epsFnr = epsFnr)
-            val vedtak = testDataHelper.vedtakForSøknadsbehandlingOgUtbetalingId(innvilget, utbetaling.id)
-            val revurdering = testDataHelper.nyRevurdering(vedtak, vedtak.periode, epsFnr)
+            val (sak, vedtak, utbetaling) = testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering(
+                epsFnr = epsFnr,
+            )
+            val revurdering = testDataHelper.persisterRevurderingOpprettet(vedtak, vedtak.periode, epsFnr)
 
-            Ctx(dataSource, testDataHelper.personRepo, innvilget, utbetaling, revurdering).test()
+            Ctx(
+                dataSource, testDataHelper.personRepo,
+                sak.søknadsbehandlinger.first() as Søknadsbehandling.Iverksatt.Innvilget, utbetaling, revurdering,
+            ).test()
         }
     }
 
@@ -180,11 +184,17 @@ internal class PersonPostgresRepoTest {
 
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val (innvilget, utbetaling) = testDataHelper.nyIverksattInnvilget(epsFnr = epsFnrBehandling)
-            val vedtak = testDataHelper.vedtakForSøknadsbehandlingOgUtbetalingId(innvilget, utbetaling.id)
-            val revurdering = testDataHelper.nyRevurdering(vedtak, vedtak.periode, epsFnrRevurdering)
+            val (sak, vedtak, utbetaling) = testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering(
+                epsFnr = epsFnrBehandling,
+            )
+            val revurdering = testDataHelper.persisterRevurderingOpprettet(vedtak, vedtak.periode, epsFnrRevurdering)
 
-            Ctx(dataSource, testDataHelper.personRepo, innvilget, utbetaling, revurdering).test()
+            Ctx(
+                dataSource = dataSource, repo = testDataHelper.personRepo,
+                innvilgetSøknadsbehandling = sak.søknadsbehandlinger.first() as Søknadsbehandling.Iverksatt.Innvilget,
+                utbetaling = utbetaling,
+                revurdering = revurdering,
+            ).test()
         }
     }
 
@@ -196,29 +206,31 @@ internal class PersonPostgresRepoTest {
 
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val (innvilget, utbetaling) = testDataHelper.nyIverksattInnvilget(epsFnr = epsFnrBehandling)
-            val vedtak = testDataHelper.vedtakForSøknadsbehandlingOgUtbetalingId(innvilget, utbetaling.id)
-            val revurdering = testDataHelper.nyRevurdering(vedtak, vedtak.periode, epsFnrRevurdering)
-            val revurderingVedtak = testDataHelper.vedtakForRevurdering(
-                RevurderingTilAttestering.Innvilget(
-                    id = revurdering.id,
-                    periode = revurdering.periode,
-                    opprettet = revurdering.opprettet,
-                    tilRevurdering = revurdering.tilRevurdering,
-                    saksbehandler = revurdering.saksbehandler,
-                    oppgaveId = revurdering.oppgaveId,
-                    fritekstTilBrev = revurdering.fritekstTilBrev,
-                    revurderingsårsak = revurdering.revurderingsårsak,
-                    beregning = innvilgetBeregning(revurdering.periode),
-                    simulering = simulering(revurdering.fnr),
-                    forhåndsvarsel = Forhåndsvarsel.Ferdigbehandlet.SkalIkkeForhåndsvarsles,
-                    grunnlagsdata = revurdering.grunnlagsdata,
-                    vilkårsvurderinger = revurdering.vilkårsvurderinger,
-                    informasjonSomRevurderes = revurdering.informasjonSomRevurderes,
-                    attesteringer = Attesteringshistorikk.empty(),
-                    avkorting = AvkortingVedRevurdering.Håndtert.IngenNyEllerUtestående
-                ),
-            ).first
+            val (_, vedtak, _) = testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering(
+                epsFnr = epsFnrBehandling,
+            )
+            val revurdering = testDataHelper.persisterRevurderingOpprettet(vedtak, vedtak.periode, epsFnrRevurdering)
+            val revurderingVedtak =
+                testDataHelper.persisterVedtakMedInnvilgetRevurderingOgOversendtUtbetalingMedKvittering(
+                    RevurderingTilAttestering.Innvilget(
+                        id = revurdering.id,
+                        periode = revurdering.periode,
+                        opprettet = revurdering.opprettet,
+                        tilRevurdering = revurdering.tilRevurdering,
+                        saksbehandler = revurdering.saksbehandler,
+                        oppgaveId = revurdering.oppgaveId,
+                        fritekstTilBrev = revurdering.fritekstTilBrev,
+                        revurderingsårsak = revurdering.revurderingsårsak,
+                        beregning = innvilgetBeregning(revurdering.periode),
+                        simulering = simulering(revurdering.fnr),
+                        forhåndsvarsel = Forhåndsvarsel.Ferdigbehandlet.SkalIkkeForhåndsvarsles,
+                        grunnlagsdata = revurdering.grunnlagsdata,
+                        vilkårsvurderinger = revurdering.vilkårsvurderinger,
+                        informasjonSomRevurderes = revurdering.informasjonSomRevurderes,
+                        attesteringer = Attesteringshistorikk.empty(),
+                        avkorting = AvkortingVedRevurdering.Håndtert.IngenNyEllerUtestående,
+                    ),
+                ).first
 
             VedtakCtx(
                 dataSource = dataSource,
@@ -237,35 +249,43 @@ internal class PersonPostgresRepoTest {
     ) {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val (innvilget, utbetaling) = testDataHelper.nyIverksattInnvilget(epsFnr = epsFnrBehandling)
-            val vedtak = testDataHelper.vedtakForSøknadsbehandlingOgUtbetalingId(innvilget, utbetaling.id)
-            val revurdering = testDataHelper.nyRevurdering(vedtak, vedtak.periode, epsFnrRevurdering)
-            val revurderingVedtak = testDataHelper.vedtakForRevurdering(
-                RevurderingTilAttestering.Innvilget(
-                    id = revurdering.id,
-                    periode = revurdering.periode,
-                    opprettet = revurdering.opprettet,
-                    tilRevurdering = revurdering.tilRevurdering,
-                    saksbehandler = revurdering.saksbehandler,
-                    oppgaveId = revurdering.oppgaveId,
-                    fritekstTilBrev = revurdering.fritekstTilBrev,
-                    revurderingsårsak = revurdering.revurderingsårsak,
-                    beregning = innvilgetBeregning(revurdering.periode),
-                    simulering = simulering(revurdering.fnr),
-                    forhåndsvarsel = Forhåndsvarsel.Ferdigbehandlet.SkalIkkeForhåndsvarsles,
-                    grunnlagsdata = revurdering.grunnlagsdata,
-                    vilkårsvurderinger = revurdering.vilkårsvurderinger,
-                    informasjonSomRevurderes = revurdering.informasjonSomRevurderes,
-                    attesteringer = Attesteringshistorikk.empty(),
-                    avkorting = AvkortingVedRevurdering.Håndtert.IngenNyEllerUtestående
-                ),
-            ).first
-            val revurderingAvRevurdering = testDataHelper.nyRevurdering(
-                revurderingVedtak,
-                revurderingVedtak.periode,
-                epsFnrRevurderingAvRevurdering,
+            val (sak, vedtak, utbetaling) = testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering(
+                epsFnr = epsFnrBehandling,
             )
-            Ctx(dataSource, testDataHelper.personRepo, innvilget, utbetaling, revurderingAvRevurdering).test()
+            val revurdering = testDataHelper.persisterRevurderingOpprettet(vedtak, vedtak.periode, epsFnrRevurdering)
+            val revurderingVedtak =
+                testDataHelper.persisterVedtakMedInnvilgetRevurderingOgOversendtUtbetalingMedKvittering(
+                    RevurderingTilAttestering.Innvilget(
+                        id = revurdering.id,
+                        periode = revurdering.periode,
+                        opprettet = revurdering.opprettet,
+                        tilRevurdering = revurdering.tilRevurdering,
+                        saksbehandler = revurdering.saksbehandler,
+                        oppgaveId = revurdering.oppgaveId,
+                        fritekstTilBrev = revurdering.fritekstTilBrev,
+                        revurderingsårsak = revurdering.revurderingsårsak,
+                        beregning = innvilgetBeregning(revurdering.periode),
+                        simulering = simulering(revurdering.fnr),
+                        forhåndsvarsel = Forhåndsvarsel.Ferdigbehandlet.SkalIkkeForhåndsvarsles,
+                        grunnlagsdata = revurdering.grunnlagsdata,
+                        vilkårsvurderinger = revurdering.vilkårsvurderinger,
+                        informasjonSomRevurderes = revurdering.informasjonSomRevurderes,
+                        attesteringer = Attesteringshistorikk.empty(),
+                        avkorting = AvkortingVedRevurdering.Håndtert.IngenNyEllerUtestående,
+                    ),
+                ).first
+            val revurderingAvRevurdering = testDataHelper.persisterRevurderingOpprettet(
+                innvilget = revurderingVedtak,
+                periode = revurderingVedtak.periode,
+                epsFnr = epsFnrRevurderingAvRevurdering,
+            )
+            Ctx(
+                dataSource = dataSource,
+                repo = testDataHelper.personRepo,
+                innvilgetSøknadsbehandling = sak.søknadsbehandlinger.first() as Søknadsbehandling.Iverksatt.Innvilget,
+                utbetaling = utbetaling,
+                revurdering = revurderingAvRevurdering,
+            ).test()
         }
     }
 
@@ -273,7 +293,7 @@ internal class PersonPostgresRepoTest {
         val dataSource: DataSource,
         val repo: PersonPostgresRepo,
         val innvilgetSøknadsbehandling: Søknadsbehandling.Iverksatt.Innvilget,
-        val utbetaling: Utbetaling.OversendtUtbetaling.UtenKvittering,
+        val utbetaling: Utbetaling.OversendtUtbetaling.MedKvittering,
         val revurdering: Revurdering,
     )
 

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/personhendelse/PersonhendelsePostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/personhendelse/PersonhendelsePostgresRepoTest.kt
@@ -44,7 +44,7 @@ internal class PersonhendelsePostgresRepoTest {
                     key = "someKey",
                 ),
             )
-            val sak = testDataHelper.nySakMedJournalførtSøknadOgOppgave()
+            val sak = testDataHelper.persisterJournalførtSøknadMedOppgave().first
             val id = UUID.randomUUID()
             repo.lagre(hendelse.tilknyttSak(id, SakIdOgNummer(sak.id, sak.saksnummer)))
 
@@ -82,7 +82,7 @@ internal class PersonhendelsePostgresRepoTest {
                     key = "someKey",
                 ),
             )
-            val sak = testDataHelper.nySakMedJournalførtSøknadOgOppgave()
+            val sak = testDataHelper.persisterJournalførtSøknadMedOppgave().first
             val id = UUID.randomUUID()
 
             repo.lagre(hendelse.tilknyttSak(id, SakIdOgNummer(sak.id, sak.saksnummer)))
@@ -126,7 +126,7 @@ internal class PersonhendelsePostgresRepoTest {
                     key = "someKey",
                 ),
             )
-            val sak = testDataHelper.nySakMedJournalførtSøknadOgOppgave()
+            val sak = testDataHelper.persisterJournalførtSøknadMedOppgave().first
             val id = UUID.randomUUID()
 
             repo.lagre(hendelse.tilknyttSak(id, SakIdOgNummer(sak.id, sak.saksnummer)))
@@ -165,10 +165,10 @@ internal class PersonhendelsePostgresRepoTest {
                 ),
             )
 
-            val sak1 = testDataHelper.nySakMedJournalførtSøknadOgOppgave()
+            val sak1 = testDataHelper.persisterJournalførtSøknadMedOppgave().first
             val id1 = UUID.randomUUID()
 
-            val sak2 = testDataHelper.nySakMedJournalførtSøknadOgOppgave()
+            val sak2 = testDataHelper.persisterJournalførtSøknadMedOppgave().first
             val id2 = UUID.randomUUID()
 
             repo.lagre(hendelse.tilknyttSak(id1, SakIdOgNummer(sak1.id, sak1.saksnummer)))
@@ -209,7 +209,7 @@ internal class PersonhendelsePostgresRepoTest {
                 ),
             )
             val id = UUID.randomUUID()
-            val sak = testDataHelper.nySakMedJournalførtSøknadOgOppgave()
+            val sak = testDataHelper.persisterJournalførtSøknadMedOppgave().first
 
             val hendelseKnyttetTilSak = hendelse.tilknyttSak(id, SakIdOgNummer(sak.id, sak.saksnummer))
             repo.lagre(hendelseKnyttetTilSak)
@@ -254,7 +254,7 @@ internal class PersonhendelsePostgresRepoTest {
                     key = "someKey",
                 ),
             )
-            val sak = testDataHelper.nySakMedJournalførtSøknadOgOppgave()
+            val sak = testDataHelper.persisterJournalførtSøknadMedOppgave().first
 
             val hendelse1KnyttetTilSak = hendelse1.tilknyttSak(id1, SakIdOgNummer(sak.id, sak.saksnummer))
             repo.lagre(hendelse1KnyttetTilSak)
@@ -306,7 +306,7 @@ internal class PersonhendelsePostgresRepoTest {
                 ),
             )
 
-            val sak = testDataHelper.nySakMedJournalførtSøknadOgOppgave()
+            val sak = testDataHelper.persisterJournalførtSøknadMedOppgave().first
 
             val hendelse1TilknyttetSak = hendelse1.tilknyttSak(hendelseId1, SakIdOgNummer(sak.id, sak.saksnummer))
             val hendelse2TilknyttetSak = hendelse2.tilknyttSak(hendelseId2, SakIdOgNummer(sak.id, sak.saksnummer))
@@ -342,7 +342,7 @@ internal class PersonhendelsePostgresRepoTest {
                 ),
             )
             val id = UUID.randomUUID()
-            val sak = testDataHelper.nySakMedJournalførtSøknadOgOppgave()
+            val sak = testDataHelper.persisterJournalførtSøknadMedOppgave().first
 
             val hendelseKnyttetTilSak = hendelse.tilknyttSak(id, SakIdOgNummer(sak.id, sak.saksnummer))
             repo.lagre(hendelseKnyttetTilSak)

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/revurdering/GjenopptakAvYtelsePostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/revurdering/GjenopptakAvYtelsePostgresRepoTest.kt
@@ -15,7 +15,7 @@ import no.nav.su.se.bakover.test.periode2021
 import no.nav.su.se.bakover.test.periodeMai2021
 import no.nav.su.se.bakover.test.saksbehandler
 import no.nav.su.se.bakover.test.simulering
-import no.nav.su.se.bakover.test.vilkårsvurderingerInnvilgetRevurdering
+import no.nav.su.se.bakover.test.vilkårsvurderingerRevurderingInnvilget
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
@@ -24,15 +24,16 @@ internal class GjenopptakAvYtelsePostgresRepoTest {
     fun `lagrer og henter revurdering for gjenopptak av ytelse`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val søknadsbehandling = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
 
             val simulertRevurdering = GjenopptaYtelseRevurdering.SimulertGjenopptakAvYtelse(
                 id = UUID.randomUUID(),
                 opprettet = fixedTidspunkt,
                 periode = periode2021,
                 grunnlagsdata = grunnlagsdataEnsligUtenFradrag(),
-                vilkårsvurderinger = vilkårsvurderingerInnvilgetRevurdering(),
-                tilRevurdering = søknadsbehandling,
+                vilkårsvurderinger = vilkårsvurderingerRevurderingInnvilget(),
+                tilRevurdering = vedtak,
                 saksbehandler = saksbehandler,
                 simulering = simulering(),
                 revurderingsårsak = Revurderingsårsak.create(
@@ -61,15 +62,16 @@ internal class GjenopptakAvYtelsePostgresRepoTest {
     fun `kan oppdatere revurdering for gjenopptak av ytelse`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val søknadsbehandling = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
 
             val simulertRevurdering = GjenopptaYtelseRevurdering.SimulertGjenopptakAvYtelse(
                 id = UUID.randomUUID(),
                 opprettet = fixedTidspunkt,
                 periode = periode2021,
                 grunnlagsdata = grunnlagsdataEnsligUtenFradrag(),
-                vilkårsvurderinger = vilkårsvurderingerInnvilgetRevurdering(),
-                tilRevurdering = søknadsbehandling,
+                vilkårsvurderinger = vilkårsvurderingerRevurderingInnvilget(),
+                tilRevurdering = vedtak,
                 saksbehandler = saksbehandler,
                 simulering = simulering(),
                 revurderingsårsak = Revurderingsårsak.create(
@@ -84,8 +86,8 @@ internal class GjenopptakAvYtelsePostgresRepoTest {
             val nyInformasjon = simulertRevurdering.copy(
                 periode = periodeMai2021,
                 grunnlagsdata = grunnlagsdataEnsligUtenFradrag(periodeMai2021),
-                vilkårsvurderinger = vilkårsvurderingerInnvilgetRevurdering(periode = periodeMai2021),
-                tilRevurdering = søknadsbehandling,
+                vilkårsvurderinger = vilkårsvurderingerRevurderingInnvilget(periode = periodeMai2021),
+                tilRevurdering = vedtak,
                 saksbehandler = NavIdentBruker.Saksbehandler("saksern"),
                 simulering = simulering().copy(
                     gjelderNavn = "et navn",
@@ -105,14 +107,15 @@ internal class GjenopptakAvYtelsePostgresRepoTest {
     fun `lagrer og henter en avsluttet gjenopptakAvYtelse`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val søknadsbehandling = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
             val simulertRevurdering = GjenopptaYtelseRevurdering.SimulertGjenopptakAvYtelse(
                 id = UUID.randomUUID(),
                 opprettet = fixedTidspunkt,
                 periode = periode2021,
                 grunnlagsdata = grunnlagsdataEnsligUtenFradrag(),
-                vilkårsvurderinger = vilkårsvurderingerInnvilgetRevurdering(),
-                tilRevurdering = søknadsbehandling,
+                vilkårsvurderinger = vilkårsvurderingerRevurderingInnvilget(),
+                tilRevurdering = vedtak,
                 saksbehandler = saksbehandler,
                 simulering = simulering(),
                 revurderingsårsak = Revurderingsårsak.create(

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/revurdering/LagreOgHentAvsluttetRevurderingTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/revurdering/LagreOgHentAvsluttetRevurderingTest.kt
@@ -11,6 +11,7 @@ import no.nav.su.se.bakover.domain.revurdering.AvsluttetRevurdering
 import no.nav.su.se.bakover.domain.revurdering.Revurdering
 import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.periode2021
+import no.nav.su.se.bakover.test.stønadsperiode2021
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
@@ -22,8 +23,10 @@ internal class LagreOgHentAvsluttetRevurderingTest {
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
 
-            val revurdering = testDataHelper.nyRevurdering(
-                innvilget = testDataHelper.vedtakMedInnvilgetSøknadsbehandling(periode2021).first,
+            val revurdering = testDataHelper.persisterRevurderingOpprettet(
+                innvilget = testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering(
+                    stønadsperiode = stønadsperiode2021,
+                ).second,
                 periode = periode2021,
             ).persistertVariant()
 
@@ -51,7 +54,7 @@ internal class LagreOgHentAvsluttetRevurderingTest {
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
 
-            val revurdering = testDataHelper.beregnetInnvilgetRevurdering().persistertVariant()
+            val revurdering = testDataHelper.persisterRevurderingBeregnetInnvilget().persistertVariant()
 
             val avsluttetRevurdering = AvsluttetRevurdering.tryCreate(
                 underliggendeRevurdering = revurdering,
@@ -77,7 +80,7 @@ internal class LagreOgHentAvsluttetRevurderingTest {
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
 
-            val revurdering = testDataHelper.beregnetOpphørtRevurdering().persistertVariant()
+            val revurdering = testDataHelper.persisterRevurderingBeregnetOpphørt().persistertVariant()
 
             val avsluttetRevurdering = AvsluttetRevurdering.tryCreate(
                 underliggendeRevurdering = revurdering,
@@ -104,7 +107,7 @@ internal class LagreOgHentAvsluttetRevurderingTest {
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
 
-            val revurdering = testDataHelper.beregnetIngenEndringRevurdering().persistertVariant()
+            val revurdering = testDataHelper.persisterRevurderingBeregningIngenEndring().persistertVariant()
 
             val avsluttetRevurdering = AvsluttetRevurdering.tryCreate(
                 underliggendeRevurdering = revurdering,
@@ -130,7 +133,7 @@ internal class LagreOgHentAvsluttetRevurderingTest {
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
 
-            val revurdering = testDataHelper.simulertInnvilgetRevurdering().persistertVariant()
+            val revurdering = testDataHelper.persisterRevurderingSimulertInnvilget().persistertVariant()
 
             val avsluttetRevurdering = AvsluttetRevurdering.tryCreate(
                 underliggendeRevurdering = revurdering,
@@ -155,7 +158,7 @@ internal class LagreOgHentAvsluttetRevurderingTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val simulert = testDataHelper.simulertInnvilgetRevurdering()
+            val simulert = testDataHelper.persisterRevurderingSimulertInnvilget()
             val simulertIngenForhåndsvarsel =
                 simulert.prøvOvergangTilSkalIkkeForhåndsvarsles().orNull()!!.also {
                     repo.lagre(it)
@@ -169,7 +172,7 @@ internal class LagreOgHentAvsluttetRevurderingTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val simulert = testDataHelper.simulertInnvilgetRevurdering()
+            val simulert = testDataHelper.persisterRevurderingSimulertInnvilget()
             val simulertIngenForhåndsvarsel =
                 simulert.prøvOvergangTilSendt().orNull()!!.also {
                     repo.lagre(it)
@@ -183,7 +186,7 @@ internal class LagreOgHentAvsluttetRevurderingTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val simulert = testDataHelper.simulertInnvilgetRevurdering()
+            val simulert = testDataHelper.persisterRevurderingSimulertInnvilget()
             val simulertIngenForhåndsvarsel =
                 simulert.prøvOvergangTilSendt().orNull()!!.prøvOvergangTilAvsluttet("").orNull()!!.also {
                     repo.lagre(it)
@@ -198,7 +201,7 @@ internal class LagreOgHentAvsluttetRevurderingTest {
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
 
-            val revurdering = testDataHelper.simulertInnvilgetRevurdering().persistertVariant()
+            val revurdering = testDataHelper.persisterRevurderingSimulertInnvilget().persistertVariant()
 
             val avsluttetRevurdering = AvsluttetRevurdering.tryCreate(
                 underliggendeRevurdering = revurdering,
@@ -224,7 +227,7 @@ internal class LagreOgHentAvsluttetRevurderingTest {
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
 
-            val revurdering = testDataHelper.underkjentRevurderingFraInnvilget().persistertVariant()
+            val revurdering = testDataHelper.persisterRevurderingUnderkjentInnvilget().persistertVariant()
 
             val avsluttetRevurdering = AvsluttetRevurdering.tryCreate(
                 underliggendeRevurdering = revurdering,
@@ -237,10 +240,10 @@ internal class LagreOgHentAvsluttetRevurderingTest {
             repo.hent(avsluttetRevurdering.id) shouldBe avsluttetRevurdering.copy(
                 underliggendeRevurdering = revurdering.copy(
                     avkorting = AvkortingVedRevurdering.Håndtert.KanIkkeHåndteres(
-                        håndtert = AvkortingVedRevurdering.Håndtert.IngenNyEllerUtestående
-                    )
-                )
-            )
+                        håndtert = AvkortingVedRevurdering.Håndtert.IngenNyEllerUtestående,
+                    ),
+                ),
+            ).persistertVariant()
         }
     }
 }

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/revurdering/RevurderingPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/revurdering/RevurderingPostgresRepoTest.kt
@@ -199,7 +199,8 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val vedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
 
             val opprettet = opprettet(vedtak)
             repo.lagre(opprettet)
@@ -217,8 +218,10 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val vedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
-            val etAnnetVedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
+            val etAnnetVedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
 
             val opprettetRevurdering = opprettet(vedtak)
             repo.lagre(opprettetRevurdering)
@@ -251,7 +254,8 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val vedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
             val opprettet = opprettet(vedtak)
 
             repo.lagre(opprettet)
@@ -279,7 +283,8 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val vedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
             val opprettet = opprettet(vedtak)
 
             repo.lagre(opprettet)
@@ -301,7 +306,8 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val vedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
             val opprettet = opprettet(vedtak)
 
             repo.lagre(opprettet)
@@ -323,7 +329,8 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val vedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
             val opprettet = opprettet(vedtak)
 
             repo.lagre(opprettet)
@@ -354,7 +361,8 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val vedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
             val opprettet = opprettet(vedtak)
 
             repo.lagre(opprettet)
@@ -386,7 +394,7 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val iverksatt = testDataHelper.iverksattRevurderingInnvilget()
+            val iverksatt = testDataHelper.persisterRevurderingIverksattInnvilget()
 
             repo.hent(iverksatt.id) shouldBe iverksatt.persistertVariant()
             dataSource.withSession {
@@ -400,7 +408,8 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val vedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
             val opprettet = opprettet(vedtak)
 
             repo.lagre(opprettet)
@@ -440,7 +449,8 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val vedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
 
             val opprettet = opprettet(vedtak)
             repo.lagre(opprettet)
@@ -494,7 +504,8 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val vedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
 
             val opprettet = opprettet(vedtak)
             repo.lagre(opprettet)
@@ -530,7 +541,8 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val vedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
 
             val opprettet = opprettet(vedtak)
             repo.lagre(opprettet)
@@ -580,7 +592,8 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val vedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
 
             val opprettet = opprettet(vedtak)
             repo.lagre(opprettet)
@@ -642,7 +655,8 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val vedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
 
             val opprettet = opprettet(vedtak)
             repo.lagre(opprettet)
@@ -677,7 +691,8 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val vedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
 
             val opprettet = opprettet(vedtak)
             repo.lagre(opprettet)
@@ -736,7 +751,7 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val simulert = testDataHelper.simulertInnvilgetRevurdering()
+            val simulert = testDataHelper.persisterRevurderingSimulertInnvilget()
             val expected = simulert.prøvOvergangTilSkalIkkeForhåndsvarsles().orNull()!!.also {
                 repo.lagre(it)
             }
@@ -751,7 +766,7 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val simulert = testDataHelper.simulertInnvilgetRevurdering()
+            val simulert = testDataHelper.persisterRevurderingSimulertInnvilget()
             val simulertIngenForhåndsvarsel =
                 simulert.prøvOvergangTilSendt().orNull()!!.also {
                     repo.lagre(it)
@@ -765,7 +780,7 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val simulert = testDataHelper.simulertInnvilgetRevurdering()
+            val simulert = testDataHelper.persisterRevurderingSimulertInnvilget()
             val simulertIngenForhåndsvarsel =
                 simulert.prøvOvergangTilSendt().orNull()!!
                     .prøvOvergangTilFortsettMedSammeGrunnlag("").orNull()!!
@@ -786,7 +801,7 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val simulert = testDataHelper.simulertInnvilgetRevurdering()
+            val simulert = testDataHelper.persisterRevurderingSimulertInnvilget()
             val simulertIngenForhåndsvarsel =
                 simulert.prøvOvergangTilSendt().orNull()!!.prøvOvergangTilEndreGrunnlaget("").orNull()!!.also {
                     repo.lagre(it)
@@ -800,7 +815,8 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val vedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
 
             val opprettet = opprettet(vedtak)
             repo.lagre(opprettet.copy(forhåndsvarsel = Forhåndsvarsel.Ferdigbehandlet.SkalIkkeForhåndsvarsles))
@@ -838,7 +854,8 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val vedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
 
             val opprettet = opprettet(vedtak)
             repo.lagre(opprettet)
@@ -875,7 +892,8 @@ internal class RevurderingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.revurderingRepo
-            val vedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
 
             val opprettet = opprettet(vedtak)
             repo.lagre(opprettet)

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/revurdering/StansAvYtelsePostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/revurdering/StansAvYtelsePostgresRepoTest.kt
@@ -16,7 +16,7 @@ import no.nav.su.se.bakover.test.periode2021
 import no.nav.su.se.bakover.test.periodeMai2021
 import no.nav.su.se.bakover.test.saksbehandler
 import no.nav.su.se.bakover.test.simulering
-import no.nav.su.se.bakover.test.vilkårsvurderingerInnvilgetRevurdering
+import no.nav.su.se.bakover.test.vilkårsvurderingerRevurderingInnvilget
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
@@ -25,15 +25,16 @@ internal class StansAvYtelsePostgresRepoTest {
     fun `lagrer og henter revurdering for stans av ytelse`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val søknadsbehandling = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
 
             val simulertRevurdering = StansAvYtelseRevurdering.SimulertStansAvYtelse(
                 id = UUID.randomUUID(),
                 opprettet = fixedTidspunkt,
                 periode = periode2021,
                 grunnlagsdata = grunnlagsdataEnsligUtenFradrag(),
-                vilkårsvurderinger = vilkårsvurderingerInnvilgetRevurdering(),
-                tilRevurdering = søknadsbehandling,
+                vilkårsvurderinger = vilkårsvurderingerRevurderingInnvilget(),
+                tilRevurdering = vedtak,
                 saksbehandler = saksbehandler,
                 simulering = simulering(),
                 revurderingsårsak = Revurderingsårsak.create(
@@ -59,15 +60,16 @@ internal class StansAvYtelsePostgresRepoTest {
     fun `kan oppdatere revurdering for stans av ytelse`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val søknadsbehandling = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
 
             val simulertRevurdering = StansAvYtelseRevurdering.SimulertStansAvYtelse(
                 id = UUID.randomUUID(),
                 opprettet = fixedTidspunkt,
                 periode = periode2021,
                 grunnlagsdata = grunnlagsdataEnsligUtenFradrag(),
-                vilkårsvurderinger = vilkårsvurderingerInnvilgetRevurdering(),
-                tilRevurdering = søknadsbehandling,
+                vilkårsvurderinger = vilkårsvurderingerRevurderingInnvilget(),
+                tilRevurdering = vedtak,
                 saksbehandler = saksbehandler,
                 simulering = simulering(),
                 revurderingsårsak = Revurderingsårsak.create(
@@ -87,8 +89,8 @@ internal class StansAvYtelsePostgresRepoTest {
                 opprettet = simulertRevurdering.opprettet,
                 periode = periodeMai2021,
                 grunnlagsdata = grunnlagsdataEnsligUtenFradrag(periodeMai2021),
-                vilkårsvurderinger = vilkårsvurderingerInnvilgetRevurdering(periode = periodeMai2021),
-                tilRevurdering = søknadsbehandling,
+                vilkårsvurderinger = vilkårsvurderingerRevurderingInnvilget(periode = periodeMai2021),
+                tilRevurdering = vedtak,
                 saksbehandler = NavIdentBruker.Saksbehandler("saksern"),
                 simulering = simulering().copy(
                     gjelderNavn = "et navn",
@@ -111,15 +113,16 @@ internal class StansAvYtelsePostgresRepoTest {
     fun `lagrer og henter en avsluttet stansAvYtelse revurdering`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val søknadsbehandling = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
 
             val simulertRevurdering = StansAvYtelseRevurdering.SimulertStansAvYtelse(
                 id = UUID.randomUUID(),
                 opprettet = fixedTidspunkt,
                 periode = periode2021,
                 grunnlagsdata = grunnlagsdataEnsligUtenFradrag(),
-                vilkårsvurderinger = vilkårsvurderingerInnvilgetRevurdering(),
-                tilRevurdering = søknadsbehandling,
+                vilkårsvurderinger = vilkårsvurderingerRevurderingInnvilget(),
+                tilRevurdering = vedtak,
                 saksbehandler = saksbehandler,
                 simulering = simulering(),
                 revurderingsårsak = Revurderingsårsak.create(

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/sak/FerdigeBehandlingerRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/sak/FerdigeBehandlingerRepoTest.kt
@@ -5,8 +5,8 @@ import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.database.TestDataHelper
 import no.nav.su.se.bakover.database.withMigratedDb
 import no.nav.su.se.bakover.domain.Saksnummer
+import no.nav.su.se.bakover.domain.klage.VurdertKlage
 import no.nav.su.se.bakover.domain.sak.Behandlingsoversikt
-import no.nav.su.se.bakover.test.saksnummer
 import org.junit.jupiter.api.Test
 
 internal class FerdigeBehandlingerRepoTest {
@@ -17,12 +17,15 @@ internal class FerdigeBehandlingerRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.sakRepo
 
-            val iverksattSøknadsbehandlingInnvilget = testDataHelper.nyIverksattInnvilget().first
-            val iverksattSøknadsbehadnlingAvslagMedBeregning = testDataHelper.nyIverksattAvslagMedBeregning()
-            val iverksattSøknadsbehadnlingAvslagUtenBeregning = testDataHelper.nyIverksattAvslagUtenBeregning()
+            val iverksattSøknadsbehandlingInnvilget =
+                testDataHelper.persisterSøknadsbehandlingIverksattInnvilget().second
+            val iverksattSøknadsbehadnlingAvslagMedBeregning =
+                testDataHelper.persisterSøknadsbehandlingIverksattAvslagMedBeregning().second
+            val iverksattSøknadsbehadnlingAvslagUtenBeregning =
+                testDataHelper.persisterSøknadsbehandlingIverksattAvslagUtenBeregning().second
 
-            testDataHelper.nyInnvilgetVilkårsvurdering()
-            testDataHelper.nyAvslåttBeregning()
+            testDataHelper.persisterSøknadsbehandlingVilkårsvurdertInnvilget()
+            testDataHelper.persisterSøknadsbehandlingBeregnetAvslag()
 
             val ferdigeBehandlinger = repo.hentFerdigeBehandlinger()
 
@@ -60,11 +63,11 @@ internal class FerdigeBehandlingerRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.sakRepo
 
-            val iverksattRevurderingInnvilget = testDataHelper.iverksattRevurderingInnvilget()
-            val iverksattRevurderingOpphørt = testDataHelper.iverksattRevurderingOpphørt()
-            val iverksattStansAvYtelse = testDataHelper.iverksattStans()
-            val iverksattGjenopptak = testDataHelper.iverksettGjenopptak()
-            val beregnetRevurdering = testDataHelper.beregnetInnvilgetRevurdering()
+            val iverksattRevurderingInnvilget = testDataHelper.persisterRevurderingIverksattInnvilget()
+            val iverksattRevurderingOpphørt = testDataHelper.persisterRevurderingIverksattOpphørt()
+            val iverksattStansAvYtelse = testDataHelper.persisterStansAvYtelseIverksatt()
+            val iverksattGjenopptak = testDataHelper.persisterGjenopptakAvYtelseIverksatt()
+            val beregnetRevurdering = testDataHelper.persisterRevurderingBeregnetInnvilget()
 
             val ferdigeBehandlinger = repo.hentFerdigeBehandlinger()
 
@@ -145,17 +148,21 @@ internal class FerdigeBehandlingerRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.sakRepo
 
-            val vedtakSak1 = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
-            val oversendtKlage = testDataHelper.oversendtKlage(vedtakSak1)
+            val vedtakSak1 =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
+            val oversendtKlage = testDataHelper.persisterKlageOversendt(vedtakSak1)
 
-            val vedtakSak2 = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
-            val iverksattAvvistKlage = testDataHelper.iverksattAvvistKlage(vedtakSak2)
+            val vedtakSak2 =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
+            val iverksattAvvistKlage = testDataHelper.persisterKlageIverksattAvvist(vedtakSak2)
 
-            val vedtakSak3 = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
-            testDataHelper.nyKlage(vedtakSak3)
+            val vedtakSak3 =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
+            testDataHelper.persisterKlageOpprettet(vedtakSak3)
 
-            val vedtakSak4 = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
-            testDataHelper.bekreftetVurdertKlage(vedtakSak4)
+            val vedtakSak4 =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
+            testDataHelper.persisterKlageVurdertBekreftet(vedtakSak4)
 
             val ferdigeBehandlinger = repo.hentFerdigeBehandlinger()
 
@@ -214,34 +221,20 @@ internal class FerdigeBehandlingerRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.sakRepo
-            val sak = testDataHelper.nySakMedNySøknad()
 
-            testDataHelper.nyLukketSøknadsbehandlingOgSøknadForEksisterendeSak(sak.toSak(saksnummer))
-            val avsluttetRevurdering = testDataHelper.avsluttetRevurdering()
-
-            val vedtakForKlage = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
-            testDataHelper.avsluttetKlage(vedtakForKlage)
+            testDataHelper.persisterLukketJournalførtSøknadMedOppgave() // 2021
+            testDataHelper.persisterSøknadsbehandlingAvsluttet() // 2022
+            val revurdering = testDataHelper.persisterRevurderingAvsluttet() // 2023
+            val klage =
+                testDataHelper.persisterKlageAvsluttet().hentUnderliggendeKlage() as VurdertKlage.Bekreftet // 2024
 
             val ferdigeBehandlinger = repo.hentFerdigeBehandlinger()
 
-            ferdigeBehandlinger.size shouldBe 2
-
-            ferdigeBehandlinger shouldContainExactlyInAnyOrder listOf(
-                Behandlingsoversikt(
-                    saksnummer = Saksnummer(2022),
-                    behandlingsId = avsluttetRevurdering.tilRevurdering.behandling.id,
-                    behandlingstype = Behandlingsoversikt.Behandlingstype.SØKNADSBEHANDLING,
-                    behandlingStartet = avsluttetRevurdering.tilRevurdering.behandling.attesteringer.hentSisteAttestering().opprettet,
-                    status = Behandlingsoversikt.Behandlingsstatus.INNVILGET,
-                ),
-                Behandlingsoversikt(
-                    saksnummer = Saksnummer(2023),
-                    behandlingsId = vedtakForKlage.behandling.id,
-                    behandlingstype = Behandlingsoversikt.Behandlingstype.SØKNADSBEHANDLING,
-                    behandlingStartet = vedtakForKlage.behandling.attesteringer.hentSisteAttestering().opprettet,
-                    status = Behandlingsoversikt.Behandlingsstatus.INNVILGET,
-                ),
-            )
+            ferdigeBehandlinger.map { it.behandlingsId }
+                .sorted() shouldBe listOf(
+                revurdering.tilRevurdering.behandling.id,
+                testDataHelper.sakRepo.hentSak(klage.sakId)!!.søknadsbehandlinger.first().id,
+            ).sorted()
         }
     }
 }

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepoTest.kt
@@ -5,13 +5,12 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.database.TestDataHelper
 import no.nav.su.se.bakover.database.TestDataHelper.Companion.søknadNy
-import no.nav.su.se.bakover.database.stønadsperiode
 import no.nav.su.se.bakover.database.withMigratedDb
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.sak.Behandlingsoversikt
 import no.nav.su.se.bakover.domain.sak.SakIdOgNummer
-import no.nav.su.se.bakover.test.saksnummer
+import no.nav.su.se.bakover.test.stønadsperiode2021
 import org.junit.jupiter.api.Test
 
 internal class SakPostgresRepoTest {
@@ -21,7 +20,7 @@ internal class SakPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.sakRepo
-            val nySak = testDataHelper.nySakMedNySøknad()
+            val nySak = testDataHelper.persisterSakMedSøknadUtenJournalføringOgOppgave()
             val opprettet: Sak = repo.hentSak(nySak.fnr)!!
             val hentetId = repo.hentSak(opprettet.id)!!
             val hentetFnr = repo.hentSak(opprettet.fnr)!!
@@ -41,7 +40,7 @@ internal class SakPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.sakRepo
-            val nySak = testDataHelper.nySakMedJournalførtSøknadOgOppgave()
+            val nySak = testDataHelper.persisterJournalførtSøknadMedOppgave().first
             repo.hentSakIdOgNummerForIdenter(nonEmptyListOf(nySak.fnr.toString())) shouldBe SakIdOgNummer(nySak.id, nySak.saksnummer)
         }
     }
@@ -51,7 +50,7 @@ internal class SakPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.sakRepo
-            val nySak = testDataHelper.nySakMedJournalførtSøknadOgOppgave()
+            val nySak = testDataHelper.persisterJournalførtSøknadMedOppgave().first
             repo.hentSakIdOgNummerForIdenter(nonEmptyListOf("1234567890123", nySak.fnr.toString())) shouldBe SakIdOgNummer(nySak.id, nySak.saksnummer)
             repo.hentSakIdOgNummerForIdenter(nonEmptyListOf(nySak.fnr.toString(), "1234567890123")) shouldBe SakIdOgNummer(nySak.id, nySak.saksnummer)
         }
@@ -62,7 +61,7 @@ internal class SakPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.sakRepo
-            val nySak = testDataHelper.nySakMedJournalførtSøknadOgOppgave()
+            val nySak = testDataHelper.persisterJournalførtSøknadMedOppgave().first
             repo.hentSakIdOgNummerForIdenter(
                 nonEmptyListOf(
                     "1234567890123",
@@ -79,10 +78,10 @@ internal class SakPostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.sakRepo
 
-            val sak = testDataHelper.nySakMedNySøknad()
-            testDataHelper.nyLukketSøknadForEksisterendeSak(sak.id)
-            testDataHelper.avsluttetRevurdering()
-            testDataHelper.avsluttetKlage()
+            val sak = testDataHelper.persisterSakMedSøknadUtenJournalføringOgOppgave()
+            testDataHelper.persisterLukketJournalførtSøknadMedOppgave(sak.id)
+            testDataHelper.persisterRevurderingAvsluttet()
+            testDataHelper.persisterKlageAvsluttet()
 
             val åpneBehandlinger = repo.hentÅpneBehandlinger()
 
@@ -105,27 +104,27 @@ internal class SakPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.sakRepo
-            val sak = testDataHelper.nySakMedNySøknad()
-            testDataHelper.nyLukketSøknadForEksisterendeSak(sak.id)
-            testDataHelper.nyLukketSøknadsbehandlingOgSøknadForEksisterendeSak(sak.toSak(saksnummer))
-            val søknadsbehandling = testDataHelper.nySøknadsbehandling()
-            val underkjent = testDataHelper.nyUnderkjenningMedBeregning()
-            val tilAttestering = testDataHelper.nyTilAvslåttAttesteringUtenBeregning()
-            testDataHelper.nyIverksattInnvilget()
+            val sak = testDataHelper.persisterSakMedSøknadUtenJournalføringOgOppgave()
+            testDataHelper.persisterLukketJournalførtSøknadMedOppgave(sakId = sak.id)
+            testDataHelper.persisterSøknadsbehandlingAvsluttet(sakId = sak.id)
+            val søknadsbehandling = testDataHelper.persisterSøknadsbehandlingVilkårsvurdertUavklart().second
+            val underkjent = testDataHelper.persisterSøknadsbehandlingUnderkjentAvslagMedBeregning().second
+            val tilAttestering = testDataHelper.persisterSøknadsbehandlingTilAttesteringAvslagUtenBeregning().second
+            testDataHelper.persisterSøknadsbehandlingIverksattInnvilget()
 
             val opprettetRevurdering =
-                testDataHelper.nyRevurdering(
-                    testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first,
-                    stønadsperiode.periode,
+                testDataHelper.persisterRevurderingOpprettet(
+                    testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second,
+                    stønadsperiode2021.periode,
                 )
-            val tilAttesteringRevurdering = testDataHelper.revurderingTilAttesteringInnvilget()
-            val underkjentRevurdering = testDataHelper.underkjentRevurderingFraInnvilget()
-            testDataHelper.iverksattRevurderingInnvilget()
+            val tilAttesteringRevurdering = testDataHelper.persisterRevurderingTilAttesteringInnvilget()
+            val underkjentRevurdering = testDataHelper.persisterRevurderingUnderkjentInnvilget()
+            testDataHelper.persisterRevurderingIverksattInnvilget()
 
-            val opprettetKlage = testDataHelper.nyKlage()
-            val vurdertKlage = testDataHelper.påbegyntVurdertKlage()
-            val klageTilAttestering = testDataHelper.avvistKlageTilAttestering()
-            testDataHelper.iverksattAvvistKlage()
+            val opprettetKlage = testDataHelper.persisterKlageOpprettet()
+            val vurdertKlage = testDataHelper.persisterKlageVurdertPåbegynt()
+            val klageTilAttestering = testDataHelper.persisterKlageTilAttesteringAvvist()
+            testDataHelper.persisterKlageIverksattAvvist()
 
             val alleRestanser = repo.hentÅpneBehandlinger()
 

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/søknad/SøknadPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/søknad/SøknadPostgresRepoTest.kt
@@ -27,8 +27,8 @@ internal class SøknadPostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val søknadRepo = testDataHelper.søknadRepo
             dataSource.withSession {
-                val sak: NySak = testDataHelper.nySakMedNySøknad()
-                val nySøknad: Søknad = testDataHelper.nySøknadForEksisterendeSak(sak.id)
+                val sak: NySak = testDataHelper.persisterSakMedSøknadUtenJournalføringOgOppgave()
+                val nySøknad: Søknad = testDataHelper.persisterSøknadUtenJournalføringOgOppgavePåEksisterendeSak(sak.id)
                 søknadRepo.hentSøknad(nySøknad.id) shouldBe nySøknad
             }
         }
@@ -39,8 +39,8 @@ internal class SøknadPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val søknadRepo = testDataHelper.søknadRepo
-            val sak: NySak = testDataHelper.nySakMedNySøknad()
-            val nySøknad: Søknad = testDataHelper.nySøknadForEksisterendeSak(sak.id)
+            val sak: NySak = testDataHelper.persisterSakMedSøknadUtenJournalføringOgOppgave()
+            val nySøknad: Søknad = testDataHelper.persisterSøknadUtenJournalføringOgOppgavePåEksisterendeSak(sak.id)
             søknadRepo.hentSøknad(nySøknad.id)!!.shouldNotBeTypeOf<Søknad.Journalført.MedOppgave.Lukket>()
         }
     }
@@ -49,8 +49,9 @@ internal class SøknadPostgresRepoTest {
     fun `lagrer og henter lukket søknad`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val nySak: Sak = testDataHelper.nySakMedJournalførtSøknadOgOppgave()
-            val journalførtSøknadMedOppgave: Søknad.Journalført.MedOppgave.IkkeLukket = nySak.journalførtSøknadMedOppgave()
+            val nySak: Sak = testDataHelper.persisterJournalførtSøknadMedOppgave().first
+            val journalførtSøknadMedOppgave: Søknad.Journalført.MedOppgave.IkkeLukket =
+                nySak.journalførtSøknadMedOppgave()
             val saksbehandler = Saksbehandler("Z993156")
             val lukketSøknad = journalførtSøknadMedOppgave
                 .lukk(
@@ -81,7 +82,7 @@ internal class SøknadPostgresRepoTest {
             }
 
             val journalpostId = JournalpostId("oppdatertJournalpostId")
-            val nySak: NySak = testDataHelper.nySakMedNySøknad()
+            val nySak: NySak = testDataHelper.persisterSakMedSøknadUtenJournalføringOgOppgave()
             hentJournalpostId(nySak) shouldBe emptyList()
             val søknad = nySak.søknad.journalfør(journalpostId)
             søknadRepo.oppdaterjournalpostId(søknad)
@@ -94,7 +95,7 @@ internal class SøknadPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val søknadRepo = testDataHelper.søknadRepo
-            val sak = testDataHelper.nySakMedJournalførtSøknad()
+            val sak = testDataHelper.persisterSakOgJournalførtSøknadUtenOppgave().first
             val journalførtSøknadMedOppgave = sak.journalførtSøknad().medOppgave(OppgaveId("oppdatertOppgaveId"))
             søknadRepo.oppdaterOppgaveId(journalførtSøknadMedOppgave)
             val hentetSøknad = søknadRepo.hentSøknad(journalførtSøknadMedOppgave.id)!!
@@ -108,9 +109,9 @@ internal class SøknadPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val søknadRepo = testDataHelper.søknadRepo
-            val sak = testDataHelper.nySakMedNySøknad()
-            testDataHelper.nySakMedJournalførtSøknad()
-            testDataHelper.nyLukketSøknadForEksisterendeSak(sak.id)
+            val sak = testDataHelper.persisterSakMedSøknadUtenJournalføringOgOppgave()
+            testDataHelper.persisterSakOgJournalførtSøknadUtenOppgave()
+            testDataHelper.persisterLukketJournalførtSøknadMedOppgave(sak.id)
             søknadRepo.hentSøknaderUtenJournalpost() shouldBe listOf(
                 sak.søknad,
             )
@@ -122,10 +123,10 @@ internal class SøknadPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val søknadRepo = testDataHelper.søknadRepo
-            val sak = testDataHelper.nySakMedNySøknad()
-            val journalførtSøknad = testDataHelper.journalførtSøknadForEksisterendeSak(sak.id)
-            testDataHelper.journalførtSøknadMedOppgaveForEksisterendeSak(sak.id)
-            testDataHelper.nyLukketSøknadForEksisterendeSak(sak.id)
+            val sak = testDataHelper.persisterSakMedSøknadUtenJournalføringOgOppgave()
+            val journalførtSøknad = testDataHelper.persisterJournalførtSøknadUtenOppgaveForEksisterendeSak(sak.id)
+            testDataHelper.persisterJournalførtSøknadMedOppgave(sak.id)
+            testDataHelper.persisterLukketJournalførtSøknadMedOppgave(sak.id)
             søknadRepo.hentSøknaderMedJournalpostMenUtenOppgave() shouldBe listOf(
                 journalførtSøknad,
             )

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/utbetaling/UtbetalingPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/utbetaling/UtbetalingPostgresRepoTest.kt
@@ -1,43 +1,26 @@
 package no.nav.su.se.bakover.database.utbetaling
 
-import arrow.core.nonEmptyListOf
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
-import io.kotest.matchers.types.shouldBeInstanceOf
-import no.nav.su.se.bakover.common.UUID30
-import no.nav.su.se.bakover.common.desember
-import no.nav.su.se.bakover.common.februar
-import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.database.TestDataHelper
-import no.nav.su.se.bakover.database.utbetalingslinje
 import no.nav.su.se.bakover.database.withMigratedDb
-import no.nav.su.se.bakover.database.withSession
-import no.nav.su.se.bakover.domain.grunnlag.Uføregrad
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
-import no.nav.su.se.bakover.domain.oppdrag.Utbetalingslinje
-import no.nav.su.se.bakover.test.fixedClock
-import no.nav.su.se.bakover.test.fixedTidspunkt
+import no.nav.su.se.bakover.domain.søknadsbehandling.Stønadsperiode
+import no.nav.su.se.bakover.test.periodeApril2021
+import no.nav.su.se.bakover.test.periodeFebruar2021
+import no.nav.su.se.bakover.test.periodeJanuar2021
+import no.nav.su.se.bakover.test.periodeMars2021
 import org.junit.jupiter.api.Test
+import java.util.UUID
 
 internal class UtbetalingPostgresRepoTest {
-
-    @Test
-    fun `opprett og hent utbetaling uten kvittering`() {
-        withMigratedDb { dataSource ->
-            val testDataHelper = TestDataHelper(dataSource)
-            val repo = testDataHelper.utbetalingRepo
-
-            val utenKvittering = testDataHelper.nyIverksattInnvilget().second
-            repo.hentUtbetaling(utenKvittering.id) shouldBe utenKvittering
-        }
-    }
 
     @Test
     fun `hent utbetaling fra avstemmingsnøkkel`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.utbetalingRepo
-            val utbetalingMedKvittering = testDataHelper.nyOversendtUtbetalingMedKvittering().second
+            val utbetalingMedKvittering =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().third
             val hentet =
                 repo.hentUtbetaling(utbetalingMedKvittering.avstemmingsnøkkel) as Utbetaling.OversendtUtbetaling.MedKvittering
             utbetalingMedKvittering shouldBe hentet
@@ -49,9 +32,69 @@ internal class UtbetalingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.utbetalingRepo
-            val utbetalingUtenKvittering = testDataHelper.nyIverksattInnvilget().second
-            testDataHelper.nyOversendtUtbetalingMedKvittering()
-            repo.hentUkvitterteUtbetalinger() shouldBe listOf(utbetalingUtenKvittering)
+            val sakId = UUID.randomUUID()
+            // Lagrer en med kvittering som ikke skal komme med i hent-operasjonen
+            testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering(
+                sakId = sakId,
+                stønadsperiode = Stønadsperiode.create(
+                    periodeJanuar2021,
+                ),
+            )
+            val utbetalingUtenKvittering1 =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingUtenKvittering(
+                    sakId = sakId,
+                    stønadsperiode = Stønadsperiode.create(
+                        periodeFebruar2021,
+                    ),
+
+                ).second
+            val utbetalingUtenKvittering2 =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingUtenKvittering(
+                    sakId = sakId,
+                    stønadsperiode = Stønadsperiode.create(
+                        periodeMars2021,
+                    ),
+                ).second
+            repo.hentUkvitterteUtbetalinger() shouldBe listOf(utbetalingUtenKvittering1, utbetalingUtenKvittering2)
+        }
+    }
+
+    @Test
+    fun `hent utbetalinger for sak`() {
+        withMigratedDb { dataSource ->
+            val testDataHelper = TestDataHelper(dataSource)
+            val repo = testDataHelper.utbetalingRepo
+            val sakId = UUID.randomUUID()
+            // Lagrer en kvittering med og uten kvittering som ikke skal komme med i hent-operasjonen
+            testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering()
+            testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering()
+
+            val utbetalingUtenKvittering1 =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering(
+                    sakId = sakId,
+                    stønadsperiode = Stønadsperiode.create(periodeJanuar2021),
+                ).third
+            val utbetalingUtenKvittering2 =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering(
+                    sakId = sakId,
+                    stønadsperiode = Stønadsperiode.create(periodeFebruar2021),
+                ).third
+            val utbetalingMedKvittering1 =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering(
+                    sakId = sakId,
+                    stønadsperiode = Stønadsperiode.create(periodeMars2021),
+                ).third
+            val utbetalingMedKvittering2 =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering(
+                    sakId = sakId,
+                    stønadsperiode = Stønadsperiode.create(periodeApril2021),
+                ).third
+            repo.hentUtbetalinger(sakId).sortedBy { it.avstemmingsnøkkel } shouldBe listOf(
+                utbetalingUtenKvittering1,
+                utbetalingUtenKvittering2,
+                utbetalingMedKvittering1,
+                utbetalingMedKvittering2,
+            ).sortedBy { it.avstemmingsnøkkel }
         }
     }
 
@@ -60,78 +103,9 @@ internal class UtbetalingPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.utbetalingRepo
-            val utbetalingMedKvittering = testDataHelper.nyOversendtUtbetalingMedKvittering().second
-            repo.hentUtbetaling(utbetalingMedKvittering.id)
-                .shouldBeInstanceOf<Utbetaling.OversendtUtbetaling.MedKvittering>()
-        }
-    }
-
-    @Test
-    fun `opprett og hent utbetalingslinjer`() {
-        val utbetalingslinjeId1 = UUID30.randomUUID()
-        val utbetalingslinjer = nonEmptyListOf(
-            utbetalingslinje().copy(
-                id = utbetalingslinjeId1,
-            ),
-            utbetalingslinje().copy(
-                forrigeUtbetalingslinjeId = utbetalingslinjeId1,
-            ),
-        )
-        withMigratedDb { dataSource ->
-            val testDataHelper = TestDataHelper(dataSource)
-            val utbetaling = testDataHelper.nyIverksattInnvilget(utbetalingslinjer = utbetalingslinjer)
-            dataSource.withSession {
-                val hentet = UtbetalingInternalRepo.hentUtbetalingslinjer(utbetaling.second.id, it)
-                hentet shouldBe utbetalingslinjer
-            }
-        }
-    }
-
-    @Test
-    fun `endring av eksisterende utbetalingslinje oppretter ny linje med status`() {
-        withMigratedDb { dataSource ->
-            val testDataHelper = TestDataHelper(dataSource)
-            val repo = testDataHelper.utbetalingRepo
-            val originalUtbetalingslinje = Utbetalingslinje.Ny(
-                opprettet = fixedTidspunkt,
-                fraOgMed = 1.januar(2020),
-                tilOgMed = 31.desember(2020),
-                forrigeUtbetalingslinjeId = null,
-                beløp = 25000,
-                uføregrad = Uføregrad.parse(50),
-            )
-
-            val (_, utbetaling) = testDataHelper.nyIverksattInnvilget(
-                utbetalingslinjer = nonEmptyListOf(originalUtbetalingslinje),
-            )
-
-            val endretUtbetalingslinje = Utbetalingslinje.Endring.Opphør(
-                utbetalingslinje = originalUtbetalingslinje,
-                virkningstidspunkt = 1.februar(2021),
-                clock = fixedClock
-            )
-
-            val opphør = utbetaling.copy(
-                id = UUID30.randomUUID(),
-                type = Utbetaling.UtbetalingsType.OPPHØR,
-                utbetalingslinjer = nonEmptyListOf(endretUtbetalingslinje),
-            )
-
-            repo.opprettUtbetaling(opphør, repo.defaultTransactionContext())
-
-            repo.hentUtbetaling(opphør.id)!!.utbetalingslinjer shouldBe nonEmptyListOf(
-                Utbetalingslinje.Endring.Opphør(
-                    id = originalUtbetalingslinje.id,
-                    opprettet = endretUtbetalingslinje.opprettet,
-                    fraOgMed = originalUtbetalingslinje.fraOgMed,
-                    tilOgMed = originalUtbetalingslinje.tilOgMed,
-                    forrigeUtbetalingslinjeId = originalUtbetalingslinje.forrigeUtbetalingslinjeId,
-                    beløp = originalUtbetalingslinje.beløp,
-                    virkningstidspunkt = endretUtbetalingslinje.virkningstidspunkt,
-                    uføregrad = originalUtbetalingslinje.uføregrad
-                ),
-            )
-            repo.hentUtbetaling(utbetaling.id) shouldNotBe repo.hentUtbetaling(opphør.id)
+            val utbetalingMedKvittering: Utbetaling.OversendtUtbetaling.MedKvittering =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().third
+            repo.hentUtbetaling(utbetalingMedKvittering.id) shouldBe utbetalingMedKvittering
         }
     }
 }

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/vedtak/LagreOgHentKlagevedtakTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/vedtak/LagreOgHentKlagevedtakTest.kt
@@ -13,7 +13,7 @@ internal class LagreOgHentKlagevedtakTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val vedtakRepo = testDataHelper.vedtakRepo
-            val vedtak = testDataHelper.vedtakForIverksattAvvistKlage()
+            val vedtak = testDataHelper.persisterVedtakForKlageIverksattAvvist()
 
             dataSource.withSession {
                 (vedtakRepo.hent(vedtak.id, it) as Klagevedtak.Avvist).shouldBeEqualComparingPublicFieldsAndInterface(vedtak)

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPostgresRepoTest.kt
@@ -1,45 +1,37 @@
 package no.nav.su.se.bakover.database.vedtak
 
 import io.kotest.matchers.shouldBe
-import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.februar
-import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.mars
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.database.TestDataHelper
-import no.nav.su.se.bakover.database.attestant
 import no.nav.su.se.bakover.database.hent
 import no.nav.su.se.bakover.database.innvilgetBeregning
 import no.nav.su.se.bakover.database.persistertVariant
-import no.nav.su.se.bakover.database.simulering
 import no.nav.su.se.bakover.database.withMigratedDb
 import no.nav.su.se.bakover.database.withSession
-import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.avkorting.AvkortingVedRevurdering
 import no.nav.su.se.bakover.domain.behandling.Attestering
 import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.revurdering.Forhåndsvarsel
-import no.nav.su.se.bakover.domain.revurdering.GjenopptaYtelseRevurdering
 import no.nav.su.se.bakover.domain.revurdering.InformasjonSomRevurderes
 import no.nav.su.se.bakover.domain.revurdering.IverksattRevurdering
 import no.nav.su.se.bakover.domain.revurdering.RevurderingTilAttestering
 import no.nav.su.se.bakover.domain.revurdering.Revurderingsteg
 import no.nav.su.se.bakover.domain.revurdering.Revurderingsårsak
-import no.nav.su.se.bakover.domain.revurdering.StansAvYtelseRevurdering
+import no.nav.su.se.bakover.domain.søknadsbehandling.Stønadsperiode
 import no.nav.su.se.bakover.domain.vedtak.Avslagsvedtak
 import no.nav.su.se.bakover.domain.vedtak.VedtakSomKanRevurderes
 import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
+import no.nav.su.se.bakover.test.attestant
 import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.fixedTidspunkt
-import no.nav.su.se.bakover.test.getOrFail
-import no.nav.su.se.bakover.test.grunnlagsdataEnsligUtenFradrag
-import no.nav.su.se.bakover.test.periode2021
-import no.nav.su.se.bakover.test.saksbehandler
-import no.nav.su.se.bakover.test.vilkårsvurderingerInnvilgetRevurdering
+import no.nav.su.se.bakover.test.periodeJanuar2021
+import no.nav.su.se.bakover.test.plus
 import org.junit.jupiter.api.Test
-import java.util.UUID
+import java.time.temporal.ChronoUnit
 
 internal class VedtakPostgresRepoTest {
 
@@ -48,7 +40,8 @@ internal class VedtakPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val vedtakRepo = testDataHelper.vedtakRepo
-            val vedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
 
             dataSource.withSession {
                 vedtakRepo.hent(vedtak.id, it) shouldBe vedtak.persistertVariant()
@@ -61,7 +54,7 @@ internal class VedtakPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val vedtakRepo = testDataHelper.vedtakRepo
-            val søknadsbehandling = testDataHelper.nyIverksattAvslagMedBeregning()
+            val søknadsbehandling = testDataHelper.persisterSøknadsbehandlingIverksattAvslagMedBeregning().second
             val vedtak = Avslagsvedtak.fromSøknadsbehandlingMedBeregning(søknadsbehandling, fixedClock)
 
             vedtakRepo.lagre(vedtak)
@@ -76,7 +69,8 @@ internal class VedtakPostgresRepoTest {
     fun `oppdaterer koblingstabell mellom søknadsbehandling og vedtak ved lagring av vedtak for søknadsbehandling`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val vedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val vedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
 
             dataSource.withSession { session ->
                 """
@@ -95,9 +89,11 @@ internal class VedtakPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val vedtakRepo = testDataHelper.vedtakRepo
-            val søknadsbehandlingVedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val søknadsbehandlingVedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
 
-            val nyRevurdering = testDataHelper.nyRevurdering(søknadsbehandlingVedtak, søknadsbehandlingVedtak.periode)
+            val nyRevurdering =
+                testDataHelper.persisterRevurderingOpprettet(søknadsbehandlingVedtak, søknadsbehandlingVedtak.periode)
             val iverksattRevurdering = IverksattRevurdering.Innvilget(
                 id = nyRevurdering.id,
                 periode = søknadsbehandlingVedtak.periode,
@@ -141,18 +137,23 @@ internal class VedtakPostgresRepoTest {
     @Test
     fun `hent alle aktive vedtak`() {
         withMigratedDb { dataSource ->
-            val testDataHelper = TestDataHelper(dataSource)
+            val testDataHelper = TestDataHelper(
+                dataSource = dataSource,
+                clock = fixedClock.plus(31, ChronoUnit.DAYS),
+            )
             val vedtakRepo = testDataHelper.vedtakRepo
-            val (søknadsbehandling, utbetaling) = testDataHelper.nyIverksattInnvilget()
-            val vedtakSomErAktivt = VedtakSomKanRevurderes.fromSøknadsbehandling(søknadsbehandling, utbetaling.id, fixedClock)
-                .copy(periode = Periode.create(1.januar(2021), 31.mars(2021)))
-            val vedtakUtenforAktivPeriode = VedtakSomKanRevurderes.fromSøknadsbehandling(søknadsbehandling, utbetaling.id, fixedClock)
-                .copy(periode = Periode.create(1.januar(2020), 31.desember(2020)))
-            vedtakRepo.lagre(vedtakSomErAktivt)
-            vedtakRepo.lagre(vedtakUtenforAktivPeriode)
-
-            val actual = vedtakRepo.hentAktive(1.februar(2021))
-            actual.first() shouldBe vedtakSomErAktivt.persistertVariant()
+            // Persisterer et ikke-aktivt vedtak
+            testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering(
+                stønadsperiode = Stønadsperiode.create(periodeJanuar2021),
+            )
+            val vedtakSomErAktivt =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering(
+                    stønadsperiode = Stønadsperiode.create(Periode.create(1.februar(2021), 31.mars(2021))),
+                ).second
+            vedtakRepo.hentAktive(1.februar(2021)).also {
+                it.size shouldBe 1
+                it.first() shouldBe vedtakSomErAktivt.persistertVariant()
+            }
         }
     }
 
@@ -161,7 +162,7 @@ internal class VedtakPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val vedtakRepo = testDataHelper.vedtakRepo
-            val søknadsbehandling = testDataHelper.nyIverksattAvslagMedBeregning()
+            val søknadsbehandling = testDataHelper.persisterSøknadsbehandlingIverksattAvslagMedBeregning().second
             val vedtak = Avslagsvedtak.fromSøknadsbehandlingMedBeregning(søknadsbehandling, fixedClock)
 
             vedtakRepo.lagre(vedtak)
@@ -183,9 +184,11 @@ internal class VedtakPostgresRepoTest {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
             val vedtakRepo = testDataHelper.vedtakRepo
-            val søknadsbehandlingVedtak = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
+            val søknadsbehandlingVedtak =
+                testDataHelper.persisterVedtakMedInnvilgetSøknadsbehandlingOgOversendtUtbetalingMedKvittering().second
 
-            val nyRevurdering = testDataHelper.nyRevurdering(søknadsbehandlingVedtak, søknadsbehandlingVedtak.periode)
+            val nyRevurdering =
+                testDataHelper.persisterRevurderingOpprettet(søknadsbehandlingVedtak, søknadsbehandlingVedtak.periode)
             val attestertRevurdering = RevurderingTilAttestering.IngenEndring(
                 id = nyRevurdering.id,
                 periode = nyRevurdering.periode,
@@ -256,34 +259,7 @@ internal class VedtakPostgresRepoTest {
     fun `oppretter og henter vedtak for stans av ytelse`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val søknadsbehandling = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
-
-            val simulertRevurdering = StansAvYtelseRevurdering.SimulertStansAvYtelse(
-                id = UUID.randomUUID(),
-                opprettet = fixedTidspunkt,
-                periode = periode2021,
-                grunnlagsdata = grunnlagsdataEnsligUtenFradrag(),
-                vilkårsvurderinger = vilkårsvurderingerInnvilgetRevurdering(),
-                tilRevurdering = søknadsbehandling,
-                saksbehandler = saksbehandler,
-                simulering = simulering(søknadsbehandling.behandling.fnr),
-                revurderingsårsak = Revurderingsårsak.create(
-                    årsak = Revurderingsårsak.Årsak.MANGLENDE_KONTROLLERKLÆRING.toString(),
-                    begrunnelse = "huffa",
-                ),
-            )
-            testDataHelper.revurderingRepo.lagre(simulertRevurdering)
-
-            val iverksattRevurdering = simulertRevurdering.iverksett(
-                Attestering.Iverksatt(NavIdentBruker.Attestant("atte"), fixedTidspunkt),
-            ).getOrFail("Feil i oppsett av testdata")
-
-            testDataHelper.revurderingRepo.lagre(iverksattRevurdering)
-
-            val utbetaling = testDataHelper.nyOversendtUtbetalingMedKvittering().second
-            val vedtak = VedtakSomKanRevurderes.from(iverksattRevurdering, utbetaling.id, fixedClock)
-
-            testDataHelper.vedtakRepo.lagre(vedtak)
+            val vedtak = testDataHelper.persisterVedtakForStans()
             testDataHelper.dataSource.withSession {
                 testDataHelper.vedtakRepo.hent(vedtak.id, it) shouldBe vedtak.persistertVariant()
             }
@@ -294,34 +270,7 @@ internal class VedtakPostgresRepoTest {
     fun `oppretter og henter vedtak for gjenopptak av ytelse`() {
         withMigratedDb { dataSource ->
             val testDataHelper = TestDataHelper(dataSource)
-            val søknadsbehandling = testDataHelper.vedtakMedInnvilgetSøknadsbehandling().first
-
-            val simulertRevurdering = GjenopptaYtelseRevurdering.SimulertGjenopptakAvYtelse(
-                id = UUID.randomUUID(),
-                opprettet = fixedTidspunkt,
-                periode = periode2021,
-                grunnlagsdata = grunnlagsdataEnsligUtenFradrag(),
-                vilkårsvurderinger = vilkårsvurderingerInnvilgetRevurdering(),
-                tilRevurdering = søknadsbehandling,
-                saksbehandler = saksbehandler,
-                simulering = simulering(søknadsbehandling.behandling.fnr),
-                revurderingsårsak = Revurderingsårsak.create(
-                    årsak = Revurderingsårsak.Årsak.MOTTATT_KONTROLLERKLÆRING.toString(),
-                    begrunnelse = "huffa",
-                ),
-            )
-            testDataHelper.revurderingRepo.lagre(simulertRevurdering)
-
-            val iverksattRevurdering = simulertRevurdering.iverksett(
-                Attestering.Iverksatt(NavIdentBruker.Attestant("atte"), fixedTidspunkt),
-            ).getOrFail("Feil i oppsett av testdata")
-
-            testDataHelper.revurderingRepo.lagre(iverksattRevurdering)
-
-            val utbetaling = testDataHelper.nyOversendtUtbetalingMedKvittering().second
-            val vedtak = VedtakSomKanRevurderes.from(iverksattRevurdering, utbetaling.id, fixedClock)
-
-            testDataHelper.vedtakRepo.lagre(vedtak)
+            val vedtak = testDataHelper.persisterVedtakForGjenopptak()
             testDataHelper.dataSource.withSession {
                 testDataHelper.vedtakRepo.hent(vedtak.id, it) shouldBe vedtak.persistertVariant()
             }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/NySøknadsbehandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/NySøknadsbehandling.kt
@@ -14,7 +14,8 @@ data class NySøknadsbehandling(
     val sakId: UUID,
     val søknad: Søknad.Journalført.MedOppgave,
     val oppgaveId: OppgaveId,
-    val behandlingsinformasjon: Behandlingsinformasjon,
     val fnr: Fnr,
-    val avkorting: AvkortingVedSøknadsbehandling.Uhåndtert.KanIkkeHåndtere
-)
+    val avkorting: AvkortingVedSøknadsbehandling.Uhåndtert.KanIkkeHåndtere,
+) {
+    val behandlingsinformasjon: Behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon()
+}

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/SøknadsbehandlingRepo.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/SøknadsbehandlingRepo.kt
@@ -2,7 +2,6 @@ package no.nav.su.se.bakover.domain.søknadsbehandling
 
 import no.nav.su.se.bakover.common.persistence.SessionContext
 import no.nav.su.se.bakover.common.persistence.TransactionContext
-import no.nav.su.se.bakover.domain.behandling.Attestering
 import no.nav.su.se.bakover.domain.behandling.avslag.AvslagManglendeDokumentasjon
 import java.util.UUID
 
@@ -10,7 +9,6 @@ interface SøknadsbehandlingRepo {
     fun lagreNySøknadsbehandling(søknadsbehandling: NySøknadsbehandling)
     fun lagre(søknadsbehandling: Søknadsbehandling, sessionContext: TransactionContext = defaultTransactionContext())
     fun hent(id: UUID): Søknadsbehandling?
-    fun hentEventuellTidligereAttestering(id: UUID): Attestering?
     fun hentForSak(sakId: UUID, sessionContext: SessionContext = defaultSessionContext()): List<Søknadsbehandling>
     fun lagreAvslagManglendeDokumentasjon(avslag: AvslagManglendeDokumentasjon, sessionContext: TransactionContext = defaultTransactionContext())
 

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/IdentifiserRevurderingsopphørSomIkkeStøttesTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/IdentifiserRevurderingsopphørSomIkkeStøttesTest.kt
@@ -24,7 +24,7 @@ import no.nav.su.se.bakover.test.uføregrunnlagForventetInntekt
 import no.nav.su.se.bakover.test.uføregrunnlagForventetInntekt0
 import no.nav.su.se.bakover.test.vilkårsvurderingerAvslåttAlleRevurdering
 import no.nav.su.se.bakover.test.vilkårsvurderingerAvslåttUføreOgAndreInnvilget
-import no.nav.su.se.bakover.test.vilkårsvurderingerInnvilget
+import no.nav.su.se.bakover.test.vilkårsvurderingerSøknadsbehandlingInnvilget
 import org.junit.jupiter.api.Test
 
 internal class IdentifiserRevurderingsopphørSomIkkeStøttesTest {
@@ -97,7 +97,7 @@ internal class IdentifiserRevurderingsopphørSomIkkeStøttesTest {
 
     @Test
     fun `identifiserer at opphør grunnet lavt beløp gjøres i kombinasjon med andre beløpsendringer - under minstegrense`() {
-        val vilkårsvurderinger = vilkårsvurderingerInnvilget()
+        val vilkårsvurderinger = vilkårsvurderingerSøknadsbehandlingInnvilget()
 
         val tidligereBeregning = beregning()
 
@@ -130,7 +130,7 @@ internal class IdentifiserRevurderingsopphørSomIkkeStøttesTest {
 
     @Test
     fun `identifiserer at opphør grunnet lavt beløp gjøres i kombinasjon med andre beløpsendringer - for høy inntekt`() {
-        val vilkårsvurderinger = vilkårsvurderingerInnvilget()
+        val vilkårsvurderinger = vilkårsvurderingerSøknadsbehandlingInnvilget()
 
         val tidligereBeregning = beregning()
 
@@ -163,7 +163,7 @@ internal class IdentifiserRevurderingsopphørSomIkkeStøttesTest {
 
     @Test
     fun `identifiserer ingen problemer hvis alle nye måneder har for lavt beløp - for høy inntekt`() {
-        val vilkårsvurderinger = vilkårsvurderingerInnvilget()
+        val vilkårsvurderinger = vilkårsvurderingerSøknadsbehandlingInnvilget()
 
         val tidligereBeregning = beregning()
 
@@ -187,7 +187,7 @@ internal class IdentifiserRevurderingsopphørSomIkkeStøttesTest {
 
     @Test
     fun `identifiserer delvis opphør hvis første måned gir opphør og andre måneder er uendret - under minstebeløp`() {
-        val vilkårsvurderinger = vilkårsvurderingerInnvilget()
+        val vilkårsvurderinger = vilkårsvurderingerSøknadsbehandlingInnvilget()
 
         val tidligereBeregning = beregning()
 
@@ -215,7 +215,7 @@ internal class IdentifiserRevurderingsopphørSomIkkeStøttesTest {
 
     @Test
     fun `identifiserer delvis opphør hvis første måned gir opphør og andre måneder er uendret - for høy inntekt`() {
-        val vilkårsvurderinger = vilkårsvurderingerInnvilget()
+        val vilkårsvurderinger = vilkårsvurderingerSøknadsbehandlingInnvilget()
 
         val tidligereBeregning = beregning()
 
@@ -247,7 +247,7 @@ internal class IdentifiserRevurderingsopphørSomIkkeStøttesTest {
 
         IdentifiserRevurderingsopphørSomIkkeStøttes.MedBeregning(
             revurderingsperiode = periode2021,
-            vilkårsvurderinger = vilkårsvurderingerInnvilget(periodeDesember2021),
+            vilkårsvurderinger = vilkårsvurderingerSøknadsbehandlingInnvilget(periodeDesember2021),
             tidligereBeregning = beregning,
             nyBeregning = beregning,
             clock = fixedClock,

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/VurderOpphørVedRevurderingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/VurderOpphørVedRevurderingTest.kt
@@ -25,7 +25,7 @@ import no.nav.su.se.bakover.test.beregningAvslagUnderMinstebeløp
 import no.nav.su.se.bakover.test.create
 import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.fradragsgrunnlagArbeidsinntekt
-import no.nav.su.se.bakover.test.vilkårsvurderingerInnvilgetRevurdering
+import no.nav.su.se.bakover.test.vilkårsvurderingerRevurderingInnvilget
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.mock
@@ -39,7 +39,7 @@ internal class VurderOpphørVedRevurderingTest {
 
     @Test
     fun `vilkår som ikke er oppfylt gir opphør`() {
-        val vilkårsvurderinger = vilkårsvurderingerInnvilgetRevurdering(
+        val vilkårsvurderinger = vilkårsvurderingerRevurderingInnvilget(
             uføre = Vilkår.Uførhet.Vurdert.create(
                 vurderingsperioder = nonEmptyListOf(
                     Vurderingsperiode.Uføre.create(
@@ -72,7 +72,7 @@ internal class VurderOpphørVedRevurderingTest {
 
     @Test
     fun `en fremtidig måned under minstebeløp gir opphør`() {
-        val vilkårsvurderinger = vilkårsvurderingerInnvilgetRevurdering()
+        val vilkårsvurderinger = vilkårsvurderingerRevurderingInnvilget()
         val beregning = beregning(
             fradragsgrunnlag = nonEmptyListOf(
                 fradragsgrunnlagArbeidsinntekt(
@@ -91,7 +91,7 @@ internal class VurderOpphørVedRevurderingTest {
 
     @Test
     fun `alle fremtidige måneder under minstebeløp gir opphør`() {
-        val vilkårsvurderinger = vilkårsvurderingerInnvilgetRevurdering()
+        val vilkårsvurderinger = vilkårsvurderingerRevurderingInnvilget()
         val beregning = beregning(
             fradragsgrunnlag = nonEmptyListOf(
                 fradragsgrunnlagArbeidsinntekt(
@@ -110,7 +110,7 @@ internal class VurderOpphørVedRevurderingTest {
 
     @Test
     fun `inneværende måned under minstebeløp gir opphør`() {
-        val vilkårsvurderinger = vilkårsvurderingerInnvilgetRevurdering()
+        val vilkårsvurderinger = vilkårsvurderingerRevurderingInnvilget()
         val beregning = beregning(
             fradragsgrunnlag = nonEmptyListOf(
                 fradragsgrunnlagArbeidsinntekt(
@@ -132,7 +132,7 @@ internal class VurderOpphørVedRevurderingTest {
 
     @Test
     fun `en fremtidig måned med beløp lik 0 gir opphør`() {
-        val vilkårsvurderinger = vilkårsvurderingerInnvilgetRevurdering()
+        val vilkårsvurderinger = vilkårsvurderingerRevurderingInnvilget()
         val beregning = beregning(
             fradragsgrunnlag = nonEmptyListOf(
                 fradragsgrunnlagArbeidsinntekt(
@@ -151,7 +151,7 @@ internal class VurderOpphørVedRevurderingTest {
 
     @Test
     fun `en måned i fortiden under minstebeløp gir ikke opphør`() {
-        val vilkårsvurderinger = vilkårsvurderingerInnvilgetRevurdering()
+        val vilkårsvurderinger = vilkårsvurderingerRevurderingInnvilget()
         val beregning = beregning(
             fradragsgrunnlag = nonEmptyListOf(
                 fradragsgrunnlagArbeidsinntekt(
@@ -170,7 +170,7 @@ internal class VurderOpphørVedRevurderingTest {
 
     @Test
     fun `en måned i fortiden med beløp lik 0 gir ikke opphør`() {
-        val vilkårsvurderinger = vilkårsvurderingerInnvilgetRevurdering()
+        val vilkårsvurderinger = vilkårsvurderingerRevurderingInnvilget()
         val beregning = beregning(
             fradragsgrunnlag = nonEmptyListOf(
                 fradragsgrunnlagArbeidsinntekt(
@@ -189,7 +189,7 @@ internal class VurderOpphørVedRevurderingTest {
 
     @Test
     fun `alle måneder i fortiden med beløp lik 0 gir opphør`() {
-        val vilkårsvurderinger = vilkårsvurderingerInnvilgetRevurdering()
+        val vilkårsvurderinger = vilkårsvurderingerRevurderingInnvilget()
         val beregning = beregningAvslagForHøyInntekt()
 
         VurderOpphørVedRevurdering.VilkårsvurderingerOgBeregning(
@@ -201,7 +201,7 @@ internal class VurderOpphørVedRevurderingTest {
 
     @Test
     fun `alle måneder i fortiden med beløp under minstegrense gir opphør`() {
-        val vilkårsvurderinger = vilkårsvurderingerInnvilgetRevurdering()
+        val vilkårsvurderinger = vilkårsvurderingerRevurderingInnvilget()
         val beregning = beregningAvslagUnderMinstebeløp()
 
         VurderOpphørVedRevurdering.VilkårsvurderingerOgBeregning(
@@ -224,7 +224,7 @@ internal class VurderOpphørVedRevurderingTest {
 
     @Test
     fun `vilkår har prioritet over beregning når det kommer til hva som fører til opphør`() {
-        val vilkårsvurderinger = vilkårsvurderingerInnvilgetRevurdering(
+        val vilkårsvurderinger = vilkårsvurderingerRevurderingInnvilget(
             uføre = avslåttUførevilkårUtenGrunnlag(),
         )
         val beregning = beregningAvslagForHøyInntekt()

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/StatusovergangTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/StatusovergangTest.kt
@@ -30,7 +30,7 @@ import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertAvslag
 import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertInnvilget
 import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertUavklart
 import no.nav.su.se.bakover.test.utlandsoppholdInnvilget
-import no.nav.su.se.bakover.test.vilkårsvurderingerInnvilget
+import no.nav.su.se.bakover.test.vilkårsvurderingerSøknadsbehandlingInnvilget
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -53,7 +53,7 @@ internal class StatusovergangTest {
 
     private val vilkårsvurdertInnvilget: Søknadsbehandling.Vilkårsvurdert.Innvilget =
         søknadsbehandlingVilkårsvurdertInnvilget(
-            vilkårsvurderinger = vilkårsvurderingerInnvilget(
+            vilkårsvurderinger = vilkårsvurderingerSøknadsbehandlingInnvilget(
                 uføre = innvilgetUførevilkårForventetInntekt12000(),
             ),
         ).second

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vilkår/VilkårsvurderingerTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vilkår/VilkårsvurderingerTest.kt
@@ -27,8 +27,8 @@ import no.nav.su.se.bakover.test.periodeJuli2021
 import no.nav.su.se.bakover.test.periodeMai2021
 import no.nav.su.se.bakover.test.vilkårsvurderingerAvslåttAlle
 import no.nav.su.se.bakover.test.vilkårsvurderingerAvslåttAlleRevurdering
-import no.nav.su.se.bakover.test.vilkårsvurderingerInnvilget
-import no.nav.su.se.bakover.test.vilkårsvurderingerInnvilgetRevurdering
+import no.nav.su.se.bakover.test.vilkårsvurderingerRevurderingInnvilget
+import no.nav.su.se.bakover.test.vilkårsvurderingerSøknadsbehandlingInnvilget
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.util.UUID
@@ -40,7 +40,7 @@ internal class VilkårsvurderingerTest {
 
         @Test
         fun `alle vilkår innvilget gir resultat innvilget`() {
-            vilkårsvurderingerInnvilget().let {
+            vilkårsvurderingerSøknadsbehandlingInnvilget().let {
                 it.resultat shouldBe Vilkårsvurderingsresultat.Innvilget(
                     setOf(
                         it.uføre,
@@ -58,7 +58,7 @@ internal class VilkårsvurderingerTest {
 
         @Test
         fun `alle vilkår innvilget bortsett fra en enkelt vurderingsperiode gir avslag`() {
-            vilkårsvurderingerInnvilget(
+            vilkårsvurderingerSøknadsbehandlingInnvilget(
                 uføre = Vilkår.Uførhet.Vurdert.tryCreate(
                     vurderingsperioder = nonEmptyListOf(
                         Vurderingsperiode.Uføre.tryCreate(
@@ -125,7 +125,7 @@ internal class VilkårsvurderingerTest {
 
         @Test
         fun `et vilkår uavklart gir uavklart`() {
-            vilkårsvurderingerInnvilget(
+            vilkårsvurderingerSøknadsbehandlingInnvilget(
                 behandlingsinformasjon = Behandlingsinformasjon().withAlleVilkårOppfylt().patch(
                     Behandlingsinformasjon(
                         lovligOpphold = Behandlingsinformasjon.LovligOpphold(
@@ -163,7 +163,7 @@ internal class VilkårsvurderingerTest {
             val gammel = Periode.create(1.januar(2021), 31.desember(2021))
             val ny = Periode.create(1.juli(2021), 31.desember(2021))
 
-            vilkårsvurderingerInnvilget(periode = gammel)
+            vilkårsvurderingerSøknadsbehandlingInnvilget(periode = gammel)
                 .let {
                     it.periode shouldBe gammel
                     it.oppdaterStønadsperiode(Stønadsperiode.create(ny, "")).periode shouldBe ny
@@ -172,8 +172,8 @@ internal class VilkårsvurderingerTest {
 
         @Test
         fun `likhet`() {
-            val a = vilkårsvurderingerInnvilget()
-            val b = vilkårsvurderingerInnvilget()
+            val a = vilkårsvurderingerSøknadsbehandlingInnvilget()
+            val b = vilkårsvurderingerSøknadsbehandlingInnvilget()
             a shouldBe b
             (a == b) shouldBe true
             a.erLik(b) shouldBe true
@@ -191,8 +191,8 @@ internal class VilkårsvurderingerTest {
 
         @Test
         fun `likhet bryr seg bare om den funksjonelle betydningen av verdiene`() {
-            val a = vilkårsvurderingerInnvilget(periode = periodeMai2021)
-            val b = vilkårsvurderingerInnvilget(periode = periodeJuli2021)
+            val a = vilkårsvurderingerSøknadsbehandlingInnvilget(periode = periodeMai2021)
+            val b = vilkårsvurderingerSøknadsbehandlingInnvilget(periode = periodeJuli2021)
 
             a shouldBe b
             (a == b) shouldBe true
@@ -201,7 +201,7 @@ internal class VilkårsvurderingerTest {
 
         @Test
         fun `oppdaterer vilkårsvurderinger med informasjon fra behandlingsinformasjon`() {
-            val innvilget = vilkårsvurderingerInnvilget()
+            val innvilget = vilkårsvurderingerSøknadsbehandlingInnvilget()
             innvilget.resultat shouldBe beOfType<Vilkårsvurderingsresultat.Innvilget>()
 
             innvilget.oppdater(
@@ -221,7 +221,7 @@ internal class VilkårsvurderingerTest {
 
         @Test
         fun `legg til erstatter eksisternde vilkår med nytt`() {
-            val innvilget = vilkårsvurderingerInnvilget()
+            val innvilget = vilkårsvurderingerSøknadsbehandlingInnvilget()
             val uavklart = Vilkårsvurderinger.Søknadsbehandling.IkkeVurdert
 
             uavklart.vilkår shouldBe setOf(
@@ -268,7 +268,7 @@ internal class VilkårsvurderingerTest {
 
         @Test
         fun `alle vilkår innvilget gir resultat innvilget`() {
-            vilkårsvurderingerInnvilgetRevurdering().let {
+            vilkårsvurderingerRevurderingInnvilget().let {
                 it.resultat shouldBe Vilkårsvurderingsresultat.Innvilget(
                     setOf(
                         it.uføre,
@@ -281,7 +281,7 @@ internal class VilkårsvurderingerTest {
 
         @Test
         fun `alle vilkår innvilget bortsett fra en enkelt vurderingsperiode gir avslag`() {
-            vilkårsvurderingerInnvilgetRevurdering(
+            vilkårsvurderingerRevurderingInnvilget(
                 uføre = Vilkår.Uførhet.Vurdert.tryCreate(
                     vurderingsperioder = nonEmptyListOf(
                         Vurderingsperiode.Uføre.tryCreate(
@@ -343,7 +343,7 @@ internal class VilkårsvurderingerTest {
 
         @Test
         fun `et vilkår uavklart gir uavklart`() {
-            vilkårsvurderingerInnvilgetRevurdering(
+            vilkårsvurderingerRevurderingInnvilget(
                 uføre = Vilkår.Uførhet.IkkeVurdert,
             ).let {
                 it.resultat shouldBe Vilkårsvurderingsresultat.Uavklart(
@@ -370,7 +370,7 @@ internal class VilkårsvurderingerTest {
             val gammel = Periode.create(1.januar(2021), 31.desember(2021))
             val ny = Periode.create(1.juli(2021), 31.desember(2021))
 
-            vilkårsvurderingerInnvilgetRevurdering(periode = gammel)
+            vilkårsvurderingerRevurderingInnvilget(periode = gammel)
                 .let {
                     it.periode shouldBe gammel
                     it.oppdaterStønadsperiode(Stønadsperiode.create(ny, "")).periode shouldBe ny
@@ -391,8 +391,8 @@ internal class VilkårsvurderingerTest {
 
         @Test
         fun `likhet`() {
-            val a = vilkårsvurderingerInnvilgetRevurdering()
-            val b = vilkårsvurderingerInnvilgetRevurdering()
+            val a = vilkårsvurderingerRevurderingInnvilget()
+            val b = vilkårsvurderingerRevurderingInnvilget()
             a shouldBe b
             (a == b) shouldBe true
             a.erLik(b) shouldBe true
@@ -410,8 +410,8 @@ internal class VilkårsvurderingerTest {
 
         @Test
         fun `likhet bryr seg bare om den funksjonelle betydningen av verdiene`() {
-            val a = vilkårsvurderingerInnvilgetRevurdering(periode = periodeMai2021)
-            val b = vilkårsvurderingerInnvilgetRevurdering(periode = periodeJuli2021)
+            val a = vilkårsvurderingerRevurderingInnvilget(periode = periodeMai2021)
+            val b = vilkårsvurderingerRevurderingInnvilget(periode = periodeJuli2021)
 
             a shouldBe b
             (a == b) shouldBe true

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitorTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitorTest.kt
@@ -76,7 +76,7 @@ import no.nav.su.se.bakover.test.opprettetRevurderingFraInnvilgetSøknadsbehandl
 import no.nav.su.se.bakover.test.simulertUtbetalingOpphør
 import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertInnvilget
 import no.nav.su.se.bakover.test.utlandsoppholdInnvilget
-import no.nav.su.se.bakover.test.vilkårsvurderingerInnvilget
+import no.nav.su.se.bakover.test.vilkårsvurderingerSøknadsbehandlingInnvilget
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.Clock
@@ -1224,7 +1224,7 @@ internal class LagBrevRequestVisitorTest {
                         bosituasjongrunnlagEnslig(periode = opphørsperiode),
                     ),
                 ),
-                vilkårsvurderinger = vilkårsvurderingerInnvilget(
+                vilkårsvurderinger = vilkårsvurderingerSøknadsbehandlingInnvilget(
                     periode = opphørsperiode,
                 ),
             ),

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceImpl.kt
@@ -126,7 +126,6 @@ internal class SøknadsbehandlingServiceImpl(
                 søknad = søknad,
                 oppgaveId = søknad.oppgaveId,
                 fnr = søknad.søknadInnhold.personopplysninger.fnr,
-                behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon(),
                 avkorting = avkorting.kanIkke(),
             ),
         )
@@ -254,8 +253,7 @@ internal class SøknadsbehandlingServiceImpl(
         }
         val eksisterendeOppgaveId: OppgaveId = søknadsbehandling.oppgaveId
 
-        val tilordnetRessurs: NavIdentBruker.Attestant? =
-            søknadsbehandlingRepo.hentEventuellTidligereAttestering(søknadsbehandling.id)?.attestant
+        val tilordnetRessurs: NavIdentBruker.Attestant? = søknadsbehandling.attesteringer.lastOrNull()?.attestant
 
         val nyOppgaveId: OppgaveId = oppgaveService.opprettOppgave(
             OppgaveConfig.AttesterSøknadsbehandling(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/LeggTilFradragsgrunnlagTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/LeggTilFradragsgrunnlagTest.kt
@@ -24,7 +24,7 @@ import no.nav.su.se.bakover.test.lagFradragsgrunnlag
 import no.nav.su.se.bakover.test.opprettetRevurderingFraInnvilgetSøknadsbehandlingsVedtak
 import no.nav.su.se.bakover.test.revurderingId
 import no.nav.su.se.bakover.test.tilAttesteringRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak
-import no.nav.su.se.bakover.test.vilkårsvurderingerInnvilget
+import no.nav.su.se.bakover.test.vilkårsvurderingerSøknadsbehandlingInnvilget
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -162,7 +162,7 @@ internal class LeggTilFradragsgrunnlagTest {
         val opprettetRevurdering = opprettetRevurderingFraInnvilgetSøknadsbehandlingsVedtak(
             revurderingsperiode = revurderingsperiode,
             grunnlagsdataOgVilkårsvurderinger = GrunnlagsdataOgVilkårsvurderinger.Søknadsbehandling(
-                vilkårsvurderinger = vilkårsvurderingerInnvilget(periode = revurderingsperiode),
+                vilkårsvurderinger = vilkårsvurderingerSøknadsbehandlingInnvilget(periode = revurderingsperiode),
                 grunnlagsdata = Grunnlagsdata.create(
                     bosituasjon = listOf(
                         Grunnlag.Bosituasjon.Fullstendig.Enslig(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OppdaterRevurderingServiceTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OppdaterRevurderingServiceTest.kt
@@ -76,7 +76,7 @@ import no.nav.su.se.bakover.test.utlandsoppholdAvslag
 import no.nav.su.se.bakover.test.vedtakRevurdering
 import no.nav.su.se.bakover.test.vedtakRevurderingIverksattInnvilget
 import no.nav.su.se.bakover.test.vedtakSøknadsbehandlingIverksattInnvilget
-import no.nav.su.se.bakover.test.vilkårsvurderingerInnvilget
+import no.nav.su.se.bakover.test.vilkårsvurderingerSøknadsbehandlingInnvilget
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -312,7 +312,7 @@ internal class OppdaterRevurderingServiceTest {
         val mocks = RevurderingServiceMocks(
             vedtakService = vedtakServiceMock,
             revurderingRepo = revurderingRepoMock,
-            avkortingsvarselRepo = mock() {
+            avkortingsvarselRepo = mock {
                 on { hentUtestående(any()) } doReturn Avkortingsvarsel.Ingen
             },
         )
@@ -358,7 +358,7 @@ internal class OppdaterRevurderingServiceTest {
         val mocks = RevurderingServiceMocks(
             vedtakService = vedtakServiceMock,
             revurderingRepo = revurderingRepoMock,
-            avkortingsvarselRepo = mock() {
+            avkortingsvarselRepo = mock {
                 on { hentUtestående(any()) } doReturn Avkortingsvarsel.Ingen
             },
         )
@@ -458,7 +458,7 @@ internal class OppdaterRevurderingServiceTest {
         val mocks = RevurderingServiceMocks(
             vedtakService = vedtakServiceMock,
             revurderingRepo = revurderingRepoMock,
-            avkortingsvarselRepo = mock() {
+            avkortingsvarselRepo = mock {
                 on { hentUtestående(any()) } doReturn Avkortingsvarsel.Ingen
             },
         )
@@ -700,18 +700,18 @@ internal class OppdaterRevurderingServiceTest {
                     ),
                     fradragsgrunnlag = listOf(
                         fradragsgrunnlagArbeidsinntekt(
-                            periodeMedEPS,
-                            5000.0,
-                            FradragTilhører.EPS,
+                            periode = periodeMedEPS,
+                            arbeidsinntekt = 5000.0,
+                            tilhører = FradragTilhører.EPS,
                         ),
                         fradragsgrunnlagArbeidsinntekt(
-                            periodeMedEPS,
-                            5000.0,
-                            FradragTilhører.BRUKER,
+                            periode = periodeMedEPS,
+                            arbeidsinntekt = 5000.0,
+                            tilhører = FradragTilhører.BRUKER,
                         ),
                     ),
                 ),
-                vilkårsvurderinger = vilkårsvurderingerInnvilget(periodeMedEPS),
+                vilkårsvurderinger = vilkårsvurderingerSøknadsbehandlingInnvilget(periodeMedEPS),
             ),
         )
 

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OpprettRevurderingServiceTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/OpprettRevurderingServiceTest.kt
@@ -75,7 +75,7 @@ import no.nav.su.se.bakover.test.uføregrunnlagForventetInntekt12000
 import no.nav.su.se.bakover.test.utlandsoppholdAvslag
 import no.nav.su.se.bakover.test.utlandsoppholdInnvilget
 import no.nav.su.se.bakover.test.vedtakRevurdering
-import no.nav.su.se.bakover.test.vilkårsvurderingerInnvilget
+import no.nav.su.se.bakover.test.vilkårsvurderingerSøknadsbehandlingInnvilget
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -98,7 +98,7 @@ internal class OpprettRevurderingServiceTest {
 
     private fun createInnvilgetBehandling() = søknadsbehandlingIverksattInnvilget(
         stønadsperiode = stønadsperiodeNesteMånedOgTreMånederFram,
-        vilkårsvurderinger = vilkårsvurderingerInnvilget(
+        vilkårsvurderinger = vilkårsvurderingerSøknadsbehandlingInnvilget(
             periode = periodeNesteMånedOgTreMånederFram,
             uføre = vilkårsvurderingUføre,
         ),

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingSendTilAttesteringTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingSendTilAttesteringTest.kt
@@ -48,7 +48,7 @@ import no.nav.su.se.bakover.test.simulertRevurderingInnvilgetFraInnvilgetSøknad
 import no.nav.su.se.bakover.test.simulertRevurderingOpphørtUføreFraInnvilgetSøknadsbehandlingsVedtak
 import no.nav.su.se.bakover.test.stønadsperiode2021
 import no.nav.su.se.bakover.test.vilkårsvurderingerAvslåttUføreOgAndreInnvilget
-import no.nav.su.se.bakover.test.vilkårsvurderingerInnvilgetRevurdering
+import no.nav.su.se.bakover.test.vilkårsvurderingerRevurderingInnvilget
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -324,7 +324,7 @@ internal class RevurderingSendTilAttesteringTest {
                 tilOgMed = revurderingsperiode.tilOgMed,
             )
 
-            val vilkårsvurderinger = vilkårsvurderingerInnvilgetRevurdering(
+            val vilkårsvurderinger = vilkårsvurderingerRevurderingInnvilget(
                 periode = revurderingsperiode,
                 formue = Vilkår.Formue.Vurdert.createFromGrunnlag(
                     grunnlag = nonEmptyListOf(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceLeggTilFradragsgrunnlagTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceLeggTilFradragsgrunnlagTest.kt
@@ -27,7 +27,7 @@ import no.nav.su.se.bakover.test.lagFradragsgrunnlag
 import no.nav.su.se.bakover.test.opprettetRevurderingFraInnvilgetSøknadsbehandlingsVedtak
 import no.nav.su.se.bakover.test.revurderingId
 import no.nav.su.se.bakover.test.tilAttesteringRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak
-import no.nav.su.se.bakover.test.vilkårsvurderingerInnvilget
+import no.nav.su.se.bakover.test.vilkårsvurderingerSøknadsbehandlingInnvilget
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 import org.mockito.kotlin.any
@@ -171,7 +171,7 @@ internal class RevurderingServiceLeggTilFradragsgrunnlagTest {
         val opprettetRevurdering = opprettetRevurderingFraInnvilgetSøknadsbehandlingsVedtak(
             revurderingsperiode = revurderingsperiode,
             grunnlagsdataOgVilkårsvurderinger = GrunnlagsdataOgVilkårsvurderinger.Søknadsbehandling(
-                vilkårsvurderinger = vilkårsvurderingerInnvilget(periode = revurderingsperiode),
+                vilkårsvurderinger = vilkårsvurderingerSøknadsbehandlingInnvilget(periode = revurderingsperiode),
                 grunnlagsdata = Grunnlagsdata.create(
                     bosituasjon = listOf(
                         Grunnlag.Bosituasjon.Fullstendig.Enslig(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceAttesteringTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceAttesteringTest.kt
@@ -98,7 +98,6 @@ class SøknadsbehandlingServiceAttesteringTest {
     fun `sjekk at vi sender inn riktig oppgaveId ved lukking av oppgave ved attestering`() {
         val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
             on { hent(any()) } doReturn simulertBehandling
-            on { hentEventuellTidligereAttestering(any()) } doReturn null
         }
 
         val personServiceMock: PersonService = mock {
@@ -144,7 +143,6 @@ class SøknadsbehandlingServiceAttesteringTest {
         inOrder(søknadsbehandlingRepoMock, personServiceMock, oppgaveServiceMock, eventObserver) {
             verify(søknadsbehandlingRepoMock).hent(simulertBehandling.id)
             verify(personServiceMock).hentAktørId(fnr)
-            verify(søknadsbehandlingRepoMock).hentEventuellTidligereAttestering(simulertBehandling.id)
             verify(oppgaveServiceMock).opprettOppgave(
                 config = OppgaveConfig.AttesterSøknadsbehandling(
                     søknadId = søknadId,
@@ -218,7 +216,6 @@ class SøknadsbehandlingServiceAttesteringTest {
     fun `svarer med feil dersom man ikke får til å opprette oppgave til attestant`() {
         val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
             on { hent(any()) } doReturn simulertBehandling
-            on { hentEventuellTidligereAttestering(simulertBehandling.id) } doReturn null
         }
 
         val personServiceMock: PersonService = mock {
@@ -240,7 +237,6 @@ class SøknadsbehandlingServiceAttesteringTest {
 
         verify(søknadsbehandlingRepoMock).hent(simulertBehandling.id)
         verify(personServiceMock).hentAktørId(simulertBehandling.fnr)
-        verify(søknadsbehandlingRepoMock).hentEventuellTidligereAttestering(simulertBehandling.id)
         verify(oppgaveServiceMock).opprettOppgave(
             argThat {
                 it shouldBe OppgaveConfig.AttesterSøknadsbehandling(
@@ -259,7 +255,6 @@ class SøknadsbehandlingServiceAttesteringTest {
     fun `sender til attestering selv om lukking av eksisterende oppgave feiler`() {
         val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
             on { hent(any()) } doReturn simulertBehandling
-            on { hentEventuellTidligereAttestering(any()) } doReturn null
         }
 
         val personServiceMock: PersonService = mock {
@@ -307,7 +302,6 @@ class SøknadsbehandlingServiceAttesteringTest {
         inOrder(søknadsbehandlingRepoMock, personServiceMock, oppgaveServiceMock, eventObserver) {
             verify(søknadsbehandlingRepoMock).hent(simulertBehandling.id)
             verify(personServiceMock).hentAktørId(fnr)
-            verify(søknadsbehandlingRepoMock).hentEventuellTidligereAttestering(simulertBehandling.id)
             verify(oppgaveServiceMock).opprettOppgave(
                 config = OppgaveConfig.AttesterSøknadsbehandling(
                     søknadId = søknadId,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceOpprettetTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceOpprettetTest.kt
@@ -244,7 +244,6 @@ internal class SøknadsbehandlingServiceOpprettetTest {
                     sakId = søknad.sakId,
                     søknad = søknad,
                     oppgaveId = søknad.oppgaveId,
-                    behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon(),
                     fnr = søknad.søknadInnhold.personopplysninger.fnr,
                     avkorting = AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående.kanIkke()
                 )

--- a/test-common/src/main/kotlin/GenerelleTestData.kt
+++ b/test-common/src/main/kotlin/GenerelleTestData.kt
@@ -78,6 +78,7 @@ fun person(
 )
 
 val stønadsperiode2021 = Stønadsperiode.create(periode2021, "stønadsperiode2021")
+val stønadsperiode2022 = Stønadsperiode.create(periode2022, "stønadsperiode2022")
 
 val attestant = NavIdentBruker.Attestant("attestant")
 const val attestantNavn = "Att E. Stant"

--- a/test-common/src/main/kotlin/GrunnlagsdataTestData.kt
+++ b/test-common/src/main/kotlin/GrunnlagsdataTestData.kt
@@ -11,24 +11,23 @@ import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import java.util.UUID
 
-val fradragsgrunnlagId: UUID = UUID.randomUUID()
-
 fun fradragsgrunnlagArbeidsinntekt1000(
     periode: Periode = periode2021,
 ): Grunnlag.Fradragsgrunnlag {
-    return fradragsgrunnlagArbeidsinntekt(periode = periode, 1000.0)
+    return fradragsgrunnlagArbeidsinntekt(periode = periode, arbeidsinntekt = 1000.0)
 }
 
 /**
  * For bruker.
  */
 fun fradragsgrunnlagArbeidsinntekt(
+    id: UUID = UUID.randomUUID(),
     periode: Periode = periode2021,
     arbeidsinntekt: Double,
     tilhører: FradragTilhører = FradragTilhører.BRUKER,
 ): Grunnlag.Fradragsgrunnlag {
     return lagFradragsgrunnlag(
-        id = fradragsgrunnlagId,
+        id = id,
         type = Fradragstype.Arbeidsinntekt,
         månedsbeløp = arbeidsinntekt,
         periode = periode,
@@ -37,10 +36,8 @@ fun fradragsgrunnlagArbeidsinntekt(
     )
 }
 
-val bosituasjonId: UUID = UUID.randomUUID()
-
 fun bosituasjongrunnlagEnslig(
-    id: UUID = bosituasjonId,
+    id: UUID = UUID.randomUUID(),
     periode: Periode = periode2021,
 ): Grunnlag.Bosituasjon.Fullstendig.Enslig {
     return Grunnlag.Bosituasjon.Fullstendig.Enslig(
@@ -52,7 +49,7 @@ fun bosituasjongrunnlagEnslig(
 }
 
 fun bosituasjongrunnlagEpsUførFlyktning(
-    id: UUID = bosituasjonId,
+    id: UUID = UUID.randomUUID(),
     periode: Periode = periode2021,
     epsFnr: Fnr = no.nav.su.se.bakover.test.epsFnr,
 ): Grunnlag.Bosituasjon.Fullstendig.EktefellePartnerSamboer {
@@ -94,6 +91,30 @@ fun grunnlagsdataEnsligMedFradrag(
         ),
     ),
     bosituasjon: Nel<Grunnlag.Bosituasjon> = nonEmptyListOf(bosituasjongrunnlagEnslig(periode = periode)),
+): Grunnlagsdata {
+    return Grunnlagsdata.create(fradragsgrunnlag, bosituasjon)
+}
+
+/**
+ * Defaults:
+ * periode: 2021
+ * fradragsgrunnlag: 1000 kroner i arbeidsinntekt/mnd for bruker
+ * bosituasjon: eps ufør flyktning
+ */
+fun grunnlagsdataMedEpsMedFradrag(
+    periode: Periode = periode2021,
+    epsFnr: Fnr = Fnr.generer(),
+    fradragsgrunnlag: NonEmptyList<Grunnlag.Fradragsgrunnlag> = nonEmptyListOf(
+        fradragsgrunnlagArbeidsinntekt1000(
+            periode = periode,
+        ),
+    ),
+    bosituasjon: Nel<Grunnlag.Bosituasjon> = nonEmptyListOf(
+        bosituasjongrunnlagEpsUførFlyktning(
+            epsFnr = epsFnr,
+            periode = periode,
+        ),
+    ),
 ): Grunnlagsdata {
     return Grunnlagsdata.create(fradragsgrunnlag, bosituasjon)
 }

--- a/test-common/src/main/kotlin/KlageTestData.kt
+++ b/test-common/src/main/kotlin/KlageTestData.kt
@@ -588,7 +588,7 @@ fun underkjentKlageTilVurdering(
     vedtaksvurdering: VurderingerTilKlage.Vedtaksvurdering = VurderingerTilKlage.Vedtaksvurdering.createOppretthold(
         hjemler = Hjemler.tryCreate(listOf(Hjemmel.SU_PARAGRAF_3, Hjemmel.SU_PARAGRAF_4)).orNull()!!,
     ).orNull()!!,
-    attestant: NavIdentBruker.Attestant = NavIdentBruker.Attestant("attestant"),
+    attestant: NavIdentBruker.Attestant = no.nav.su.se.bakover.test.attestant,
     attesteringsgrunn: Attestering.Underkjent.Grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
     attesteringskommentar: String = "attesteringskommentar",
     sakMedVedtak: Sak = vedtakSøknadsbehandlingIverksattInnvilget().first,
@@ -639,7 +639,7 @@ fun underkjentAvvistKlage(
     erUnderskrevet: VilkårsvurderingerTilKlage.Svarord = VilkårsvurderingerTilKlage.Svarord.JA,
     begrunnelse: String = "begrunnelse",
     sakMedVedtak: Sak = vedtakSøknadsbehandlingIverksattInnvilget().first,
-    attestant: NavIdentBruker.Attestant = NavIdentBruker.Attestant("attestant"),
+    attestant: NavIdentBruker.Attestant = no.nav.su.se.bakover.test.attestant,
     attesteringsgrunn: Attestering.Underkjent.Grunn = Attestering.Underkjent.Grunn.ANDRE_FORHOLD,
     attesteringskommentar: String = "attesteringskommentar",
 ): Pair<Sak, AvvistKlage> {
@@ -737,7 +737,7 @@ fun oversendtKlage(
     vedtaksvurdering: VurderingerTilKlage.Vedtaksvurdering = VurderingerTilKlage.Vedtaksvurdering.createOppretthold(
         hjemler = Hjemler.tryCreate(listOf(Hjemmel.SU_PARAGRAF_3, Hjemmel.SU_PARAGRAF_4)).orNull()!!,
     ).orNull()!!,
-    attestant: NavIdentBruker.Attestant = NavIdentBruker.Attestant("attestant"),
+    attestant: NavIdentBruker.Attestant = no.nav.su.se.bakover.test.attestant,
     sakMedVedtak: Sak = vedtakSøknadsbehandlingIverksattInnvilget().first,
 ): Pair<Sak, OversendtKlage> {
     return vurdertKlageTilAttestering(
@@ -784,7 +784,7 @@ fun iverksattAvvistKlage(
     erUnderskrevet: VilkårsvurderingerTilKlage.Svarord = VilkårsvurderingerTilKlage.Svarord.JA,
     begrunnelse: String = "begrunnelse",
     fritekstTilBrev: String = "dette er en fritekst med person opplysninger",
-    attestant: NavIdentBruker.Attestant = NavIdentBruker.Attestant("attestant"),
+    attestant: NavIdentBruker.Attestant = no.nav.su.se.bakover.test.attestant,
     sakMedVedtak: Sak = vedtakSøknadsbehandlingIverksattInnvilget().first,
 ): Pair<Sak, IverksattAvvistKlage> {
     return avvistKlageTilAttestering(

--- a/test-common/src/main/kotlin/PeriodeTestData.kt
+++ b/test-common/src/main/kotlin/PeriodeTestData.kt
@@ -17,6 +17,9 @@ import no.nav.su.se.bakover.common.september
 /** 2021-01-01 - 2021-12-31 */
 val periode2021 = Periode.create(fraOgMed = 1.januar(2021), tilOgMed = 31.desember(2021))
 
+/** 2022-01-01 - 2022-12-31 */
+val periode2022 = Periode.create(fraOgMed = 1.januar(2022), tilOgMed = 31.desember(2022))
+
 val periodeJanuar2021 = Periode.create(1.januar(2021), 31.januar(2021))
 val periodeFebruar2021 = Periode.create(1.februar(2021), 28.februar(2021))
 val periodeMars2021 = Periode.create(1.mars(2021), 31.mars(2021))

--- a/test-common/src/main/kotlin/RevurderingTestData.kt
+++ b/test-common/src/main/kotlin/RevurderingTestData.kt
@@ -1212,7 +1212,7 @@ fun underkjentInnvilgetRevurderingFraInnvilgetSøknadsbehandlingsVedtak(
     fritekstTilBrev: String = "",
     forhåndsvarsel: Forhåndsvarsel = Forhåndsvarsel.Ferdigbehandlet.SkalIkkeForhåndsvarsles,
     attestering: Attestering.Underkjent = Attestering.Underkjent(
-        attestant = NavIdentBruker.Attestant(navIdent = "attestant"),
+        attestant = no.nav.su.se.bakover.test.attestant,
         grunn = Attestering.Underkjent.Grunn.INNGANGSVILKÅRENE_ER_FEILVURDERT,
         kommentar = "feil vilkår man",
         opprettet = fixedTidspunkt,
@@ -1265,7 +1265,7 @@ fun iverksattRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak(
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
     fritekstTilBrev: String = "",
     forhåndsvarsel: Forhåndsvarsel = Forhåndsvarsel.Ferdigbehandlet.SkalIkkeForhåndsvarsles,
-    attestant: NavIdentBruker.Attestant = NavIdentBruker.Attestant("Attestant"),
+    attestant: NavIdentBruker.Attestant = no.nav.su.se.bakover.test.attestant,
     revurderingsårsak: Revurderingsårsak = no.nav.su.se.bakover.test.revurderingsårsak,
 ): Pair<Sak, IverksattRevurdering.Innvilget> {
     return tilAttesteringRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak(

--- a/test-common/src/main/kotlin/SakEx.kt
+++ b/test-common/src/main/kotlin/SakEx.kt
@@ -1,0 +1,17 @@
+package no.nav.su.se.bakover.test
+
+import no.nav.su.se.bakover.domain.Sak
+import no.nav.su.se.bakover.domain.søknadsbehandling.Stønadsperiode
+import no.nav.su.se.bakover.domain.vedtak.GjeldendeVedtaksdata
+import java.time.LocalDate
+
+fun Sak.gjeldendeVedtaksdata(stønadsperiode: Stønadsperiode): GjeldendeVedtaksdata {
+    return this.gjeldendeVedtaksdata(
+        fraOgMed = stønadsperiode.periode.fraOgMed,
+    )
+}
+
+// TODO jah+Jacob: Her har vi allerede en opprettet revurdering med gitt stønadsperiode. Kan vi gjøre noe her? Produksjonskoden bruker vedtakservice, men tenker den burde bruke samme domenekode som her.
+fun Sak.gjeldendeVedtaksdata(fraOgMed: LocalDate): GjeldendeVedtaksdata {
+    return this.kopierGjeldendeVedtaksdata(fraOgMed, fixedClock).orNull()!!
+}

--- a/test-common/src/main/kotlin/SøknadsbehandlingTestData.kt
+++ b/test-common/src/main/kotlin/SøknadsbehandlingTestData.kt
@@ -79,7 +79,7 @@ fun søknadsbehandlingVilkårsvurdertInnvilget(
     stønadsperiode: Stønadsperiode = stønadsperiode2021,
     behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,
     grunnlagsdata: Grunnlagsdata = grunnlagsdataEnsligUtenFradrag(stønadsperiode.periode),
-    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerInnvilget(stønadsperiode.periode),
+    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerSøknadsbehandlingInnvilget(stønadsperiode.periode),
     avkorting: AvkortingVedSøknadsbehandling.Uhåndtert = AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående,
 ): Pair<Sak, Søknadsbehandling.Vilkårsvurdert.Innvilget> {
     return søknadsbehandlingVilkårsvurdertUavklart(
@@ -137,7 +137,7 @@ fun søknadsbehandlingBeregnetInnvilget(
     stønadsperiode: Stønadsperiode = stønadsperiode2021,
     behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,
     grunnlagsdata: Grunnlagsdata = grunnlagsdataEnsligUtenFradrag(stønadsperiode.periode),
-    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerInnvilget(stønadsperiode.periode),
+    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerSøknadsbehandlingInnvilget(stønadsperiode.periode),
     avkorting: AvkortingVedSøknadsbehandling.Uhåndtert = AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående,
 ): Pair<Sak, Søknadsbehandling.Beregnet.Innvilget> {
     return søknadsbehandlingVilkårsvurdertInnvilget(
@@ -172,7 +172,7 @@ fun søknadsbehandlingBeregnetAvslag(
     stønadsperiode: Stønadsperiode = stønadsperiode2021,
     behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,
     grunnlagsdata: Grunnlagsdata = grunnlagsdataEnsligUtenFradrag(stønadsperiode.periode),
-    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerInnvilget(
+    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerSøknadsbehandlingInnvilget(
         periode = stønadsperiode.periode,
         uføre = innvilgetUførevilkårForventetInntekt0(
             id = UUID.randomUUID(),
@@ -209,7 +209,7 @@ fun søknadsbehandlingSimulert(
     stønadsperiode: Stønadsperiode = stønadsperiode2021,
     behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,
     grunnlagsdata: Grunnlagsdata = grunnlagsdataEnsligUtenFradrag(stønadsperiode.periode),
-    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerInnvilget(stønadsperiode.periode),
+    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerSøknadsbehandlingInnvilget(stønadsperiode.periode),
     avkorting: AvkortingVedSøknadsbehandling.Uhåndtert = AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående,
 ): Pair<Sak, Søknadsbehandling.Simulert> {
     return søknadsbehandlingBeregnetInnvilget(
@@ -242,7 +242,7 @@ fun søknadsbehandlingTilAttesteringInnvilget(
     stønadsperiode: Stønadsperiode = stønadsperiode2021,
     behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,
     grunnlagsdata: Grunnlagsdata = grunnlagsdataEnsligUtenFradrag(stønadsperiode.periode),
-    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerInnvilget(stønadsperiode.periode),
+    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerSøknadsbehandlingInnvilget(stønadsperiode.periode),
     avkorting: AvkortingVedSøknadsbehandling.Uhåndtert = AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående,
 ): Pair<Sak, Søknadsbehandling.TilAttestering.Innvilget> {
     return søknadsbehandlingSimulert(
@@ -271,7 +271,7 @@ fun søknadsbehandlingTilAttesteringAvslagMedBeregning(
     stønadsperiode: Stønadsperiode = stønadsperiode2021,
     behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,
     grunnlagsdata: Grunnlagsdata = grunnlagsdataEnsligUtenFradrag(stønadsperiode.periode),
-    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerInnvilget(
+    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerSøknadsbehandlingInnvilget(
         periode = stønadsperiode.periode,
         uføre = innvilgetUførevilkårForventetInntekt0(
             id = UUID.randomUUID(),
@@ -335,7 +335,7 @@ fun søknadsbehandlingUnderkjentInnvilget(
     stønadsperiode: Stønadsperiode = stønadsperiode2021,
     behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,
     grunnlagsdata: Grunnlagsdata = grunnlagsdataEnsligUtenFradrag(stønadsperiode.periode),
-    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerInnvilget(stønadsperiode.periode),
+    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerSøknadsbehandlingInnvilget(stønadsperiode.periode),
     clock: Clock = fixedClock,
     attestering: Attestering = attesteringUnderkjent(clock = clock),
 ): Pair<Sak, Søknadsbehandling.Underkjent.Innvilget> {
@@ -391,7 +391,7 @@ fun søknadsbehandlingUnderkjentAvslagMedBeregning(
     stønadsperiode: Stønadsperiode = stønadsperiode2021,
     behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,
     grunnlagsdata: Grunnlagsdata = grunnlagsdataEnsligUtenFradrag(stønadsperiode.periode),
-    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerInnvilget(
+    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerSøknadsbehandlingInnvilget(
         periode = stønadsperiode.periode,
         uføre = innvilgetUførevilkårForventetInntekt0(
             id = UUID.randomUUID(),
@@ -429,7 +429,7 @@ fun søknadsbehandlingIverksattInnvilget(
     stønadsperiode: Stønadsperiode = stønadsperiode2021,
     behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,
     grunnlagsdata: Grunnlagsdata = grunnlagsdataEnsligUtenFradrag(stønadsperiode.periode),
-    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerInnvilget(stønadsperiode.periode),
+    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerSøknadsbehandlingInnvilget(stønadsperiode.periode),
     clock: Clock = fixedClock,
     avkorting: AvkortingVedSøknadsbehandling.Uhåndtert = AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående,
 ): Pair<Sak, Søknadsbehandling.Iverksatt.Innvilget> {
@@ -458,7 +458,7 @@ fun søknadsbehandlingIverksattAvslagMedBeregning(
     stønadsperiode: Stønadsperiode = stønadsperiode2021,
     behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,
     grunnlagsdata: Grunnlagsdata = grunnlagsdataEnsligUtenFradrag(stønadsperiode.periode),
-    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerInnvilget(
+    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerSøknadsbehandlingInnvilget(
         periode = stønadsperiode.periode,
         uføre = innvilgetUførevilkårForventetInntekt0(
             id = UUID.randomUUID(),

--- a/test-common/src/main/kotlin/VedtakTestData.kt
+++ b/test-common/src/main/kotlin/VedtakTestData.kt
@@ -37,7 +37,7 @@ fun vedtakSøknadsbehandlingIverksattInnvilget(
     stønadsperiode: Stønadsperiode = stønadsperiode2021,
     behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,
     grunnlagsdata: Grunnlagsdata = grunnlagsdataEnsligUtenFradrag(stønadsperiode.periode),
-    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerInnvilget(stønadsperiode.periode),
+    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerSøknadsbehandlingInnvilget(stønadsperiode.periode),
     clock: Clock = fixedClock,
     avkorting: AvkortingVedSøknadsbehandling.Uhåndtert = AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående,
 ): Pair<Sak, VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling> {
@@ -77,7 +77,7 @@ fun vedtakSøknadsbehandlingIverksattAvslagMedBeregning(
     stønadsperiode: Stønadsperiode = stønadsperiode2021,
     behandlingsinformasjon: Behandlingsinformasjon = behandlingsinformasjonAlleVilkårInnvilget,
     grunnlagsdata: Grunnlagsdata = grunnlagsdataEnsligUtenFradrag(stønadsperiode.periode),
-    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerInnvilget(
+    vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling = vilkårsvurderingerSøknadsbehandlingInnvilget(
         periode = stønadsperiode.periode,
         uføre = innvilgetUførevilkårForventetInntekt0(
             id = UUID.randomUUID(),

--- a/test-common/src/main/kotlin/VilkårsvurderingerTestData.kt
+++ b/test-common/src/main/kotlin/VilkårsvurderingerTestData.kt
@@ -18,15 +18,12 @@ import no.nav.su.se.bakover.domain.vilkår.Vurderingsperiode
 import no.nav.su.se.bakover.domain.vilkår.VurderingsperiodeUtenlandsopphold
 import java.util.UUID
 
-val uføregrunnlagId: UUID = UUID.randomUUID()
-val utenlandsoppholdId: UUID = UUID.randomUUID()
-
 /**
  * 100% uføregrad
  * 0 forventet inntekt
  * */
 fun uføregrunnlagForventetInntekt0(
-    id: UUID = uføregrunnlagId,
+    id: UUID = UUID.randomUUID(),
     opprettet: Tidspunkt = fixedTidspunkt,
     periode: Periode = periode2021,
 ): Grunnlag.Uføregrunnlag {
@@ -43,7 +40,7 @@ fun uføregrunnlagForventetInntekt0(
  * 12000 forventet inntekt per år / 1000 per måned
  * */
 fun uføregrunnlagForventetInntekt12000(
-    id: UUID = uføregrunnlagId,
+    id: UUID = UUID.randomUUID(),
     opprettet: Tidspunkt = fixedTidspunkt,
     periode: Periode = periode2021,
 ): Grunnlag.Uføregrunnlag {
@@ -57,7 +54,7 @@ fun uføregrunnlagForventetInntekt12000(
 
 /** 100% uføregrad */
 fun uføregrunnlagForventetInntekt(
-    id: UUID = uføregrunnlagId,
+    id: UUID = UUID.randomUUID(),
     opprettet: Tidspunkt = fixedTidspunkt,
     periode: Periode = periode2021,
     forventetInntekt: Int,
@@ -72,7 +69,7 @@ fun uføregrunnlagForventetInntekt(
 }
 
 fun uføregrunnlag(
-    id: UUID = uføregrunnlagId,
+    id: UUID = UUID.randomUUID(),
     opprettet: Tidspunkt = fixedTidspunkt,
     periode: Periode = periode2021,
     forventetInntekt: Int = 0,
@@ -87,14 +84,12 @@ fun uføregrunnlag(
     )
 }
 
-val uførevilkårId: UUID = UUID.randomUUID()
-
 fun innvilgetUførevilkårForventetInntekt0(
-    id: UUID = uførevilkårId,
+    id: UUID = UUID.randomUUID(),
     opprettet: Tidspunkt = fixedTidspunkt,
     periode: Periode = periode2021,
     uføregrunnlag: Grunnlag.Uføregrunnlag = uføregrunnlagForventetInntekt0(
-        id = uføregrunnlagId,
+        id = UUID.randomUUID(),
         opprettet = opprettet,
         periode = periode,
     )
@@ -114,7 +109,7 @@ fun innvilgetUførevilkårForventetInntekt0(
 }
 
 fun utlandsoppholdInnvilget(
-    id: UUID = utenlandsoppholdId,
+    id: UUID = UUID.randomUUID(),
     opprettet: Tidspunkt = fixedTidspunkt,
     periode: Periode = periode2021,
     grunnlag: Utenlandsoppholdgrunnlag? = null,
@@ -134,7 +129,7 @@ fun utlandsoppholdInnvilget(
 }
 
 fun utlandsoppholdAvslag(
-    id: UUID = utenlandsoppholdId,
+    id: UUID = UUID.randomUUID(),
     opprettet: Tidspunkt = fixedTidspunkt,
     periode: Periode = periode2021,
 ): UtenlandsoppholdVilkår.Vurdert {
@@ -159,7 +154,7 @@ fun innvilgetUførevilkårForventetInntekt12000(
     return Vilkår.Uførhet.Vurdert.create(
         vurderingsperioder = nonEmptyListOf(
             Vurderingsperiode.Uføre.create(
-                id = uførevilkårId,
+                id = UUID.randomUUID(),
                 opprettet = opprettet,
                 resultat = Resultat.Innvilget,
                 grunnlag = uføregrunnlagForventetInntekt12000(opprettet = opprettet, periode = periode),
@@ -171,8 +166,8 @@ fun innvilgetUførevilkårForventetInntekt12000(
 }
 
 fun innvilgetUførevilkår(
-    vurderingsperiodeId: UUID = uførevilkårId,
-    grunnlagsId: UUID = uføregrunnlagId,
+    vurderingsperiodeId: UUID = UUID.randomUUID(),
+    grunnlagsId: UUID = UUID.randomUUID(),
     opprettet: Tidspunkt = fixedTidspunkt,
     periode: Periode = periode2021,
     begrunnelse: String? = "innvilgetUførevilkårForventetInntekt0",
@@ -206,7 +201,7 @@ fun avslåttUførevilkårUtenGrunnlag(
     return Vilkår.Uførhet.Vurdert.create(
         vurderingsperioder = nonEmptyListOf(
             Vurderingsperiode.Uføre.create(
-                id = uførevilkårId,
+                id = UUID.randomUUID(),
                 opprettet = opprettet,
                 resultat = Resultat.Avslag,
                 grunnlag = null,
@@ -310,11 +305,13 @@ fun formuevilkårAvslåttPgrBrukersformue(
 }
 
 /**
+ * periode: 2021
  * uføre: innvilget med forventet inntekt 0
  * bosituasjon: enslig
- * formue: ingen eps, sum 0
+ * formue (via behandlingsinformasjon): ingen eps, sum 0
+ * utenlandsopphold: innvilget
  */
-fun vilkårsvurderingerInnvilget(
+fun vilkårsvurderingerSøknadsbehandlingInnvilget(
     periode: Periode = periode2021,
     uføre: Vilkår.Uførhet = innvilgetUførevilkårForventetInntekt0(
         id = UUID.randomUUID(),
@@ -344,7 +341,7 @@ fun vilkårsvurderingerInnvilget(
     )
 }
 
-fun vilkårsvurderingerInnvilgetRevurdering(
+fun vilkårsvurderingerRevurderingInnvilget(
     periode: Periode = periode2021,
     uføre: Vilkår.Uførhet = innvilgetUførevilkårForventetInntekt0(periode = periode),
     bosituasjon: Grunnlag.Bosituasjon.Fullstendig = bosituasjongrunnlagEnslig(periode = periode),
@@ -362,7 +359,7 @@ fun vilkårsvurderingerAvslåttRevurdering(
     periode: Periode,
     vilkår: Vilkår
 ): Vilkårsvurderinger.Revurdering {
-    return vilkårsvurderingerInnvilgetRevurdering(
+    return vilkårsvurderingerRevurderingInnvilget(
         periode = periode
     ).leggTil(vilkår)
 }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutesKtTest.kt
@@ -843,7 +843,6 @@ internal class SøknadsbehandlingRoutesKtTest {
             sakId = sak.id,
             søknad = søknadMedOppgave,
             oppgaveId = OppgaveId("1234"),
-            behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon(),
             fnr = sak.fnr,
             avkorting = AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående.kanIkke(),
         )

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/beregning/BeregnRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/beregning/BeregnRoutesKtTest.kt
@@ -247,7 +247,6 @@ internal class BeregnRoutesKtTest {
             sakId = sak.id,
             søknad = søknadMedOppgave,
             oppgaveId = OppgaveId("1234"),
-            behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon(),
             fnr = sak.fnr,
             avkorting = AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående.kanIkke(),
         )


### PR DESCRIPTION
I hovedsak ryddet opp i TestDataHelper.kt i databaselaget slik at den skal være litt mer forståelig/enklere å jobbe med. Det er fremdeles mange forbedringspunkter. Spesielt dersom persisteringsfunksjonene kunne persistert mer enn én tilstand om gangen. Da kunne vi gjenbrukt mye mer fra `test-common`-modulen. En annen ting som ville lettet testene i database-modulen er hvis vi utvider web-regresjonstest til å gjøre fler asserts på blant annet søknadsbehandlings-, revurderings-, regulerings, og klageflyten (json-nivå). Disse happy-path testene vil i praksis gjøre at vi kan slette veldig mange av dagens database-tester og noen av service-testene og.