### PR TITLE
Bytt fra utgående til innkommende dokument for klages journalpostid

### DIFF
--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/journalpost/JournalpostClientStub.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/journalpost/JournalpostClientStub.kt
@@ -18,8 +18,8 @@ object JournalpostClientStub : JournalpostClient {
     ): Either<KunneIkkeHenteJournalpost, FerdigstiltJournalpost> {
         return FerdigstiltJournalpost.create(
             tema = Tema.SUP,
-            journalstatus = JournalpostStatus.FERDIGSTILT,
-            journalpostType = JournalpostType.UTGÅENDE_DOKUMENT,
+            journalstatus = JournalpostStatus.JOURNALFOERT,
+            journalpostType = JournalpostType.INNKOMMENDE_DOKUMENT,
             saksnummer = saksnummer,
         ).right()
     }

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/journalpost/JournalpostHttpClient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/journalpost/JournalpostHttpClient.kt
@@ -59,7 +59,7 @@ internal class JournalpostHttpClient(
         return hentJournalpostFraSaf(request).mapLeft {
             it
         }.flatMap {
-            it.toValidertJournalpost(saksnummer)
+            it.toValidertInnkommendeJournalførtJournalpost(saksnummer)
         }
     }
 

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/journalpost/JournalpostResponse.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/journalpost/JournalpostResponse.kt
@@ -13,18 +13,21 @@ import no.nav.su.se.bakover.domain.journalpost.Tema
 internal data class JournalpostResponse(
     val journalpost: Journalpost?,
 ) {
-    fun toValidertJournalpost(saksnummer: Saksnummer): Either<KunneIkkeHenteJournalpost, FerdigstiltJournalpost> {
+    /**
+     * Denne flyten er skreddersydd for å hente innkommende, journalførte dokumenter som tilhører SUP.
+     */
+    fun toValidertInnkommendeJournalførtJournalpost(saksnummer: Saksnummer): Either<KunneIkkeHenteJournalpost, FerdigstiltJournalpost> {
         if (journalpost == null) {
             return KunneIkkeHenteJournalpost.FantIkkeJournalpost.left()
         }
         if (journalpost.tema == null || journalpost.tema != Tema.SUP.toString()) {
             return KunneIkkeHenteJournalpost.JournalpostTemaErIkkeSUP.left()
         }
-        if (journalpost.journalposttype == null || journalpost.journalposttype != JournalpostType.UTGÅENDE_DOKUMENT.value) {
-            return KunneIkkeHenteJournalpost.JournalpostenErIkkeEtUtgåendeDokument.left()
+        if (journalpost.journalposttype == null || journalpost.journalposttype != JournalpostType.INNKOMMENDE_DOKUMENT.value) {
+            return KunneIkkeHenteJournalpost.JournalpostenErIkkeEtInnkommendeDokument.left()
         }
 
-        if (journalpost.journalstatus == null || journalpost.journalstatus != JournalpostStatus.FERDIGSTILT.toString()) {
+        if (journalpost.journalstatus == null || journalpost.journalstatus != JournalpostStatus.JOURNALFOERT.toString()) {
             return KunneIkkeHenteJournalpost.JournalpostenErIkkeFerdigstilt.left()
         }
 

--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/journalpost/JournalpostHttpClientTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/journalpost/JournalpostHttpClientTest.kt
@@ -53,8 +53,8 @@ internal class JournalpostHttpClientTest {
               "data": {
                 "journalpost": {
                   "tema": "SUP",
-                  "journalstatus": "FERDIGSTILT",
-                  "journalposttype": "U",
+                  "journalstatus": "JOURNALFOERT",
+                  "journalposttype": "I",
                   "sak": {
                   "fagsakId": "2021"
                   }
@@ -82,8 +82,8 @@ internal class JournalpostHttpClientTest {
 
         client.hentFerdigstiltJournalpost(Saksnummer(2021), JournalpostId("j")) shouldBe FerdigstiltJournalpost.create(
             tema = Tema.SUP,
-            journalstatus = JournalpostStatus.FERDIGSTILT,
-            journalpostType = JournalpostType.UTGÅENDE_DOKUMENT,
+            journalstatus = JournalpostStatus.JOURNALFOERT,
+            journalpostType = JournalpostType.INNKOMMENDE_DOKUMENT,
             saksnummer = Saksnummer(2021),
         ).right()
     }

--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/journalpost/JournalpostResponseTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/journalpost/JournalpostResponseTest.kt
@@ -15,11 +15,11 @@ internal class JournalpostResponseTest {
 
     @Test
     fun `mapper journalpostResponse til FerdigstiltJournalpost`() {
-        val jpr = JournalpostResponse(Journalpost("SUP", "FERDIGSTILT", "U", Sak("2021")))
-        jpr.toValidertJournalpost(Saksnummer(2021)) shouldBe FerdigstiltJournalpost.create(
+        val jpr = JournalpostResponse(Journalpost("SUP", "JOURNALFOERT", "I", Sak("2021")))
+        jpr.toValidertInnkommendeJournalførtJournalpost(Saksnummer(2021)) shouldBe FerdigstiltJournalpost.create(
             tema = Tema.SUP,
-            journalstatus = JournalpostStatus.FERDIGSTILT,
-            journalpostType = JournalpostType.UTGÅENDE_DOKUMENT,
+            journalstatus = JournalpostStatus.JOURNALFOERT,
+            journalpostType = JournalpostType.INNKOMMENDE_DOKUMENT,
             saksnummer = Saksnummer(2021),
         ).right()
     }
@@ -27,42 +27,42 @@ internal class JournalpostResponseTest {
     @Test
     fun `får feil dersom journalpost er null, og prøver å mappe til FerdigstiltJournalpost`() {
         val jpr = JournalpostResponse(null)
-        jpr.toValidertJournalpost(Saksnummer(2022)) shouldBe KunneIkkeHenteJournalpost.FantIkkeJournalpost.left()
+        jpr.toValidertInnkommendeJournalførtJournalpost(Saksnummer(2022)) shouldBe KunneIkkeHenteJournalpost.FantIkkeJournalpost.left()
     }
 
     @Test
     fun `får feil dersom tema er null eller ikke er SUP`() {
-        val jpr = JournalpostResponse(Journalpost(null, "FERDIGSTILT", "U", Sak("2021")))
-        jpr.toValidertJournalpost(Saksnummer(3333)) shouldBe KunneIkkeHenteJournalpost.JournalpostTemaErIkkeSUP.left()
+        val jpr = JournalpostResponse(Journalpost(null, "JOURNALFOERT", "I", Sak("2021")))
+        jpr.toValidertInnkommendeJournalførtJournalpost(Saksnummer(3333)) shouldBe KunneIkkeHenteJournalpost.JournalpostTemaErIkkeSUP.left()
 
-        val jpr2 = JournalpostResponse(Journalpost("SUPPE", "FERDIGSTILT", "U", Sak("2021")))
-        jpr2.toValidertJournalpost(Saksnummer(3333)) shouldBe KunneIkkeHenteJournalpost.JournalpostTemaErIkkeSUP.left()
+        val jpr2 = JournalpostResponse(Journalpost("UGYLDIG_TEMA", "JOURNALFOERT", "I", Sak("2021")))
+        jpr2.toValidertInnkommendeJournalførtJournalpost(Saksnummer(3333)) shouldBe KunneIkkeHenteJournalpost.JournalpostTemaErIkkeSUP.left()
     }
 
     @Test
     fun `får feil dersom status er null eller ikke er ferdigstilt`() {
-        val jpr = JournalpostResponse(Journalpost("SUP", null, "U", Sak("2021")))
-        jpr.toValidertJournalpost(Saksnummer(3333)) shouldBe KunneIkkeHenteJournalpost.JournalpostenErIkkeFerdigstilt.left()
+        val jpr = JournalpostResponse(Journalpost("SUP", null, "I", Sak("2021")))
+        jpr.toValidertInnkommendeJournalførtJournalpost(Saksnummer(3333)) shouldBe KunneIkkeHenteJournalpost.JournalpostenErIkkeFerdigstilt.left()
 
-        val jpr2 = JournalpostResponse(Journalpost("SUP", "FERDIGSTILTETET", "U", Sak("2021")))
-        jpr2.toValidertJournalpost(Saksnummer(3333)) shouldBe KunneIkkeHenteJournalpost.JournalpostenErIkkeFerdigstilt.left()
+        val jpr2 = JournalpostResponse(Journalpost("SUP", "UGYLDIG_JOURNALPOSTSTATUS", "I", Sak("2021")))
+        jpr2.toValidertInnkommendeJournalførtJournalpost(Saksnummer(3333)) shouldBe KunneIkkeHenteJournalpost.JournalpostenErIkkeFerdigstilt.left()
     }
 
     @Test
-    fun `får feil dersom journalposttype er null eller ikke utgående`() {
-        val jpr = JournalpostResponse(Journalpost("SUP", "FERDIGSTILT", null, Sak("2021")))
-        jpr.toValidertJournalpost(Saksnummer(2022)) shouldBe KunneIkkeHenteJournalpost.JournalpostenErIkkeEtUtgåendeDokument.left()
+    fun `får feil dersom journalposttype er null eller ikke innkommende`() {
+        val jpr = JournalpostResponse(Journalpost("SUP", "JOURNALFOERT", null, Sak("2021")))
+        jpr.toValidertInnkommendeJournalførtJournalpost(Saksnummer(2022)) shouldBe KunneIkkeHenteJournalpost.JournalpostenErIkkeEtInnkommendeDokument.left()
 
-        val jpr2 = JournalpostResponse(Journalpost("SUP", "FERDIGSTILT", ":)", Sak("2021")))
-        jpr2.toValidertJournalpost(Saksnummer(2022)) shouldBe KunneIkkeHenteJournalpost.JournalpostenErIkkeEtUtgåendeDokument.left()
+        val jpr2 = JournalpostResponse(Journalpost("SUP", "JOURNALFOERT", "UGYLDIG_JOURNALPOSTID", Sak("2021")))
+        jpr2.toValidertInnkommendeJournalførtJournalpost(Saksnummer(2022)) shouldBe KunneIkkeHenteJournalpost.JournalpostenErIkkeEtInnkommendeDokument.left()
     }
 
     @Test
     fun `får feil dersom journalposten ikke er knyttet til saken`() {
-        val jpr = JournalpostResponse(Journalpost("SUP", "FERDIGSTILT", "U", null))
-        jpr.toValidertJournalpost(Saksnummer(3333)) shouldBe KunneIkkeHenteJournalpost.JournalpostIkkeKnyttetTilSak.left()
+        val jpr = JournalpostResponse(Journalpost("SUP", "JOURNALFOERT", "I", null))
+        jpr.toValidertInnkommendeJournalførtJournalpost(Saksnummer(3333)) shouldBe KunneIkkeHenteJournalpost.JournalpostIkkeKnyttetTilSak.left()
 
-        val jpr2 = JournalpostResponse(Journalpost("SUP", "FERDIGSTILT", "U", Sak("2021")))
-        jpr2.toValidertJournalpost(Saksnummer(3333)) shouldBe KunneIkkeHenteJournalpost.JournalpostIkkeKnyttetTilSak.left()
+        val jpr2 = JournalpostResponse(Journalpost("SUP", "JOURNALFOERT", "I", Sak("2021")))
+        jpr2.toValidertInnkommendeJournalførtJournalpost(Saksnummer(3333)) shouldBe KunneIkkeHenteJournalpost.JournalpostIkkeKnyttetTilSak.left()
     }
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/journalpost/FerdigstiltJournalpost.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/journalpost/FerdigstiltJournalpost.kt
@@ -27,11 +27,11 @@ enum class Tema {
 }
 
 enum class JournalpostStatus {
-    FERDIGSTILT
+    JOURNALFOERT;
 }
 
 enum class JournalpostType(val value: String) {
-    UTGÅENDE_DOKUMENT("U");
+    INNKOMMENDE_DOKUMENT("I");
 
     companion object {
         fun fromString(value: String): JournalpostType {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/journalpost/JournalpostClient.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/journalpost/JournalpostClient.kt
@@ -18,7 +18,7 @@ sealed interface KunneIkkeHenteJournalpost {
     object TekniskFeil : KunneIkkeHenteJournalpost
     object UgyldigInput : KunneIkkeHenteJournalpost
     object JournalpostIkkeKnyttetTilSak : KunneIkkeHenteJournalpost
-    object JournalpostenErIkkeEtUtgåendeDokument : KunneIkkeHenteJournalpost
+    object JournalpostenErIkkeEtInnkommendeDokument : KunneIkkeHenteJournalpost
     object JournalpostTemaErIkkeSUP : KunneIkkeHenteJournalpost
     object JournalpostenErIkkeFerdigstilt : KunneIkkeHenteJournalpost
 }

--- a/test-common/src/main/kotlin/HenterJournalpostTestData.kt
+++ b/test-common/src/main/kotlin/HenterJournalpostTestData.kt
@@ -9,8 +9,8 @@ import no.nav.su.se.bakover.domain.journalpost.Tema
 fun getHentetJournalpost(): FerdigstiltJournalpost {
     return FerdigstiltJournalpost.create(
         tema = Tema.SUP,
-        journalstatus = JournalpostStatus.FERDIGSTILT,
-        journalpostType = JournalpostType.UTGÅENDE_DOKUMENT,
+        journalstatus = JournalpostStatus.JOURNALFOERT,
+        journalpostType = JournalpostType.INNKOMMENDE_DOKUMENT,
         saksnummer = Saksnummer(2021),
     )
 }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/klage/KlageRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/klage/KlageRoutes.kt
@@ -545,9 +545,9 @@ private fun KunneIkkeHenteJournalpost.toErrorJson(): Resultat {
             "Journalposten er ikke ferdigstilt",
             "journalpost_er_ikke_ferdigstilt",
         )
-        KunneIkkeHenteJournalpost.JournalpostenErIkkeEtUtgåendeDokument -> BadRequest.errorJson(
-            "Journalposten er ikke et utgående dokument",
-            "journalpost_er_ikke_et_utgående_dokument",
+        KunneIkkeHenteJournalpost.JournalpostenErIkkeEtInnkommendeDokument -> BadRequest.errorJson(
+            "Journalposten er ikke et innkommende dokument",
+            "journalpost_er_ikke_et_innkommende_dokument",
         )
     }
 }


### PR DESCRIPTION
Vi rotet litt med begrepene fra dette ble implementert første gang og en liten patch vi gjorde. Så dette er en ganske stor blocker i produkasjon 😬 .

Brukerens klage er et innkommende dokument og ikke et utgående. Da vil også typen endre seg fra FERDIGSTILT til JOURNALFØRT