### PR TITLE
Byt til riktig referans til paragrafnummer i loven

### DIFF
--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/avslag/Avslagsgrunn.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/avslag/Avslagsgrunn.kt
@@ -33,7 +33,7 @@ enum class Avslagsgrunn {
     // TODO: bør lage en paragraf-type/enum
     fun getParagrafer() = when (this) {
         UFØRHET -> listOf(1, 2)
-        FLYKTNING -> listOf(1, 2)
+        FLYKTNING -> listOf(2, 3)
         OPPHOLDSTILLATELSE -> listOf(1, 2)
         PERSONLIG_OPPMØTE -> listOf(17)
         FORMUE -> listOf(8)

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/brev/AvslagsBrevInnholdTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/brev/AvslagsBrevInnholdTest.kt
@@ -59,7 +59,7 @@ class AvslagsBrevInnholdTest {
               "halvGrunnbeløp": 10,
               "harEktefelle": false,
               "beregningsperioder": [],
-              "avslagsparagrafer": [1,2],
+              "avslagsparagrafer": [2,3],
               "saksbehandlerNavn": "Sak Sakesen",
               "attestantNavn": "Att Attestantsen",
               "fritekst": "Fritekst til brevet",
@@ -85,7 +85,7 @@ class AvslagsBrevInnholdTest {
     fun `mapper avslagsgrunn til korrekt paragraf`() {
         mapOf(
             Avslagsgrunn.UFØRHET to listOf(1, 2),
-            Avslagsgrunn.FLYKTNING to listOf(1, 2),
+            Avslagsgrunn.FLYKTNING to listOf(2, 3),
             Avslagsgrunn.OPPHOLDSTILLATELSE to listOf(1, 2),
             Avslagsgrunn.PERSONLIG_OPPMØTE to listOf(17),
             Avslagsgrunn.FORMUE to listOf(8),
@@ -100,7 +100,7 @@ class AvslagsBrevInnholdTest {
 
     @Test
     fun `plukker ut distinkte paragrafer for tilfeller hvor flere grunner benytter samme paragraf`() {
-        listOf(Avslagsgrunn.UFØRHET, Avslagsgrunn.FLYKTNING).getDistinkteParagrafer() shouldBe listOf(1, 2)
+        listOf(Avslagsgrunn.UFØRHET, Avslagsgrunn.FLYKTNING).getDistinkteParagrafer() shouldBe listOf(1, 2, 3)
         listOf(
             Avslagsgrunn.UFØRHET,
             Avslagsgrunn.BOR_OG_OPPHOLDER_SEG_I_NORGE,


### PR DESCRIPTION
Ref: https://trello.com/c/9v4p0arj/1237-feil-henvisning-til-i-brev