### PR TITLE
Fjern paragraf 2 for flyktningsstatus

### DIFF
--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/avslag/Avslagsgrunn.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/avslag/Avslagsgrunn.kt
@@ -33,7 +33,7 @@ enum class Avslagsgrunn {
     // TODO: bør lage en paragraf-type/enum
     fun getParagrafer() = when (this) {
         UFØRHET -> listOf(1, 2)
-        FLYKTNING -> listOf(2, 3)
+        FLYKTNING -> listOf(3)
         OPPHOLDSTILLATELSE -> listOf(1, 2)
         PERSONLIG_OPPMØTE -> listOf(17)
         FORMUE -> listOf(8)

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/brev/AvslagsBrevInnholdTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/brev/AvslagsBrevInnholdTest.kt
@@ -59,7 +59,7 @@ class AvslagsBrevInnholdTest {
               "halvGrunnbeløp": 10,
               "harEktefelle": false,
               "beregningsperioder": [],
-              "avslagsparagrafer": [2,3],
+              "avslagsparagrafer": [3],
               "saksbehandlerNavn": "Sak Sakesen",
               "attestantNavn": "Att Attestantsen",
               "fritekst": "Fritekst til brevet",
@@ -85,7 +85,7 @@ class AvslagsBrevInnholdTest {
     fun `mapper avslagsgrunn til korrekt paragraf`() {
         mapOf(
             Avslagsgrunn.UFØRHET to listOf(1, 2),
-            Avslagsgrunn.FLYKTNING to listOf(2, 3),
+            Avslagsgrunn.FLYKTNING to listOf(3),
             Avslagsgrunn.OPPHOLDSTILLATELSE to listOf(1, 2),
             Avslagsgrunn.PERSONLIG_OPPMØTE to listOf(17),
             Avslagsgrunn.FORMUE to listOf(8),


### PR DESCRIPTION
Egentligen skal rekkefølgen i vedtaket være "§§ 3 og 2" men kommer ut som "§§ 2 og 3" fordi vi sortere avslagsparagrafene når vi sender det till pdfgen.

Enkleste løsningen er å fjerne paragraf 2 fordi paragraf 3 er primærparagrafen og paragraf 2 er relevant men ikke nødvendig å ha med i vedtaket.