### PR TITLE
Endre mottattdato for klage i statistikk

### DIFF
--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/statistikk/mappers/BehandlingStatistikkMapper.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/statistikk/mappers/BehandlingStatistikkMapper.kt
@@ -279,7 +279,7 @@ class BehandlingStatistikkMapper(
             funksjonellTid = nå,
             tekniskTid = nå,
             registrertDato = klage.opprettet.toLocalDate(zoneIdOslo),
-            mottattDato = klage.opprettet.toLocalDate(zoneIdOslo),
+            mottattDato = klage.datoKlageMottatt,
             behandlingId = klage.id,
             sakId = klage.sakId,
             saksnummer = klage.saksnummer.nummer,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/BehandlingStatistikkMapperTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/BehandlingStatistikkMapperTest.kt
@@ -1,6 +1,7 @@
 package no.nav.su.se.bakover.service.statistikk
 
 import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.februar
 import no.nav.su.se.bakover.common.periode.år
 import no.nav.su.se.bakover.common.zoneIdOslo
@@ -479,7 +480,7 @@ internal class BehandlingStatistikkMapperTest {
         BehandlingStatistikkMapper(fixedClock).map(klage) shouldBe Statistikk.Behandling(
             funksjonellTid = klage.opprettet,
             tekniskTid = fixedTidspunkt,
-            mottattDato = klage.opprettet.toLocalDate(zoneIdOslo),
+            mottattDato = 1.desember(2021),
             registrertDato = klage.opprettet.toLocalDate(zoneIdOslo),
             behandlingId = klage.id,
             relatertBehandlingId = klage.vilkårsvurderinger.vedtakId,


### PR DESCRIPTION
MottattDato beskrives enligt `behandling_schema`:n vi har som: _"Denne datoen forteller fra hvilken dato behandlingen først ble initiert. Datoen brukes i beregning av saksbehandlingstid og skal samsvare med brukerens opplevelse av at saksbehandlingen har startet"_

Tänker att det då burde være den dato som brukern har sendt in klagen enligt saksbehandler.