### PR TITLE
Legger inn informasjon om hvem inntekt tilhører

### DIFF
--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/klage/klageinstans/KlageinstanshendelsePostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/klage/klageinstans/KlageinstanshendelsePostgresRepo.kt
@@ -43,7 +43,7 @@ internal class KlageinstanshendelsePostgresRepo(
                         .insert(
                             params = mapOf(
                                 "id" to hendelse.id,
-                                "opprettet" to hendelse.opprettet,
+                                /**/"opprettet" to hendelse.opprettet,
                                 "type" to KlageinstanshendelseType.UPROSESSERT.toString(),
                                 "metadata" to hendelse.metadata.toDatabaseJson(),
                             ),

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/klage/klageinstans/KlageinstanshendelsePostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/klage/klageinstans/KlageinstanshendelsePostgresRepo.kt
@@ -43,7 +43,7 @@ internal class KlageinstanshendelsePostgresRepo(
                         .insert(
                             params = mapOf(
                                 "id" to hendelse.id,
-                                /**/"opprettet" to hendelse.opprettet,
+                                "opprettet" to hendelse.opprettet,
                                 "type" to KlageinstanshendelseType.UPROSESSERT.toString(),
                                 "metadata" to hendelse.metadata.toDatabaseJson(),
                             ),

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
@@ -16,6 +16,7 @@ import no.nav.su.se.bakover.common.periode.Periode.UgyldigPeriode.FraOgMedDatoM�
 import no.nav.su.se.bakover.common.periode.Periode.UgyldigPeriode.FraOgMedDatoMåVæreFørsteDagIMåneden
 import no.nav.su.se.bakover.common.periode.Periode.UgyldigPeriode.TilOgMedDatoMåVæreSisteDagIMåneden
 import no.nav.su.se.bakover.common.periode.minsteAntallSammenhengendePerioder
+import no.nav.su.se.bakover.domain.beregning.Beregning
 import no.nav.su.se.bakover.domain.beregning.Månedsberegning
 import no.nav.su.se.bakover.domain.klage.Klage
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
@@ -151,15 +152,15 @@ data class Sak(
     }
 
     /**
-     * Brukes for å hente den seneste gjeldenden/brukte månedsberegningen for en gitt måned i saken.
+     * Brukes for å hente den seneste gjeldenden/brukte beregningen for en gitt måned i saken.
      *
      * Per nå så er det kun Vedtak i form av [VedtakSomKanRevurderes.EndringIYtelse] som bidrar til dette, bortsett fra [VedtakSomKanRevurderes.IngenEndringIYtelse] som har
      * andre beregnings-beløp som ikke skal ha en påverkan på saken.
      * */
-    fun hentGjeldendeMånedsberegningForMåned(
+    fun hentGjeldendeBeregningForEndringIYtelse(
         måned: Måned,
         clock: Clock,
-    ): Månedsberegning? {
+    ): Beregning? {
         return GjeldendeVedtaksdata(
             periode = måned,
             vedtakListe = NonEmptyList.fromListUnsafe(
@@ -180,8 +181,6 @@ data class Sak(
                 is VedtakSomKanRevurderes.EndringIYtelse.StansAvYtelse -> throw IllegalStateException("Kodefeil: Skal ha filtrert bort Vedtak.EndringIYtelse.StansAvYtelse")
                 is VedtakSomKanRevurderes.EndringIYtelse.GjenopptakAvYtelse -> throw IllegalStateException("Kodefeil: Skal ha filtrert bort Vedtak.EndringIYtelse.GjenopptakAvYtelse")
             }
-        }?.let { beregning ->
-            beregning.getMånedsberegninger().associateBy { it.periode }[måned]
         }
     }
 

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
@@ -156,7 +156,7 @@ data class Sak(
      * Per nå så er det kun Vedtak i form av [VedtakSomKanRevurderes.EndringIYtelse] som bidrar til dette, bortsett fra [VedtakSomKanRevurderes.IngenEndringIYtelse] som har
      * andre beregnings-beløp som ikke skal ha en påverkan på saken.
      * */
-    fun hentGjeldendeBeregningForEndringIYtelse(
+    fun hentGjeldendeBeregningForEndringIYtelsePåDato(
         måned: Måned,
         clock: Clock,
     ): Beregning? {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
@@ -17,7 +17,6 @@ import no.nav.su.se.bakover.common.periode.Periode.UgyldigPeriode.FraOgMedDatoM�
 import no.nav.su.se.bakover.common.periode.Periode.UgyldigPeriode.TilOgMedDatoMåVæreSisteDagIMåneden
 import no.nav.su.se.bakover.common.periode.minsteAntallSammenhengendePerioder
 import no.nav.su.se.bakover.domain.beregning.Beregning
-import no.nav.su.se.bakover.domain.beregning.Månedsberegning
 import no.nav.su.se.bakover.domain.klage.Klage
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling.Companion.hentOversendteUtbetalingerUtenFeil

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/statistikk/Statistikk.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/statistikk/Statistikk.kt
@@ -191,6 +191,8 @@ sealed class Statistikk {
     data class Inntekt(
         val inntektstype: String,
         val beløp: Long,
+        val tilhører: String,
+        val erUtenlandsk: Boolean
     )
 
     data class Aktør(val aktorId: Int, val rolle: String, val rolleBeskrivelse: String)

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/statistikk/mappers/StønadsstatistikkMapper.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/statistikk/mappers/StønadsstatistikkMapper.kt
@@ -93,7 +93,6 @@ private fun mapBeregning(
     val alleFradrag = beregning.tilFradragPerMåned()
     val månedsberegninger = beregning.getMånedsberegninger().associateBy { it.måned }
 
-
     return beregning.periode.måneder().map { måned ->
         Statistikk.Stønad.Månedsbeløp(
             inntekter = alleFradrag[måned]?.map { it ->
@@ -117,7 +116,6 @@ fun Beregning?.tilFradragPerMåned(): Map<Måned, List<FradragForMåned>> = this
     beregning.getFradrag()
         .flatMap { FradragFactory.periodiser(it) }
 }?.groupBy { it.måned } ?: emptyMap()
-
 
 private fun mapBeregning(
     vedtak: VedtakSomKanRevurderes.EndringIYtelse.GjenopptakAvYtelse,

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/statistikk/mappers/StønadsstatistikkMapper.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/statistikk/mappers/StønadsstatistikkMapper.kt
@@ -1,19 +1,21 @@
 package no.nav.su.se.bakover.service.statistikk.mappers
 
 import no.nav.su.se.bakover.common.Tidspunkt
+import no.nav.su.se.bakover.common.periode.Måned
 import no.nav.su.se.bakover.common.zoneIdOslo
 import no.nav.su.se.bakover.domain.AktørId
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.behandling.Behandling
 import no.nav.su.se.bakover.domain.beregning.Beregning
 import no.nav.su.se.bakover.domain.beregning.Månedsberegning
+import no.nav.su.se.bakover.domain.beregning.fradrag.FradragFactory
+import no.nav.su.se.bakover.domain.beregning.fradrag.FradragForMåned
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
 import no.nav.su.se.bakover.domain.vedtak.VedtakSomKanRevurderes
 import no.nav.su.se.bakover.service.statistikk.Statistikk
 import no.nav.su.se.bakover.service.statistikk.stønadsklassifisering
 import java.time.Clock
 import java.time.LocalDate
-import kotlin.math.roundToInt
 
 class StønadsstatistikkMapper(
     private val clock: Clock,
@@ -87,40 +89,46 @@ class StønadsstatistikkMapper(
 private fun mapBeregning(
     vedtak: VedtakSomKanRevurderes.EndringIYtelse,
     beregning: Beregning,
-): List<Statistikk.Stønad.Månedsbeløp> =
-    beregning.getMånedsberegninger().map {
-        tilMånedsbeløp(it, vedtak)
+): List<Statistikk.Stønad.Månedsbeløp> {
+    val alleFradrag = beregning.tilFradragPerMåned()
+    val månedsberegninger = beregning.getMånedsberegninger().associateBy { it.måned }
+
+
+    return beregning.periode.måneder().map { måned ->
+        Statistikk.Stønad.Månedsbeløp(
+            inntekter = alleFradrag[måned]?.map { it ->
+                Statistikk.Inntekt(
+                    inntektstype = it.fradragstype.toString(),
+                    beløp = it.månedsbeløp.toLong(),
+                    tilhører = it.tilhører.toString(),
+                    erUtenlandsk = it.utenlandskInntekt != null,
+                )
+            } ?: emptyList(),
+            bruttosats = månedsberegninger[måned]?.getSatsbeløp()?.toLong()!!,
+            fradragSum = månedsberegninger[måned]?.getSumFradrag()?.toLong()!!,
+            måned = måned.toString(),
+            nettosats = månedsberegninger[måned]?.getSatsbeløp()?.toLong()!! - månedsberegninger[måned]?.getSumFradrag()?.toLong()!!,
+            stonadsklassifisering = stønadsklassifisering(vedtak.behandling, månedsberegninger[måned]!!),
+        )
     }
+}
+
+fun Beregning?.tilFradragPerMåned(): Map<Måned, List<FradragForMåned>> = this?.let { beregning ->
+    beregning.getFradrag()
+        .flatMap { FradragFactory.periodiser(it) }
+}?.groupBy { it.måned } ?: emptyMap()
+
 
 private fun mapBeregning(
     vedtak: VedtakSomKanRevurderes.EndringIYtelse.GjenopptakAvYtelse,
     sak: Sak,
     clock: Clock,
-): List<Statistikk.Stønad.Månedsbeløp> =
-    vedtak.periode.måneder().map {
-        sak.hentGjeldendeMånedsberegningForMåned(it, clock)!!
-    }.map {
-        tilMånedsbeløp(it, vedtak)
+): List<Statistikk.Stønad.Månedsbeløp> {
+    val beregning: Beregning = vedtak.periode.måneder().firstNotNullOf {
+        sak.hentGjeldendeBeregningForEndringIYtelse(it, clock)
     }
-
-private fun tilMånedsbeløp(
-    månedsberegning: Månedsberegning,
-    vedtak: VedtakSomKanRevurderes.EndringIYtelse,
-) = Statistikk.Stønad.Månedsbeløp(
-    måned = månedsberegning.periode.fraOgMed.toString(),
-    stonadsklassifisering = stønadsklassifisering(vedtak.behandling, månedsberegning),
-    bruttosats = månedsberegning.getSatsbeløp().roundToInt().toLong(),
-    nettosats = månedsberegning.getSumYtelse().toLong(),
-    inntekter = månedsberegning.getFradrag().map { fradrag ->
-        Statistikk.Inntekt(
-            inntektstype = fradrag.fradragstype.toString(),
-            beløp = fradrag.månedsbeløp.toLong(),
-            tilhører = fradrag.tilhører.toString(),
-            erUtenlandsk = fradrag.utenlandskInntekt != null
-        )
-    },
-    fradragSum = månedsberegning.getSumFradrag().toLong(),
-)
+    return mapBeregning(vedtak, beregning)
+}
 
 private fun vedtakstype(vedtak: VedtakSomKanRevurderes.EndringIYtelse) = when (vedtak) {
     is VedtakSomKanRevurderes.EndringIYtelse.GjenopptakAvYtelse -> Statistikk.Stønad.Vedtakstype.GJENOPPTAK

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/statistikk/mappers/StønadsstatistikkMapper.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/statistikk/mappers/StønadsstatistikkMapper.kt
@@ -115,6 +115,8 @@ private fun tilMånedsbeløp(
         Statistikk.Inntekt(
             inntektstype = fradrag.fradragstype.toString(),
             beløp = fradrag.månedsbeløp.toLong(),
+            tilhører = fradrag.tilhører.toString(),
+            erUtenlandsk = fradrag.utenlandskInntekt != null
         )
     },
     fradragSum = månedsberegning.getSumFradrag().toLong(),

--- a/service/src/main/resources/statistikk/stonad_schema.json
+++ b/service/src/main/resources/statistikk/stonad_schema.json
@@ -124,7 +124,15 @@
                 "beløp": {
                   "type": "number",
                   "description": "Inntekten i kroner per måned."
-                }
+                },
+	            "tilhører": {
+		          "type": "string",
+		          "description": "Hvem tilhører inntekten? "
+	            },
+	            "erUtenlandsk": {
+		          "type": "boolean",
+		          "description": "Er inntekten fra utlandet?"
+	            }
               }
             }
           },

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/StatistikkSchemaValidatorTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/StatistikkSchemaValidatorTest.kt
@@ -57,7 +57,7 @@ internal class StatistikkSchemaValidatorTest {
                     stonadsklassifisering = Statistikk.Stønadsklassifisering.BOR_ALENE,
                     bruttosats = 10000,
                     nettosats = 5000,
-                    inntekter = listOf(Statistikk.Inntekt("Arbeidsinntekt", 5000)),
+                    inntekter = listOf(Statistikk.Inntekt("Arbeidsinntekt", 5000, "BRUKER", false)),
                     fradragSum = 5000,
                 ),
             ),

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/StønadsstatistikkMapperTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/StønadsstatistikkMapperTest.kt
@@ -96,6 +96,8 @@ internal class StønadsstatistikkMapperTest {
                             Statistikk.Inntekt(
                                 inntektstype = "ForventetInntekt",
                                 beløp = 3000,
+                                tilhører = "BRUKER",
+                                erUtenlandsk = false
                             ),
                         ),
                         fradragSum = 3000,
@@ -111,6 +113,8 @@ internal class StønadsstatistikkMapperTest {
                             Statistikk.Inntekt(
                                 inntektstype = "ForventetInntekt",
                                 beløp = 3000,
+                                tilhører = "BRUKER",
+                                erUtenlandsk = false
                             ),
                         ),
                         fradragSum = 3000,
@@ -159,7 +163,9 @@ internal class StønadsstatistikkMapperTest {
                       "inntekter": [
                         {
                           "inntektstype": "ForventetInntekt",
-                          "beløp": 3000
+                          "beløp": 3000,
+                          "tilhører": "BRUKER",
+                          "erUtenlandsk": false
                         }
                       ],
                       "fradragSum": 3000
@@ -172,7 +178,9 @@ internal class StønadsstatistikkMapperTest {
                       "inntekter": [
                         {
                           "inntektstype": "ForventetInntekt",
-                          "beløp": 3000
+                          "beløp": 3000,
+                          "tilhører": "BRUKER",
+                          "erUtenlandsk": false
                         }
                       ],
                       "fradragSum": 3000
@@ -185,7 +193,9 @@ internal class StønadsstatistikkMapperTest {
                       "inntekter": [
                         {
                           "inntektstype": "ForventetInntekt",
-                          "beløp": 3000
+                          "beløp": 3000,
+                          "tilhører": "BRUKER",
+                          "erUtenlandsk": false
                         }
                       ],
                       "fradragSum": 3000
@@ -198,7 +208,9 @@ internal class StønadsstatistikkMapperTest {
                       "inntekter": [
                         {
                           "inntektstype": "ForventetInntekt",
-                          "beløp": 3000
+                          "beløp": 3000,
+                          "tilhører": "BRUKER",
+                          "erUtenlandsk": false
                         }
                       ],
                       "fradragSum": 3000
@@ -211,7 +223,9 @@ internal class StønadsstatistikkMapperTest {
                       "inntekter": [
                         {
                           "inntektstype": "ForventetInntekt",
-                          "beløp": 3000
+                          "beløp": 3000,
+                          "tilhører": "BRUKER",
+                          "erUtenlandsk": false
                         }
                       ],
                       "fradragSum": 3000
@@ -224,7 +238,9 @@ internal class StønadsstatistikkMapperTest {
                       "inntekter": [
                         {
                           "inntektstype": "ForventetInntekt",
-                          "beløp": 3000
+                          "beløp": 3000,
+                          "tilhører": "BRUKER",
+                          "erUtenlandsk": false
                         }
                       ],
                       "fradragSum": 3000
@@ -237,7 +253,9 @@ internal class StønadsstatistikkMapperTest {
                       "inntekter": [
                         {
                           "inntektstype": "ForventetInntekt",
-                          "beløp": 3000
+                          "beløp": 3000,
+                          "tilhører": "BRUKER",
+                          "erUtenlandsk": false
                         }
                       ],
                       "fradragSum": 3000
@@ -250,7 +268,9 @@ internal class StønadsstatistikkMapperTest {
                       "inntekter": [
                         {
                           "inntektstype": "ForventetInntekt",
-                          "beløp": 3000
+                          "beløp": 3000,
+                          "tilhører": "BRUKER",
+                          "erUtenlandsk": false
                         }
                       ],
                       "fradragSum": 3000
@@ -263,7 +283,9 @@ internal class StønadsstatistikkMapperTest {
                       "inntekter": [
                         {
                           "inntektstype": "ForventetInntekt",
-                          "beløp": 3000
+                          "beløp": 3000,
+                          "tilhører": "BRUKER",
+                          "erUtenlandsk": false
                         }
                       ],
                       "fradragSum": 3000
@@ -276,7 +298,9 @@ internal class StønadsstatistikkMapperTest {
                       "inntekter": [
                         {
                           "inntektstype": "ForventetInntekt",
-                          "beløp": 3000
+                          "beløp": 3000,
+                          "tilhører": "BRUKER",
+                          "erUtenlandsk": false
                         }
                       ],
                       "fradragSum": 3000
@@ -289,7 +313,9 @@ internal class StønadsstatistikkMapperTest {
                       "inntekter": [
                         {
                           "inntektstype": "ForventetInntekt",
-                          "beløp": 3000
+                          "beløp": 3000,
+                          "tilhører": "BRUKER",
+                          "erUtenlandsk": false
                         }
                       ],
                       "fradragSum": 3000
@@ -302,7 +328,9 @@ internal class StønadsstatistikkMapperTest {
                       "inntekter": [
                         {
                           "inntektstype": "ForventetInntekt",
-                          "beløp": 3000
+                          "beløp": 3000,
+                          "tilhører": "BRUKER",
+                          "erUtenlandsk": false
                         }
                       ],
                       "fradragSum": 3000

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/StønadsstatistikkMapperTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/StønadsstatistikkMapperTest.kt
@@ -425,7 +425,9 @@ internal class StønadsstatistikkMapperTest {
                       "inntekter": [
                         {
                           "inntektstype": "ForventetInntekt",
-                          "beløp": 0
+                          "beløp": 0,
+                          "tilhører": "BRUKER",
+                          "erUtenlandsk": false
                         }
                       ],
                       "fradragSum": 0
@@ -438,7 +440,9 @@ internal class StønadsstatistikkMapperTest {
                       "inntekter": [
                         {
                           "inntektstype": "ForventetInntekt",
-                          "beløp": 0
+                          "beløp": 0,
+                          "tilhører": "BRUKER",
+                          "erUtenlandsk": false
                         }
                       ],
                       "fradragSum": 0
@@ -491,7 +495,9 @@ internal class StønadsstatistikkMapperTest {
                       "inntekter": [
                         {
                           "inntektstype": "ForventetInntekt",
-                          "beløp": 0
+                          "beløp": 0,
+                          "tilhører": "BRUKER",
+                          "erUtenlandsk": false
                         }
                       ],
                       "fradragSum": 0
@@ -504,7 +510,9 @@ internal class StønadsstatistikkMapperTest {
                       "inntekter": [
                         {
                           "inntektstype": "ForventetInntekt",
-                          "beløp": 0
+                          "beløp": 0,
+                          "tilhører": "BRUKER",
+                          "erUtenlandsk": false
                         }
                       ],
                       "fradragSum": 0

--- a/test-common/src/main/kotlin/RevurderingTestData.kt
+++ b/test-common/src/main/kotlin/RevurderingTestData.kt
@@ -1399,8 +1399,8 @@ fun simulertStansAvYtelseFraIverksattSøknadsbehandlingsvedtak(
             id = revurderingId,
             opprettet = Tidspunkt.now(clock),
             periode = periode,
-            grunnlagsdata = vedtak.behandling.grunnlagsdata,
-            vilkårsvurderinger = vedtak.behandling.vilkårsvurderinger.tilVilkårsvurderingerRevurdering(),
+            grunnlagsdata = sak.kopierGjeldendeVedtaksdata(periode.fraOgMed, clock).getOrFail().grunnlagsdata,
+            vilkårsvurderinger = sak.kopierGjeldendeVedtaksdata(periode.fraOgMed, clock).getOrFail().vilkårsvurderinger,
             tilRevurdering = vedtak,
             saksbehandler = saksbehandler,
             simulering = simulering,
@@ -1478,6 +1478,8 @@ fun simulertGjenopptakelseAvytelseFraVedtakStansAvYtelse(
         clock = clock,
     ),
 ): Pair<Sak, GjenopptaYtelseRevurdering.SimulertGjenopptakAvYtelse> {
+    require(sakOgVedtakSomKanRevurderes.first.vedtakListe.last() is VedtakSomKanRevurderes.EndringIYtelse.StansAvYtelse)
+
     return sakOgVedtakSomKanRevurderes.let { (sak, vedtak) ->
         val revurdering = GjenopptaYtelseRevurdering.SimulertGjenopptakAvYtelse(
             id = revurderingId,


### PR DESCRIPTION
Det er et ønske fra DVH å rapportere statistikk på EPS sine inntekter.
For å lettest muliggjøre dette legger vi på informasjon om hvem det
tilhører.

(det var opprinnelig et ønske om mange enum-verdier custom mappet men
det er mye stress og det kan de heller fikses slik konsumenter vil
ha det)