### PR TITLE
Legg til type på sak

### DIFF
--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepo.kt
@@ -100,7 +100,7 @@ internal class SakPostgresRepo(
         return dbMetrics.timeQuery("opprettSak") {
             sessionFactory.withSession { session ->
                 """
-                with inserted_sak as (insert into sak (id, fnr, opprettet) values (:sakId, :fnr, :opprettet))
+                with inserted_sak as (insert into sak (id, fnr, opprettet, type) values (:sakId, :fnr, :opprettet, :type))
                 insert into søknad (id, sakId, søknadInnhold, opprettet) values (:soknadId, :sakId, to_json(:soknad::json), :opprettet)
                 """.insert(
                     mapOf(
@@ -109,6 +109,7 @@ internal class SakPostgresRepo(
                         "opprettet" to sak.opprettet,
                         "soknadId" to sak.søknad.id,
                         "soknad" to objectMapper.writeValueAsString(sak.søknad.søknadInnhold),
+                        "type" to sak.søknad.type.value
                     ),
                     session,
                 )

--- a/database/src/main/resources/db/migration/V137__legg_til_type_på_sak.sql
+++ b/database/src/main/resources/db/migration/V137__legg_til_type_på_sak.sql
@@ -1,0 +1,2 @@
+alter table sak
+    add column if not exists type text default 'uføre';

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Søknadsinnhold.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Søknadsinnhold.kt
@@ -32,6 +32,11 @@ sealed interface SøknadInnhold {
             personopplysninger = personopplysninger.copy(fnr = fnr),
         )
     }
+
+    fun type() = when (this) {
+        is SøknadsinnholdAlder -> Søknadstype.ALDER
+        is SøknadsinnholdUføre -> Søknadstype.UFØRE
+    }
 }
 
 data class SøknadsinnholdAlder(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/SøknadTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/SøknadTest.kt
@@ -11,7 +11,6 @@ import no.nav.su.se.bakover.client.dokarkiv.Journalpost
 import no.nav.su.se.bakover.client.pdf.PdfGenerator
 import no.nav.su.se.bakover.client.stubs.person.PersonOppslagStub
 import no.nav.su.se.bakover.common.Tidspunkt
-import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.NySak
 import no.nav.su.se.bakover.domain.Person
@@ -27,6 +26,7 @@ import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
 import no.nav.su.se.bakover.domain.oppgave.OppgaveFeil.KunneIkkeOppretteOppgave
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.person.KunneIkkeHentePerson
+import no.nav.su.se.bakover.domain.sak.SakIdSaksnummerFnr
 import no.nav.su.se.bakover.domain.søknad.SøknadMetrics
 import no.nav.su.se.bakover.domain.søknad.SøknadPdfInnhold
 import no.nav.su.se.bakover.domain.søknad.SøknadRepo
@@ -114,7 +114,7 @@ class SøknadTest {
             on { hentPerson(any()) } doReturn person.right()
         }
         val sakServiceMock: SakService = mock {
-            on { hentSak(any<Fnr>()) } doReturn FantIkkeSak.left() doReturn sak.right()
+            on { hentSakidOgSaksnummer(any()) } doReturn FantIkkeSak.left() doReturn SakIdSaksnummerFnr(sak.id, sak.saksnummer, fnr).right()
         }
 
         val pdfGeneratorMock: PdfGenerator = mock {
@@ -144,7 +144,7 @@ class SøknadTest {
             pdfGeneratorMock
         ) {
             verify(personServiceMock).hentPerson(argThat { it shouldBe fnr })
-            verify(sakServiceMock).hentSak(argThat<Fnr> { it shouldBe fnr })
+            verify(sakServiceMock).hentSakidOgSaksnummer(argThat { it shouldBe fnr })
             verify(sakServiceMock).opprettSak(
                 argThat {
                     it shouldBe NySak(
@@ -160,7 +160,7 @@ class SøknadTest {
                     )
                 }
             )
-            verify(sakServiceMock).hentSak(argThat<Fnr> { it shouldBe fnr })
+            verify(sakServiceMock).hentSakidOgSaksnummer(argThat { it shouldBe fnr })
             verify(pdfGeneratorMock).genererPdf(
                 argThat<SøknadPdfInnhold> {
                     it shouldBe SøknadPdfInnhold.create(
@@ -212,7 +212,7 @@ class SøknadTest {
             on { hentPerson(any()) } doReturn person.right()
         }
         val sakServiceMock: SakService = mock {
-            on { hentSak(any<Fnr>()) } doReturn sak.right()
+            on { hentSakidOgSaksnummer(any()) } doReturn SakIdSaksnummerFnr(sak.id, sak.saksnummer, fnr).right()
         }
         val søknadRepoMock: SøknadRepo = mock()
         val pdfGeneratorMock: PdfGenerator = mock {
@@ -251,7 +251,7 @@ class SøknadTest {
             observerMock
         ) {
             verify(personServiceMock).hentPerson(argThat { it shouldBe fnr })
-            verify(sakServiceMock).hentSak(argThat<Fnr> { it shouldBe fnr })
+            verify(sakServiceMock).hentSakidOgSaksnummer(argThat { it shouldBe fnr })
             verify(søknadRepoMock).opprettSøknad(
                 argThat {
                     it shouldBe Søknad.Ny(
@@ -299,7 +299,7 @@ class SøknadTest {
             on { hentPerson(any()) } doReturn person.right()
         }
         val sakServiceMock: SakService = mock {
-            on { hentSak(any<Fnr>()) } doReturn sak.right()
+            on { hentSakidOgSaksnummer(any()) } doReturn SakIdSaksnummerFnr(sak.id, sak.saksnummer, fnr).right()
         }
         val søknadRepoMock: SøknadRepo = mock()
         val pdfGeneratorMock: PdfGenerator = mock {
@@ -334,7 +334,7 @@ class SøknadTest {
             dokArkivMock
         ) {
             verify(personServiceMock).hentPerson(argThat { it shouldBe fnr })
-            verify(sakServiceMock).hentSak(argThat<Fnr> { it shouldBe fnr })
+            verify(sakServiceMock).hentSakidOgSaksnummer(argThat { it shouldBe fnr })
             verify(søknadRepoMock).opprettSøknad(
                 argThat {
                     it shouldBe Søknad.Ny(
@@ -400,7 +400,7 @@ class SøknadTest {
 
         SøknadserviceOgMocks(
             sakService = mock {
-                on { hentSak(any<Fnr>()) } doReturn sak.right()
+                on { hentSakidOgSaksnummer(any()) } doReturn SakIdSaksnummerFnr(sak.id, sak.saksnummer, fnr).right()
             },
             pdfGenerator = mock {
                 on { genererPdf(any<SøknadPdfInnhold>()) } doReturn pdf.right()
@@ -419,7 +419,7 @@ class SøknadTest {
             val actual = service.nySøknad(søknadInnhold, innsender)
             inOrder(*allMocks()) {
                 verify(personService).hentPerson(argThat { it shouldBe sak.fnr })
-                verify(sakService).hentSak(argThat<Fnr> { it shouldBe sak.fnr })
+                verify(sakService).hentSakidOgSaksnummer(argThat { it shouldBe sak.fnr })
                 verify(søknadRepo).opprettSøknad(
                     argThat {
                         it shouldBe Søknad.Ny(
@@ -506,7 +506,7 @@ class SøknadTest {
             on { hentPerson(any()) } doReturn person.right()
         }
         val sakServiceMock: SakService = mock {
-            on { hentSak(any<Fnr>()) } doReturn sak.right()
+            on { hentSakidOgSaksnummer(any()) } doReturn SakIdSaksnummerFnr(sak.id, sak.saksnummer, fnr).right()
         }
         val søknadRepoMock: SøknadRepo = mock()
         val pdfGeneratorMock: PdfGenerator = mock {
@@ -543,7 +543,7 @@ class SøknadTest {
             oppgaveServiceMock
         ) {
             verify(personServiceMock).hentPerson(argThat { it shouldBe fnr })
-            verify(sakServiceMock).hentSak(argThat<Fnr> { it shouldBe fnr })
+            verify(sakServiceMock).hentSakidOgSaksnummer(argThat { it shouldBe fnr })
             verify(søknadRepoMock).opprettSøknad(
                 argThat {
                     it shouldBe Søknad.Ny(


### PR DESCRIPTION
* Legger til type-felt på sak i db (alder / uføre - samme som for søknadsinnhold)
* I steden for å hente hele den nye saken når man oppretter en ny sak, så henter vi nå bare to id-er, så slipper vi masse oppslag og mappinger