### PR TITLE
Unngå å opprett ny satsfactory for hver måned i beregning.

### DIFF
--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/beregning/PersistertBeregning.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/beregning/PersistertBeregning.kt
@@ -6,6 +6,7 @@ import no.nav.su.se.bakover.common.deserialize
 import no.nav.su.se.bakover.common.periode.PeriodeJson
 import no.nav.su.se.bakover.common.periode.PeriodeJson.Companion.toJson
 import no.nav.su.se.bakover.common.serialize
+import no.nav.su.se.bakover.common.zoneIdOslo
 import no.nav.su.se.bakover.domain.beregning.Beregning
 import no.nav.su.se.bakover.domain.beregning.BeregningMedFradragBeregnetMånedsvis
 import no.nav.su.se.bakover.domain.satser.SatsFactory
@@ -25,6 +26,11 @@ private data class PersistertBeregning(
     val begrunnelse: String?,
 ) {
     fun toBeregning(satsFactory: SatsFactory): BeregningMedFradragBeregnetMånedsvis {
+        /**
+         * For å håndtere at grunnbeløpet kan ha endret seg siden beregningen ble gjort, må vi bruke
+         * satsfactory slik den så ut ved opprettelse av beregningen for å få hentet ut korrekt data.
+         */
+        val satsFactoryForOpprettelsestidspunkt = satsFactory.gjeldende(påDato = opprettet.toLocalDate(zoneIdOslo))
         return BeregningMedFradragBeregnetMånedsvis(
             id = id,
             opprettet = opprettet,
@@ -36,8 +42,7 @@ private data class PersistertBeregning(
             månedsberegninger = Nel.fromListUnsafe(
                 månedsberegninger.map {
                     it.toMånedsberegning(
-                        satsFactory = satsFactory,
-                        opprettet = opprettet,
+                        satsFactory = satsFactoryForOpprettelsestidspunkt,
                     )
                 },
             ),

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/beregning/PersistertMånedsberegning.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/beregning/PersistertMånedsberegning.kt
@@ -1,9 +1,7 @@
 package no.nav.su.se.bakover.database.beregning
 
-import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.periode.MånedJson
 import no.nav.su.se.bakover.common.periode.MånedJson.Companion.toJson
-import no.nav.su.se.bakover.common.zoneIdOslo
 import no.nav.su.se.bakover.domain.beregning.BeregningForMåned
 import no.nav.su.se.bakover.domain.beregning.Merknader
 import no.nav.su.se.bakover.domain.beregning.Månedsberegning
@@ -21,26 +19,20 @@ internal data class PersistertMånedsberegning(
     val fribeløpForEps: Double,
     val merknader: List<PersistertMerknad.Beregning> = emptyList(),
 ) {
-    fun toMånedsberegning(satsFactory: SatsFactory, opprettet: Tidspunkt): BeregningForMåned {
+    fun toMånedsberegning(satsFactory: SatsFactory): BeregningForMåned {
         val måned = periode.tilMåned()
         return BeregningForMåned(
             måned = måned,
-            fullSupplerendeStønadForMåned = satsFactory
-                /**
-                 * For å håndtere at grunnbeløpet kan ha endret seg siden beregningen ble gjort, må vi bruke
-                 * satsfactory slik den så ut ved opprettelse av beregningen for å få hentet ut korrekt data.
-                 */
-                .gjeldende(påDato = opprettet.toLocalDate(zoneIdOslo))
-                .forSatskategori(
-                    måned = måned,
-                    satskategori = sats,
-                ).also {
-                    assert(benyttetGrunnbeløp == it.grunnbeløp.grunnbeløpPerÅr) {
-                        "Hentet benyttetGrunnbeløp: $benyttetGrunnbeløp fra databasen, mens den utleda verdien for grunnbeløp var: ${it.grunnbeløp.grunnbeløpPerÅr}"
-                    }
-                    assert(satsbeløp == it.satsForMånedAsDouble)
-                    assert(sats == it.satskategori)
-                },
+            fullSupplerendeStønadForMåned = satsFactory.forSatskategori(
+                måned = måned,
+                satskategori = sats,
+            ).also {
+                assert(benyttetGrunnbeløp == it.grunnbeløp.grunnbeløpPerÅr) {
+                    "Hentet benyttetGrunnbeløp: $benyttetGrunnbeløp fra databasen, mens den utleda verdien for grunnbeløp var: ${it.grunnbeløp.grunnbeløpPerÅr}"
+                }
+                assert(satsbeløp == it.satsForMånedAsDouble)
+                assert(sats == it.satskategori)
+            },
             fradrag = fradrag.map { it.toFradragForMåned() },
             fribeløpForEps = fribeløpForEps,
             merknader = Merknader.Beregningsmerknad(merknader.map { it.toDomain() }.toMutableList()),


### PR DESCRIPTION
-Gjeldende satsfactory er en dyr operasjon, spesielt mtp minne. Opprettelse av denne for hver måned i beregningen gir et unødvendig stort minne-footprint. Opprettet for beregningen som helhet og månedene er det samme, holder dermed å finne gjeldende satsfactory 1 gang.