### PR TITLE
Legger til håndtering av flere saker i henting av info

### DIFF
--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepo.kt
@@ -54,10 +54,18 @@ internal class SakPostgresRepo(
         }
     }
 
-    override fun hentSak(fnr: Fnr): Sak? {
+    override fun hentSak(fnr: Fnr, type: Søknadstype): Sak? {
         return dbMetrics.timeQuery("hentSakForFnr") {
             sessionFactory.withSessionContext {
-                hentSakInternal(fnr, it)
+                hentSakInternal(fnr, type, it)
+            }
+        }
+    }
+
+    override fun hentSaker(fnr: Fnr): List<Sak> {
+        return dbMetrics.timeQuery("hentSakerForFnr") {
+            sessionFactory.withSessionContext {
+                hentSakerInternal(fnr, it)
             }
         }
     }
@@ -162,11 +170,11 @@ internal class SakPostgresRepo(
         }
     }
 
-    private fun hentSakInternal(fnr: Fnr, sessionContext: SessionContext): Sak? {
+    private fun hentSakInternal(fnr: Fnr, type: Søknadstype, sessionContext: SessionContext): Sak? {
         return dbMetrics.timeQuery("hentSakInternalForFnr") {
             sessionContext.withSession { session ->
-                "select * from sak where fnr=:fnr"
-                    .hent(mapOf("fnr" to fnr.toString()), session) { it.toSak(sessionContext) }
+                "select * from sak where fnr=:fnr and type=:type"
+                    .hent(mapOf("fnr" to fnr.toString(), "type" to type.value), session) { it.toSak(sessionContext) }
             }
         }
     }
@@ -185,6 +193,15 @@ internal class SakPostgresRepo(
             sessionContext.withSession { session ->
                 "select * from sak where saksnummer=:saksnummer"
                     .hent(mapOf("saksnummer" to saksnummer.nummer), session) { it.toSak(sessionContext) }
+            }
+        }
+    }
+
+    private fun hentSakerInternal(fnr: Fnr, sessionContext: SessionContext): List<Sak> {
+        return dbMetrics.timeQuery("hentSakerInternalForFnr") {
+            sessionContext.withSession { session ->
+                "select * from sak where fnr=:fnr"
+                    .hentListe(mapOf("fnr" to fnr.toString()), session) { it.toSak(sessionContext) }
             }
         }
     }

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepo.kt
@@ -54,7 +54,7 @@ internal class SakPostgresRepo(
         }
     }
 
-    override fun hentSak(fnr: Fnr, type: Søknadstype): Sak? {
+    override fun hentSak(fnr: Fnr, type: Sakstype): Sak? {
         return dbMetrics.timeQuery("hentSakForFnr") {
             sessionFactory.withSessionContext {
                 hentSakInternal(fnr, type, it)
@@ -170,7 +170,7 @@ internal class SakPostgresRepo(
         }
     }
 
-    private fun hentSakInternal(fnr: Fnr, type: Søknadstype, sessionContext: SessionContext): Sak? {
+    private fun hentSakInternal(fnr: Fnr, type: Sakstype, sessionContext: SessionContext): Sak? {
         return dbMetrics.timeQuery("hentSakInternalForFnr") {
             sessionContext.withSession { session ->
                 "select * from sak where fnr=:fnr and type=:type"

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepoTest.kt
@@ -8,6 +8,7 @@ import no.nav.su.se.bakover.database.TestDataHelper.Companion.søknadNy
 import no.nav.su.se.bakover.database.withMigratedDb
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.Saksnummer
+import no.nav.su.se.bakover.domain.Søknadstype
 import no.nav.su.se.bakover.domain.sak.Behandlingsoversikt
 import no.nav.su.se.bakover.domain.sak.SakInfo
 import no.nav.su.se.bakover.test.stønadsperiode2021
@@ -21,9 +22,9 @@ internal class SakPostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.sakRepo
             val nySak = testDataHelper.persisterSakMedSøknadUtenJournalføringOgOppgave()
-            val opprettet: Sak = repo.hentSak(nySak.fnr)!!
+            val opprettet: Sak = repo.hentSak(nySak.fnr, Søknadstype.UFØRE)!!
             val hentetId = repo.hentSak(opprettet.id)!!
-            val hentetFnr = repo.hentSak(opprettet.fnr)!!
+            val hentetFnr = repo.hentSak(opprettet.fnr, Søknadstype.UFØRE)!!
 
             opprettet shouldBe hentetId
             hentetId shouldBe hentetFnr

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepoTest.kt
@@ -8,7 +8,7 @@ import no.nav.su.se.bakover.database.TestDataHelper.Companion.søknadNy
 import no.nav.su.se.bakover.database.withMigratedDb
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.Saksnummer
-import no.nav.su.se.bakover.domain.Søknadstype
+import no.nav.su.se.bakover.domain.Sakstype
 import no.nav.su.se.bakover.domain.sak.Behandlingsoversikt
 import no.nav.su.se.bakover.domain.sak.SakInfo
 import no.nav.su.se.bakover.test.stønadsperiode2021
@@ -22,9 +22,9 @@ internal class SakPostgresRepoTest {
             val testDataHelper = TestDataHelper(dataSource)
             val repo = testDataHelper.sakRepo
             val nySak = testDataHelper.persisterSakMedSøknadUtenJournalføringOgOppgave()
-            val opprettet: Sak = repo.hentSak(nySak.fnr, Søknadstype.UFØRE)!!
+            val opprettet: Sak = repo.hentSak(nySak.fnr, Sakstype.UFØRE)!!
             val hentetId = repo.hentSak(opprettet.id)!!
-            val hentetFnr = repo.hentSak(opprettet.fnr, Søknadstype.UFØRE)!!
+            val hentetFnr = repo.hentSak(opprettet.fnr, Sakstype.UFØRE)!!
 
             opprettet shouldBe hentetId
             hentetId shouldBe hentetFnr

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
@@ -448,7 +448,7 @@ class SakFactory(
     }
 }
 
-data class BegrensetSakerInfo(
+data class AlleredeGjeldendeSakForBruker(
     val uføre: BegrensetSakinfo,
     val alder: BegrensetSakinfo
 )

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
@@ -448,6 +448,11 @@ class SakFactory(
     }
 }
 
+data class BegrensetSakerInfo(
+    val uføre: BegrensetSakinfo,
+    val alder: BegrensetSakinfo
+)
+
 data class BegrensetSakinfo(
     val harÅpenSøknad: Boolean,
     val iverksattInnvilgetStønadsperiode: Periode?,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakRepo.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakRepo.kt
@@ -5,12 +5,12 @@ import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NySak
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.Saksnummer
-import no.nav.su.se.bakover.domain.Søknadstype
+import no.nav.su.se.bakover.domain.Sakstype
 import java.util.UUID
 
 interface SakRepo {
     fun hentSak(sakId: UUID): Sak?
-    fun hentSak(fnr: Fnr, type: Søknadstype): Sak?
+    fun hentSak(fnr: Fnr, type: Sakstype): Sak?
     fun hentSak(saksnummer: Saksnummer): Sak?
     fun hentSakInfoForIdenter(personidenter: NonEmptyList<String>): SakInfo?
     fun opprettSak(sak: NySak)

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakRepo.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakRepo.kt
@@ -5,11 +5,12 @@ import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NySak
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.Saksnummer
+import no.nav.su.se.bakover.domain.Søknadstype
 import java.util.UUID
 
 interface SakRepo {
     fun hentSak(sakId: UUID): Sak?
-    fun hentSak(fnr: Fnr): Sak?
+    fun hentSak(fnr: Fnr, type: Søknadstype): Sak?
     fun hentSak(saksnummer: Saksnummer): Sak?
     fun hentSakInfoForIdenter(personidenter: NonEmptyList<String>): SakInfo?
     fun opprettSak(sak: NySak)
@@ -17,4 +18,5 @@ interface SakRepo {
     fun hentFerdigeBehandlinger(): List<Behandlingsoversikt>
     fun hentSakIdSaksnummerOgFnrForAlleSaker(): List<SakInfo>
     fun hentSakerSomVenterPåForhåndsvarsling(): List<Saksnummer>
+    fun hentSaker(fnr: Fnr): List<Sak>
 }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
@@ -15,10 +15,10 @@ import no.nav.su.se.bakover.domain.NySak
 import no.nav.su.se.bakover.domain.Person
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.Saksnummer
+import no.nav.su.se.bakover.domain.Sakstype
 import no.nav.su.se.bakover.domain.SendPåminnelseNyStønadsperiodeContext
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnhold
-import no.nav.su.se.bakover.domain.Søknadstype
 import no.nav.su.se.bakover.domain.behandling.Attestering
 import no.nav.su.se.bakover.domain.behandling.Behandling
 import no.nav.su.se.bakover.domain.behandling.avslag.AvslagManglendeDokumentasjon
@@ -281,7 +281,7 @@ open class AccessCheckProxy(
                         }
                 }
 
-                override fun hentSak(fnr: Fnr, type: Søknadstype): Either<FantIkkeSak, Sak> {
+                override fun hentSak(fnr: Fnr, type: Sakstype): Either<FantIkkeSak, Sak> {
                     // Siden vi også vil kontrollere på EPS må vi hente ut saken først
                     // og sjekke på hele den (i stedet for å gjøre assertHarTilgangTilPerson(fnr))
                     return services.sak.hentSak(fnr, type)
@@ -323,7 +323,7 @@ open class AccessCheckProxy(
                     return services.sak.hentFerdigeBehandlingerForAlleSaker()
                 }
 
-                override fun hentBegrensetSakerInfo(fnr: Fnr): Either<FantIkkeSak, BegrensetSakerInfo> {
+                override fun hentBegrensetSakerInfo(fnr: Fnr): BegrensetSakerInfo {
                     assertHarTilgangTilPerson(fnr)
                     return services.sak.hentBegrensetSakerInfo(fnr)
                 }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
@@ -8,7 +8,7 @@ import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.common.persistence.SessionContext
 import no.nav.su.se.bakover.common.persistence.TransactionContext
 import no.nav.su.se.bakover.domain.AktørId
-import no.nav.su.se.bakover.domain.BegrensetSakerInfo
+import no.nav.su.se.bakover.domain.AlleredeGjeldendeSakForBruker
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.NySak
@@ -323,9 +323,9 @@ open class AccessCheckProxy(
                     return services.sak.hentFerdigeBehandlingerForAlleSaker()
                 }
 
-                override fun hentBegrensetSakerInfo(fnr: Fnr): BegrensetSakerInfo {
+                override fun hentAlleredeGjeldendeSakForBruker(fnr: Fnr): AlleredeGjeldendeSakForBruker {
                     assertHarTilgangTilPerson(fnr)
-                    return services.sak.hentBegrensetSakerInfo(fnr)
+                    return services.sak.hentAlleredeGjeldendeSakForBruker(fnr)
                 }
             },
             søknad = object : SøknadService {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/sak/SakService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/sak/SakService.kt
@@ -2,11 +2,12 @@ package no.nav.su.se.bakover.service.sak
 
 import arrow.core.Either
 import no.nav.su.se.bakover.common.periode.Periode
-import no.nav.su.se.bakover.domain.BegrensetSakinfo
+import no.nav.su.se.bakover.domain.BegrensetSakerInfo
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NySak
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.Saksnummer
+import no.nav.su.se.bakover.domain.Søknadstype
 import no.nav.su.se.bakover.domain.sak.Behandlingsoversikt
 import no.nav.su.se.bakover.domain.sak.SakInfo
 import no.nav.su.se.bakover.domain.vedtak.GjeldendeVedtaksdata
@@ -14,7 +15,8 @@ import java.util.UUID
 
 interface SakService {
     fun hentSak(sakId: UUID): Either<FantIkkeSak, Sak>
-    fun hentSak(fnr: Fnr): Either<FantIkkeSak, Sak>
+    fun hentSak(fnr: Fnr, type: Søknadstype): Either<FantIkkeSak, Sak>
+    fun hentSaker(fnr: Fnr): Either<FantIkkeSak, List<Sak>>
     fun hentSak(saksnummer: Saksnummer): Either<FantIkkeSak, Sak>
     fun hentGjeldendeVedtaksdata(
         sakId: UUID,
@@ -24,7 +26,7 @@ interface SakService {
     fun opprettSak(sak: NySak)
     fun hentÅpneBehandlingerForAlleSaker(): List<Behandlingsoversikt>
     fun hentFerdigeBehandlingerForAlleSaker(): List<Behandlingsoversikt>
-    fun hentBegrensetSakinfo(fnr: Fnr): Either<FantIkkeSak, BegrensetSakinfo>
+    fun hentBegrensetSakerInfo(fnr: Fnr): Either<FantIkkeSak, BegrensetSakerInfo>
     fun hentSakidOgSaksnummer(fnr: Fnr): Either<FantIkkeSak, SakInfo>
 }
 

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/sak/SakService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/sak/SakService.kt
@@ -2,7 +2,7 @@ package no.nav.su.se.bakover.service.sak
 
 import arrow.core.Either
 import no.nav.su.se.bakover.common.periode.Periode
-import no.nav.su.se.bakover.domain.BegrensetSakerInfo
+import no.nav.su.se.bakover.domain.AlleredeGjeldendeSakForBruker
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NySak
 import no.nav.su.se.bakover.domain.Sak
@@ -26,7 +26,7 @@ interface SakService {
     fun opprettSak(sak: NySak)
     fun hentÅpneBehandlingerForAlleSaker(): List<Behandlingsoversikt>
     fun hentFerdigeBehandlingerForAlleSaker(): List<Behandlingsoversikt>
-    fun hentBegrensetSakerInfo(fnr: Fnr): BegrensetSakerInfo
+    fun hentAlleredeGjeldendeSakForBruker(fnr: Fnr): AlleredeGjeldendeSakForBruker
     fun hentSakidOgSaksnummer(fnr: Fnr): Either<FantIkkeSak, SakInfo>
 }
 

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/sak/SakService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/sak/SakService.kt
@@ -7,7 +7,7 @@ import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NySak
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.Saksnummer
-import no.nav.su.se.bakover.domain.Søknadstype
+import no.nav.su.se.bakover.domain.Sakstype
 import no.nav.su.se.bakover.domain.sak.Behandlingsoversikt
 import no.nav.su.se.bakover.domain.sak.SakInfo
 import no.nav.su.se.bakover.domain.vedtak.GjeldendeVedtaksdata
@@ -15,7 +15,7 @@ import java.util.UUID
 
 interface SakService {
     fun hentSak(sakId: UUID): Either<FantIkkeSak, Sak>
-    fun hentSak(fnr: Fnr, type: Søknadstype): Either<FantIkkeSak, Sak>
+    fun hentSak(fnr: Fnr, type: Sakstype): Either<FantIkkeSak, Sak>
     fun hentSaker(fnr: Fnr): Either<FantIkkeSak, List<Sak>>
     fun hentSak(saksnummer: Saksnummer): Either<FantIkkeSak, Sak>
     fun hentGjeldendeVedtaksdata(
@@ -26,7 +26,7 @@ interface SakService {
     fun opprettSak(sak: NySak)
     fun hentÅpneBehandlingerForAlleSaker(): List<Behandlingsoversikt>
     fun hentFerdigeBehandlingerForAlleSaker(): List<Behandlingsoversikt>
-    fun hentBegrensetSakerInfo(fnr: Fnr): Either<FantIkkeSak, BegrensetSakerInfo>
+    fun hentBegrensetSakerInfo(fnr: Fnr): BegrensetSakerInfo
     fun hentSakidOgSaksnummer(fnr: Fnr): Either<FantIkkeSak, SakInfo>
 }
 

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/sak/SakServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/sak/SakServiceImpl.kt
@@ -12,8 +12,8 @@ import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NySak
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.Saksnummer
+import no.nav.su.se.bakover.domain.Sakstype
 import no.nav.su.se.bakover.domain.Søknad
-import no.nav.su.se.bakover.domain.Søknadstype
 import no.nav.su.se.bakover.domain.sak.Behandlingsoversikt
 import no.nav.su.se.bakover.domain.sak.SakInfo
 import no.nav.su.se.bakover.domain.sak.SakRepo
@@ -37,7 +37,7 @@ internal class SakServiceImpl(
         return sakRepo.hentSak(sakId)?.right() ?: FantIkkeSak.left()
     }
 
-    override fun hentSak(fnr: Fnr, type: Søknadstype): Either<FantIkkeSak, Sak> {
+    override fun hentSak(fnr: Fnr, type: Sakstype): Either<FantIkkeSak, Sak> {
         return sakRepo.hentSak(fnr, type)?.right() ?: FantIkkeSak.left()
     }
 
@@ -57,12 +57,9 @@ internal class SakServiceImpl(
         sakId: UUID,
         periode: Periode,
     ): Either<KunneIkkeHenteGjeldendeVedtaksdata, GjeldendeVedtaksdata?> {
-        return hentSak(sakId)
-            .mapLeft { KunneIkkeHenteGjeldendeVedtaksdata.FantIkkeSak }
-            .flatMap { sak ->
-                sak.hentGjeldendeVedtaksdata(periode, clock)
-                    .mapLeft { KunneIkkeHenteGjeldendeVedtaksdata.IngenVedtak }
-            }
+        return hentSak(sakId).mapLeft { KunneIkkeHenteGjeldendeVedtaksdata.FantIkkeSak }.flatMap { sak ->
+            sak.hentGjeldendeVedtaksdata(periode, clock).mapLeft { KunneIkkeHenteGjeldendeVedtaksdata.IngenVedtak }
+        }
     }
 
     override fun hentSakidOgSaksnummer(fnr: Fnr): Either<FantIkkeSak, SakInfo> {
@@ -89,14 +86,21 @@ internal class SakServiceImpl(
         return sakRepo.hentFerdigeBehandlinger()
     }
 
-    override fun hentBegrensetSakerInfo(fnr: Fnr): Either<FantIkkeSak, BegrensetSakerInfo> {
-        return hentSaker(fnr)
-            .map { saker ->
+    override fun hentBegrensetSakerInfo(fnr: Fnr): BegrensetSakerInfo {
+        return hentSaker(fnr).fold(
+            ifLeft = {
                 BegrensetSakerInfo(
-                    uføre = sakTilBegrensetSakInfo(saker.find { it.type == Søknadstype.UFØRE }),
-                    alder = sakTilBegrensetSakInfo(saker.find { it.type == Søknadstype.ALDER })
+                    sakTilBegrensetSakInfo(null),
+                    sakTilBegrensetSakInfo(null),
                 )
-            }
+            },
+            ifRight = { saker ->
+                BegrensetSakerInfo(
+                    uføre = sakTilBegrensetSakInfo(saker.find { it.type == Sakstype.UFØRE }),
+                    alder = sakTilBegrensetSakInfo(saker.find { it.type == Sakstype.ALDER }),
+                )
+            },
+        )
     }
 
     private fun sakTilBegrensetSakInfo(sak: Sak?): BegrensetSakinfo {
@@ -104,15 +108,10 @@ internal class SakServiceImpl(
             return BegrensetSakinfo(false, null)
         }
         return BegrensetSakinfo(
-            harÅpenSøknad = sak.søknader
-                .any { søknad ->
-                    val behandling = sak.søknadsbehandlinger
-                        .find { b -> b.søknad.id == søknad.id }
-                    (
-                        søknad !is Søknad.Journalført.MedOppgave.Lukket &&
-                            (behandling == null || !behandling.erIverksatt)
-                        )
-                },
+            harÅpenSøknad = sak.søknader.any { søknad ->
+                val behandling = sak.søknadsbehandlinger.find { b -> b.søknad.id == søknad.id }
+                (søknad !is Søknad.Journalført.MedOppgave.Lukket && (behandling == null || !behandling.erIverksatt))
+            },
             iverksattInnvilgetStønadsperiode = sak.hentGjeldendeStønadsperiode(clock),
         )
     }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/sak/SakServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/sak/SakServiceImpl.kt
@@ -6,7 +6,7 @@ import arrow.core.left
 import arrow.core.nonEmptyListOf
 import arrow.core.right
 import no.nav.su.se.bakover.common.periode.Periode
-import no.nav.su.se.bakover.domain.BegrensetSakerInfo
+import no.nav.su.se.bakover.domain.AlleredeGjeldendeSakForBruker
 import no.nav.su.se.bakover.domain.BegrensetSakinfo
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NySak
@@ -86,16 +86,16 @@ internal class SakServiceImpl(
         return sakRepo.hentFerdigeBehandlinger()
     }
 
-    override fun hentBegrensetSakerInfo(fnr: Fnr): BegrensetSakerInfo {
+    override fun hentAlleredeGjeldendeSakForBruker(fnr: Fnr): AlleredeGjeldendeSakForBruker {
         return hentSaker(fnr).fold(
             ifLeft = {
-                BegrensetSakerInfo(
+                AlleredeGjeldendeSakForBruker(
                     sakTilBegrensetSakInfo(null),
                     sakTilBegrensetSakInfo(null),
                 )
             },
             ifRight = { saker ->
-                BegrensetSakerInfo(
+                AlleredeGjeldendeSakForBruker(
                     uføre = sakTilBegrensetSakInfo(saker.find { it.type == Sakstype.UFØRE }),
                     alder = sakTilBegrensetSakInfo(saker.find { it.type == Sakstype.ALDER }),
                 )

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/AccessCheckProxyTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/AccessCheckProxyTest.kt
@@ -65,7 +65,7 @@ internal class AccessCheckProxyTest {
                 services = services.copy(
                     sak = mock {
                         on {
-                            hentSak(fnr, Søknadstype.UFØRE)
+                            hentSak(fnr, Sakstype.UFØRE)
                         } doReturn Either.Right(
                             Sak(
                                 id = sakId,
@@ -92,7 +92,7 @@ internal class AccessCheckProxyTest {
                 ),
             ).proxy()
 
-            shouldThrow<Tilgangssjekkfeil> { proxied.sak.hentSak(fnr, Søknadstype.UFØRE) }
+            shouldThrow<Tilgangssjekkfeil> { proxied.sak.hentSak(fnr, Sakstype.UFØRE) }
         }
 
         @Test
@@ -207,7 +207,7 @@ internal class AccessCheckProxyTest {
         private val servicesReturningSak = services.copy(
             sak = mock {
                 on {
-                    hentSak(fnr, Søknadstype.UFØRE)
+                    hentSak(fnr, Sakstype.UFØRE)
                 } doReturn Either.Right(
                     Sak(
                         id = UUID.randomUUID(),
@@ -259,8 +259,8 @@ internal class AccessCheckProxyTest {
 
         @Test
         fun `Når man gjør oppslag på fnr`() {
-            proxied.sak.hentSak(fnr, Søknadstype.UFØRE)
-            verify(servicesReturningSak.sak).hentSak(fnr = argShouldBe(fnr), type = argShouldBe(Søknadstype.UFØRE))
+            proxied.sak.hentSak(fnr, Sakstype.UFØRE)
+            verify(servicesReturningSak.sak).hentSak(fnr = argShouldBe(fnr), type = argShouldBe(Sakstype.UFØRE))
         }
 
         @Test

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/AccessCheckProxyTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/AccessCheckProxyTest.kt
@@ -65,7 +65,7 @@ internal class AccessCheckProxyTest {
                 services = services.copy(
                     sak = mock {
                         on {
-                            hentSak(fnr)
+                            hentSak(fnr, Søknadstype.UFØRE)
                         } doReturn Either.Right(
                             Sak(
                                 id = sakId,
@@ -92,7 +92,7 @@ internal class AccessCheckProxyTest {
                 ),
             ).proxy()
 
-            shouldThrow<Tilgangssjekkfeil> { proxied.sak.hentSak(fnr) }
+            shouldThrow<Tilgangssjekkfeil> { proxied.sak.hentSak(fnr, Søknadstype.UFØRE) }
         }
 
         @Test
@@ -207,7 +207,7 @@ internal class AccessCheckProxyTest {
         private val servicesReturningSak = services.copy(
             sak = mock {
                 on {
-                    hentSak(fnr)
+                    hentSak(fnr, Søknadstype.UFØRE)
                 } doReturn Either.Right(
                     Sak(
                         id = UUID.randomUUID(),
@@ -259,8 +259,8 @@ internal class AccessCheckProxyTest {
 
         @Test
         fun `Når man gjør oppslag på fnr`() {
-            proxied.sak.hentSak(fnr)
-            verify(servicesReturningSak.sak).hentSak(fnr = argShouldBe(fnr))
+            proxied.sak.hentSak(fnr, Søknadstype.UFØRE)
+            verify(servicesReturningSak.sak).hentSak(fnr = argShouldBe(fnr), type = argShouldBe(Søknadstype.UFØRE))
         }
 
         @Test

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/Feilresponser.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/Feilresponser.kt
@@ -12,6 +12,10 @@ import no.nav.su.se.bakover.web.errorJson
 import kotlin.reflect.KClass
 
 internal object Feilresponser {
+    val ugyldigTypeSak = BadRequest.errorJson(
+        "Ugyldig type sak",
+        "ugyldig_type_sak"
+    )
     val fantIkkeBehandling = NotFound.errorJson(
         "Fant ikke behandling",
         "fant_ikke_behandling",

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/sak/SakJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/sak/SakJson.kt
@@ -65,7 +65,7 @@ internal data class SakJson(
     }
 }
 
-internal data class BegrensetSakerInfoJson(
+internal data class AlleredeGjeldendeSakForBrukerJson(
     val uføre: BegrensetSakinfoJson,
     val alder: BegrensetSakinfoJson
 )

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/sak/SakJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/sak/SakJson.kt
@@ -65,6 +65,10 @@ internal data class SakJson(
     }
 }
 
+internal data class BegrensetSakerInfoJson(
+    val uføre: BegrensetSakinfoJson,
+    val alder: BegrensetSakinfoJson
+)
 internal data class BegrensetSakinfoJson(
     val harÅpenSøknad: Boolean,
     val iverksattInnvilgetStønadsperiode: PeriodeJson?,

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/sak/SakRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/sak/SakRoutes.kt
@@ -136,9 +136,9 @@ internal fun Route.sakRoutes(
                         .mapLeft { Feilresponser.ugyldigFødselsnummer }
                 }
                 .map { fnr ->
-                    sakService.hentBegrensetSakerInfo(fnr)
+                    sakService.hentAlleredeGjeldendeSakForBruker(fnr)
                         .let { info ->
-                            BegrensetSakerInfoJson(
+                            AlleredeGjeldendeSakForBrukerJson(
                                 uføre = BegrensetSakinfoJson(
                                     harÅpenSøknad = info.uføre.harÅpenSøknad,
                                     iverksattInnvilgetStønadsperiode = info.uføre.iverksattInnvilgetStønadsperiode?.toJson()

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/sak/SakRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/sak/SakRoutesKtTest.kt
@@ -23,6 +23,7 @@ import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.SakFactory
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
+import no.nav.su.se.bakover.domain.Søknadstype
 import no.nav.su.se.bakover.service.ServiceBuilder
 import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.generer
@@ -74,7 +75,7 @@ internal class SakRoutesKtTest {
                 SakFactory(clock = fixedClock).nySakMedNySøknad(Fnr(sakFnr01), søknadInnhold).also {
                     repos.sak.opprettSak(it)
                 }
-                val opprettetSakId: Sak = repos.sak.hentSak(Fnr(sakFnr01))!!
+                val opprettetSakId: Sak = repos.sak.hentSak(Fnr(sakFnr01), Søknadstype.UFØRE)!!
 
                 defaultRequest(
                     Get,
@@ -98,7 +99,7 @@ internal class SakRoutesKtTest {
                 repos.sak.opprettSak(SakFactory(clock = fixedClock).nySakMedNySøknad(Fnr(sakFnr01), søknadInnhold))
 
                 defaultRequest(HttpMethod.Post, "$sakPath/søk", listOf(Brukerrolle.Saksbehandler)) {
-                    setBody("""{"fnr":"$sakFnr01"}""")
+                    setBody("""{"fnr":"$sakFnr01", "type": "uføre"}""")
                 }.apply {
                     status shouldBe OK
                     bodyAsText() shouldContain """"fnr":"$sakFnr01""""
@@ -124,8 +125,14 @@ internal class SakRoutesKtTest {
                         status shouldBe OK
                         bodyAsText() shouldMatchJson """
                             {
-                                "harÅpenSøknad": false,
-                                "iverksattInnvilgetStønadsperiode": null
+                                "uføre": {
+                                    "harÅpenSøknad": false,
+                                    "iverksattInnvilgetStønadsperiode": null
+                                },
+                                "alder": {
+                                    "harÅpenSøknad": false,
+                                    "iverksattInnvilgetStønadsperiode": null
+                                }
                             }
                         """.trimIndent()
                     }
@@ -151,8 +158,14 @@ internal class SakRoutesKtTest {
                             status shouldBe OK
                             bodyAsText() shouldMatchJson """
                             {
-                                "harÅpenSøknad": true,
-                                "iverksattInnvilgetStønadsperiode": null
+                                "uføre": {
+                                    "harÅpenSøknad": true,
+                                    "iverksattInnvilgetStønadsperiode": null
+                                },
+                                "alder": {
+                                    "harÅpenSøknad": false,
+                                    "iverksattInnvilgetStønadsperiode": null
+                                }
                             }
                             """.trimIndent()
                         }
@@ -174,7 +187,7 @@ internal class SakRoutesKtTest {
                 val services = services(repos)
 
                 val sakSpy = spy(services.sak)
-                doReturn(sak.right()).`when`(sakSpy).hentSak(any<Fnr>())
+                doReturn(listOf(sak).right()).`when`(sakSpy).hentSaker(any())
 
                 testApplication {
                     application {
@@ -193,10 +206,16 @@ internal class SakRoutesKtTest {
                         status shouldBe OK
                         bodyAsText() shouldMatchJson """
                             {
-                                "harÅpenSøknad": false,
-                                "iverksattInnvilgetStønadsperiode": {
-                                    "fraOgMed": "${stønadsperiode.periode.fraOgMed}",
-                                    "tilOgMed": "${stønadsperiode.periode.tilOgMed}"
+                                "uføre": {
+                                    "harÅpenSøknad": false,
+                                    "iverksattInnvilgetStønadsperiode": {
+                                        "fraOgMed": "${stønadsperiode.periode.fraOgMed}",
+                                        "tilOgMed": "${stønadsperiode.periode.tilOgMed}"
+                                    }
+                                },
+                                "alder": {
+                                    "harÅpenSøknad": false,
+                                    "iverksattInnvilgetStønadsperiode": null
                                 }
                             }
                         """.trimIndent()
@@ -218,7 +237,7 @@ internal class SakRoutesKtTest {
             }
 
             defaultRequest(HttpMethod.Post, "$sakPath/søk", listOf(Brukerrolle.Veileder)) {
-                setBody("""{"fnr":"${Fnr.generer()}"}""")
+                setBody("""{"fnr":"${Fnr.generer()}", type: "uføre"}""")
             }.apply {
                 status shouldBe Forbidden
             }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/sak/SakRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/sak/SakRoutesKtTest.kt
@@ -22,8 +22,8 @@ import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.SakFactory
 import no.nav.su.se.bakover.domain.Saksnummer
+import no.nav.su.se.bakover.domain.Sakstype
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
-import no.nav.su.se.bakover.domain.Søknadstype
 import no.nav.su.se.bakover.service.ServiceBuilder
 import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.generer
@@ -75,7 +75,7 @@ internal class SakRoutesKtTest {
                 SakFactory(clock = fixedClock).nySakMedNySøknad(Fnr(sakFnr01), søknadInnhold).also {
                     repos.sak.opprettSak(it)
                 }
-                val opprettetSakId: Sak = repos.sak.hentSak(Fnr(sakFnr01), Søknadstype.UFØRE)!!
+                val opprettetSakId: Sak = repos.sak.hentSak(Fnr(sakFnr01), Sakstype.UFØRE)!!
 
                 defaultRequest(
                     Get,

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutesKtTest.kt
@@ -139,7 +139,7 @@ internal class SøknadRoutesKtTest {
 
                 shouldNotThrow<Throwable> { objectMapper.readValue<OpprettetSøknadJson>(createResponse.bodyAsText()) }
 
-                val sakFraDb = repos.sak.hentSak(fnr, Søknadstype.UFØRE)
+                val sakFraDb = repos.sak.hentSak(fnr, Sakstype.UFØRE)
                 sakFraDb shouldNotBe null
                 sakFraDb!!.søknader shouldHaveAtLeastSize 1
             }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutesKtTest.kt
@@ -139,7 +139,7 @@ internal class SøknadRoutesKtTest {
 
                 shouldNotThrow<Throwable> { objectMapper.readValue<OpprettetSøknadJson>(createResponse.bodyAsText()) }
 
-                val sakFraDb = repos.sak.hentSak(fnr)
+                val sakFraDb = repos.sak.hentSak(fnr, Søknadstype.UFØRE)
                 sakFraDb shouldNotBe null
                 sakFraDb!!.søknader shouldHaveAtLeastSize 1
             }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutesKtTest.kt
@@ -33,9 +33,9 @@ import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.SakFactory
+import no.nav.su.se.bakover.domain.Sakstype
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
-import no.nav.su.se.bakover.domain.Søknadstype
 import no.nav.su.se.bakover.domain.avkorting.AvkortingVedSøknadsbehandling
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
@@ -829,7 +829,7 @@ internal class SøknadsbehandlingRoutesKtTest {
         SakFactory(clock = fixedClock).nySakMedNySøknad(fnr, søknadInnhold).also {
             repos.sak.opprettSak(it)
         }
-        val sak: Sak = repos.sak.hentSak(fnr, Søknadstype.UFØRE)!!
+        val sak: Sak = repos.sak.hentSak(fnr, Sakstype.UFØRE)!!
         val journalpostId = JournalpostId("12")
         val oppgaveId = OppgaveId("12")
         val søknadMedOppgave: Søknad.Journalført.MedOppgave.IkkeLukket = (sak.søknader[0] as Søknad.Ny)

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutesKtTest.kt
@@ -35,6 +35,7 @@ import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.SakFactory
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
+import no.nav.su.se.bakover.domain.Søknadstype
 import no.nav.su.se.bakover.domain.avkorting.AvkortingVedSøknadsbehandling
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
@@ -828,7 +829,7 @@ internal class SøknadsbehandlingRoutesKtTest {
         SakFactory(clock = fixedClock).nySakMedNySøknad(fnr, søknadInnhold).also {
             repos.sak.opprettSak(it)
         }
-        val sak: Sak = repos.sak.hentSak(fnr)!!
+        val sak: Sak = repos.sak.hentSak(fnr, Søknadstype.UFØRE)!!
         val journalpostId = JournalpostId("12")
         val oppgaveId = OppgaveId("12")
         val søknadMedOppgave: Søknad.Journalført.MedOppgave.IkkeLukket = (sak.søknader[0] as Søknad.Ny)

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/beregning/BeregnRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/beregning/BeregnRoutesKtTest.kt
@@ -19,9 +19,9 @@ import no.nav.su.se.bakover.domain.DatabaseRepos
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.SakFactory
+import no.nav.su.se.bakover.domain.Sakstype
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
-import no.nav.su.se.bakover.domain.Søknadstype
 import no.nav.su.se.bakover.domain.avkorting.AvkortingVedSøknadsbehandling
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
@@ -220,7 +220,7 @@ internal class BeregnRoutesKtTest {
         SakFactory(clock = fixedClock).nySakMedNySøknad(fnr, søknadInnhold).also {
             repos.sak.opprettSak(it)
         }
-        val sak: Sak = repos.sak.hentSak(fnr, Søknadstype.UFØRE)!!
+        val sak: Sak = repos.sak.hentSak(fnr, Sakstype.UFØRE)!!
         val journalpostId = JournalpostId("12")
         val oppgaveId = OppgaveId("12")
         val søknadMedOppgave: Søknad.Journalført.MedOppgave.IkkeLukket = (sak.søknader[0] as Søknad.Ny)

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/beregning/BeregnRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/beregning/BeregnRoutesKtTest.kt
@@ -21,6 +21,7 @@ import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.SakFactory
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
+import no.nav.su.se.bakover.domain.Søknadstype
 import no.nav.su.se.bakover.domain.avkorting.AvkortingVedSøknadsbehandling
 import no.nav.su.se.bakover.domain.behandling.Behandlingsinformasjon
 import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
@@ -219,7 +220,7 @@ internal class BeregnRoutesKtTest {
         SakFactory(clock = fixedClock).nySakMedNySøknad(fnr, søknadInnhold).also {
             repos.sak.opprettSak(it)
         }
-        val sak: Sak = repos.sak.hentSak(fnr)!!
+        val sak: Sak = repos.sak.hentSak(fnr, Søknadstype.UFØRE)!!
         val journalpostId = JournalpostId("12")
         val oppgaveId = OppgaveId("12")
         val søknadMedOppgave: Søknad.Journalført.MedOppgave.IkkeLukket = (sak.søknader[0] as Søknad.Ny)


### PR DESCRIPTION
Baserer seg på PR'en for å legge til type søknad

Når både uføre- og aldersøknader kan finnes på samme person vil man kunne få flere forskjellige saker for samme person. hentSak for Fnr legger til et ekstra parameter for hvilken type sak man trenger.

Det er nok også nyttig med et endepunkt for å hente alle sakene for et Fnr også, men der er det foreløpig kun laget på repo- / service-nivå.