### PR TITLE
Fikser uthenting av statistikk for gjenopptak

### DIFF
--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/statistikk/mappers/StønadsstatistikkMapper.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/statistikk/mappers/StønadsstatistikkMapper.kt
@@ -95,7 +95,9 @@ private fun mapBeregning(
     val alleFradrag = beregning.tilFradragPerMåned()
     val månedsberegninger = beregning.getMånedsberegninger().associateBy { it.måned }
 
-    return beregning.periode.måneder().toList().map { måned ->
+    val månederIVedtakOgBeregning = vedtak.periode.måneder().toSet().intersect(beregning.periode.måneder().toSet()).toList()
+
+    return månederIVedtakOgBeregning.map { måned ->
         val fradrag = høgstAvForventetInntektOgArbeidsInntekt(alleFradrag[måned]!!)
 
         Statistikk.Stønad.Månedsbeløp(


### PR DESCRIPTION
Gjenopptak prøvde å hente informasjon som gikk utover perioden
gjenopptakelsesperioden gjaldt. Nå ser vi kun på felles måneder
mellom vedtak og behandlingen vi regner ut for, slik at vi ikke
prøver å hente statistikk for måneder utenfor selve vedtaket.