### PR TITLE
Fjern støy i den vanlige loggen, men behold sikkerlog

### DIFF
--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/personhendelser/PersonhendelseService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/personhendelser/PersonhendelseService.kt
@@ -23,10 +23,8 @@ class PersonhendelseService(
     fun prosesserNyHendelse(personhendelse: Personhendelse.IkkeTilknyttetSak) {
         val eksisterendeSakIdOgNummer =
             sakRepo.hentSakInfoForIdenter(personhendelse.metadata.personidenter) ?: return Unit.also {
-                log.debug("Personhendelse ikke knyttet til sak: Ignorerer ${personhendelse.hendelse} med hendelsesid ${personhendelse.metadata.hendelseId}, offset ${personhendelse.metadata.offset}, partisjon ${personhendelse.metadata.partisjon} og endringstype ${personhendelse.endringstype}")
                 sikkerLogg.debug("Personhendelse ikke knyttet til sak: $personhendelse")
             }
-        log.info("Personhendelse for sak id ${eksisterendeSakIdOgNummer.sakId}: Persisterer ${personhendelse.hendelse} med hendelsesid ${personhendelse.metadata.hendelseId}, offset ${personhendelse.metadata.offset}, partisjon ${personhendelse.metadata.partisjon} og endringstype ${personhendelse.endringstype}")
         sikkerLogg.debug("Personhendelse for sak: $personhendelse")
         personhendelseRepo.lagre(
             personhendelse = personhendelse.tilknyttSak(UUID.randomUUID(), eksisterendeSakIdOgNummer),


### PR DESCRIPTION
Er veldig mye støy i loggingen fra personhendelse-consumern. Tenker att det hade varit fint att kun ha det kvar i sikkerloggen hvis en feil skulle uppstå.