### PR TITLE
Fjern futuristiske satser

### DIFF
--- a/common/src/main/kotlin/no/nav/su/se/bakover/common/periode/Måned.kt
+++ b/common/src/main/kotlin/no/nav/su/se/bakover/common/periode/Måned.kt
@@ -1,7 +1,10 @@
 package no.nav.su.se.bakover.common.periode
 
+import no.nav.su.se.bakover.common.erFørsteDagIMåned
+import no.nav.su.se.bakover.common.erSisteDagIMåned
 import java.time.Clock
 import java.time.LocalDate
+import java.time.Month
 import java.time.YearMonth
 import java.time.temporal.ChronoUnit
 
@@ -40,7 +43,24 @@ data class Måned private constructor(
             return factory.fra(yearMonth)
         }
 
+        fun fra(year: Int, month: Month): Måned {
+            return factory.fra(YearMonth.of(year, month))
+        }
+
+        fun fra(dato: LocalDate): Måned {
+            require(dato.erFørsteDagIMåned()) {
+                "$dato må være den 1. i måneden for å mappes til en måned."
+            }
+            return factory.fra(YearMonth.of(dato.year, dato.month))
+        }
+
         fun fra(fraOgMed: LocalDate, tilOgMed: LocalDate): Måned {
+            require(fraOgMed.erFørsteDagIMåned()) {
+                "fraOgMed: $fraOgMed må være den 1. i måneden for å mappes til en måned."
+            }
+            require(tilOgMed.erSisteDagIMåned()) {
+                "tilOgMed: $tilOgMed må være den siste i måneden for å mappes til en måned."
+            }
             return factory.fra(fraOgMed, tilOgMed)
         }
 

--- a/common/src/test/kotlin/no/nav/su/se/bakover/common/periode/MånedTest.kt
+++ b/common/src/test/kotlin/no/nav/su/se/bakover/common/periode/MånedTest.kt
@@ -111,7 +111,7 @@ internal class MånedTest {
                     fraOgMed = 2.januar(2021),
                     tilOgMed = 31.januar(2021),
                 )
-            }.message shouldBe "FraOgMedDatoMåVæreFørsteDagIMåneden"
+            }.message shouldBe "fraOgMed: 2021-01-02 må være den 1. i måneden for å mappes til en måned."
         }
 
         @Test
@@ -121,7 +121,7 @@ internal class MånedTest {
                     fraOgMed = 1.januar(2021),
                     tilOgMed = 1.januar(2021),
                 )
-            }.message shouldBe "TilOgMedDatoMåVæreSisteDagIMåneden"
+            }.message shouldBe "tilOgMed: 2021-01-01 må være den siste i måneden for å mappes til en måned."
         }
 
         @Test

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/satser/FullSupplerendeStønadForMåned.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/satser/FullSupplerendeStønadForMåned.kt
@@ -50,6 +50,8 @@ sealed interface FullSupplerendeStønadForMåned {
         init {
             require(satsForMåned >= BigDecimal.ZERO)
             require(toProsentAvHøyForMåned >= BigDecimal.ZERO)
+            require(måned == minsteÅrligYtelseForUføretrygdede.måned)
+            require(måned == grunnbeløp.måned)
         }
 
         /** Nyeste ikraftredelsen av grunnbeløpet og minsteÅrligYtelseForUføretrygdede som gjelder for denne måneden. */
@@ -79,6 +81,7 @@ sealed interface FullSupplerendeStønadForMåned {
         init {
             require(satsForMåned >= BigDecimal.ZERO)
             require(toProsentAvHøyForMåned >= BigDecimal.ZERO)
+            require(måned == garantipensjonForMåned.måned)
         }
 
         override val ikrafttredelse: LocalDate = garantipensjonForMåned.ikrafttredelse

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/satser/GarantipensjonFactory.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/satser/GarantipensjonFactory.kt
@@ -1,9 +1,10 @@
 package no.nav.su.se.bakover.domain.satser
 
+import arrow.core.NonEmptyList
 import no.nav.su.se.bakover.common.erSortertOgUtenDuplikater
 import no.nav.su.se.bakover.common.periode.Måned
-import no.nav.su.se.bakover.common.periode.periode
-import no.nav.su.se.bakover.common.periode.periodisert
+import no.nav.su.se.bakover.common.periode.erSammenhengendeSortertOgUtenDuplikater
+import no.nav.su.se.bakover.domain.satser.Knekkpunkt.Companion.compareTo
 import java.time.LocalDate
 
 /**
@@ -11,17 +12,36 @@ import java.time.LocalDate
  * - Med garantipensjonsnivå meiner ein i lova her satsene etter [folketrygdlova § 20-9](https://lovdata.no/dokument/NL/lov/1997-02-28-19/KAPITTEL_7-2#%C2%A720-9).
  * - Garantipensjonen fastsettes med en ordinær og en høy sats som gjelder ved 67 år for ugradert pensjon med full trygdetid.
  * - Satser: https://www.nav.no/no/nav-og-samfunn/kontakt-nav/oversikt-over-satser/garantipensjon_kap
+ *
+ * @param knekkpunkt ikrafttredelsesdatoen til en gitt lov/sats. Brukes for å finne ut hvilke satser som gjaldt på en gitt dato.
+ * @param tidligsteTilgjengeligeMåned Første måned denne satsen er aktuell. Som for denne satsen er 2021-01-01, men siden vi har tester som antar den gjelder før dette er den dynamisk.
  */
-data class GarantipensjonFactory(
+data class GarantipensjonFactory private constructor(
     val ordinær: Map<Måned, GarantipensjonForMåned>,
     val høy: Map<Måned, GarantipensjonForMåned>,
+    val knekkpunkt: Knekkpunkt,
+    val tidligsteTilgjengeligeMåned: Måned,
 ) {
+    private val sisteMånedMedEndring = ordinær.keys.last()
+
+    init {
+        require(ordinær.keys == høy.keys) {
+            "ordinær og høy må ha de samme månedene"
+        }
+        require(ordinær.values.all { it.ikrafttredelse <= knekkpunkt })
+        require(høy.values.all { it.ikrafttredelse <= knekkpunkt })
+        require(ordinær.isNotEmpty())
+        require(ordinær.erSammenhengendeSortertOgUtenDuplikater())
+        require(ordinær.keys.first() == tidligsteTilgjengeligeMåned)
+    }
+
     companion object {
 
         fun createFromSatser(
             ordinær: List<Garantipensjonsendring>,
             høy: List<Garantipensjonsendring>,
-            påDato: LocalDate,
+            knekkpunkt: Knekkpunkt,
+            tidligsteTilgjengeligeMåned: Måned,
         ): GarantipensjonFactory {
             val ikrafttredelseMessage: () -> String = {
                 "Ikrafttredelse for minste årlig ytelse for uføretrygdede må være i stigende rekkefølge og uten duplikater, men var: ${ordinær.map { it.virkningstidspunkt }}"
@@ -36,18 +56,22 @@ data class GarantipensjonFactory(
             require(høy.map { it.virkningstidspunkt }.erSortertOgUtenDuplikater(), virkningstidspunktMessage)
 
             return GarantipensjonFactory(
-                ordinær = ordinær.periodiserIftVirkningstidspunkt(påDato, Satskategori.ORDINÆR),
-                høy = høy.periodiserIftVirkningstidspunkt(påDato, Satskategori.HØY),
+                ordinær = ordinær.periodiserIftVirkningstidspunkt(knekkpunkt, tidligsteTilgjengeligeMåned, Satskategori.ORDINÆR),
+                høy = høy.periodiserIftVirkningstidspunkt(knekkpunkt, tidligsteTilgjengeligeMåned, Satskategori.HØY),
+                knekkpunkt = knekkpunkt,
+                tidligsteTilgjengeligeMåned = tidligsteTilgjengeligeMåned,
             )
         }
 
         private fun List<Garantipensjonsendring>.periodiserIftVirkningstidspunkt(
-            senesteIkrafttredelse: LocalDate,
+            knekkpunkt: Knekkpunkt,
+            tidligsteTilgjengeligeMåned: Måned,
             satskategori: Satskategori,
         ): Map<Måned, GarantipensjonForMåned> {
-            return filterNot { it.ikrafttredelse > senesteIkrafttredelse }
-                .map { it.virkningstidspunkt to it }
-                .periodisert()
+            return filterNot { it.ikrafttredelse > knekkpunkt }
+                .map { RåSats(it.virkningstidspunkt, it) }
+                .let { RåSatser(NonEmptyList.fromListUnsafe(it)) }
+                .periodisert(tidligsteTilgjengeligeMåned)
                 .associate { (virkningstidspunkt, måned, garantipensjonsendring) ->
                     måned to GarantipensjonForMåned(
                         måned = måned,
@@ -66,7 +90,11 @@ data class GarantipensjonFactory(
             Satskategori.HØY -> høy
         }
         return satser[måned]
-            ?: throw IllegalStateException("Har ikke garantipensjon for måned: $måned. Vi har bare data for perioden: ${satser.periode()}")
+            ?: (
+                if (måned > sisteMånedMedEndring) satser[sisteMånedMedEndring]!!.copy(
+                    måned = måned,
+                ) else throw IllegalArgumentException("Har ikke data for etterspurt måned: $måned. Vi har bare data fra og med måned: ${satser.keys.first()}")
+                )
     }
 
     data class Garantipensjonsendring(

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/satser/Knekkpunkt.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/satser/Knekkpunkt.kt
@@ -1,0 +1,22 @@
+package no.nav.su.se.bakover.domain.satser
+
+import no.nav.su.se.bakover.common.periode.Måned
+import java.time.LocalDate
+
+/**
+ * Ikrafttredelsesdatoen til en gitt lov/sats.
+ * Brukes for å finne ut hvilke satser som gjaldt på en gitt dato.
+ * @throws IllegalArgumentException dersom det ikke er den 1. i måneden
+ */
+@JvmInline
+value class Knekkpunkt(
+    private val value: LocalDate,
+) {
+    fun måned(): Måned = Måned.fra(value)
+
+    companion object {
+        operator fun LocalDate.compareTo(knekkpunkt: Knekkpunkt): Int {
+            return this.compareTo(knekkpunkt.value)
+        }
+    }
+}

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/satser/MånedsperiodiserteSatser.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/satser/MånedsperiodiserteSatser.kt
@@ -1,0 +1,106 @@
+package no.nav.su.se.bakover.domain.satser
+
+import arrow.core.Nel
+import arrow.core.NonEmptyList
+import arrow.core.nonEmptyListOf
+import no.nav.su.se.bakover.common.erFørsteDagIMåned
+import no.nav.su.se.bakover.common.erSortertOgUtenDuplikater
+import no.nav.su.se.bakover.common.periode.Måned
+import no.nav.su.se.bakover.common.periode.erSammenhengende
+import no.nav.su.se.bakover.common.periode.erSammenhengendeSortertOgUtenDuplikater
+import no.nav.su.se.bakover.common.periode.erSortert
+import no.nav.su.se.bakover.common.periode.harDuplikater
+import java.time.LocalDate
+
+/**
+ * Gjør om en liste med key-value par av ([LocalDate] - [T]) til en avgrenset, sammenhengende liste hvor verdien [T]
+ * hvert element i [this] ekstrapoleres fra [LocalDate] til [LocalDate] for neste element i listen.
+ *
+ * Eksempelbruk er satser (f.eks. grunnbeløp, garantipensjon o.l.)
+ *
+ * Garanterer at tidslinjen er sammenhengende, sortert og ikke har duplikater.
+ * @throws IllegalArgumentException dersom listen inneholder duplikate eller usorterte datoer; eller en dato ikke er den første i måneden.
+ * @param tidligsteTilgjengeligeMåned filtrerer vekk alle månedene før dette.
+ */
+fun <T> RåSatser<T>.periodisert(tidligsteTilgjengeligeMåned: Måned): Månedssatser<T> {
+
+    assert(this.any { it.måned <= tidligsteTilgjengeligeMåned }) {
+        "Kan ikke periodisere siden vi mangler data for første ønsket måned: $tidligsteTilgjengeligeMåned. Tidligste måned tilgjengelig er ${this.first().måned}"
+    }
+    if (this.size == 1 || this.all { it.måned < tidligsteTilgjengeligeMåned }) {
+        // 1. Dersom vi kun har et element, returner det. Bump måned til tidligsteTilgjengeligeMåned dersom nødvendig.
+        // 2. Dersom alle elementene i lista er før tidligsteTilgjengeligeMåned, returner det yngste.
+        return this.last().let {
+            Månedssatser(Månedssats(it.virkningstidspunkt, maxOf(it.måned, tidligsteTilgjengeligeMåned), it.verdi))
+        }
+    }
+    return this
+        .windowed(size = 2, step = 1, partialWindows = true)
+        .flatMap { satser ->
+            if (satser.size == 1) {
+                // Må ha med sisteelementet
+                satser.first().let {
+                    listOf(Månedssats(it.virkningstidspunkt, it.måned, it.verdi))
+                }
+            } else {
+                val (tidligste, seneste) = satser
+                // Fjerner de parene hvor begge er tidligere enn første måned
+                if (seneste.måned >= tidligsteTilgjengeligeMåned) {
+                    val tidligsteMåned = maxOf(tidligste.måned, tidligsteTilgjengeligeMåned)
+                    tidligsteMåned.until(seneste.måned).map {
+                        Månedssats(tidligste.virkningstidspunkt, it, tidligste.verdi)
+                    }
+                } else emptyList()
+            }
+        }.let { Månedssatser(it) }
+}
+
+data class RåSatser<T>(
+    val satser: NonEmptyList<RåSats<T>>,
+) : List<RåSats<T>> by satser {
+    constructor(sats: RåSats<T>) : this(nonEmptyListOf(sats))
+
+    init {
+        assert(this.map { it.virkningstidspunkt }.erSortertOgUtenDuplikater()) {
+            // Dersom vi fjerner denne, trenger vi et konsept om kunngjøringsdato eller en form for siste element har presedens over første.
+            "Datoene må være sortert i stigende rekkefølge og uten duplikater: ${this.map { it.virkningstidspunkt }}"
+        }
+    }
+}
+
+data class RåSats<T>(
+    val virkningstidspunkt: LocalDate,
+    val verdi: T,
+) {
+    val måned = Måned.fra(virkningstidspunkt)
+
+    init {
+        assert(virkningstidspunkt.erFørsteDagIMåned()) { "Kan kun periodisere datoer hvor virkningstidspunkt er første dag i måneden." }
+    }
+}
+
+data class Månedssatser<T>(
+    val satser: NonEmptyList<Månedssats<T>>,
+) : List<Månedssats<T>> by satser {
+    constructor(sats: Månedssats<T>) : this(nonEmptyListOf(sats))
+    constructor(satser: List<Månedssats<T>>) : this(Nel.fromListUnsafe(satser))
+
+    init {
+        satser.map { it.måned }.let {
+            assert(it.erSammenhengendeSortertOgUtenDuplikater()) {
+                "Kunne ikke periodisere. Sammenhengende: ${it.erSammenhengende()}, duplikate: ${it.harDuplikater()}, sortert: ${it.erSortert()}"
+            }
+        }
+    }
+}
+
+data class Månedssats<T>(
+    val virkningstidspunkt: LocalDate,
+    val måned: Måned,
+    val verdi: T,
+) {
+    init {
+        assert(virkningstidspunkt.erFørsteDagIMåned()) { "Kan kun periodisere datoer hvor virkningstidspunkt er første dag i måneden." }
+        assert(måned >= Måned.fra(virkningstidspunkt))
+    }
+}

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/satser/SatsFactory.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/satser/SatsFactory.kt
@@ -19,8 +19,16 @@ interface SatsFactory {
     ): FullSupplerendeStønadForMåned.Uføre
 
     /**  Hvordan verden så ut på denne datoen. */
-    val gjeldendePåDato: LocalDate
+    val knekkpunkt: Knekkpunkt
 
+    /**
+     * Inclusive. Vi har ikke satser før denne måneden, dette året.
+     */
+    val tidligsteTilgjengeligeMåned: Måned
+
+    /**
+     * TODO jah: Bytt ut denne med en formuegrenseForMåned og formuegrenser etter en gitt dato/måned.
+     */
     val formuegrenserFactory: FormuegrenserFactory
 
     /** høy supplerende stønad for uføre */

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/satser/SatsFactoryForSupplerendeStønadPåKnekkpunkt.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/satser/SatsFactoryForSupplerendeStønadPåKnekkpunkt.kt
@@ -4,21 +4,21 @@ import no.nav.su.se.bakover.common.periode.Måned
 import no.nav.su.se.bakover.domain.grunnbeløp.GrunnbeløpFactory
 import no.nav.su.se.bakover.domain.grunnbeløp.GrunnbeløpForMåned
 import no.nav.su.se.bakover.domain.vilkår.FormuegrenserFactory
-import java.time.LocalDate
 
 /**
  * Satser for supplerende stønad som er gyldig på en gitt dato.
  * Denne er knyttet til ikrafttredelse-datoen i tilhørende lovendringer.
  * Vi ønsker å skille denne fra virkningstidspunktet, da disse har begynt å skille lag i senere år.
  */
-class SatsFactoryForSupplerendeStønadPåDato(
+class SatsFactoryForSupplerendeStønadPåKnekkpunkt(
     private val grunnbeløpFactory: GrunnbeløpFactory,
     override val formuegrenserFactory: FormuegrenserFactory,
     private val uføreOrdinær: FullSupplerendeStønadFactory.Ordinær.Ufør,
     private val uføreHøy: FullSupplerendeStønadFactory.Høy.Ufør,
     private val alderOrdinær: FullSupplerendeStønadFactory.Ordinær.Alder,
     private val alderHøy: FullSupplerendeStønadFactory.Høy.Alder,
-    override val gjeldendePåDato: LocalDate,
+    override val knekkpunkt: Knekkpunkt,
+    override val tidligsteTilgjengeligeMåned: Måned,
 ) : SatsFactory {
 
     /** full supplerende stønad for uføre*/

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vilkår/FormuegrenseForMåned.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vilkår/FormuegrenseForMåned.kt
@@ -26,6 +26,7 @@ data class FormuegrenseForMåned(
      * Når det kommer til lover kan ikrafttredesen være både før og etter virkningstidspunktet.
      */
     val virkningstidspunkt: LocalDate = grunnbeløpForMåned.virkningstidspunkt
+    val ikrafttredelse: LocalDate = grunnbeløpForMåned.ikrafttredelse
 
     val formuegrense: BigDecimal = grunnbeløpForMåned.grunnbeløpPerÅr.toBigDecimal().multiply(faktor.toBigDecimal())
     val formuegrenseMedToDesimaler: Double = grunnbeløpForMåned.grunnbeløpPerÅr.toBigDecimal().multiply(faktor.toBigDecimal()).roundToDecimals(2)

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/grunnbeløp/GrunnbeløpFactoryTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/grunnbeløp/GrunnbeløpFactoryTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.mai
 import no.nav.su.se.bakover.common.periode.april
+import no.nav.su.se.bakover.common.periode.januar
 import no.nav.su.se.bakover.common.periode.mai
 import no.nav.su.se.bakover.domain.satser.SatsFactoryForSupplerendeStønad
 import org.junit.jupiter.api.Test
@@ -13,6 +14,7 @@ import java.time.LocalDate
 internal class GrunnbeløpFactoryTest {
 
     private val factory = SatsFactoryForSupplerendeStønad(
+        tidligsteTilgjengeligeMåned = januar(2016),
         grunnbeløpsendringer = nonEmptyListOf(
             Grunnbeløpsendring(1.mai(2005), 1.mai(2005), 60699),
             Grunnbeløpsendring(1.mai(2006), 1.mai(2006), 62892),

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/satser/GarantipensjonFactoryTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/satser/GarantipensjonFactoryTest.kt
@@ -19,43 +19,41 @@ import java.math.BigDecimal
 
 internal class GarantipensjonFactoryTest {
     @Test
-    fun `ordinært garantipensjonsnivå før desember 2015 skal være udefinert`() {
+    fun `ordinært garantipensjonsnivå før desember 2019 skal være udefinert`() {
         shouldThrow<RuntimeException> {
-            satsFactoryTestPåDato().ordinærAlder(desember(2015))
+            satsFactoryTestPåDato().ordinærAlder(desember(2019))
         }
     }
 
     @Test
-    fun `høyt garantipensjonsnivå før desember 2015 skal være udefinert`() {
+    fun `høyt garantipensjonsnivå før desember 2019 skal være udefinert`() {
         shouldThrow<RuntimeException> {
-            satsFactoryTestPåDato().høyAlder(desember(2015))
+            satsFactoryTestPåDato().høyAlder(desember(2019))
         }
     }
 
     @Test
-    fun `ordinært garantipensjonsnivå fra januar 2016 skal være definert`() {
+    fun `ordinært garantipensjonsnivå fra januar 2020 skal være definert`() {
         shouldNotThrow<Throwable> {
-            satsFactoryTestPåDato().ordinærAlder(januar(2016))
+            satsFactoryTestPåDato().ordinærAlder(januar(2020))
         }
     }
 
     @Test
-    fun `høyt garantipensjonsnivå fra januar 2016 skal være definert`() {
+    fun `høyt garantipensjonsnivå fra januar 2020 skal være definert`() {
         shouldNotThrow<Throwable> {
-            satsFactoryTestPåDato().høyAlder(januar(2016))
+            satsFactoryTestPåDato().høyAlder(januar(2020))
         }
     }
 
     @Test
-    fun `ordinært garantipensjonsnivå mellom sept 2019 og mai 2020 skal være 176 099 kr`() {
-        satsFactoryTestPåDato().ordinærAlder(september(2019)).satsPerÅr.intValueExact() shouldBe 176099
+    fun `ordinært garantipensjonsnivå mellom januar 2020 og mai 2020 skal være 176 099 kr`() {
         satsFactoryTestPåDato().ordinærAlder(januar(2020)).satsPerÅr.intValueExact() shouldBe 176099
         satsFactoryTestPåDato().ordinærAlder(april(2020)).satsPerÅr.intValueExact() shouldBe 176099
     }
 
     @Test
-    fun `høyt garantipensjonsnivå mellom sept 2019 og mai 2020 skal være 190 368 kr`() {
-        satsFactoryTestPåDato().høyAlder(september(2019)).satsPerÅr.intValueExact() shouldBe 190368
+    fun `høyt garantipensjonsnivå mellom januar 2020 og mai 2020 skal være 190 368 kr`() {
         satsFactoryTestPåDato().høyAlder(januar(2020)).satsPerÅr.intValueExact() shouldBe 190368
         satsFactoryTestPåDato().høyAlder(april(2020)).satsPerÅr.intValueExact() shouldBe 190368
     }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/satser/Periode_periodisert_Test.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/satser/Periode_periodisert_Test.kt
@@ -1,0 +1,213 @@
+package no.nav.su.se.bakover.domain.satser
+
+import arrow.core.nonEmptyListOf
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.common.april
+import no.nav.su.se.bakover.common.august
+import no.nav.su.se.bakover.common.desember
+import no.nav.su.se.bakover.common.januar
+import no.nav.su.se.bakover.common.juli
+import no.nav.su.se.bakover.common.juni
+import no.nav.su.se.bakover.common.mai
+import no.nav.su.se.bakover.common.periode.april
+import no.nav.su.se.bakover.common.periode.august
+import no.nav.su.se.bakover.common.periode.desember
+import no.nav.su.se.bakover.common.periode.februar
+import no.nav.su.se.bakover.common.periode.januar
+import no.nav.su.se.bakover.common.periode.juli
+import no.nav.su.se.bakover.common.periode.juni
+import no.nav.su.se.bakover.common.periode.mai
+import no.nav.su.se.bakover.common.periode.mars
+import no.nav.su.se.bakover.common.periode.november
+import no.nav.su.se.bakover.common.periode.oktober
+import no.nav.su.se.bakover.common.periode.september
+import org.junit.jupiter.api.Test
+
+internal class Periode_periodisert_Test {
+
+    @Test
+    fun `må være sortert i stigende rekkefølge`() {
+        shouldThrow<AssertionError> {
+            RåSatser(
+                nonEmptyListOf(
+                    RåSats(1.mai(2019), "a"),
+                    RåSats(1.mai(2018), "b"),
+                ),
+            ).periodisert(mai(2019))
+        }.message shouldBe "Datoene må være sortert i stigende rekkefølge og uten duplikater: [2019-05-01, 2018-05-01]"
+    }
+
+    @Test
+    fun `kan ikke inneholde duplikater`() {
+        shouldThrow<AssertionError> {
+            RåSatser(
+                nonEmptyListOf(
+                    RåSats(1.mai(2019), "a"),
+                    RåSats(1.mai(2019), "b"),
+                ),
+            ).periodisert(mai(2019))
+        }.message shouldBe "Datoene må være sortert i stigende rekkefølge og uten duplikater: [2019-05-01, 2019-05-01]"
+    }
+
+    @Test
+    fun `et element eldre enn tidligsteTilgjengeligeMåned gir exception`() {
+        // I dette tilfellet vil vi mangle data for april 2018. Det er ikke ønskelig.
+        shouldThrow<AssertionError> {
+            RåSatser(RåSats(1.mai(2018), "a")).periodisert(april(2018))
+        }.message shouldBe "Kan ikke periodisere siden vi mangler data for første ønsket måned: Måned(årOgMåned=2018-04). Tidligste måned tilgjengelig er Måned(årOgMåned=2018-05)"
+    }
+
+    @Test
+    fun `to elementer eldre enn tidligsteTilgjengeligeMåned gir exception`() {
+        // I dette tilfellet vil vi mange verdier for april 2018. Det er ikke noe vi ønsker å støtte.
+        shouldThrow<AssertionError> {
+            RåSatser(
+                nonEmptyListOf(
+                    RåSats(1.mai(2018), "a"),
+                    RåSats(1.mai(2019), "b"),
+                ),
+            ).periodisert(april(2018))
+        }.message shouldBe "Kan ikke periodisere siden vi mangler data for første ønsket måned: Måned(årOgMåned=2018-04). Tidligste måned tilgjengelig er Måned(årOgMåned=2018-05)"
+    }
+
+    @Test
+    fun `tre elementer eldre enn tidligsteTilgjengeligeMåned gir exception`() {
+        // I dette tilfellet vil vi mange verdier for april 2018. Det er ikke noe vi ønsker å støtte.
+        shouldThrow<AssertionError> {
+            RåSatser(
+                nonEmptyListOf(
+                    RåSats(1.mai(2018), "a"),
+                    RåSats(1.mai(2019), "b"),
+                    RåSats(1.mai(2020), "c"),
+                ),
+            ).periodisert(april(2018))
+        }.message shouldBe "Kan ikke periodisere siden vi mangler data for første ønsket måned: Måned(årOgMåned=2018-04). Tidligste måned tilgjengelig er Måned(årOgMåned=2018-05)"
+    }
+
+    @Test
+    fun `et element likt som tidligsteTilgjengeligeMåned`() {
+        RåSatser(
+            nonEmptyListOf(
+                RåSats(1.mai(2019), "a"),
+            ),
+        ).periodisert(mai(2019)) shouldBe Månedssatser(
+            nonEmptyListOf(
+                Månedssats(1.mai(2019), mai(2019), "a"),
+            ),
+        )
+    }
+
+    @Test
+    fun `et element yngre enn tidligsteTilgjengeligeMåned`() {
+        RåSatser(
+            nonEmptyListOf(
+                RåSats(1.mai(2019), "a"),
+            ),
+        ).periodisert(juni(2019)) shouldBe Månedssatser(
+            nonEmptyListOf(Månedssats(1.mai(2019), juni(2019), "a")),
+        )
+    }
+
+    @Test
+    fun `to elementer yngre enn tidligsteTilgjengeligeMåned`() {
+        RåSatser(
+            nonEmptyListOf(
+                RåSats(1.mai(2018), "a"),
+                RåSats(1.mai(2019), "b"),
+            ),
+        ).periodisert(juni(2019)) shouldBe Månedssatser(
+            nonEmptyListOf(
+                Månedssats(1.mai(2019), juni(2019), "b"),
+            ),
+        )
+    }
+
+    @Test
+    fun `et element yngre og et likt som tidligsteTilgjengeligeMåned`() {
+        RåSatser(
+            nonEmptyListOf(
+                RåSats(1.mai(2018), "a"),
+                RåSats(1.mai(2019), "b"),
+            ),
+        ).periodisert(mai(2019)) shouldBe Månedssatser(
+            nonEmptyListOf(
+                Månedssats(1.mai(2019), mai(2019), "b"),
+            ),
+        )
+    }
+
+    @Test
+    fun `et element likt og et eldre enn tidligsteTilgjengeligeMåned`() {
+        RåSatser(
+            nonEmptyListOf(
+                RåSats(1.juni(2018), "a"),
+                RåSats(1.juli(2018), "b"),
+            ),
+        ).periodisert(juli(2018)) shouldBe Månedssatser(
+            nonEmptyListOf(
+                Månedssats(1.juli(2018), juli(2018), "b"),
+            ),
+        )
+    }
+
+    @Test
+    fun `et element yngre og et eldre enn tidligsteTilgjengeligeMåned`() {
+        RåSatser(
+            nonEmptyListOf(
+                RåSats(1.mai(2018), "a"),
+                RåSats(1.juli(2018), "b"),
+            ),
+        ).periodisert(juni(2018)) shouldBe Månedssatser(
+            nonEmptyListOf(
+                Månedssats(1.mai(2018), juni(2018), "a"),
+                Månedssats(1.juli(2018), juli(2018), "b"),
+            ),
+        )
+    }
+
+    @Test
+    fun `et element yngre og et likt og et eldre enn tidligsteTilgjengeligeMåned`() {
+        RåSatser(
+            nonEmptyListOf(
+                RåSats(1.april(2018), "a"),
+                RåSats(1.juni(2018), "b"),
+                RåSats(1.august(2018), "c"),
+            ),
+        ).periodisert(juni(2018)) shouldBe Månedssatser(
+            nonEmptyListOf(
+                Månedssats(1.juni(2018), juni(2018), "b"),
+                Månedssats(1.juni(2018), juli(2018), "b"),
+                Månedssats(1.august(2018), august(2018), "c"),
+            ),
+        )
+    }
+
+    @Test
+    fun `er sortert over 3 år`() {
+        RåSatser(
+            nonEmptyListOf(
+                RåSats(1.desember(2018), "a"),
+                RåSats(1.mai(2019), "b"),
+                RåSats(1.januar(2020), "c"),
+            ),
+        ).periodisert(desember(2018)) shouldBe Månedssatser(
+            nonEmptyListOf(
+                Månedssats(1.desember(2018), desember(2018), "a"),
+                Månedssats(1.desember(2018), januar(2019), "a"),
+                Månedssats(1.desember(2018), februar(2019), "a"),
+                Månedssats(1.desember(2018), mars(2019), "a"),
+                Månedssats(1.desember(2018), april(2019), "a"),
+                Månedssats(1.mai(2019), mai(2019), "b"),
+                Månedssats(1.mai(2019), juni(2019), "b"),
+                Månedssats(1.mai(2019), juli(2019), "b"),
+                Månedssats(1.mai(2019), august(2019), "b"),
+                Månedssats(1.mai(2019), september(2019), "b"),
+                Månedssats(1.mai(2019), oktober(2019), "b"),
+                Månedssats(1.mai(2019), november(2019), "b"),
+                Månedssats(1.mai(2019), desember(2019), "b"),
+                Månedssats(1.januar(2020), januar(2020), "c"),
+            ),
+        )
+    }
+}

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/satser/SatsFactoryForSupplerendeStønadUføreTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/satser/SatsFactoryForSupplerendeStønadUføreTest.kt
@@ -37,16 +37,16 @@ internal class SatsFactoryForSupplerendeStønadUføreTest {
     inner class UførFlyktning {
         @Test
         fun `ordinær - desember 2019 er ikke tilgjengelig`() {
-            shouldThrow<IllegalStateException> {
+            shouldThrow<IllegalArgumentException> {
                 satsFactoryTestPåDato(påDato = LocalDate.now()).ordinærUføre(desember(2019))
-            }.message shouldBe "Kan ikke avgjøre full supplerende stønad for måned: Måned(årOgMåned=2019-12). Vi har bare data for perioden: Periode(fraOgMed=2020-01-01, tilOgMed=2029-12-31)"
+            }.message shouldBe "Har ikke data for etterspurt måned: Måned(årOgMåned=2019-12). Vi har bare data fra og med måned: Måned(årOgMåned=2020-01)"
         }
 
         @Test
         fun `høy - desember 2019 er ikke tilgjengelig`() {
-            shouldThrow<IllegalStateException> {
+            shouldThrow<IllegalArgumentException> {
                 satsFactoryTestPåDato(påDato = LocalDate.now()).høyUføre(desember(2019))
-            }.message shouldBe "Kan ikke avgjøre full supplerende stønad for måned: Måned(årOgMåned=2019-12). Vi har bare data for perioden: Periode(fraOgMed=2020-01-01, tilOgMed=2029-12-31)"
+            }.message shouldBe "Har ikke data for etterspurt måned: Måned(årOgMåned=2019-12). Vi har bare data fra og med måned: Måned(årOgMåned=2020-01)"
         }
 
         @Test
@@ -374,31 +374,28 @@ internal class SatsFactoryForSupplerendeStønadUføreTest {
         fun `Cache tar høyde for knekkpunkter på tvers av satser og grunnbeløps ikraftredelser`() {
 
             val satsFactory = SatsFactoryForSupplerendeStønad(
+                tidligsteTilgjengeligeMåned = november(2021),
                 garantipensjonsendringerOrdinær = nonEmptyListOf(
-                    GarantipensjonFactory.Garantipensjonsendring(1.mai(2021), 1.mai(2021), 0),
+                    GarantipensjonFactory.Garantipensjonsendring(1.november(2021), 1.november(2021), 0),
                     GarantipensjonFactory.Garantipensjonsendring(1.januar(2022), 1.januar(2022), 5),
                     GarantipensjonFactory.Garantipensjonsendring(1.mai(2022), 1.mai(2022), 10),
                 ),
                 garantipensjonsendringerHøy = nonEmptyListOf(
-                    GarantipensjonFactory.Garantipensjonsendring(1.mai(2021), 1.mai(2021), 0),
+                    GarantipensjonFactory.Garantipensjonsendring(1.november(2021), 1.november(2021), 0),
                     GarantipensjonFactory.Garantipensjonsendring(1.januar(2022), 1.januar(2022), 10),
                     GarantipensjonFactory.Garantipensjonsendring(1.mai(2022), 1.mai(2022), 20),
                 ),
                 grunnbeløpsendringer = nonEmptyListOf(
-                    // Kan slette den første her når vi har fått satt supplerendeStønadAlderFlyktningIkrafttredelse til 2021-01-01
-                    Grunnbeløpsendring(1.januar(2020), 1.januar(2020), 5),
                     Grunnbeløpsendring(1.november(2021), 30.desember(2021), 10),
                     Grunnbeløpsendring(1.desember(2021), 31.desember(2021), 20),
                     Grunnbeløpsendring(1.februar(2022), 2.januar(2022), 30),
                 ),
                 minsteÅrligYtelseForUføretrygdedeOrdinær = nonEmptyListOf(
-                    MinsteÅrligUføre(1.januar(2020), 1.januar(2020), Faktor(0.00001)),
                     MinsteÅrligUføre(1.november(2021), 16.november(2021), Faktor(1.0)),
                     MinsteÅrligUføre(1.desember(2021), 18.desember(2021), Faktor(2.0)),
                     MinsteÅrligUføre(1.januar(2022), 2.januar(2022), Faktor(3.0)),
                 ),
                 minsteÅrligYtelseForUføretrygdedeHøy = nonEmptyListOf(
-                    MinsteÅrligUføre(1.januar(2020), 1.januar(2020), Faktor(0.00002)),
                     MinsteÅrligUføre(1.november(2021), 16.november(2021), Faktor(4.0)),
                     MinsteÅrligUføre(1.desember(2021), 18.desember(2021), Faktor(5.0)),
                     MinsteÅrligUføre(1.januar(2022), 2.januar(2022), Faktor(6.0)),

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vilkår/FormuegrenserFactoryTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vilkår/FormuegrenserFactoryTest.kt
@@ -12,14 +12,13 @@ import no.nav.su.se.bakover.common.periode.mars
 import no.nav.su.se.bakover.common.september
 import no.nav.su.se.bakover.domain.grunnbeløp.GrunnbeløpForMåned
 import no.nav.su.se.bakover.domain.satser.Faktor
+import no.nav.su.se.bakover.domain.satser.SatsFactoryForSupplerendeStønad
 import no.nav.su.se.bakover.test.formuegrenserFactoryTestPåDato
 import no.nav.su.se.bakover.test.satsFactoryTestPåDato
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.LocalDate
-import java.time.Month
-import java.time.YearMonth
 
 internal class FormuegrenserFactoryTest {
 
@@ -117,12 +116,9 @@ internal class FormuegrenserFactoryTest {
     @Nested
     inner class `virkningstidspunkt()` {
         @Test
-        fun `virkningstidspunkt fra mai 2005`() {
-            formuegrenserFactoryTestPåDato(LocalDate.now()).virkningstidspunkt(
-                YearMonth.of(
-                    2005,
-                    Month.MAY,
-                ),
+        fun `virkningstidspunkt fra januar 2016`() {
+            SatsFactoryForSupplerendeStønad(tidligsteTilgjengeligeMåned = januar(2016)).gjeldende(LocalDate.now()).formuegrenserFactory.virkningstidspunkt(
+                januar(2016),
             ) shouldBe listOf(
                 1.mai(2022) to BigDecimal("55738.5"),
                 1.mai(2021) to BigDecimal("53199.5"),
@@ -132,26 +128,24 @@ internal class FormuegrenserFactoryTest {
                 1.mai(2017) to BigDecimal("46817.0"),
                 1.mai(2016) to BigDecimal("46288.0"),
                 1.mai(2015) to BigDecimal("45034.0"),
-                1.mai(2014) to BigDecimal("44185.0"),
-                1.mai(2013) to BigDecimal("42622.5"),
-                1.mai(2012) to BigDecimal("41061.0"),
-                1.mai(2011) to BigDecimal("39608.0"),
-                1.mai(2010) to BigDecimal("37820.5"),
-                1.mai(2009) to BigDecimal("36440.5"),
-                1.mai(2008) to BigDecimal("35128.0"),
-                1.mai(2007) to BigDecimal("33406.0"),
-                1.mai(2006) to BigDecimal("31446.0"),
-                1.mai(2005) to BigDecimal("30349.5"),
+                // TODO jah: Disse har gått igjennom verifikasjon. De skal nok inn igjen når vi skal begynne å revurdere alder.
+                // 1.mai(2014) to BigDecimal("44185.0"),
+                // 1.mai(2013) to BigDecimal("42622.5"),
+                // 1.mai(2012) to BigDecimal("41061.0"),
+                // 1.mai(2011) to BigDecimal("39608.0"),
+                // 1.mai(2010) to BigDecimal("37820.5"),
+                // 1.mai(2009) to BigDecimal("36440.5"),
+                // 1.mai(2008) to BigDecimal("35128.0"),
+                // 1.mai(2007) to BigDecimal("33406.0"),
+                // 1.mai(2006) to BigDecimal("31446.0"),
+                // 1.mai(2005) to BigDecimal("30349.5"),
             )
         }
 
         @Test
         fun `virkningstidspunkt fra mai 2021`() {
             formuegrenserFactoryTestPåDato(LocalDate.now()).virkningstidspunkt(
-                YearMonth.of(
-                    2021,
-                    Month.MAY,
-                ),
+                mai(2021),
             ) shouldBe listOf(
                 1.mai(2022) to BigDecimal("55738.5"),
                 1.mai(2021) to BigDecimal("53199.5"),
@@ -161,10 +155,7 @@ internal class FormuegrenserFactoryTest {
         @Test
         fun `virkningstidspunkt fra mai 2022`() {
             formuegrenserFactoryTestPåDato(LocalDate.now()).virkningstidspunkt(
-                YearMonth.of(
-                    2022,
-                    Month.MAY,
-                ),
+                mai(2022),
             ) shouldBe listOf(
                 1.mai(2022) to BigDecimal("55738.5"),
             )
@@ -173,10 +164,7 @@ internal class FormuegrenserFactoryTest {
         @Test
         fun `virkningstidspunkt fra mai 2023`() {
             formuegrenserFactoryTestPåDato(LocalDate.now()).virkningstidspunkt(
-                YearMonth.of(
-                    2023,
-                    Month.MAY,
-                ),
+                mai(2023),
             ) shouldBe listOf(
                 1.mai(2022) to BigDecimal("55738.5"),
             )
@@ -187,7 +175,7 @@ internal class FormuegrenserFactoryTest {
             satsFactoryTestPåDato(
                 påDato = 1.januar(2021),
             ).formuegrenserFactory.virkningstidspunkt(
-                fraOgMed = YearMonth.of(2021, Month.JANUARY),
+                fraOgMed = januar(2021),
             ) shouldBe listOf(1.mai(2020) to BigDecimal("50675.5"))
         }
 
@@ -196,7 +184,7 @@ internal class FormuegrenserFactoryTest {
             satsFactoryTestPåDato(
                 påDato = 1.april(2021),
             ).formuegrenserFactory.virkningstidspunkt(
-                fraOgMed = YearMonth.of(2021, Month.JANUARY),
+                fraOgMed = januar(2021),
             ) shouldBe listOf(1.mai(2020) to BigDecimal("50675.5"))
         }
 
@@ -205,7 +193,7 @@ internal class FormuegrenserFactoryTest {
             satsFactoryTestPåDato(
                 påDato = 21.mai(2021),
             ).formuegrenserFactory.virkningstidspunkt(
-                fraOgMed = YearMonth.of(2021, Month.JANUARY),
+                fraOgMed = januar(2021),
             ) shouldBe listOf(1.mai(2021) to BigDecimal("53199.5"), 1.mai(2020) to BigDecimal("50675.5"))
         }
 
@@ -214,7 +202,7 @@ internal class FormuegrenserFactoryTest {
             satsFactoryTestPåDato(
                 påDato = 1.april(2022),
             ).formuegrenserFactory.virkningstidspunkt(
-                fraOgMed = YearMonth.of(2021, Month.JANUARY),
+                fraOgMed = januar(2021),
             ) shouldBe listOf(1.mai(2021) to BigDecimal("53199.5"), 1.mai(2020) to BigDecimal("50675.5"))
         }
 
@@ -223,7 +211,7 @@ internal class FormuegrenserFactoryTest {
             satsFactoryTestPåDato(
                 påDato = 20.mai(2022),
             ).formuegrenserFactory.virkningstidspunkt(
-                fraOgMed = YearMonth.of(2021, Month.JANUARY),
+                fraOgMed = januar(2021),
             ) shouldBe listOf(
                 1.mai(2022) to BigDecimal("55738.5"),
                 1.mai(2021) to BigDecimal("53199.5"),

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/grunnlag/FormuevilkårJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/grunnlag/FormuevilkårJson.kt
@@ -3,13 +3,13 @@ package no.nav.su.se.bakover.web.routes.grunnlag
 import no.nav.su.se.bakover.common.avrund
 import no.nav.su.se.bakover.common.periode.PeriodeJson
 import no.nav.su.se.bakover.common.periode.PeriodeJson.Companion.toJson
+import no.nav.su.se.bakover.common.periode.mai
 import no.nav.su.se.bakover.domain.satser.SatsFactory
 import no.nav.su.se.bakover.domain.vilkår.Resultat
 import no.nav.su.se.bakover.domain.vilkår.Vilkår
 import no.nav.su.se.bakover.domain.vilkår.Vurderingsperiode
 import java.math.BigDecimal
 import java.time.LocalDate
-import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 
 internal data class FormuevilkårJson(
@@ -41,7 +41,7 @@ internal fun Vilkår.Formue.toJson(satsFactory: SatsFactory): FormuevilkårJson 
         // TODO jah + jacob:  Denne bør flyttes til et eget endepunkt i de tilfellene vi ikke har fylt ut formuegrunnlaget/vilkåret enda.
         //  I de tilfellene vi har fylt ut formue og det har blitt lagret i databasen, bør grunnlaget innholde grensene og frontend bør bruke de derfra.
         // jah: For ufør trenger vi fra 2021-01-01 og da gjelder grunnbeløpet med virkningstidspunkt 2020-05-01 fram til og med 2021-04-30
-        formuegrenser = satsFactory.formuegrenserFactory.virkningstidspunkt(YearMonth.of(2020, 5)).toJson(),
+        formuegrenser = satsFactory.formuegrenserFactory.virkningstidspunkt(mai(2020)).toJson(),
     )
 }
 


### PR DESCRIPTION
Et forsøk på å krympe inn minneforbruket til satser. Fjernet satser/grunnlag før 2020-01 og etter siste virkningstidspunkt (2022-05).