### PR TITLE
Legger inn sakstype i brevinnhold med default til uføre

### DIFF
--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/pdf/PdfClient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/pdf/PdfClient.kt
@@ -7,6 +7,7 @@ import com.github.kittinunf.fuel.httpPost
 import no.nav.su.se.bakover.client.ClientError
 import no.nav.su.se.bakover.common.getOrCreateCorrelationId
 import no.nav.su.se.bakover.common.objectMapper
+import no.nav.su.se.bakover.domain.Sakstype
 import no.nav.su.se.bakover.domain.brev.BrevInnhold
 import no.nav.su.se.bakover.domain.søknad.SøknadPdfInnhold
 import org.slf4j.Logger
@@ -14,6 +15,7 @@ import org.slf4j.LoggerFactory
 
 internal const val suPdfGenPath = "/api/v1/genpdf/supdfgen"
 internal const val SOKNAD_TEMPLATE = "soknad"
+internal const val ALDER_MISSING_TEMPLATE = "alderHarIkkeBrevEnda"
 
 internal class PdfClient(private val baseUrl: String) : PdfGenerator {
 
@@ -24,8 +26,17 @@ internal class PdfClient(private val baseUrl: String) : PdfGenerator {
     }
 
     override fun genererPdf(brevInnhold: BrevInnhold): Either<KunneIkkeGenererePdf, ByteArray> {
-        return genererPdf(brevInnhold.toJson(), brevInnhold.brevTemplate.template())
+        return genererPdf(brevInnhold.toJson(), brevInnhold.brevTemplate.template(), brevInnhold.sakstype)
             .mapLeft { KunneIkkeGenererePdf }
+    }
+
+    // TODO øh: Håndter alderbrev på en annen måte når det er på plass
+    private fun genererPdf(input: String, template: String, brevtype: Sakstype): Either<ClientError, ByteArray> {
+        if (brevtype == Sakstype.UFØRE) {
+            return genererPdf(input, template)
+        }
+        // Manuelt overstyrer alle aldersbrev til denne
+        return genererPdf(input, ALDER_MISSING_TEMPLATE)
     }
 
     private fun genererPdf(input: String, template: String): Either<ClientError, ByteArray> {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/VedtakInnholdTestdataBuilder.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/VedtakInnholdTestdataBuilder.kt
@@ -47,5 +47,6 @@ object VedtakInnholdTestdataBuilder {
                 ),
             ),
         ),
+        sakstype = Sakstype.UFØRE
     )
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/BrevInnhold.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/BrevInnhold.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.domain.Fnr
+import no.nav.su.se.bakover.domain.Sakstype
 import no.nav.su.se.bakover.domain.behandling.avslag.Avslagsgrunn
 import no.nav.su.se.bakover.domain.behandling.avslag.Avslagsgrunn.Companion.getDistinkteParagrafer
 import no.nav.su.se.bakover.domain.behandling.avslag.Opphørsgrunn
@@ -17,6 +18,10 @@ abstract class BrevInnhold {
     abstract val brevTemplate: BrevTemplate
     // TODO CHM 05.05.2021: Se på å samle mer av det som er felles for brevinnholdene, f.eks. personalia
 
+    // TODO ØH 21.06.2022: Denne bør være abstract på sikt, og settes for alle brev eksplisitt
+    @get:JsonIgnore
+    open val sakstype: Sakstype = Sakstype.UFØRE
+
     data class AvslagsBrevInnhold(
         val personalia: Personalia,
         val avslagsgrunner: List<Avslagsgrunn>,
@@ -29,6 +34,7 @@ abstract class BrevInnhold {
         val forventetInntektStørreEnn0: Boolean,
         val formueVerdier: FormueForBrev?,
         val satsoversikt: Satsoversikt?,
+        override val sakstype: Sakstype,
     ) : BrevInnhold() {
         @Suppress("unused")
         @JsonInclude
@@ -52,6 +58,7 @@ abstract class BrevInnhold {
         val attestantNavn: String,
         val fritekst: String,
         val satsoversikt: Satsoversikt,
+        override val sakstype: Sakstype
     ) : BrevInnhold() {
         override val brevTemplate: BrevTemplate = BrevTemplate.InnvilgetVedtak
 
@@ -207,7 +214,7 @@ abstract class BrevInnhold {
     data class PåminnelseNyStønadsperiode(
         val personalia: Personalia,
         val utløpsdato: String,
-        val halvtGrunnbeløp: Int
+        val halvtGrunnbeløp: Int,
     ) : BrevInnhold() {
         override val brevTemplate = BrevTemplate.PåminnelseNyStønadsperiode
     }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/LagBrevRequest.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/LagBrevRequest.kt
@@ -9,6 +9,7 @@ import no.nav.su.se.bakover.common.ddMMyyyy
 import no.nav.su.se.bakover.common.toBrevformat
 import no.nav.su.se.bakover.domain.Person
 import no.nav.su.se.bakover.domain.Saksnummer
+import no.nav.su.se.bakover.domain.Sakstype
 import no.nav.su.se.bakover.domain.behandling.avslag.Avslag
 import no.nav.su.se.bakover.domain.behandling.avslag.Opphørsgrunn
 import no.nav.su.se.bakover.domain.behandling.avslag.Opphørsgrunn.Companion.getDistinkteParagrafer
@@ -51,6 +52,7 @@ interface LagBrevRequest {
         override val dagensDato: LocalDate,
         override val saksnummer: Saksnummer,
         private val satsoversikt: Satsoversikt,
+        private val sakstype: Sakstype
     ) : LagBrevRequest {
         override val brevInnhold = BrevInnhold.InnvilgetVedtak(
             personalia = lagPersonalia(),
@@ -62,7 +64,8 @@ interface LagBrevRequest {
             saksbehandlerNavn = saksbehandlerNavn,
             attestantNavn = attestantNavn,
             fritekst = fritekst,
-            satsoversikt = satsoversikt
+            satsoversikt = satsoversikt,
+            sakstype = sakstype,
         )
 
         override fun tilDokument(genererPdf: (lagBrevRequest: LagBrevRequest) -> Either<KunneIkkeGenererePdf, ByteArray>): Either<KunneIkkeGenererePdf, Dokument.UtenMetadata.Vedtak> {
@@ -87,7 +90,8 @@ interface LagBrevRequest {
         private val forventetInntektStørreEnn0: Boolean,
         override val dagensDato: LocalDate,
         override val saksnummer: Saksnummer,
-        private val satsoversikt: Satsoversikt?
+        private val satsoversikt: Satsoversikt?,
+        private val sakstype: Sakstype,
     ) : LagBrevRequest {
         override val brevInnhold = BrevInnhold.AvslagsBrevInnhold(
             personalia = lagPersonalia(),
@@ -102,6 +106,7 @@ interface LagBrevRequest {
             forventetInntektStørreEnn0 = forventetInntektStørreEnn0,
             formueVerdier = avslag.formuegrunnlag?.tilFormueForBrev(),
             satsoversikt = satsoversikt,
+            sakstype = sakstype
         )
 
         override fun tilDokument(genererPdf: (lagBrevRequest: LagBrevRequest) -> Either<KunneIkkeGenererePdf, ByteArray>): Either<KunneIkkeGenererePdf, Dokument.UtenMetadata.Vedtak> {
@@ -191,7 +196,7 @@ interface LagBrevRequest {
         private val gjeldendeMånedsutbetaling: Int,
         override val dagensDato: LocalDate,
         override val saksnummer: Saksnummer,
-        private val satsoversikt: Satsoversikt
+        private val satsoversikt: Satsoversikt,
     ) : LagBrevRequest {
         override val brevInnhold = BrevInnhold.VedtakIngenEndring(
             personalia = lagPersonalia(),
@@ -329,7 +334,7 @@ interface LagBrevRequest {
         override val forventetInntektStørreEnn0: Boolean,
         override val dagensDato: LocalDate,
         override val saksnummer: Saksnummer,
-        private val satsoversikt: Satsoversikt
+        private val satsoversikt: Satsoversikt,
     ) : LagBrevRequest, Revurdering {
         override val brevInnhold = BrevInnhold.RevurderingAvInntekt(
             personalia = lagPersonalia(),
@@ -339,7 +344,7 @@ interface LagBrevRequest {
             fritekst = fritekst,
             harEktefelle = harEktefelle,
             forventetInntektStørreEnn0 = forventetInntektStørreEnn0,
-            satsoversikt = satsoversikt
+            satsoversikt = satsoversikt,
         )
 
         override fun tilDokument(genererPdf: (lagBrevRequest: LagBrevRequest) -> Either<KunneIkkeGenererePdf, ByteArray>): Either<KunneIkkeGenererePdf, Dokument.UtenMetadata.Vedtak> {
@@ -358,7 +363,7 @@ interface LagBrevRequest {
     data class TilbakekrevingAvPenger(
         private val ordinærtRevurderingBrev: Inntekt,
         private val tilbakekreving: Tilbakekreving,
-        private val satsoversikt: Satsoversikt
+        private val satsoversikt: Satsoversikt,
     ) : LagBrevRequest, Revurdering by ordinærtRevurderingBrev {
         override val brevInnhold: BrevInnhold = BrevInnhold.RevurderingMedTilbakekrevingAvPenger(
             personalia = lagPersonalia(),
@@ -371,7 +376,7 @@ interface LagBrevRequest {
             tilbakekreving = tilbakekreving.tilbakekrevingavdrag,
             periodeStart = tilbakekreving.periodeStart,
             periodeSlutt = tilbakekreving.periodeSlutt,
-            satsoversikt = satsoversikt
+            satsoversikt = satsoversikt,
         )
 
         override fun tilDokument(genererPdf: (lagBrevRequest: LagBrevRequest) -> Either<KunneIkkeGenererePdf, ByteArray>): Either<KunneIkkeGenererePdf, Dokument.UtenMetadata.Vedtak> {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/Stønadsvedtak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/Stønadsvedtak.kt
@@ -85,18 +85,17 @@ sealed interface VedtakSomKanRevurderes : Stønadsvedtak {
             søknadsbehandling: Søknadsbehandling.Iverksatt.Innvilget,
             utbetalingId: UUID30,
             clock: Clock,
-        ) =
-            EndringIYtelse.InnvilgetSøknadsbehandling(
-                id = UUID.randomUUID(),
-                opprettet = Tidspunkt.now(clock),
-                periode = søknadsbehandling.periode,
-                behandling = søknadsbehandling,
-                beregning = søknadsbehandling.beregning,
-                simulering = søknadsbehandling.simulering,
-                saksbehandler = søknadsbehandling.saksbehandler,
-                attestant = søknadsbehandling.attesteringer.hentSisteAttestering().attestant,
-                utbetalingId = utbetalingId,
-            )
+        ) = EndringIYtelse.InnvilgetSøknadsbehandling(
+            id = UUID.randomUUID(),
+            opprettet = Tidspunkt.now(clock),
+            periode = søknadsbehandling.periode,
+            behandling = søknadsbehandling,
+            beregning = søknadsbehandling.beregning,
+            simulering = søknadsbehandling.simulering,
+            saksbehandler = søknadsbehandling.saksbehandler,
+            attestant = søknadsbehandling.attesteringer.hentSisteAttestering().attestant,
+            utbetalingId = utbetalingId,
+        )
 
         fun from(revurdering: IverksattRevurdering.IngenEndring, clock: Clock) = IngenEndringIYtelse(
             id = UUID.randomUUID(),
@@ -483,7 +482,6 @@ sealed interface Avslagsvedtak : Stønadsvedtak, Visitable<VedtakVisitor>, ErAvs
         override val periode: Periode,
     ) : Avslagsvedtak {
         override fun harIdentifisertBehovForFremtidigAvkorting() = false
-
         override fun accept(visitor: VedtakVisitor) {
             visitor.visit(this)
         }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitor.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitor.kt
@@ -754,6 +754,7 @@ class LagBrevRequestVisitor(
             saksnummer = saksnummer,
             // Ikke inkluder satsoversikt dersom beregning ikke er utført
             satsoversikt = beregning?.let { Satsoversikt.fra(bosituasjon, satsFactory, sakstype) },
+            sakstype = sakstype
         )
     }
 
@@ -776,6 +777,7 @@ class LagBrevRequestVisitor(
         dagensDato = LocalDate.now(clock),
         saksnummer = saksnummer,
         satsoversikt = Satsoversikt.fra(bosituasjon, satsFactory, sakstype),
+        sakstype = sakstype
     )
 
     private data class PersonOgNavn(

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/brev/AvslagsBrevInnholdTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/brev/AvslagsBrevInnholdTest.kt
@@ -3,6 +3,7 @@ package no.nav.su.se.bakover.domain.brev
 import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.domain.Fnr
+import no.nav.su.se.bakover.domain.Sakstype
 import no.nav.su.se.bakover.domain.behandling.avslag.Avslagsgrunn
 import no.nav.su.se.bakover.domain.behandling.avslag.Avslagsgrunn.Companion.getDistinkteParagrafer
 import org.junit.jupiter.api.Test
@@ -39,6 +40,7 @@ class AvslagsBrevInnholdTest {
                 ),
             ),
         ),
+        sakstype = Sakstype.UFØRE
     )
 
     @Test

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/brev/BrevInnholdTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/brev/BrevInnholdTest.kt
@@ -7,6 +7,7 @@ import no.nav.su.se.bakover.common.periode.januar
 import no.nav.su.se.bakover.domain.Beløp
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.MånedBeløp
+import no.nav.su.se.bakover.domain.Sakstype
 import no.nav.su.se.bakover.domain.behandling.avslag.Opphørsgrunn
 import no.nav.su.se.bakover.domain.brev.beregning.Beregningsperiode
 import no.nav.su.se.bakover.domain.brev.beregning.BrevPeriode
@@ -90,6 +91,7 @@ internal class BrevInnholdTest {
                     ),
                 ),
             ),
+            sakstype = Sakstype.UFØRE
         )
 
         val actualJson = objectMapper.writeValueAsString(innvilgetVedtak)

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitorTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitorTest.kt
@@ -200,6 +200,7 @@ internal class LagBrevRequestVisitorTest {
                     dagensDato = fixedLocalDate,
                     saksnummer = vilkårsvurdertInnvilget.saksnummer,
                     satsoversikt = null,
+                    sakstype = Sakstype.UFØRE
                 ).right()
 
                 it.brevRequest.map { brevRequest ->
@@ -262,6 +263,7 @@ internal class LagBrevRequestVisitorTest {
                     dagensDato = fixedLocalDate,
                     saksnummer = vilkårsvurdertInnvilget.saksnummer,
                     satsoversikt = null,
+                    sakstype = Sakstype.UFØRE
                 ).right()
 
                 it.brevRequest.map { brevRequest ->
@@ -300,6 +302,7 @@ internal class LagBrevRequestVisitorTest {
                         dagensDato = fixedLocalDate,
                         saksnummer = vilkårsvurdertInnvilget.saksnummer,
                         satsoversikt = `satsoversikt2021EnsligPr01-01-21`,
+                        sakstype = Sakstype.UFØRE
                     ).right()
                 }
             }
@@ -349,6 +352,7 @@ internal class LagBrevRequestVisitorTest {
                     dagensDato = fixedLocalDate,
                     saksnummer = vilkårsvurdertInnvilget.saksnummer,
                     satsoversikt = `satsoversikt2021EnsligPr01-01-21`,
+                    sakstype = Sakstype.UFØRE
                 ).right()
             }
         }
@@ -388,6 +392,7 @@ internal class LagBrevRequestVisitorTest {
                         dagensDato = fixedLocalDate,
                         saksnummer = vilkårsvurdertInnvilget.saksnummer,
                         satsoversikt = `satsoversikt2021EnsligPr01-01-21`,
+                        sakstype = Sakstype.UFØRE
                     ).right()
 
                     it.brevRequest.map { brevRequest ->
@@ -434,6 +439,7 @@ internal class LagBrevRequestVisitorTest {
                         dagensDato = fixedLocalDate,
                         saksnummer = vilkårsvurdertInnvilget.saksnummer,
                         satsoversikt = null,
+                        sakstype = Sakstype.UFØRE
                     ).right()
                 }
             }
@@ -487,6 +493,7 @@ internal class LagBrevRequestVisitorTest {
                         dagensDato = fixedLocalDate,
                         saksnummer = vilkårsvurdertInnvilget.saksnummer,
                         satsoversikt = `satsoversikt2021EnsligPr01-01-21`,
+                        sakstype = Sakstype.UFØRE
                     ).right()
                 }
             }
@@ -528,6 +535,7 @@ internal class LagBrevRequestVisitorTest {
                         dagensDato = fixedLocalDate,
                         saksnummer = vilkårsvurdertInnvilget.saksnummer,
                         satsoversikt = `satsoversikt2021EnsligPr01-01-21`,
+                        sakstype = Sakstype.UFØRE
                     ).right()
                 }
             }
@@ -575,6 +583,7 @@ internal class LagBrevRequestVisitorTest {
                         dagensDato = fixedLocalDate,
                         saksnummer = vilkårsvurdertInnvilget.saksnummer,
                         satsoversikt = null,
+                        sakstype = Sakstype.UFØRE
                     ).right()
                 }
             }
@@ -637,6 +646,7 @@ internal class LagBrevRequestVisitorTest {
                         dagensDato = fixedLocalDate,
                         saksnummer = vilkårsvurdertInnvilget.saksnummer,
                         satsoversikt = `satsoversikt2021EnsligPr01-01-21`,
+                        sakstype = Sakstype.UFØRE
                     ).right()
                 }
             }
@@ -686,6 +696,7 @@ internal class LagBrevRequestVisitorTest {
                         dagensDato = fixedLocalDate,
                         saksnummer = vilkårsvurdertInnvilget.saksnummer,
                         satsoversikt = `satsoversikt2021EnsligPr01-01-21`,
+                        sakstype = Sakstype.UFØRE
                     ).right()
                 }
             }
@@ -728,6 +739,7 @@ internal class LagBrevRequestVisitorTest {
                         dagensDato = fixedLocalDate,
                         saksnummer = vilkårsvurdertInnvilget.saksnummer,
                         satsoversikt = null,
+                        sakstype = Sakstype.UFØRE
                     ).right()
                 }
             }
@@ -785,6 +797,7 @@ internal class LagBrevRequestVisitorTest {
                         dagensDato = fixedLocalDate,
                         saksnummer = vilkårsvurdertInnvilget.saksnummer,
                         satsoversikt = `satsoversikt2021EnsligPr01-01-21`,
+                        sakstype = Sakstype.UFØRE
                     ).right()
                 }
             }
@@ -827,6 +840,7 @@ internal class LagBrevRequestVisitorTest {
                         dagensDato = fixedLocalDate,
                         saksnummer = vilkårsvurdertInnvilget.saksnummer,
                         satsoversikt = `satsoversikt2021EnsligPr01-01-21`,
+                        sakstype = Sakstype.UFØRE
                     ).right()
                 }
             }
@@ -883,6 +897,7 @@ internal class LagBrevRequestVisitorTest {
             dagensDato = fixedLocalDate,
             saksnummer = søknadsbehandling.saksnummer,
             satsoversikt = `satsoversikt2021EnsligPr01-01-21`,
+            sakstype = Sakstype.UFØRE
         ).right()
     }
 
@@ -947,6 +962,7 @@ internal class LagBrevRequestVisitorTest {
             dagensDato = fixedLocalDate,
             saksnummer = søknadsbehandling.saksnummer,
             satsoversikt = `satsoversikt2021EnsligPr01-01-21`,
+            sakstype = Sakstype.UFØRE
         ).right()
     }
 
@@ -1000,6 +1016,7 @@ internal class LagBrevRequestVisitorTest {
             dagensDato = fixedLocalDate,
             saksnummer = søknadsbehandling.saksnummer,
             satsoversikt = null,
+            sakstype = Sakstype.UFØRE
         ).right()
     }
 
@@ -1071,6 +1088,7 @@ internal class LagBrevRequestVisitorTest {
             dagensDato = fixedLocalDate,
             saksnummer = søknadsbehandling.saksnummer,
             satsoversikt = null,
+            sakstype = Sakstype.UFØRE
         ).right()
     }
 


### PR DESCRIPTION
For vedtaksbrev og avslagsbrev er disse satt ut fra saksbehandlingen. Når
(om™) vi får aldersbrev implementert for de forskjellige så må pdfclient
gjøre en smartere override og sakstype må settes riktig for de forskjellige
brevene slik at vi kan bruke det i templates i pdfgen.

Eller løse forskjellige brevinnhold for alder og uføre på en annen måte.
Time will tell.