### PR TITLE
Alltid tom liste for uføregrunnlag i vilkårsvurdering for alder

### DIFF
--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitor.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitor.kt
@@ -564,7 +564,7 @@ class LagBrevRequestVisitor(
             is Vilkårsvurderinger.Revurdering.Uføre -> this.uføre.grunnlag
             is Vilkårsvurderinger.Søknadsbehandling.Uføre -> this.uføre.grunnlag
             is Vilkårsvurderinger.Revurdering.Alder -> TODO("vilkårsvurdering_alder brev for alder ikke implementert enda")
-            is Vilkårsvurderinger.Søknadsbehandling.Alder -> TODO("vilkårsvurdering_alder brev for alder ikke implementert enda")
+            is Vilkårsvurderinger.Søknadsbehandling.Alder -> emptyList() // TODO("vilkårsvurdering_alder brev for alder ikke implementert enda")
         }
     }
 

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/komponenttest/SøknadsbehandlingAlder.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/komponenttest/SøknadsbehandlingAlder.kt
@@ -3,7 +3,6 @@ package no.nav.su.se.bakover.web.komponenttest
 import arrow.core.nonEmptyListOf
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldContain
 import no.nav.su.se.bakover.common.fixedClock
 import no.nav.su.se.bakover.common.juni
 import no.nav.su.se.bakover.domain.Sakstype
@@ -260,17 +259,6 @@ internal class SøknadsbehandlingAlder {
                 request = SøknadsbehandlingService.HentRequest(behandlingId = søknadsbehandling.id),
             ).getOrFail().also { oppdatert ->
                 oppdatert.vilkårsvurderinger.resultat.shouldBeType<Vilkårsvurderingsresultat.Avslag>()
-            }
-
-            assertThrows<NotImplementedError> {
-                appComponents.services.søknadsbehandling.brev(
-                    request = SøknadsbehandlingService.BrevRequest.MedFritekst(
-                        behandling = avslag,
-                        fritekst = "",
-                    ),
-                )
-            }.also {
-                it.message shouldContain "vilkårsvurdering_alder brev for alder ikke implementert enda"
             }
         }
     }


### PR DESCRIPTION
Dette er skikkelig hacky, men ble ikke stoppet for å lage brev for alder i lokal testing 