### PR TITLE
Bump Kotlin from 1.6.2. to 1.7.0

### DIFF
--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakPåTidslinjeTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakPåTidslinjeTest.kt
@@ -45,7 +45,7 @@ internal class VedtakPåTidslinjeTest {
     @Test
     fun `bevarer korrekte verdier ved kopiering for plassering på tidslinje - full kopi`() {
         // TODO("endre denne testen til å bruke en faktisk")
-        val originaltVedtak = mock<VedtakSomKanRevurderes.EndringIYtelse>()
+        val originaltVedtak = mock<VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling>()
 
         val periode = år(2021)
         val uføregrunnlag = Grunnlag.Uføregrunnlag(
@@ -191,7 +191,7 @@ internal class VedtakPåTidslinjeTest {
     @Test
     fun `bevarer korrekte verdier ved kopiering for plassering på tidslinje - ny periode`() {
         // TODO("endre denne testen til å bruke en faktisk")
-        val originaltVedtak = mock<VedtakSomKanRevurderes.EndringIYtelse>()
+        val originaltVedtak = mock<VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling>()
 
         val periode = år(2021)
         val uføregrunnlag = Grunnlag.Uføregrunnlag(

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakTest.kt
@@ -15,6 +15,7 @@ import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Sakstype
+import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.avkorting.AvkortingVedSøknadsbehandling
 import no.nav.su.se.bakover.domain.behandling.Attestering
 import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
@@ -497,7 +498,7 @@ internal class VedtakTest {
                 opprettet = Tidspunkt.now(clock),
                 sakId = UUID.randomUUID(),
                 saksnummer = Saksnummer(2222),
-                søknad = mock(),
+                søknad = mock<Søknad.Journalført.MedOppgave.IkkeLukket>(),
                 oppgaveId = mock(),
                 behandlingsinformasjon = Behandlingsinformasjon.lagTomBehandlingsinformasjon().withAlleVilkårOppfylt(),
                 fnr = Fnr.generer(),

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.jvmargs=-Xmx2000m
 org.gradle.parallel=true
-kotlinVersion=1.6.20
+kotlinVersion=1.7.0
 ktorVersion=2.0.2

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/LagBrevutkastForRevurderingTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/LagBrevutkastForRevurderingTest.kt
@@ -238,7 +238,7 @@ internal class LagBrevutkastForRevurderingTest {
         val revurderingRepoMock = mock<RevurderingRepo> {
             on { hent(revurderingId) } doReturn revurdering
         }
-        val utbetalingMock = mock<Utbetaling> {
+        val utbetalingMock = mock<Utbetaling.OversendtUtbetaling.MedKvittering> {
             on { utbetalingslinjer } doReturn nonEmptyListOf(
                 utbetalingslinje(
                     periode = RevurderingTestUtils.periodeNesteMånedOgTreMånederFram,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RegulerGrunnbeløpServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RegulerGrunnbeløpServiceImplTest.kt
@@ -25,6 +25,7 @@ import no.nav.su.se.bakover.domain.revurdering.Revurderingsteg
 import no.nav.su.se.bakover.domain.revurdering.Revurderingsårsak
 import no.nav.su.se.bakover.domain.revurdering.UnderkjentRevurdering
 import no.nav.su.se.bakover.domain.vilkår.Vilkår
+import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
 import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderingsresultat
 import no.nav.su.se.bakover.service.argThat
 import no.nav.su.se.bakover.service.beregning.TestBeregning
@@ -235,7 +236,7 @@ internal class RegulerGrunnbeløpServiceImplTest {
             attesteringer = mock(),
             forhåndsvarsel = Forhåndsvarsel.Ferdigbehandlet.SkalIkkeForhåndsvarsles,
             grunnlagsdata = Grunnlagsdata.IkkeVurdert,
-            vilkårsvurderinger = mock {
+            vilkårsvurderinger = mock<Vilkårsvurderinger.Revurdering.Uføre> {
                 on { resultat } doReturn Vilkårsvurderingsresultat.Innvilget(emptySet())
             },
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
@@ -292,7 +293,7 @@ internal class RegulerGrunnbeløpServiceImplTest {
             beregning = TestBeregning,
             forhåndsvarsel = null,
             grunnlagsdata = Grunnlagsdata.IkkeVurdert,
-            vilkårsvurderinger = mock {
+            vilkårsvurderinger = mock<Vilkårsvurderinger.Revurdering.Uføre> {
                 on { resultat } doReturn Vilkårsvurderingsresultat.Innvilget(emptySet())
             },
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
@@ -373,7 +374,7 @@ internal class RegulerGrunnbeløpServiceImplTest {
             skalFøreTilUtsendingAvVedtaksbrev = true,
             forhåndsvarsel = Forhåndsvarsel.Ferdigbehandlet.SkalIkkeForhåndsvarsles,
             grunnlagsdata = Grunnlagsdata.IkkeVurdert,
-            vilkårsvurderinger = mock {
+            vilkårsvurderinger = mock<Vilkårsvurderinger.Revurdering.Uføre> {
                 on { resultat } doReturn Vilkårsvurderingsresultat.Innvilget(emptySet())
             },
             informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceAttesteringTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceAttesteringTest.kt
@@ -19,7 +19,7 @@ import no.nav.su.se.bakover.domain.behandling.withAlleVilkårOppfylt
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.journal.JournalpostId
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
-import no.nav.su.se.bakover.domain.oppdrag.tilbakekreving.Tilbakekrevingsbehandling
+import no.nav.su.se.bakover.domain.oppdrag.tilbakekreving.AvventerKravgrunnlag
 import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
 import no.nav.su.se.bakover.domain.oppgave.OppgaveFeil.KunneIkkeLukkeOppgave
 import no.nav.su.se.bakover.domain.oppgave.OppgaveFeil.KunneIkkeOppretteOppgave
@@ -357,7 +357,7 @@ class SøknadsbehandlingServiceAttesteringTest {
     @Test
     fun `får ikke sendt til attestering dersom det eksisterer revurderinger som avventer kravgrunnlag`() {
         val søknadsbehandling = søknadsbehandlingSimulert().second
-        val mock = mock<Tilbakekrevingsbehandling.Ferdigbehandlet.UtenKravgrunnlag.AvventerKravgrunnlag>()
+        val mock = mock<AvventerKravgrunnlag>()
 
         SøknadsbehandlingServiceAndMocks(
             søknadsbehandlingRepo = mock {

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceHentTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceHentTest.kt
@@ -26,7 +26,7 @@ internal class SøknadsbehandlingServiceHentTest {
 
     @Test
     fun `svarer med behandling dersom alt er ok`() {
-        val behandlingMock = mock<Søknadsbehandling>()
+        val behandlingMock = mock<Søknadsbehandling.Vilkårsvurdert.Uavklart>()
         val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
             on { hent(any()) } doReturn behandlingMock
         }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/vedtak/VedtakServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/vedtak/VedtakServiceImplTest.kt
@@ -156,7 +156,7 @@ internal class VedtakServiceImplTest {
 
     @Test
     fun `kopier gjeldende vedtaksdata - ugyldig periode`() {
-        val vedtakMock = mock<VedtakSomKanRevurderes.EndringIYtelse> {
+        val vedtakMock = mock<VedtakSomKanRevurderes.EndringIYtelse.InnvilgetSøknadsbehandling> {
             on { periode } doReturn år(2021)
         }
         val sakServiceMock = mock<SakService> {

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/komponenttest/SøknadsbehandlingAlder.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/komponenttest/SøknadsbehandlingAlder.kt
@@ -255,7 +255,7 @@ internal class SøknadsbehandlingAlder {
                 it.vilkårsvurderinger.resultat.shouldBeType<Vilkårsvurderingsresultat.Avslag>()
             }
 
-            val avslag = appComponents.services.søknadsbehandling.hent(
+            appComponents.services.søknadsbehandling.hent(
                 request = SøknadsbehandlingService.HentRequest(behandlingId = søknadsbehandling.id),
             ).getOrFail().also { oppdatert ->
                 oppdatert.vilkårsvurderinger.resultat.shouldBeType<Vilkårsvurderingsresultat.Avslag>()

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -57,3 +57,7 @@ tasks.named<Jar>("jar") {
         }
     }
 }
+
+// Pluginen burde sette opp dette selv, men den virker discontinued.
+tasks.named("compileKotlin").get().dependsOn(":web:generateAvroJava")
+tasks.named("compileTestKotlin").get().dependsOn(":web:generateTestAvroJava")

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BrevutkastForRevurderingRouteTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/BrevutkastForRevurderingRouteTest.kt
@@ -12,7 +12,8 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.server.testing.testApplication
 import no.nav.su.se.bakover.domain.Brukerrolle
-import no.nav.su.se.bakover.domain.revurdering.Revurdering
+import no.nav.su.se.bakover.domain.revurdering.IverksattRevurdering
+import no.nav.su.se.bakover.domain.revurdering.OpprettetRevurdering
 import no.nav.su.se.bakover.service.revurdering.KunneIkkeLageBrevutkastForRevurdering
 import no.nav.su.se.bakover.service.revurdering.RevurderingService
 import no.nav.su.se.bakover.web.defaultRequest
@@ -58,7 +59,7 @@ internal class BrevutkastForRevurderingRouteTest {
     @Test
     fun `kan lage brevutkast`() {
         val pdfAsBytes = "<myPreciousByteArray.org".toByteArray()
-        val revurderingMock = mock<Revurdering> {
+        val revurderingMock = mock<IverksattRevurdering.Innvilget> {
             on { fnr } doReturn mock()
         }
         val revurderingServiceMock = mock<RevurderingService> {
@@ -149,7 +150,7 @@ internal class BrevutkastForRevurderingRouteTest {
     ) {
         val revurderingServiceMock = mock<RevurderingService> {
             on { lagBrevutkastForRevurdering(any(), any()) } doReturn error.left()
-            on { hentRevurdering(any()) } doReturn mock()
+            on { hentRevurdering(any()) } doReturn mock<OpprettetRevurdering>()
         }
 
         testApplication {


### PR DESCRIPTION
Kan ikke lenger mock'e sealed class / sealed interface virker det som. Kan være fordi det ikke kan kombineres med `open`.