### PR TITLE
Lowercase sakstype

### DIFF
--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/sak/SakJsonMatcher.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/sak/SakJsonMatcher.kt
@@ -19,7 +19,7 @@ fun assertSakJson(
     expectedVedtak: String = "[]",
     expectedKlager: String = "[]",
     expectedReguleringer: String = "[]",
-    expectedSakstype: String = "UFØRE",
+    expectedSakstype: String = "uføre",
 ) {
     // language=JSON
     val expectedSakJson = """

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/søknadsbehandling/SøknadsbehandlingJsonMatcher.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/søknadsbehandling/SøknadsbehandlingJsonMatcher.kt
@@ -25,7 +25,7 @@ fun assertSøknadsbehandlingJson(
     expectedGrunnlagsdataOgVilkårsvurderinger: String,
     expectedErLukket: Boolean = false,
     expectedSimuleringForAvkortingsvarsel: String? = null,
-    expectedSakstype: String = "UFØRE",
+    expectedSakstype: String = "uføre",
 ) {
     val expectedSakJson = """
     {

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/søknadsbehandling/pensjon/LeggTilPensjonsVilkårIT.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/søknadsbehandling/pensjon/LeggTilPensjonsVilkårIT.kt
@@ -40,7 +40,7 @@ internal class LeggTilPensjonsVilkårIT {
                         SharedRegressionTestData.epsFnr,
                     )
                     }]",
-                    expectedSakstype = "ALDER",
+                    expectedSakstype = "alder",
                 )
 
                 nySøknadsbehandling(
@@ -56,7 +56,7 @@ internal class LeggTilPensjonsVilkårIT {
                         expectedSøknad = JSONObject(nyBehandlingResponse).getJSONObject("søknad").toString(),
                         expectedSakId = sakId,
                         expectedGrunnlagsdataOgVilkårsvurderinger = tomGrunnlagsdataOgVilkårsvurderingerResponse(),
-                        expectedSakstype = "ALDER",
+                        expectedSakstype = "alder",
                     )
 
                     val fraOgMed: String = 1.januar(2022).toString()

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/sak/SakJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/sak/SakJson.kt
@@ -75,8 +75,8 @@ enum class SakstypeJson {
 
 internal fun Sakstype.toJson(): String {
     return when (this) {
-        Sakstype.ALDER -> SakstypeJson.ALDER.toString()
-        Sakstype.UFØRE -> SakstypeJson.UFØRE.toString()
+        Sakstype.ALDER -> SakstypeJson.ALDER.toString().lowercase()
+        Sakstype.UFØRE -> SakstypeJson.UFØRE.toString().lowercase()
     }
 }
 

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingJsonTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingJsonTest.kt
@@ -150,7 +150,7 @@ internal class RevurderingJsonTest {
                   "Inntekt": "IkkeVurdert"
                 },
                 "attesteringer": [],
-                "sakstype": "UFØRE"
+                "sakstype": "uføre"
             }
             """.trimIndent()
 
@@ -237,7 +237,7 @@ internal class RevurderingJsonTest {
                   "Inntekt": "IkkeVurdert"
                 },
                 "attesteringer": [],
-                "sakstype": "UFØRE"
+                "sakstype": "uføre"
             }
             """.trimIndent()
 
@@ -323,7 +323,7 @@ internal class RevurderingJsonTest {
                   "Inntekt": "IkkeVurdert"
                 },
                 "attesteringer": [],
-                "sakstype": "UFØRE"
+                "sakstype": "uføre"
             }
             """.trimIndent()
 
@@ -403,7 +403,7 @@ internal class RevurderingJsonTest {
                   "Inntekt": "IkkeVurdert"
                 },
                 "attesteringer": [],
-                "sakstype": "UFØRE"
+                "sakstype": "uføre"
             }
             """.trimIndent()
 
@@ -495,7 +495,7 @@ internal class RevurderingJsonTest {
                   "Inntekt": "IkkeVurdert"
                 },
                 "attesteringer": [],
-                "sakstype": "UFØRE",
+                "sakstype": "uføre",
                 "simuleringForAvkortingsvarsel": null,
                 "tilbakekrevingsbehandling": {
                   "avgjørelse": "IKKE_AVGJORT"
@@ -585,7 +585,7 @@ internal class RevurderingJsonTest {
                   "Inntekt": "IkkeVurdert"
                 },
                 "attesteringer": [],
-                "sakstype": "UFØRE",
+                "sakstype": "uføre",
                 "simuleringForAvkortingsvarsel": null,
                 "tilbakekrevingsbehandling": null
             }
@@ -674,7 +674,7 @@ internal class RevurderingJsonTest {
                   "Inntekt": "Vurdert"
                 },
                 "attesteringer": [],
-                "sakstype": "UFØRE",
+                "sakstype": "uføre",
                 "simuleringForAvkortingsvarsel": null,
                 "tilbakekrevingsbehandling": null
             }
@@ -763,7 +763,7 @@ internal class RevurderingJsonTest {
                   "Inntekt": "IkkeVurdert"
                 },
                 "attesteringer": [],
-                "sakstype": "UFØRE",
+                "sakstype": "uføre",
                 "simuleringForAvkortingsvarsel": null,
                 "tilbakekrevingsbehandling": null
             }
@@ -847,7 +847,7 @@ internal class RevurderingJsonTest {
                   "Inntekt": "IkkeVurdert"
                 },
                 "attesteringer": [],
-                "sakstype": "UFØRE",
+                "sakstype": "uføre",
                 "simuleringForAvkortingsvarsel": null,
                 "tilbakekrevingsbehandling": null
             }
@@ -922,7 +922,7 @@ internal class RevurderingJsonTest {
                         "kommentar": "Dokumentasjon mangler"
                     }
                 }],
-                "sakstype": "UFØRE",
+                "sakstype": "uføre",
                 "fritekstTilBrev": "",
                 "skalFøreTilBrevutsending": true,
                 "årsak": "MELDING_FRA_BRUKER",
@@ -1025,7 +1025,7 @@ internal class RevurderingJsonTest {
                         "kommentar": "Dokumentasjon mangler"
                     }
                 }],
-                "sakstype": "UFØRE",
+                "sakstype": "uføre",
                 "fritekstTilBrev": "",
                 "skalFøreTilBrevutsending": true,
                 "årsak": "MELDING_FRA_BRUKER",
@@ -1124,7 +1124,7 @@ internal class RevurderingJsonTest {
                         "kommentar": "Dokumentasjon mangler"
                     }
                 }],
-                "sakstype": "UFØRE",
+                "sakstype": "uføre",
                 "fritekstTilBrev": "",
                 "skalFøreTilBrevutsending": false,
                 "årsak": "MELDING_FRA_BRUKER",
@@ -1256,7 +1256,7 @@ internal class RevurderingJsonTest {
                   "Inntekt": "IkkeVurdert"
                 },
                 "attesteringer": [{"attestant":"attestant", "opprettet": "$attesteringOpprettet", "underkjennelse": null}],
-                "sakstype": "UFØRE",
+                "sakstype": "uføre",
                 "simuleringForAvkortingsvarsel": null,
                 "tilbakekrevingsbehandling": {
                   "avgjørelse": "TILBAKEKREV"
@@ -1353,7 +1353,7 @@ internal class RevurderingJsonTest {
                   "Inntekt": "IkkeVurdert"
                 },
                 "attesteringer": [{"attestant": "attestant", "opprettet": "$attesteringOpprettet", "underkjennelse": null}],
-                "sakstype": "UFØRE",
+                "sakstype": "uføre",
                 "simuleringForAvkortingsvarsel": null,
                 "tilbakekrevingsbehandling": null
             }
@@ -1444,7 +1444,7 @@ internal class RevurderingJsonTest {
                   "Inntekt": "IkkeVurdert"
                 },
                 "attesteringer": [{"attestant": "attestant", "opprettet": "$attesteringOpprettet", "underkjennelse": null}],
-                "sakstype": "UFØRE",
+                "sakstype": "uføre",
                 "simuleringForAvkortingsvarsel": null,
                 "tilbakekrevingsbehandling": null
             }
@@ -1487,7 +1487,7 @@ internal class RevurderingJsonTest {
                   "familiegjenforening": null
                 },
                 "attesteringer": [],
-                "sakstype": "UFØRE"
+                "sakstype": "uføre"
             }
             """.trimIndent()
 
@@ -1528,7 +1528,7 @@ internal class RevurderingJsonTest {
                   "familiegjenforening": null
                 },
                 "attesteringer": [{"attestant": "attestant", "opprettet": "$fixedTidspunkt", "underkjennelse": null}],
-                "sakstype": "UFØRE"
+                "sakstype": "uføre"
             }
             """.trimIndent()
 
@@ -1571,7 +1571,7 @@ internal class RevurderingJsonTest {
                   "familiegjenforening": null
                 },
                 "attesteringer": [],
-                "sakstype": "UFØRE"
+                "sakstype": "uføre"
 
             }
             """.trimIndent()
@@ -1612,7 +1612,7 @@ internal class RevurderingJsonTest {
                   "familiegjenforening": null
                 },
                 "attesteringer": [{"attestant": "attestant", "opprettet": "$fixedTidspunkt", "underkjennelse": null}],
-                "sakstype": "UFØRE"
+                "sakstype": "uføre"
             }
             """.trimIndent()
 

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/sak/SakJsonTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/sak/SakJsonTest.kt
@@ -60,7 +60,7 @@ internal class SakJsonTest {
                 "vedtak": [],
                 "klager": [],
                 "reguleringer": [],
-                "sakstype": "UFØRE"
+                "sakstype": "uføre"
             }
         """.trimIndent()
 

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingJsonTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingJsonTest.kt
@@ -106,7 +106,7 @@ internal class SøknadsbehandlingJsonTest {
           "fritekstTilBrev": "",
           "erLukket": false,
           "simuleringForAvkortingsvarsel": null,
-          "sakstype": "UFØRE"
+          "sakstype": "uføre"
         }
             """.trimIndent()
     }
@@ -188,7 +188,7 @@ internal class SøknadsbehandlingJsonTest {
           "fritekstTilBrev": "",
           "erLukket": false,
           "simuleringForAvkortingsvarsel": null,
-          "sakstype": "UFØRE"
+          "sakstype": "uføre"
         }
             """
 


### PR DESCRIPTION
Det er en inkosekvens i sakstypene vi dytter til front atm:
* Søknadsinnhold kjører lowercase
* Sak har type-felt i uppercase

Om de burde være upper eller lower er for så vidt ikke riktig, men de burde være like