### PR TITLE
Legger til brev for innvilgelse / avslag alder

### DIFF
--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/pdf/PdfClient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/pdf/PdfClient.kt
@@ -7,7 +7,6 @@ import com.github.kittinunf.fuel.httpPost
 import no.nav.su.se.bakover.client.ClientError
 import no.nav.su.se.bakover.common.getOrCreateCorrelationId
 import no.nav.su.se.bakover.common.objectMapper
-import no.nav.su.se.bakover.domain.Sakstype
 import no.nav.su.se.bakover.domain.brev.BrevInnhold
 import no.nav.su.se.bakover.domain.søknad.SøknadPdfInnhold
 import org.slf4j.Logger
@@ -15,7 +14,6 @@ import org.slf4j.LoggerFactory
 
 internal const val suPdfGenPath = "/api/v1/genpdf/supdfgen"
 internal const val SOKNAD_TEMPLATE = "soknad"
-internal const val ALDER_MISSING_TEMPLATE = "alderHarIkkeBrevEnda"
 
 internal class PdfClient(private val baseUrl: String) : PdfGenerator {
 
@@ -26,17 +24,8 @@ internal class PdfClient(private val baseUrl: String) : PdfGenerator {
     }
 
     override fun genererPdf(brevInnhold: BrevInnhold): Either<KunneIkkeGenererePdf, ByteArray> {
-        return genererPdf(brevInnhold.toJson(), brevInnhold.brevTemplate.template(), brevInnhold.sakstype)
+        return genererPdf(brevInnhold.toJson(), brevInnhold.brevTemplate.template())
             .mapLeft { KunneIkkeGenererePdf }
-    }
-
-    // TODO øh: Håndter alderbrev på en annen måte når det er på plass
-    private fun genererPdf(input: String, template: String, brevtype: Sakstype): Either<ClientError, ByteArray> {
-        if (brevtype == Sakstype.UFØRE) {
-            return genererPdf(input, template)
-        }
-        // Manuelt overstyrer alle aldersbrev til denne
-        return genererPdf(input, ALDER_MISSING_TEMPLATE)
     }
 
     private fun genererPdf(input: String, template: String): Either<ClientError, ByteArray> {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/avslag/Avslagsgrunn.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/avslag/Avslagsgrunn.kt
@@ -18,7 +18,10 @@ enum class Avslagsgrunn {
     INNLAGT_PÅ_INSTITUSJON,
     MANGLENDE_DOKUMENTASJON,
     SØKNAD_MANGLER_DOKUMENTASJON,
-    PENSJON,
+    PENSJON, // TODO: Fjern denne fra listen, og rydd opp i basen i dev
+    MANGLER_VEDTAK_ALDERSPENSJON_FOLKETRYGDEN,
+    MANGLER_VEDTAK_ANDRE_NORSKE_PENSJONSORDNINGER,
+    MANGLER_VEDTAK_UTENLANDSKE_PENSJONSORDNINGER,
     FAMILIEGJENFORENING;
 
     companion object {
@@ -46,8 +49,11 @@ enum class Avslagsgrunn {
         UTENLANDSOPPHOLD_OVER_90_DAGER -> listOf(1, 2, 4)
         INNLAGT_PÅ_INSTITUSJON -> listOf(12)
         MANGLENDE_DOKUMENTASJON -> listOf(18)
+        PENSJON -> TODO("SKAL FJERNES")
         SØKNAD_MANGLER_DOKUMENTASJON -> listOf(18)
-        PENSJON -> listOf(3) // TODO("finn ut om denne er korrekt")
+        MANGLER_VEDTAK_ALDERSPENSJON_FOLKETRYGDEN -> listOf(3)
+        MANGLER_VEDTAK_ANDRE_NORSKE_PENSJONSORDNINGER -> listOf(3)
+        MANGLER_VEDTAK_UTENLANDSKE_PENSJONSORDNINGER -> listOf(3)
         FAMILIEGJENFORENING -> listOf(3)
     }
 
@@ -65,8 +71,11 @@ enum class Avslagsgrunn {
             INNLAGT_PÅ_INSTITUSJON -> TODO()
             MANGLENDE_DOKUMENTASJON -> Opphørsgrunn.MANGLENDE_DOKUMENTASJON
             SØKNAD_MANGLER_DOKUMENTASJON -> TODO()
-            PENSJON -> TODO("Gjør det mulig å revurdere vilkåret + brev + etc")
             FAMILIEGJENFORENING -> TODO("legg inn opphørsgrunn når det skal revurderes")
+            PENSJON -> TODO("SKAL FJERNES")
+            MANGLER_VEDTAK_ALDERSPENSJON_FOLKETRYGDEN -> TODO("Gjør det mulig å revurdere vilkåret + brev + etc")
+            MANGLER_VEDTAK_ANDRE_NORSKE_PENSJONSORDNINGER -> TODO("Gjør det mulig å revurdere vilkåret + brev + etc")
+            MANGLER_VEDTAK_UTENLANDSKE_PENSJONSORDNINGER -> TODO("Gjør det mulig å revurdere vilkåret + brev + etc")
         }
     }
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/BrevInnhold.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/BrevInnhold.kt
@@ -2,6 +2,7 @@ package no.nav.su.se.bakover.domain.brev
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
 import no.nav.su.se.bakover.common.objectMapper
 import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.Sakstype
@@ -21,6 +22,9 @@ abstract class BrevInnhold {
     // TODO ØH 21.06.2022: Denne bør være abstract på sikt, og settes for alle brev eksplisitt
     @get:JsonIgnore
     open val sakstype: Sakstype = Sakstype.UFØRE
+
+    @JsonProperty
+    fun erAldersbrev(): Boolean = this.sakstype == Sakstype.ALDER
 
     data class AvslagsBrevInnhold(
         val personalia: Personalia,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vilkår/Vilkårsvurderingsresultat.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vilkår/Vilkårsvurderingsresultat.kt
@@ -12,43 +12,47 @@ sealed class Vilkårsvurderingsresultat {
     data class Avslag(
         val vilkår: Set<Vilkår>,
     ) : Vilkårsvurderingsresultat() {
-        val avslagsgrunner = vilkår.map { it.avslagsgrunn() }
+        val avslagsgrunner: List<Avslagsgrunn> = vilkår.flatMap { it.avslagsgrunner() }
         val tidligsteDatoForAvslag = vilkår.minOf { it.hentTidligesteDatoForAvslag()!! }
 
-        private fun Vilkår.avslagsgrunn(): Avslagsgrunn {
+        private fun Vilkår.avslagsgrunner(): List<Avslagsgrunn> {
             return when (this) {
                 is FastOppholdINorgeVilkår -> {
-                    Avslagsgrunn.BOR_OG_OPPHOLDER_SEG_I_NORGE
+                    listOf(Avslagsgrunn.BOR_OG_OPPHOLDER_SEG_I_NORGE)
                 }
                 is FlyktningVilkår -> {
-                    Avslagsgrunn.FLYKTNING
+                    listOf(Avslagsgrunn.FLYKTNING)
                 }
                 is FormueVilkår -> {
-                    Avslagsgrunn.FORMUE
+                    listOf(Avslagsgrunn.FORMUE)
                 }
                 is InstitusjonsoppholdVilkår -> {
-                    Avslagsgrunn.INNLAGT_PÅ_INSTITUSJON
+                    listOf(Avslagsgrunn.INNLAGT_PÅ_INSTITUSJON)
                 }
                 is LovligOppholdVilkår -> {
-                    Avslagsgrunn.OPPHOLDSTILLATELSE
+                    listOf(Avslagsgrunn.OPPHOLDSTILLATELSE)
                 }
                 is OpplysningspliktVilkår -> {
-                    Avslagsgrunn.MANGLENDE_DOKUMENTASJON
+                    listOf(Avslagsgrunn.MANGLENDE_DOKUMENTASJON)
                 }
                 is PersonligOppmøteVilkår -> {
-                    Avslagsgrunn.PERSONLIG_OPPMØTE
+                    listOf(Avslagsgrunn.PERSONLIG_OPPMØTE)
                 }
                 is UføreVilkår -> {
-                    Avslagsgrunn.UFØRHET
+                    listOf(Avslagsgrunn.UFØRHET)
                 }
                 is UtenlandsoppholdVilkår -> {
-                    Avslagsgrunn.UTENLANDSOPPHOLD_OVER_90_DAGER
+                    listOf(Avslagsgrunn.UTENLANDSOPPHOLD_OVER_90_DAGER)
                 }
                 is FamiliegjenforeningVilkår -> {
-                    Avslagsgrunn.FAMILIEGJENFORENING
+                    listOf(Avslagsgrunn.FAMILIEGJENFORENING)
                 }
                 is PensjonsVilkår -> {
-                    Avslagsgrunn.PENSJON
+                    listOfNotNull(
+                        this.grunnlag.find { it.pensjonsopplysninger.søktUtenlandskePensjoner.resultat() == Vurdering.Avslag }?.let { Avslagsgrunn.MANGLER_VEDTAK_UTENLANDSKE_PENSJONSORDNINGER },
+                        this.grunnlag.find { it.pensjonsopplysninger.søktPensjonFolketrygd.resultat() == Vurdering.Avslag }?.let { Avslagsgrunn.MANGLER_VEDTAK_ALDERSPENSJON_FOLKETRYGDEN },
+                        this.grunnlag.find { it.pensjonsopplysninger.søktAndreNorskePensjoner.resultat() == Vurdering.Avslag }?.let { Avslagsgrunn.MANGLER_VEDTAK_ANDRE_NORSKE_PENSJONSORDNINGER },
+                    )
                 }
             }
         }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/brev/AvslagsBrevInnholdTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/brev/AvslagsBrevInnholdTest.kt
@@ -57,6 +57,7 @@ class AvslagsBrevInnholdTest {
                   "saksnummer": 2021
               },
               "avslagsgrunner": ["FLYKTNING"],
+              "erAldersbrev": false,
               "harFlereAvslagsgrunner": false,
               "halvGrunnbeløp": 10,
               "harEktefelle": false,
@@ -146,6 +147,7 @@ class AvslagsBrevInnholdTest {
                   "saksnummer": 2021
               },
               "avslagsgrunner": ["FORMUE"],
+              "erAldersbrev": false,
               "harFlereAvslagsgrunner": false,
               "halvGrunnbeløp": 10,
               "harEktefelle": false,
@@ -223,6 +225,7 @@ class AvslagsBrevInnholdTest {
                   "saksnummer": 2021
               },
               "avslagsgrunner": ["FORMUE"],
+              "erAldersbrev": false,
               "harFlereAvslagsgrunner": false,
               "halvGrunnbeløp": 10,
               "harEktefelle": false,

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/brev/BrevInnholdTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/brev/BrevInnholdTest.kt
@@ -131,6 +131,7 @@ internal class BrevInnholdTest {
                 "saksbehandlerNavn": "Hei",
                 "attestantNavn": "Hopp",
                 "fritekst": "",
+                "erAldersbrev": false,
                 "harAvkorting": false,
                 "satsoversikt": {
                   "perioder": [
@@ -168,6 +169,7 @@ internal class BrevInnholdTest {
                   "etternavn": "Strømøy",
                   "saksnummer": 2021
               },
+              "erAldersbrev": false,
               "datoSøknadOpprettet": "01.01.2020",
               "trukketDato": "01.02.2020",
               "saksbehandlerNavn": "saksbehandler"
@@ -245,6 +247,7 @@ internal class BrevInnholdTest {
                 "saksbehandlerNavn": "Hei",
                 "attestantNavn": "Hopp",
                 "fritekst": "",
+                "erAldersbrev": false,
                 "opphørsgrunner" : ["FOR_HØY_INNTEKT"],
                 "avslagsparagrafer" : [1],
                 "forventetInntektStørreEnn0" : false,
@@ -288,6 +291,7 @@ internal class BrevInnholdTest {
                     "etternavn": "Strømøy",
                     "saksnummer": 12345676
                 },
+                "erAldersbrev": false,
                 "saksbehandlerNavn": "saks",
                 "fritekst": "fri",
             }
@@ -317,6 +321,7 @@ internal class BrevInnholdTest {
                     "etternavn": "Strømøy",
                     "saksnummer": 12345676
                 },
+                "erAldersbrev": false,
                 "saksbehandlerNavn": "saks",
                 "fritekst": "fri",
                 "bruttoTilbakekreving":"5${nbsp}000${nbsp}000",

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/IverksettAvvistKlageTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/IverksettAvvistKlageTest.kt
@@ -306,7 +306,7 @@ internal class IverksettAvvistKlageTest {
                         opprettet = it.opprettet,
                         tittel = "Avvist klage",
                         generertDokument = dokument,
-                        generertDokumentJson = "{\"personalia\":{\"dato\":\"01.01.2021\",\"fødselsnummer\":\"${klage.fnr}\",\"fornavn\":\"Tore\",\"etternavn\":\"Strømøy\",\"saksnummer\":${klage.saksnummer}},\"saksbehandlerNavn\":\"Johnny\",\"fritekst\":\"dette er min fritekst\",\"saksnummer\":${klage.saksnummer}}",
+                        generertDokumentJson = "{\"personalia\":{\"dato\":\"01.01.2021\",\"fødselsnummer\":\"${klage.fnr}\",\"fornavn\":\"Tore\",\"etternavn\":\"Strømøy\",\"saksnummer\":${klage.saksnummer}},\"saksbehandlerNavn\":\"Johnny\",\"fritekst\":\"dette er min fritekst\",\"saksnummer\":${klage.saksnummer},\"erAldersbrev\":false}",
                     ),
                     metadata = Dokument.Metadata(
                         sakId = klage.sakId,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/OversendKlageTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/OversendKlageTest.kt
@@ -300,7 +300,7 @@ internal class OversendKlageTest {
                         opprettet = it.opprettet,
                         tittel = "Oversendelsesbrev til klager",
                         generertDokument = pdfAsBytes,
-                        generertDokumentJson = "{\"personalia\":{\"dato\":\"01.01.2021\",\"fødselsnummer\":\"${sak.fnr}\",\"fornavn\":\"Tore\",\"etternavn\":\"Strømøy\",\"saksnummer\":12345676},\"saksbehandlerNavn\":\"Some name\",\"fritekst\":\"fritekstTilBrev\",\"klageDato\":\"01.12.2021\",\"vedtakDato\":\"01.01.2021\",\"saksnummer\":12345676}",
+                        generertDokumentJson = "{\"personalia\":{\"dato\":\"01.01.2021\",\"fødselsnummer\":\"${sak.fnr}\",\"fornavn\":\"Tore\",\"etternavn\":\"Strømøy\",\"saksnummer\":12345676},\"saksbehandlerNavn\":\"Some name\",\"fritekst\":\"fritekstTilBrev\",\"klageDato\":\"01.12.2021\",\"vedtakDato\":\"01.01.2021\",\"saksnummer\":12345676,\"erAldersbrev\":false}",
                     ),
                     metadata = Dokument.Metadata(
                         sakId = sak.id,
@@ -537,7 +537,7 @@ internal class OversendKlageTest {
                         opprettet = it.opprettet,
                         tittel = "Oversendelsesbrev til klager",
                         generertDokument = pdfAsBytes,
-                        generertDokumentJson = "{\"personalia\":{\"dato\":\"01.01.2021\",\"fødselsnummer\":\"${sak.fnr}\",\"fornavn\":\"Tore\",\"etternavn\":\"Strømøy\",\"saksnummer\":12345676},\"saksbehandlerNavn\":\"Some name\",\"fritekst\":\"fritekstTilBrev\",\"klageDato\":\"01.12.2021\",\"vedtakDato\":\"01.01.2021\",\"saksnummer\":12345676}",
+                        generertDokumentJson = "{\"personalia\":{\"dato\":\"01.01.2021\",\"fødselsnummer\":\"${sak.fnr}\",\"fornavn\":\"Tore\",\"etternavn\":\"Strømøy\",\"saksnummer\":12345676},\"saksbehandlerNavn\":\"Some name\",\"fritekst\":\"fritekstTilBrev\",\"klageDato\":\"01.12.2021\",\"vedtakDato\":\"01.01.2021\",\"saksnummer\":12345676,\"erAldersbrev\":false}",
                     ),
                     metadata = Dokument.Metadata(
                         sakId = sak.id,


### PR DESCRIPTION
Se PR i su-pdfgen for de nye tekstene. `Avlagsgrunn.PENSJON` er enda ikke fjernet, siden denne er lagret i databasen i dev for noen saker. Siden vi uansett snakket om å slette alderssakene fra dev tenker jeg at det ikke er hensiktsmessig å lage en migrering for dette.