### PR TITLE
Saksnummerfactory

### DIFF
--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepo.kt
@@ -89,6 +89,18 @@ internal class SakPostgresRepo(
         }
     }
 
+    override fun hentNesteSaksnummer(): Saksnummer? {
+        return sessionFactory.withSessionContext { sessionContext ->
+            sessionContext.withSession { session ->
+                "select max(saksnummer) as max from sak".hent(emptyMap(), session) { row ->
+                    row.longOrNull("max")?.let {
+                        Saksnummer(it).inc()
+                    }
+                }
+            }
+        }
+    }
+
     /***
      * @param personidenter Inneholder alle identer til brukeren, f.eks fnr og aktørid.
      */

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
@@ -100,6 +100,7 @@ import no.nav.su.se.bakover.domain.revurdering.Revurderingsårsak
 import no.nav.su.se.bakover.domain.revurdering.SimulertRevurdering
 import no.nav.su.se.bakover.domain.revurdering.StansAvYtelseRevurdering
 import no.nav.su.se.bakover.domain.revurdering.UnderkjentRevurdering
+import no.nav.su.se.bakover.domain.sak.SaksnummerFactoryProd
 import no.nav.su.se.bakover.domain.satser.SatsFactoryForSupplerendeStønad
 import no.nav.su.se.bakover.domain.søknadinnhold.SøknadsinnholdUføre
 import no.nav.su.se.bakover.domain.søknadsbehandling.LukketSøknadsbehandling
@@ -132,6 +133,7 @@ import no.nav.su.se.bakover.test.gjeldendeVedtaksdata
 import no.nav.su.se.bakover.test.grunnlag.uføregrunnlagForventetInntekt
 import no.nav.su.se.bakover.test.grunnlagsdataEnsligMedFradrag
 import no.nav.su.se.bakover.test.grunnlagsdataMedEpsMedFradrag
+import no.nav.su.se.bakover.test.saksnummer
 import no.nav.su.se.bakover.test.satsFactoryTest
 import no.nav.su.se.bakover.test.satsFactoryTestPåDato
 import no.nav.su.se.bakover.test.simulerNyUtbetaling
@@ -419,6 +421,7 @@ internal class TestDataHelper(
                     return ids.pop()
                 }
             },
+            saksnummerFactory = SaksnummerFactoryProd() { saksnummer },
         ).nySakMedNySøknad(fnr, søknadInnhold).also {
             sakRepo.opprettSak(it)
         }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
@@ -27,6 +27,7 @@ import no.nav.su.se.bakover.domain.revurdering.AbstraktRevurdering
 import no.nav.su.se.bakover.domain.revurdering.GjenopptaYtelseRevurdering
 import no.nav.su.se.bakover.domain.revurdering.StansAvYtelseRevurdering
 import no.nav.su.se.bakover.domain.sak.SakInfo
+import no.nav.su.se.bakover.domain.sak.SaksnummerFactory
 import no.nav.su.se.bakover.domain.søknadinnhold.SøknadInnhold
 import no.nav.su.se.bakover.domain.søknadsbehandling.Stønadsperiode
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
@@ -66,6 +67,10 @@ data class Saksnummer(@JsonValue val nummer: Long) {
     }
 
     object UgyldigSaksnummer
+
+    operator fun inc(): Saksnummer {
+        return Saksnummer(nummer + 1)
+    }
 }
 
 data class Sak(
@@ -427,6 +432,7 @@ data class Sak(
 
 data class NySak(
     val id: UUID = UUID.randomUUID(),
+    val saksnummer: Saksnummer,
     val opprettet: Tidspunkt,
     val fnr: Fnr,
     val søknad: Søknad.Ny,
@@ -451,6 +457,7 @@ data class NySak(
 class SakFactory(
     private val uuidFactory: UUIDFactory = UUIDFactory(),
     private val clock: Clock,
+    private val saksnummerFactory: SaksnummerFactory,
 ) {
     fun nySakMedNySøknad(
         fnr: Fnr,
@@ -460,8 +467,9 @@ class SakFactory(
         val sakId = uuidFactory.newUUID()
         return NySak(
             id = sakId,
-            fnr = fnr,
+            saksnummer = saksnummerFactory.neste(),
             opprettet = opprettet,
+            fnr = fnr,
             søknad = Søknad.Ny(
                 id = uuidFactory.newUUID(),
                 opprettet = opprettet,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakRepo.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakRepo.kt
@@ -21,4 +21,6 @@ interface SakRepo {
     fun hentSaker(fnr: Fnr): List<Sak>
 
     fun hentSakForRevurdering(revurderingId: UUID): Sak
+
+    fun hentNesteSaksnummer(): Saksnummer?
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SaksnummerFactory.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SaksnummerFactory.kt
@@ -1,0 +1,42 @@
+package no.nav.su.se.bakover.domain.sak
+
+import no.nav.su.se.bakover.domain.Saksnummer
+
+abstract class SaksnummerFactory(
+    private val nesteSaksnummer: () -> Saksnummer?,
+) {
+    protected open fun hentNesteSaksnummer(): Saksnummer? {
+        return nesteSaksnummer()
+    }
+
+    abstract fun neste(): Saksnummer
+}
+
+class SaksnummerFactoryProd(
+    nesteSaksnummer: () -> Saksnummer?,
+) : SaksnummerFactory(nesteSaksnummer) {
+    private val minimum = 2021L
+
+    @Synchronized
+    override fun neste(): Saksnummer {
+        return super.hentNesteSaksnummer() ?: Saksnummer(minimum)
+    }
+}
+
+/**
+ * Eget factory for test slik at vi har mulighet til å sette startverdien til et minimum som ikke overlapper med
+ * noe som allerede eksisterer i prod. Behover oppstår som følge av jevnlig datalast fra prod til test i OS.
+ * Eksisterende oppdrag for våre syntetiske brukere fjernes i denne prosessen (siden de ikke eksisterer i prod).
+ * Etter tømming av vår database, er vi avhengige av at de nye saksnummerne (brukes fagsystem-id mot OS) som opprettes
+ * ikke er i konflikt med dataene som ble lastet inn i OS fra prod.
+ */
+class SaksnummerFactoryTest(
+    nesteSaksnummer: () -> Saksnummer?,
+) : SaksnummerFactory(nesteSaksnummer) {
+    private val minimum = 10002021L
+
+    @Synchronized
+    override fun neste(): Saksnummer {
+        return super.hentNesteSaksnummer() ?: Saksnummer(minimum)
+    }
+}

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/ServiceBuilder.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/ServiceBuilder.kt
@@ -5,6 +5,7 @@ import no.nav.su.se.bakover.client.Clients
 import no.nav.su.se.bakover.domain.DatabaseRepos
 import no.nav.su.se.bakover.domain.SakFactory
 import no.nav.su.se.bakover.domain.behandling.BehandlingMetrics
+import no.nav.su.se.bakover.domain.sak.SaksnummerFactory
 import no.nav.su.se.bakover.domain.satser.SatsFactory
 import no.nav.su.se.bakover.domain.søknad.SøknadMetrics
 import no.nav.su.se.bakover.service.avstemming.AvstemmingServiceImpl
@@ -41,6 +42,7 @@ object ServiceBuilder {
         clock: Clock,
         unleash: Unleash,
         satsFactory: SatsFactory,
+        saksnummerFactory: SaksnummerFactory,
     ): Services {
         val personService = PersonServiceImpl(clients.personOppslag)
         val toggleService = ToggleServiceImpl(unleash)
@@ -81,7 +83,10 @@ object ServiceBuilder {
         val søknadService = SøknadServiceImpl(
             søknadRepo = databaseRepos.søknad,
             sakService = sakService,
-            sakFactory = SakFactory(clock = clock),
+            sakFactory = SakFactory(
+                clock = clock,
+                saksnummerFactory = saksnummerFactory
+            ),
             pdfGenerator = clients.pdfGenerator,
             dokArkiv = clients.dokArkiv,
             personService = personService,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/ServiceBuilderTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/ServiceBuilderTest.kt
@@ -3,10 +3,12 @@ package no.nav.su.se.bakover.service
 import io.kotest.matchers.collections.shouldContain
 import no.nav.su.se.bakover.client.Clients
 import no.nav.su.se.bakover.domain.DatabaseRepos
+import no.nav.su.se.bakover.domain.sak.SaksnummerFactoryProd
 import no.nav.su.se.bakover.service.revurdering.RevurderingServiceImpl
 import no.nav.su.se.bakover.service.sak.SakServiceImpl
 import no.nav.su.se.bakover.service.søknadsbehandling.SøknadsbehandlingServiceImpl
 import no.nav.su.se.bakover.test.defaultMock
+import no.nav.su.se.bakover.test.saksnummer
 import no.nav.su.se.bakover.test.satsFactoryTestPåDato
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
@@ -57,13 +59,14 @@ internal class ServiceBuilderTest {
                 journalpostClient = mock(),
                 tilbakekrevingClient = mock(),
                 skatteOppslag = mock(),
-                maskinportenClient = mock()
+                maskinportenClient = mock(),
             ),
             behandlingMetrics = mock(),
             søknadMetrics = mock(),
             clock = Clock.systemUTC(),
             unleash = mock(),
             satsFactory = satsFactoryTestPåDato(),
+            saksnummerFactory = SaksnummerFactoryProd() { saksnummer },
         ).let {
             (it.sak as SakServiceImpl).observers shouldContain it.statistikk
             (it.søknadsbehandling as SøknadsbehandlingServiceImpl).getObservers() shouldContain it.statistikk

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/SøknadserviceOgMocks.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/SøknadserviceOgMocks.kt
@@ -3,6 +3,7 @@ package no.nav.su.se.bakover.service.søknad
 import no.nav.su.se.bakover.client.dokarkiv.DokArkiv
 import no.nav.su.se.bakover.client.pdf.PdfGenerator
 import no.nav.su.se.bakover.domain.SakFactory
+import no.nav.su.se.bakover.domain.sak.SaksnummerFactoryProd
 import no.nav.su.se.bakover.domain.søknad.SøknadMetrics
 import no.nav.su.se.bakover.domain.søknad.SøknadRepo
 import no.nav.su.se.bakover.service.oppgave.OppgaveService
@@ -10,6 +11,7 @@ import no.nav.su.se.bakover.service.person.PersonService
 import no.nav.su.se.bakover.service.sak.SakService
 import no.nav.su.se.bakover.service.toggles.ToggleService
 import no.nav.su.se.bakover.test.fixedClock
+import no.nav.su.se.bakover.test.saksnummer
 import org.mockito.kotlin.mock
 import java.time.Clock
 
@@ -19,7 +21,10 @@ import java.time.Clock
 internal data class SøknadserviceOgMocks(
     val søknadRepo: SøknadRepo = mock(),
     val sakService: SakService = mock(),
-    val sakFactory: SakFactory = SakFactory(clock = fixedClock),
+    val sakFactory: SakFactory = SakFactory(
+        clock = fixedClock,
+        saksnummerFactory = SaksnummerFactoryProd() { saksnummer },
+    ),
     val pdfGenerator: PdfGenerator = mock(),
     val dokArkiv: DokArkiv = mock(),
     val personService: PersonService = mock(),

--- a/test-common/src/main/kotlin/SakTestData.kt
+++ b/test-common/src/main/kotlin/SakTestData.kt
@@ -9,6 +9,7 @@ import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.grunnlag.GrunnlagsdataOgVilkårsvurderinger
 import no.nav.su.se.bakover.domain.sak.SakInfo
+import no.nav.su.se.bakover.domain.sak.SaksnummerFactoryProd
 import no.nav.su.se.bakover.domain.søknadinnhold.SøknadInnhold
 import no.nav.su.se.bakover.domain.søknadinnhold.SøknadsinnholdAlder
 import no.nav.su.se.bakover.domain.søknadinnhold.SøknadsinnholdUføre
@@ -90,6 +91,7 @@ fun nySak(
                 return ids.pop()
             }
         },
+        saksnummerFactory = SaksnummerFactoryProd { sakInfo.saksnummer },
     ).let { sakFactory ->
         sakFactory.nySakMedNySøknad(
             fnr = sakInfo.fnr,

--- a/test-common/src/main/kotlin/SøknadTestData.kt
+++ b/test-common/src/main/kotlin/SøknadTestData.kt
@@ -11,6 +11,7 @@ import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.journal.JournalpostId
 import no.nav.su.se.bakover.domain.klage.Klage
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
+import no.nav.su.se.bakover.domain.sak.SaksnummerFactoryProd
 import no.nav.su.se.bakover.domain.søknadinnhold.ForNav
 import no.nav.su.se.bakover.domain.søknadinnhold.Personopplysninger
 import no.nav.su.se.bakover.domain.søknadinnhold.SøknadInnhold
@@ -44,6 +45,7 @@ fun nySakMedNySøknad(
         }
     },
     clock = fixedClock,
+    saksnummerFactory = SaksnummerFactoryProd() { saksnummer },
 ).nySakMedNySøknad(
     fnr = fnr,
     søknadInnhold = søknadinnhold(fnr),

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/SharedRegressionTestData.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/SharedRegressionTestData.kt
@@ -41,6 +41,7 @@ import no.nav.su.se.bakover.database.withMigratedDb
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.DatabaseRepos
 import no.nav.su.se.bakover.domain.Fnr
+import no.nav.su.se.bakover.domain.sak.SaksnummerFactoryProd
 import no.nav.su.se.bakover.domain.satser.SatsFactoryForSupplerendeStønad
 import no.nav.su.se.bakover.service.AccessCheckProxy
 import no.nav.su.se.bakover.service.ServiceBuilder
@@ -141,7 +142,7 @@ internal object SharedRegressionTestData {
                 wellKnownUrl = "maskinportenWellKnownUrl",
                 issuer = "maskinportenIssuer",
                 jwksUri = "maskinportenJwksUri",
-                tokenEndpoint = "maskinporteTokenEndpointn"
+                tokenEndpoint = "maskinporteTokenEndpointn",
             ),
             skatteetatenConfig = ApplicationConfig.ClientsConfig.SkatteetatenConfig(apiUri = "a"),
         ),
@@ -238,6 +239,7 @@ internal object SharedRegressionTestData {
             clock = clock,
             unleash = unleash,
             satsFactory = satsFactoryTestPåDato(LocalDate.now(clock)),
+            saksnummerFactory = SaksnummerFactoryProd(databaseRepos.sak::hentNesteSaksnummer),
         ),
         accessCheckProxy: AccessCheckProxy = AccessCheckProxy(databaseRepos.person, services),
     ) {
@@ -298,7 +300,7 @@ data class TestClientsBuilder(
         journalpostClient = JournalpostClientStub,
         tilbakekrevingClient = TilbakekrevingClientStub(clock),
         skatteOppslag = SkatteClientStub(),
-        maskinportenClient = MaskinportenClientStub(clock)
+        maskinportenClient = MaskinportenClientStub(clock),
     )
 
     override fun build(applicationConfig: ApplicationConfig): Clients = testClients

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/komponenttest/Komponenttest.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/komponenttest/Komponenttest.kt
@@ -8,6 +8,7 @@ import no.finn.unleash.Unleash
 import no.nav.su.se.bakover.client.Clients
 import no.nav.su.se.bakover.database.withMigratedDb
 import no.nav.su.se.bakover.domain.DatabaseRepos
+import no.nav.su.se.bakover.domain.sak.SaksnummerFactoryProd
 import no.nav.su.se.bakover.service.AccessCheckProxy
 import no.nav.su.se.bakover.service.ServiceBuilder
 import no.nav.su.se.bakover.service.Services
@@ -56,6 +57,7 @@ class AppComponents private constructor(
                 clock = clock,
                 unleash = unleash,
                 satsFactory = satsFactory,
+                saksnummerFactory = SaksnummerFactoryProd(databaseRepos.sak::hentNesteSaksnummer)
             )
             val accessCheckProxy = AccessCheckProxy(
                 personRepo = databaseRepos.person,

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/TestEnvironment.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/TestEnvironment.kt
@@ -17,6 +17,7 @@ import no.nav.su.se.bakover.database.DbMetrics
 import no.nav.su.se.bakover.database.migratedDb
 import no.nav.su.se.bakover.domain.Brukerrolle
 import no.nav.su.se.bakover.domain.DatabaseRepos
+import no.nav.su.se.bakover.domain.sak.SaksnummerFactoryProd
 import no.nav.su.se.bakover.domain.satser.SatsFactory
 import no.nav.su.se.bakover.domain.satser.SatsFactoryForSupplerendeStønad
 import no.nav.su.se.bakover.service.AccessCheckProxy
@@ -156,6 +157,7 @@ internal fun Application.testSusebakover(
         clock = clock,
         unleash = unleash,
         satsFactory = satsFactory,
+        saksnummerFactory = SaksnummerFactoryProd(databaseRepos.sak::hentNesteSaksnummer),
     ),
     accessCheckProxy: AccessCheckProxy = AccessCheckProxy(
         databaseRepos.person,

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/sak/SakRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/sak/SakRoutesKtTest.kt
@@ -24,6 +24,7 @@ import no.nav.su.se.bakover.domain.SakFactory
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Sakstype
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
+import no.nav.su.se.bakover.domain.sak.SaksnummerFactoryProd
 import no.nav.su.se.bakover.service.ServiceBuilder
 import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.generer
@@ -61,6 +62,7 @@ internal class SakRoutesKtTest {
         clock = fixedClock,
         unleash = FakeUnleash().apply { enableAll() },
         satsFactory = satsFactoryTestPåDato(),
+        saksnummerFactory = SaksnummerFactoryProd(reps.sak::hentNesteSaksnummer),
     )
 
     private val søknadInnhold = SøknadInnholdTestdataBuilder.build()
@@ -73,7 +75,10 @@ internal class SakRoutesKtTest {
             testApplication {
                 application { testSusebakover(databaseRepos = repos) }
 
-                SakFactory(clock = fixedClock).nySakMedNySøknad(Fnr(sakFnr01), søknadInnhold).also {
+                SakFactory(
+                    clock = fixedClock,
+                    saksnummerFactory = SaksnummerFactoryProd(repos.sak::hentNesteSaksnummer)
+                ).nySakMedNySøknad(Fnr(sakFnr01), søknadInnhold).also {
                     repos.sak.opprettSak(it)
                 }
                 val opprettetSakId: Sak = repos.sak.hentSak(Fnr(sakFnr01), Sakstype.UFØRE)!!
@@ -97,7 +102,12 @@ internal class SakRoutesKtTest {
             testApplication {
                 application { testSusebakover(databaseRepos = repos) }
 
-                repos.sak.opprettSak(SakFactory(clock = fixedClock).nySakMedNySøknad(Fnr(sakFnr01), søknadInnhold))
+                repos.sak.opprettSak(
+                    SakFactory(
+                        clock = fixedClock,
+                        saksnummerFactory = SaksnummerFactoryProd(repos.sak::hentNesteSaksnummer)
+                    ).nySakMedNySøknad(Fnr(sakFnr01), søknadInnhold)
+                )
 
                 defaultRequest(HttpMethod.Post, "$sakPath/søk", listOf(Brukerrolle.Saksbehandler)) {
                     setBody("""{"fnr":"$sakFnr01", "type": "uføre"}""")
@@ -148,7 +158,10 @@ internal class SakRoutesKtTest {
 
                 testApplication {
                     application { testSusebakover(databaseRepos = repos) }
-                    SakFactory(clock = fixedClock).nySakMedNySøknad(Fnr(sakFnr01), søknadInnhold).also {
+                    SakFactory(
+                        clock = fixedClock,
+                        saksnummerFactory = SaksnummerFactoryProd(repos.sak::hentNesteSaksnummer)
+                    ).nySakMedNySøknad(Fnr(sakFnr01), søknadInnhold).also {
                         repos.sak.opprettSak(it)
 
                         defaultRequest(

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutesKtTest.kt
@@ -43,6 +43,7 @@ import no.nav.su.se.bakover.domain.oppgave.OppgaveClient
 import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.person.PersonOppslag
+import no.nav.su.se.bakover.domain.sak.SaksnummerFactoryProd
 import no.nav.su.se.bakover.domain.søknad.LukkSøknadRequest
 import no.nav.su.se.bakover.domain.søknad.SøknadPdfInnhold
 import no.nav.su.se.bakover.domain.søknadinnhold.SøknadsinnholdUføre
@@ -203,7 +204,7 @@ internal class SøknadRoutesKtTest {
                 embeddedDatasource = dataSource,
                 dbMetrics = dbMetricsStub,
                 clock = fixedClock,
-                satsFactory = satsFactoryTest
+                satsFactory = satsFactoryTest,
             )
 
             val clients = TestClientsBuilder(fixedClock, repos).build(applicationConfig).copy(
@@ -221,6 +222,7 @@ internal class SøknadRoutesKtTest {
                 clock = fixedClock,
                 unleash = mock(),
                 satsFactory = satsFactoryTestPåDato(),
+                saksnummerFactory = SaksnummerFactoryProd() { Saksnummer(saksnummer) },
             )
 
             testApplication {

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutesKtTest.kt
@@ -53,6 +53,7 @@ import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
 import no.nav.su.se.bakover.domain.oppgave.OppgaveFeil
 import no.nav.su.se.bakover.domain.oppgave.OppgaveFeil.KunneIkkeOppretteOppgave
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
+import no.nav.su.se.bakover.domain.sak.SaksnummerFactoryProd
 import no.nav.su.se.bakover.domain.søknadsbehandling.KunneIkkeIverksette
 import no.nav.su.se.bakover.domain.søknadsbehandling.NySøknadsbehandling
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
@@ -131,6 +132,7 @@ internal class SøknadsbehandlingRoutesKtTest {
             clock = fixedClock,
             unleash = mock(),
             satsFactory = satsFactory,
+            saksnummerFactory = SaksnummerFactoryProd(databaseRepos.sak::hentNesteSaksnummer),
         )
 
     @Nested
@@ -836,7 +838,10 @@ internal class SøknadsbehandlingRoutesKtTest {
     ): UavklartVilkårsvurdertSøknadsbehandling {
         val søknadInnhold = SøknadInnholdTestdataBuilder.build()
         val fnr: Fnr = Fnr.generer()
-        SakFactory(clock = fixedClock).nySakMedNySøknad(fnr, søknadInnhold).also {
+        SakFactory(
+            clock = fixedClock,
+            saksnummerFactory = SaksnummerFactoryProd(repos.sak::hentNesteSaksnummer),
+        ).nySakMedNySøknad(fnr, søknadInnhold).also {
             repos.sak.opprettSak(it)
         }
         val sak: Sak = repos.sak.hentSak(fnr, Sakstype.UFØRE)!!


### PR DESCRIPTION
Factory for å kunne håndtere situasjoner hvor vi må tømme databasen pga datalast i oppdrag. Unngår at saksnummerne i test havner i konflikt med dataene som lastes inn fra prod til test i oppdrag (Q1).