### PR TITLE
Åpne opp for en ekstra servicebruker mot frikort

### DIFF
--- a/common/src/main/kotlin/no/nav/su/se/bakover/common/Config.kt
+++ b/common/src/main/kotlin/no/nav/su/se/bakover/common/Config.kt
@@ -91,17 +91,17 @@ data class ApplicationConfig(
     }
 
     data class FrikortConfig(
-        val serviceUsername: String,
+        val serviceUsername: List<String>,
         val useStubForSts: Boolean,
     ) {
         companion object {
             fun createFromEnvironmentVariables() = FrikortConfig(
-                serviceUsername = getEnvironmentVariableOrThrow("FRIKORT_SERVICE_USERNAME"),
+                serviceUsername = getEnvironmentVariableOrThrow("FRIKORT_SERVICE_USERNAME").split(","),
                 useStubForSts = false,
             )
 
             fun createLocalConfig() = FrikortConfig(
-                serviceUsername = getEnvironmentVariableOrDefault("FRIKORT_SERVICE_USERNAME", "frikort"),
+                serviceUsername = getEnvironmentVariableOrDefault("FRIKORT_SERVICE_USERNAME", "frikort").split(","),
                 useStubForSts = getEnvironmentVariableOrDefault("USE_STUB_FOR_STS", "true") == "true",
             )
         }

--- a/common/src/test/kotlin/no/nav/su/se/bakover/common/ApplicationConfigTest.kt
+++ b/common/src/test/kotlin/no/nav/su/se/bakover/common/ApplicationConfigTest.kt
@@ -35,7 +35,7 @@ internal class ApplicationConfigTest {
             ),
         ),
         frikort = ApplicationConfig.FrikortConfig(
-            serviceUsername = "frikort",
+            serviceUsername = listOf("frikort"),
             useStubForSts = false,
         ),
         oppdrag = ApplicationConfig.OppdragConfig(
@@ -239,7 +239,7 @@ internal class ApplicationConfigTest {
                     password = "unused",
                 ),
                 frikort = ApplicationConfig.FrikortConfig(
-                    serviceUsername = "frikort",
+                    serviceUsername = listOf("frikort"),
                     useStubForSts = true,
                 ),
                 oppdrag = ApplicationConfig.OppdragConfig(

--- a/nais-dev.json
+++ b/nais-dev.json
@@ -26,7 +26,7 @@
     "MQ_SEND_QUEUE_UTBETALING": "QA.Q1_231.OB04_OPPDRAG_XML",
     "MQ_REPLY_TO": "QA.Q1_SU_SE_BAKOVER.OPPDRAG_KVITTERING",
     "MQ_SEND_QUEUE_AVSTEMMING": "queue:///QA.Q1_234.OB29_AVSTEMMING_XML?targetClient=1",
-    "FRIKORT_SERVICE_USERNAME": "srvfrikortborger",
+    "FRIKORT_SERVICE_USERNAME": "srvfrikortborger,srvfrikorttjenester",
     "PDL_CLIENT_ID": "api://dev-fss.pdl.pdl-api",
     "KABAL_URL": "https://kabal-api.dev.intern.nav.no",
     "KABAL_CLIENT_ID": "api://dev-gcp.klage.kabal-api",

--- a/nais-prod.json
+++ b/nais-prod.json
@@ -26,7 +26,7 @@
     "MQ_SEND_QUEUE_UTBETALING": "QA.P231.OB04_OPPDRAG_XML",
     "MQ_REPLY_TO": "QA.P_SU_SE_BAKOVER.OPPDRAG_KVITTERING",
     "MQ_SEND_QUEUE_AVSTEMMING": "queue:///QA.P234.OB29_AVSTEMMING_XML?targetClient=1",
-    "FRIKORT_SERVICE_USERNAME": "srvfrikortborger",
+    "FRIKORT_SERVICE_USERNAME": "srvfrikortborger,srvfrikorttjenester",
     "PDL_CLIENT_ID": "api://prod-fss.pdl.pdl-api",
     "KABAL_URL": "https://kabal-api.intern.nav.no",
     "KABAL_CLIENT_ID": "api://prod-gcp.klage.kabal-api",

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/SharedRegressionTestData.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/SharedRegressionTestData.kt
@@ -87,7 +87,7 @@ internal object SharedRegressionTestData {
             ),
         ),
         frikort = ApplicationConfig.FrikortConfig(
-            serviceUsername = "frikort",
+            serviceUsername = listOf("frikort"),
             useStubForSts = true,
         ),
         oppdrag = ApplicationConfig.OppdragConfig(

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/AuthenticationConfig.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/AuthenticationConfig.kt
@@ -85,7 +85,7 @@ internal fun Application.configureAuthentication(
             verifier(jwkStsProvider, stsJwkConfig.getString("issuer"))
             realm = "su-se-bakover"
             validate { credentials ->
-                if (credentials.payload.subject != applicationConfig.frikort.serviceUsername && credentials.payload.subject != applicationConfig.serviceUser.username) {
+                if (credentials.payload.subject !in applicationConfig.frikort.serviceUsername && credentials.payload.subject != applicationConfig.serviceUser.username) {
                     log.debug("Frikort Auth: Invalid subject")
                     null
                 } else { JWTPrincipal(credentials.payload) }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/TestEnvironment.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/TestEnvironment.kt
@@ -52,7 +52,7 @@ val applicationConfig = ApplicationConfig(
         ),
     ),
     frikort = ApplicationConfig.FrikortConfig(
-        serviceUsername = "frikort",
+        serviceUsername = listOf("frikort"),
         useStubForSts = true,
     ),
     oppdrag = ApplicationConfig.OppdragConfig(

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/external/FrikortRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/external/FrikortRoutesKtTest.kt
@@ -57,7 +57,7 @@ internal class FrikortRoutesKtTest {
                 header(HttpHeaders.XCorrelationId, DEFAULT_CALL_ID)
                 header(
                     HttpHeaders.Authorization,
-                    jwtStub.createJwtToken(subject = applicationConfig.frikort.serviceUsername).asBearerToken(),
+                    jwtStub.createJwtToken(subject = applicationConfig.frikort.serviceUsername.first()).asBearerToken(),
                 )
             }.apply {
                 this.status shouldBe HttpStatusCode.OK
@@ -75,7 +75,7 @@ internal class FrikortRoutesKtTest {
                 header(HttpHeaders.XCorrelationId, DEFAULT_CALL_ID)
                 header(
                     HttpHeaders.Authorization,
-                    jwtStub.createJwtToken(subject = applicationConfig.frikort.serviceUsername).asBearerToken(),
+                    jwtStub.createJwtToken(subject = applicationConfig.frikort.serviceUsername.first()).asBearerToken(),
                 )
             }.apply {
                 this.status shouldBe HttpStatusCode.BadRequest
@@ -103,7 +103,7 @@ internal class FrikortRoutesKtTest {
                 header(HttpHeaders.XCorrelationId, DEFAULT_CALL_ID)
                 header(
                     HttpHeaders.Authorization,
-                    jwtStub.createJwtToken(subject = applicationConfig.frikort.serviceUsername).asBearerToken(),
+                    jwtStub.createJwtToken(subject = applicationConfig.frikort.serviceUsername.first()).asBearerToken(),
                 )
             }
             JSONAssert.assertEquals(frikortJsonString, response.bodyAsText(), true)
@@ -130,7 +130,7 @@ internal class FrikortRoutesKtTest {
                 header(HttpHeaders.XCorrelationId, DEFAULT_CALL_ID)
                 header(
                     HttpHeaders.Authorization,
-                    jwtStub.createJwtToken(subject = applicationConfig.frikort.serviceUsername).asBearerToken(),
+                    jwtStub.createJwtToken(subject = applicationConfig.frikort.serviceUsername.first()).asBearerToken(),
                 )
             }
             JSONAssert.assertEquals(frikortJsonString, response.bodyAsText(), true)
@@ -156,7 +156,7 @@ internal class FrikortRoutesKtTest {
                 header(HttpHeaders.XCorrelationId, DEFAULT_CALL_ID)
                 header(
                     HttpHeaders.Authorization,
-                    jwtStub.createJwtToken(subject = applicationConfig.frikort.serviceUsername).asBearerToken(),
+                    jwtStub.createJwtToken(subject = applicationConfig.frikort.serviceUsername.first()).asBearerToken(),
                 )
             }
             JSONAssert.assertEquals(frikortJsonString, response.bodyAsText(), true)


### PR DESCRIPTION
Åpne opp for `srvfrikorttjenester` mot frikort-routes. `srvfrikortborger` skal fases ut når `srvfrikorttjenester` er oppe og kjører