### PR TITLE
Hent utestående avkorting sammen med sak

### DIFF
--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/kabal/KabalRequest.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/kabal/KabalRequest.kt
@@ -3,7 +3,6 @@ package no.nav.su.se.bakover.client.kabal
 import com.fasterxml.jackson.annotation.JsonValue
 import no.nav.su.se.bakover.domain.journal.JournalpostId
 import no.nav.su.se.bakover.domain.klage.Hjemler
-import no.nav.su.se.bakover.domain.klage.Hjemmel
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -68,6 +67,7 @@ internal data class KabalRequest(
         LOV_OM_SUPPLERENDE_STØNAD_PARAGRAF_4("SUP_ST_L_4"),
         LOV_OM_SUPPLERENDE_STØNAD_PARAGRAF_5("SUP_ST_L_5"),
         LOV_OM_SUPPLERENDE_STØNAD_PARAGRAF_6("SUP_ST_L_6"),
+        LOV_OM_SUPPLERENDE_STØNAD_PARAGRAF_7("SUP_ST_L_7"),
         LOV_OM_SUPPLERENDE_STØNAD_PARAGRAF_8("SUP_ST_L_8"),
         LOV_OM_SUPPLERENDE_STØNAD_PARAGRAF_9("SUP_ST_L_9"),
         LOV_OM_SUPPLERENDE_STØNAD_PARAGRAF_10("SUP_ST_L_10"),
@@ -88,6 +88,7 @@ internal data class KabalRequest(
                         no.nav.su.se.bakover.domain.klage.Hjemmel.SU_PARAGRAF_4 -> LOV_OM_SUPPLERENDE_STØNAD_PARAGRAF_4
                         no.nav.su.se.bakover.domain.klage.Hjemmel.SU_PARAGRAF_5 -> LOV_OM_SUPPLERENDE_STØNAD_PARAGRAF_5
                         no.nav.su.se.bakover.domain.klage.Hjemmel.SU_PARAGRAF_6 -> LOV_OM_SUPPLERENDE_STØNAD_PARAGRAF_6
+                        no.nav.su.se.bakover.domain.klage.Hjemmel.SU_PARAGRAF_7 -> LOV_OM_SUPPLERENDE_STØNAD_PARAGRAF_7
                         no.nav.su.se.bakover.domain.klage.Hjemmel.SU_PARAGRAF_8 -> LOV_OM_SUPPLERENDE_STØNAD_PARAGRAF_8
                         no.nav.su.se.bakover.domain.klage.Hjemmel.SU_PARAGRAF_9 -> LOV_OM_SUPPLERENDE_STØNAD_PARAGRAF_9
                         no.nav.su.se.bakover.domain.klage.Hjemmel.SU_PARAGRAF_10 -> LOV_OM_SUPPLERENDE_STØNAD_PARAGRAF_10

--- a/common/src/main/kotlin/no/nav/su/se/bakover/common/Extensions.kt
+++ b/common/src/main/kotlin/no/nav/su/se/bakover/common/Extensions.kt
@@ -1,5 +1,6 @@
 package no.nav.su.se.bakover.common
 
+import arrow.core.NonEmptyList
 import org.slf4j.MDC
 import java.lang.Double.max
 import java.lang.Double.min
@@ -33,4 +34,9 @@ fun getOrCreateCorrelationId(): String {
 
 fun String.trimWhitespace(): String {
     return this.filterNot { it.isWhitespace() }
+}
+
+fun <T> List<T>.nonEmpty(): NonEmptyList<T> {
+    require(this.isNotEmpty()) { "Kan ikke lage NonEmptyList for en tom liste" }
+    return NonEmptyList.fromListUnsafe(this)
 }

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/DatabaseBuilder.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/DatabaseBuilder.kt
@@ -191,11 +191,8 @@ object DatabaseBuilder {
             sessionFactory = sessionFactory,
             dbMetrics = dbMetrics,
             grunnlagsdataOgVilkårsvurderingerPostgresRepo = grunnlagsdataOgVilkårsvurderingerPostgresRepo,
-            søknadsbehandlingRepo = søknadsbehandlingRepo,
-            klageRepo = klageRepo,
             avkortingsvarselRepo = avkortingsvarselRepo,
             tilbakekrevingRepo = tilbakekrevingRepo,
-            reguleringPostgresRepo = reguleringRepo,
             satsFactory = satsFactory,
         )
         val vedtakRepo = VedtakPostgresRepo(

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/DatabaseBuilder.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/DatabaseBuilder.kt
@@ -229,6 +229,7 @@ object DatabaseBuilder {
                 vedtakPostgresRepo = vedtakRepo,
                 klageRepo = klageRepo,
                 reguleringRepo = reguleringRepo,
+                avkortingsvarselRepo = avkortingsvarselRepo,
             ),
             person = PersonPostgresRepo(
                 sessionFactory = sessionFactory,

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/klage/KlagePostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/klage/KlagePostgresRepo.kt
@@ -697,6 +697,7 @@ internal class KlagePostgresRepo(
                 SU_PARAGRAF_4("su_paragraf_4"),
                 SU_PARAGRAF_5("su_paragraf_5"),
                 SU_PARAGRAF_6("su_paragraf_6"),
+                SU_PARAGRAF_7("su_paragraf_7"),
                 SU_PARAGRAF_8("su_paragraf_8"),
                 SU_PARAGRAF_9("su_paragraf_9"),
                 SU_PARAGRAF_10("su_paragraf_10"),
@@ -713,6 +714,7 @@ internal class KlagePostgresRepo(
                         SU_PARAGRAF_4 -> no.nav.su.se.bakover.domain.klage.Hjemmel.SU_PARAGRAF_4
                         SU_PARAGRAF_5 -> no.nav.su.se.bakover.domain.klage.Hjemmel.SU_PARAGRAF_5
                         SU_PARAGRAF_6 -> no.nav.su.se.bakover.domain.klage.Hjemmel.SU_PARAGRAF_6
+                        SU_PARAGRAF_7 -> no.nav.su.se.bakover.domain.klage.Hjemmel.SU_PARAGRAF_7
                         SU_PARAGRAF_8 -> no.nav.su.se.bakover.domain.klage.Hjemmel.SU_PARAGRAF_8
                         SU_PARAGRAF_9 -> no.nav.su.se.bakover.domain.klage.Hjemmel.SU_PARAGRAF_9
                         SU_PARAGRAF_10 -> no.nav.su.se.bakover.domain.klage.Hjemmel.SU_PARAGRAF_10
@@ -733,6 +735,7 @@ internal class KlagePostgresRepo(
                                 no.nav.su.se.bakover.domain.klage.Hjemmel.SU_PARAGRAF_4 -> SU_PARAGRAF_4
                                 no.nav.su.se.bakover.domain.klage.Hjemmel.SU_PARAGRAF_5 -> SU_PARAGRAF_5
                                 no.nav.su.se.bakover.domain.klage.Hjemmel.SU_PARAGRAF_6 -> SU_PARAGRAF_6
+                                no.nav.su.se.bakover.domain.klage.Hjemmel.SU_PARAGRAF_7 -> SU_PARAGRAF_7
                                 no.nav.su.se.bakover.domain.klage.Hjemmel.SU_PARAGRAF_8 -> SU_PARAGRAF_8
                                 no.nav.su.se.bakover.domain.klage.Hjemmel.SU_PARAGRAF_9 -> SU_PARAGRAF_9
                                 no.nav.su.se.bakover.domain.klage.Hjemmel.SU_PARAGRAF_10 -> SU_PARAGRAF_10

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/revurdering/AvsluttetRevurderingInfo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/revurdering/AvsluttetRevurderingInfo.kt
@@ -1,9 +1,52 @@
 package no.nav.su.se.bakover.database.revurdering
 
 import no.nav.su.se.bakover.common.Tidspunkt
+import no.nav.su.se.bakover.domain.brev.Brevvalg
 
 data class AvsluttetRevurderingInfo(
     val begrunnelse: String,
-    val fritekst: String?,
+    val brevvalg: BrevvalgJson?,
     val tidspunktAvsluttet: Tidspunkt,
-)
+) {
+    data class BrevvalgJson(
+        val fritekst: String?,
+        val begrunnelse: String?,
+        val type: Type,
+    ) {
+        companion object {
+            fun Brevvalg.toJson() = BrevvalgJson(
+                fritekst = this.fritekst,
+                begrunnelse = this.begrunnelse,
+                type = when (this) {
+                    is Brevvalg.SaksbehandlersValg.SkalSendeBrev.MedFritekst -> Type.SAKSBEHANDLER_VALG_SKAL_SENDE_BREV_MED_FRITEKST
+                    is Brevvalg.SaksbehandlersValg.SkalIkkeSendeBrev -> Type.SAKSBEHANDLER_VALG_SKAL_IKKE_SENDE_BREV
+                    is Brevvalg.SkalSendeBrev.MedFritekst -> Type.SKAL_SENDE_BREV_MED_FRITEKST
+                    is Brevvalg.SkalIkkeSendeBrev -> Type.SKAL_IKKE_SENDE_BREV
+                },
+            )
+        }
+
+        fun toDomain(): Brevvalg {
+            return when (this.type) {
+                Type.SAKSBEHANDLER_VALG_SKAL_SENDE_BREV_MED_FRITEKST -> Brevvalg.SaksbehandlersValg.SkalSendeBrev.MedFritekst(
+                    fritekst = this.fritekst!!,
+                )
+                Type.SAKSBEHANDLER_VALG_SKAL_IKKE_SENDE_BREV -> Brevvalg.SaksbehandlersValg.SkalIkkeSendeBrev(
+                    begrunnelse = this.begrunnelse!!,
+                )
+                Type.SKAL_SENDE_BREV_MED_FRITEKST -> Brevvalg.SkalSendeBrev.MedFritekst(
+                    fritekst = this.fritekst!!,
+                    begrunnelse = this.begrunnelse!!,
+                )
+                Type.SKAL_IKKE_SENDE_BREV -> Brevvalg.SkalIkkeSendeBrev(begrunnelse = this.begrunnelse!!)
+            }
+        }
+
+        enum class Type {
+            SAKSBEHANDLER_VALG_SKAL_SENDE_BREV_MED_FRITEKST,
+            SAKSBEHANDLER_VALG_SKAL_IKKE_SENDE_BREV,
+            SKAL_SENDE_BREV_MED_FRITEKST,
+            SKAL_IKKE_SENDE_BREV,
+        }
+    }
+}

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/revurdering/GjenopptakAvYtelsePostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/revurdering/GjenopptakAvYtelsePostgresRepo.kt
@@ -106,7 +106,7 @@ internal class GjenopptakAvYtelsePostgresRepo(
                             "avsluttet" to serialize(
                                 AvsluttetRevurderingInfo(
                                     begrunnelse = revurdering.begrunnelse,
-                                    fritekst = null,
+                                    brevvalg = null,
                                     tidspunktAvsluttet = revurdering.tidspunktAvsluttet,
                                 ),
                             ),

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/revurdering/StansAvYtelsePostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/revurdering/StansAvYtelsePostgresRepo.kt
@@ -106,7 +106,7 @@ internal class StansAvYtelsePostgresRepo(
                             "avsluttet" to serialize(
                                 AvsluttetRevurderingInfo(
                                     begrunnelse = revurdering.begrunnelse,
-                                    fritekst = null,
+                                    brevvalg = null,
                                     tidspunktAvsluttet = revurdering.tidspunktAvsluttet,
                                 ),
                             ),

--- a/database/src/main/resources/db/migration/V156__avsluttet_revurdering_brevvalg.sql
+++ b/database/src/main/resources/db/migration/V156__avsluttet_revurdering_brevvalg.sql
@@ -1,0 +1,16 @@
+-- nb: fjerner ikke avsluttet->fritekst i denne migreringen.
+
+update revurdering set avsluttet = jsonb_set(avsluttet, '{brevvalg}', '{"type":"SKAL_SENDE_BREV_MED_FRITEKST"}') where avsluttet is not null and (avsluttet->>'fritekst') is not null;
+update revurdering set avsluttet = jsonb_set(avsluttet, '{brevvalg}', '{"type":"SKAL_IKKE_SENDE_BREV"}') where avsluttet is not null and (avsluttet->>'fritekst') is null;
+
+update revurdering set avsluttet = jsonb_insert(avsluttet, '{brevvalg, fritekst}', to_jsonb(avsluttet->>'fritekst'),true) where avsluttet is not null and (avsluttet->>'fritekst') is not null;
+update revurdering set avsluttet = jsonb_insert(avsluttet, '{brevvalg, fritekst}', 'null',true) where avsluttet is not null and (avsluttet->>'fritekst') is null;
+
+update revurdering set avsluttet = jsonb_insert(avsluttet, '{brevvalg, begrunnelse}', to_jsonb((avsluttet->>'begrunnelse')),true) where avsluttet is not null and (avsluttet->>'begrunnelse') is not null;
+update revurdering set avsluttet = jsonb_insert(avsluttet, '{brevvalg, begrunnelse}', 'null',true) where avsluttet is not null and (avsluttet->>'begrunnelse') is null;
+
+-- Testdata http://sqlfiddle.com/#!17/5831f5/11:
+-- create table if not exists revurdering(id int primary key, avsluttet jsonb);
+-- insert into revurdering (id,avsluttet) values (1,'{"begrunnelse":"b1","fritekst":"f1"}');
+-- insert into revurdering (id,avsluttet) values (2,'{"begrunnelse":"b2","fritekst":null}');
+-- insert into revurdering (id,avsluttet) values (3,null);

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
@@ -403,6 +403,7 @@ internal class TestDataHelper(
         vedtakPostgresRepo = vedtakRepo,
         klageRepo = klagePostgresRepo,
         reguleringRepo = reguleringRepo,
+        avkortingsvarselRepo = avkortingsvarselRepo,
     )
 
     internal val avstemmingRepo = AvstemmingPostgresRepo(

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
@@ -370,11 +370,8 @@ internal class TestDataHelper(
         sessionFactory = sessionFactory,
         dbMetrics = dbMetrics,
         grunnlagsdataOgVilkårsvurderingerPostgresRepo = grunnlagsdataOgVilkårsvurderingerPostgresRepo,
-        søknadsbehandlingRepo = søknadsbehandlingRepo,
-        klageRepo = klagePostgresRepo,
         avkortingsvarselRepo = avkortingsvarselRepo,
         tilbakekrevingRepo = tilbakekrevingRepo,
-        reguleringPostgresRepo = reguleringRepo,
         satsFactory = satsFactory,
     )
     internal val vedtakRepo = VedtakPostgresRepo(
@@ -1071,7 +1068,7 @@ internal class TestDataHelper(
             periode = stønadsperiode2021.periode,
         ).avslutt(
             begrunnelse = "",
-            fritekst = null,
+            brevvalg = null,
             tidspunktAvsluttet = fixedTidspunkt,
         ).getOrFail().also { revurderingRepo.lagre(it) }
     }

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/revurdering/AvsluttetRevurderingJsonTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/revurdering/AvsluttetRevurderingJsonTest.kt
@@ -11,7 +11,11 @@ internal class AvsluttetRevurderingJsonTest {
         //language=JSON
         val avsluttetJson = """
           {
-            "fritekst": "en fri tekst", 
+            "brevvalg": {
+              "fritekst": "en fri tekst", 
+              "begrunnelse": null,
+              "type": "SAKSBEHANDLER_VALG_SKAL_SENDE_BREV_MED_FRITEKST"
+            },
             "begrunnelse": "en begrunnelse", 
             "tidspunktAvsluttet": "2021-01-01T01:02:03.456789Z"
           }
@@ -22,7 +26,7 @@ internal class AvsluttetRevurderingJsonTest {
             serialize(
                 AvsluttetRevurderingInfo(
                     begrunnelse = "en begrunnelse",
-                    fritekst = "en fri tekst",
+                    brevvalg = AvsluttetRevurderingInfo.BrevvalgJson("en fri tekst", null, AvsluttetRevurderingInfo.BrevvalgJson.Type.SAKSBEHANDLER_VALG_SKAL_SENDE_BREV_MED_FRITEKST),
                     tidspunktAvsluttet = fixedTidspunkt,
                 ),
             ),

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/revurdering/LagreOgHentAvsluttetRevurderingTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/revurdering/LagreOgHentAvsluttetRevurderingTest.kt
@@ -8,6 +8,7 @@ import no.nav.su.se.bakover.database.TestDataHelper
 import no.nav.su.se.bakover.database.withMigratedDb
 import no.nav.su.se.bakover.domain.avkorting.AvkortingVedRevurdering
 import no.nav.su.se.bakover.domain.revurdering.AvsluttetRevurdering
+import no.nav.su.se.bakover.domain.revurdering.Forhåndsvarsel
 import no.nav.su.se.bakover.domain.revurdering.Revurdering
 import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.stønadsperiode2021
@@ -32,7 +33,7 @@ internal class LagreOgHentAvsluttetRevurderingTest {
             val avsluttetRevurdering = AvsluttetRevurdering.tryCreate(
                 underliggendeRevurdering = revurdering,
                 begrunnelse = "avslutter denne revurderingen",
-                fritekst = null,
+                brevvalg = null,
                 tidspunktAvsluttet = fixedTidspunkt,
             ).getOrHandle { fail("$it") }
 
@@ -58,7 +59,7 @@ internal class LagreOgHentAvsluttetRevurderingTest {
             val avsluttetRevurdering = AvsluttetRevurdering.tryCreate(
                 underliggendeRevurdering = revurdering,
                 begrunnelse = "avslutter denne revurderingen",
-                fritekst = null,
+                brevvalg = null,
                 tidspunktAvsluttet = fixedTidspunkt,
             ).getOrHandle { fail("$it") }
 
@@ -84,7 +85,7 @@ internal class LagreOgHentAvsluttetRevurderingTest {
             val avsluttetRevurdering = AvsluttetRevurdering.tryCreate(
                 underliggendeRevurdering = revurdering,
                 begrunnelse = "avslutter denne revurderingen",
-                fritekst = null,
+                brevvalg = null,
                 tidspunktAvsluttet = fixedTidspunkt,
             ).getOrHandle { fail("$it") }
 
@@ -111,7 +112,7 @@ internal class LagreOgHentAvsluttetRevurderingTest {
             val avsluttetRevurdering = AvsluttetRevurdering.tryCreate(
                 underliggendeRevurdering = revurdering,
                 begrunnelse = "avslutter denne revurderingen",
-                fritekst = null,
+                brevvalg = null,
                 tidspunktAvsluttet = fixedTidspunkt,
             ).getOrHandle { fail("$it") }
 
@@ -137,7 +138,7 @@ internal class LagreOgHentAvsluttetRevurderingTest {
             val avsluttetRevurdering = AvsluttetRevurdering.tryCreate(
                 underliggendeRevurdering = revurdering,
                 begrunnelse = "avslutter denne revurderingen",
-                fritekst = null,
+                brevvalg = null,
                 tidspunktAvsluttet = fixedTidspunkt,
             ).getOrHandle { fail("$it") }
 
@@ -187,7 +188,10 @@ internal class LagreOgHentAvsluttetRevurderingTest {
             val repo = testDataHelper.revurderingRepo
             val simulert = testDataHelper.persisterRevurderingSimulertInnvilget()
             val simulertIngenForhåndsvarsel =
-                simulert.markerForhåndsvarselSomSendt().orNull()!!.prøvOvergangTilAvsluttet("").orNull()!!.also {
+                simulert.markerForhåndsvarselSomSendt().orNull()!!.copy(
+                    // Vi har fjernet muligheten for å endre til denne tilstanden, men vi må støtte ikke-migrerte verdier i databasen.
+                    forhåndsvarsel = Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.Avsluttet("")
+                ).also {
                     repo.lagre(it)
                 }
             (repo.hent(simulert.id) as Revurdering) shouldBe simulertIngenForhåndsvarsel
@@ -205,7 +209,7 @@ internal class LagreOgHentAvsluttetRevurderingTest {
             val avsluttetRevurdering = AvsluttetRevurdering.tryCreate(
                 underliggendeRevurdering = revurdering,
                 begrunnelse = "avslutter denne revurderingen",
-                fritekst = null,
+                brevvalg = null,
                 tidspunktAvsluttet = fixedTidspunkt,
             ).getOrHandle { fail("$it") }
 
@@ -231,7 +235,7 @@ internal class LagreOgHentAvsluttetRevurderingTest {
             val avsluttetRevurdering = AvsluttetRevurdering.tryCreate(
                 underliggendeRevurdering = revurdering,
                 begrunnelse = "avslutter denne revurderingen",
-                fritekst = null,
+                brevvalg = null,
                 tidspunktAvsluttet = fixedTidspunkt,
             ).getOrHandle { fail("$it") }
 

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonValue
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.UUIDFactory
 import no.nav.su.se.bakover.common.log
+import no.nav.su.se.bakover.common.nonEmpty
 import no.nav.su.se.bakover.common.periode.Måned
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.common.periode.Periode.UgyldigPeriode.FraOgMedDatoMåVæreFørTilOgMedDato
@@ -460,11 +461,11 @@ data class Sak(
 
     object FantIkkeSøknad
 
-    fun hentÅpneSøknadsbehandlinger(): Either<IngenÅpneSøknadsbehandlinger, List<Søknadsbehandling>> {
+    fun hentÅpneSøknadsbehandlinger(): Either<IngenÅpneSøknadsbehandlinger, NonEmptyList<Søknadsbehandling>> {
         return søknadsbehandlinger
-            .filterNot { it.erIverksatt }
-            .filterNot { it.erLukket }
+            .filter { it.erÅpen() }
             .ifEmpty { return IngenÅpneSøknadsbehandlinger.left() }
+            .nonEmpty()
             .right()
     }
 

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/Brevvalg.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/Brevvalg.kt
@@ -1,0 +1,90 @@
+package no.nav.su.se.bakover.domain.brev
+
+/**
+ * Ved vedtak, lukking av behandling, forhåndsvarsling og andre handlinger ønsker vi 3 muligheter for brevsending:
+ *  1. Send alltid brev.
+ *  2. Saksbehandler velger om det skal sendes brev.
+ *  3. Aldri send brev.
+ *
+ *  Tidligere har dette vært mer eller mindre hardkodet eller evt. blitt spesifisert per tilfelle.
+ *  Dette er et forsøk på å ha det litt mer enhetlig.
+ */
+sealed interface Brevvalg {
+
+    fun skalSendeBrev(): Boolean
+
+    /** null for de variantene som ikke skal sende brev og eventuelle brev som ikke har fritekst. */
+    val fritekst: String?
+
+    val begrunnelse: String?
+
+    /**
+     * Tilfeller der vi aldri skal sende brev, f.eks. dersom man har avsluttet en behandling som ikke skulle vært startet.
+     * Kan også brukes i forbindelse ved migrering.
+     *
+     * @param begrunnelse Systemet sin begrunnelse for etterlevelse og evt. migrering.
+     */
+    data class SkalIkkeSendeBrev(
+        override val begrunnelse: String,
+    ) : Brevvalg {
+        override fun skalSendeBrev() = false
+        override val fritekst = null
+    }
+
+    /**
+     * Tilfeller der vi alltid skal sende brev.
+     * Kan også brukes i forbindelse med migrering.
+     */
+    sealed interface SkalSendeBrev : Brevvalg {
+        override fun skalSendeBrev() = true
+
+        /**
+         * Tilfeller der vi alltid skal sende brev med fritekst.
+         * Kan også brukes i forbindelse med migrering.
+         *
+         * @param begrunnelse Systemet sin begrunnelse for etterlevelse og evt. migrering.
+         */
+        data class MedFritekst(
+            override val fritekst: String,
+            override val begrunnelse: String,
+        ) : SkalSendeBrev
+    }
+
+    /**
+     * Saksbehandler velger om det skal sendes brev.
+     * Bør ikke brukes dersom man skal migrere fra brevutsendingstilfeller der saksbehandler ikke hadde et valg.
+     */
+    sealed interface SaksbehandlersValg : Brevvalg {
+        /**
+         * Saksbehandler har valgt at det skal sendes brev.
+         */
+        sealed interface SkalSendeBrev : SaksbehandlersValg {
+
+            override fun skalSendeBrev() = true
+
+            /**
+             * Denne brevtypen har støtte for friktekst.
+             * Her er det mulig å utvide med UtenFritekst, evt. gjøre feltet nullable i supertypen.
+             */
+            data class MedFritekst(
+                override val fritekst: String,
+                // TODO jah: Spør John Are om vi trenger en begrunnelse i dette tilfellet.
+            ) : SkalSendeBrev {
+                override val begrunnelse = null
+            }
+        }
+
+        /**
+         * Saksbehandler har valgt at det ikke skal sendes brev.
+         * I første iterasjon krever vi en begrunnelse.
+         * Dersom det i senere iterasjoner ikke ønskes begrunnelse kan den gjøres nullable eller splittes i 2 typer.
+         */
+        data class SkalIkkeSendeBrev(
+            override val begrunnelse: String,
+        ) : SaksbehandlersValg {
+            override val fritekst = null
+        }
+
+        override fun skalSendeBrev() = false
+    }
+}

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/Hjemler.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/Hjemler.kt
@@ -80,6 +80,9 @@ enum class Hjemmel(val kapittel: Int, val paragrafnummer: Int) {
     /** Kapittel 3 - § 6.Inntekt som går til frådrag i supplerande stønad (2021-01-01) */
     SU_PARAGRAF_6(3, 6),
 
+    /** Kapittel 3 - § 7.Utmåling av supplerande stønad (2021-01-01) */
+    SU_PARAGRAF_7(3, 7),
+
     /** Kapittel 3 - § 8.Formue (2021-01-01) */
     SU_PARAGRAF_8(3, 8),
 

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Forhåndsvarsel.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Forhåndsvarsel.kt
@@ -13,7 +13,6 @@ sealed interface Forhåndsvarsel {
 
     fun prøvOvergangTilSkalIkkeForhåndsvarsles(): Either<UgyldigTilstandsovergang, Ferdigbehandlet.SkalIkkeForhåndsvarsles>
     fun prøvOvergangTilSendt(): Either<UgyldigTilstandsovergang, UnderBehandling.Sendt>
-    fun prøvOvergangTilAvsluttet(begrunnelse: String): Either<UgyldigTilstandsovergang, Ferdigbehandlet.Forhåndsvarslet.Avsluttet>
     fun prøvOvergangTilEndreGrunnlaget(begrunnelse: String): Either<UgyldigTilstandsovergang, Ferdigbehandlet.Forhåndsvarslet.EndreGrunnlaget>
     fun prøvOvergangTilFortsettMedSammeGrunnlag(begrunnelse: String): Either<UgyldigTilstandsovergang, Ferdigbehandlet.Forhåndsvarslet.FortsettMedSammeGrunnlag>
 
@@ -38,12 +37,6 @@ sealed interface Forhåndsvarsel {
                 til = Sendt::class,
             ).left()
 
-            override fun prøvOvergangTilAvsluttet(
-                begrunnelse: String,
-            ): Either<Nothing, Ferdigbehandlet.Forhåndsvarslet.Avsluttet> {
-                return Ferdigbehandlet.Forhåndsvarslet.Avsluttet(begrunnelse).right()
-            }
-
             override fun prøvOvergangTilEndreGrunnlaget(
                 begrunnelse: String,
             ): Either<Nothing, Ferdigbehandlet.Forhåndsvarslet.EndreGrunnlaget> {
@@ -64,11 +57,6 @@ sealed interface Forhåndsvarsel {
      */
     sealed interface Ferdigbehandlet : Forhåndsvarsel {
         override fun erKlarForAttestering() = true
-
-        override fun prøvOvergangTilAvsluttet(begrunnelse: String) = UgyldigTilstandsovergang(
-            fra = this::class,
-            til = Forhåndsvarslet.Avsluttet::class,
-        ).left()
 
         override fun prøvOvergangTilEndreGrunnlaget(begrunnelse: String) = UgyldigTilstandsovergang(
             fra = this::class,
@@ -101,6 +89,10 @@ sealed interface Forhåndsvarsel {
                 til = UnderBehandling.Sendt::class,
             ).left()
 
+            /**
+             * Gjenstår så lenge 'avsluttet' finnes i databasen.
+             * Denne skal kun brukes av ytterpunktene i applikasjonen (database->databaselaget->routes).
+             */
             data class Avsluttet(val begrunnelse: String) : Forhåndsvarslet
             data class FortsettMedSammeGrunnlag(val begrunnelse: String) : Forhåndsvarslet
             data class EndreGrunnlaget(val begrunnelse: String) : Forhåndsvarslet
@@ -118,13 +110,6 @@ fun Forhåndsvarsel?.prøvOvergangTilSkalIkkeForhåndsvarsles(): Either<Forhånd
 
 fun Forhåndsvarsel?.prøvOvergangTilSendt(): Either<Forhåndsvarsel.UgyldigTilstandsovergang, Forhåndsvarsel.UnderBehandling.Sendt> {
     return this?.prøvOvergangTilSendt() ?: Forhåndsvarsel.UnderBehandling.Sendt.right()
-}
-
-fun Forhåndsvarsel?.prøvOvergangTilAvsluttet(begrunnelse: String): Either<Forhåndsvarsel.UgyldigTilstandsovergang, Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.Avsluttet> {
-    return this?.prøvOvergangTilAvsluttet(begrunnelse) ?: Forhåndsvarsel.UgyldigTilstandsovergang(
-        fra = Nothing::class,
-        til = Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.Avsluttet::class,
-    ).left()
 }
 
 fun Forhåndsvarsel?.prøvOvergangTilEndreGrunnlaget(begrunnelse: String): Either<Forhåndsvarsel.UgyldigTilstandsovergang, Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.EndreGrunnlaget> {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurderingsårsak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurderingsårsak.kt
@@ -19,6 +19,7 @@ data class Revurderingsårsak(
         REGULER_GRUNNBELØP,
         MANGLENDE_KONTROLLERKLÆRING,
         MOTTATT_KONTROLLERKLÆRING,
+        IKKE_MOTTATT_ETTERSPURT_DOKUMENTASJON,
 
         /* Reservert for migrering */
         MIGRERT;

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakRepo.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakRepo.kt
@@ -21,4 +21,5 @@ interface SakRepo {
     fun hentSaker(fnr: Fnr): List<Sak>
 
     fun hentSakForRevurdering(revurderingId: UUID): Sak
+    fun hentSakForSøknad(søknadId: UUID): Sak?
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitor.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitor.kt
@@ -325,13 +325,18 @@ class LagBrevRequestVisitor(
     }
 
     override fun visit(revurdering: AvsluttetRevurdering) {
+        if (!revurdering.brevvalg.skalSendeBrev()) {
+            throw IllegalArgumentException("Kan ikke lage brev for avsluttet revurdering ${revurdering.id} siden brevvalget tilsier at det ikke skal sendes brev.")
+        }
         brevRequest = hentPersonOgNavn(
+            fnr = revurdering.fnr,
+            saksbehandler = revurdering.saksbehandler,
             // siden avslutt-brevet er et informasjons-brev, trengs ikke attestant
-            fnr = revurdering.fnr, saksbehandler = revurdering.saksbehandler, attestant = null,
+            attestant = null,
         ).map {
             LagBrevRequest.AvsluttRevurdering(
                 person = it.person,
-                fritekst = revurdering.fritekst,
+                fritekst = revurdering.brevvalg.fritekst,
                 saksbehandlerNavn = it.saksbehandlerNavn,
                 dagensDato = LocalDate.now(clock),
                 saksnummer = revurdering.saksnummer,
@@ -506,90 +511,113 @@ class LagBrevRequestVisitor(
                         is AvkortingVedRevurdering.DelvisHåndtert.AnnullerUtestående -> {
                             null
                         }
+
                         is AvkortingVedRevurdering.DelvisHåndtert.IngenUtestående -> {
                             null
                         }
+
                         is AvkortingVedRevurdering.DelvisHåndtert.KanIkkeHåndtere -> {
                             null
                         }
                     }
                 }
+
                 is IverksattRevurdering.Opphørt -> {
                     when (revurdering.avkorting) {
                         is AvkortingVedRevurdering.Iverksatt.AnnullerUtestående -> {
                             null
                         }
+
                         is AvkortingVedRevurdering.Iverksatt.IngenNyEllerUtestående -> {
                             null
                         }
+
                         is AvkortingVedRevurdering.Iverksatt.KanIkkeHåndteres -> {
                             null
                         }
+
                         is AvkortingVedRevurdering.Iverksatt.OpprettNyttAvkortingsvarsel -> {
                             revurdering.avkorting.avkortingsvarsel.hentUtbetalteBeløp().sum()
                         }
+
                         is AvkortingVedRevurdering.Iverksatt.OpprettNyttAvkortingsvarselOgAnnullerUtestående -> {
                             revurdering.avkorting.avkortingsvarsel.hentUtbetalteBeløp().sum()
                         }
                     }
                 }
+
                 is RevurderingTilAttestering.Opphørt -> {
                     when (revurdering.avkorting) {
                         is AvkortingVedRevurdering.Håndtert.AnnullerUtestående -> {
                             null
                         }
+
                         is AvkortingVedRevurdering.Håndtert.IngenNyEllerUtestående -> {
                             null
                         }
+
                         is AvkortingVedRevurdering.Håndtert.KanIkkeHåndteres -> {
                             null
                         }
+
                         is AvkortingVedRevurdering.Håndtert.OpprettNyttAvkortingsvarsel -> {
                             revurdering.avkorting.avkortingsvarsel.hentUtbetalteBeløp().sum()
                         }
+
                         is AvkortingVedRevurdering.Håndtert.OpprettNyttAvkortingsvarselOgAnnullerUtestående -> {
                             revurdering.avkorting.avkortingsvarsel.hentUtbetalteBeløp().sum()
                         }
                     }
                 }
+
                 is SimulertRevurdering.Opphørt -> {
                     when (revurdering.avkorting) {
                         is AvkortingVedRevurdering.Håndtert.AnnullerUtestående -> {
                             null
                         }
+
                         is AvkortingVedRevurdering.Håndtert.IngenNyEllerUtestående -> {
                             null
                         }
+
                         is AvkortingVedRevurdering.Håndtert.KanIkkeHåndteres -> {
                             null
                         }
+
                         is AvkortingVedRevurdering.Håndtert.OpprettNyttAvkortingsvarsel -> {
                             revurdering.avkorting.avkortingsvarsel.hentUtbetalteBeløp().sum()
                         }
+
                         is AvkortingVedRevurdering.Håndtert.OpprettNyttAvkortingsvarselOgAnnullerUtestående -> {
                             revurdering.avkorting.avkortingsvarsel.hentUtbetalteBeløp().sum()
                         }
                     }
                 }
+
                 is UnderkjentRevurdering.Opphørt -> {
                     when (revurdering.avkorting) {
                         is AvkortingVedRevurdering.Håndtert.AnnullerUtestående -> {
                             null
                         }
+
                         is AvkortingVedRevurdering.Håndtert.IngenNyEllerUtestående -> {
                             null
                         }
+
                         is AvkortingVedRevurdering.Håndtert.KanIkkeHåndteres -> {
                             null
                         }
+
                         is AvkortingVedRevurdering.Håndtert.OpprettNyttAvkortingsvarsel -> {
                             revurdering.avkorting.avkortingsvarsel.hentUtbetalteBeløp().sum()
                         }
+
                         is AvkortingVedRevurdering.Håndtert.OpprettNyttAvkortingsvarselOgAnnullerUtestående -> {
                             revurdering.avkorting.avkortingsvarsel.hentUtbetalteBeløp().sum()
                         }
                     }
                 }
+
                 else -> {
                     null
                 }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/SakTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/SakTest.kt
@@ -27,6 +27,7 @@ import no.nav.su.se.bakover.common.periode.mars
 import no.nav.su.se.bakover.common.periode.november
 import no.nav.su.se.bakover.common.periode.år
 import no.nav.su.se.bakover.common.september
+import no.nav.su.se.bakover.domain.avkorting.Avkortingsvarsel
 import no.nav.su.se.bakover.domain.søknadsbehandling.Stønadsperiode
 import no.nav.su.se.bakover.domain.vedtak.GjeldendeVedtaksdata
 import no.nav.su.se.bakover.domain.vedtak.VedtakSomKanRevurderes
@@ -87,6 +88,7 @@ internal class SakTest {
                 revurderinger = listOf(),
                 vedtakListe = listOf(),
                 type = Sakstype.UFØRE,
+                uteståendeAvkorting = Avkortingsvarsel.Ingen,
             ).hentPerioderMedLøpendeYtelse() shouldBe emptyList()
         }
 

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/AvsluttetRevurderingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/AvsluttetRevurderingTest.kt
@@ -3,6 +3,7 @@ package no.nav.su.se.bakover.domain.revurdering
 import arrow.core.left
 import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.domain.brev.Brevvalg
 import no.nav.su.se.bakover.test.beregnetRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak
 import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.getOrFail
@@ -21,7 +22,7 @@ internal class AvsluttetRevurderingTest {
         AvsluttetRevurdering.tryCreate(
             underliggendeRevurdering = opprettetRevurderingFraInnvilgetSøknadsbehandlingsVedtak().second,
             begrunnelse = "Begrunnelse for hvorfor denne har blitt avsluttet",
-            fritekst = null,
+            brevvalg = null,
             tidspunktAvsluttet = fixedTidspunkt,
         ).shouldBeRight()
     }
@@ -31,7 +32,7 @@ internal class AvsluttetRevurderingTest {
         AvsluttetRevurdering.tryCreate(
             underliggendeRevurdering = beregnetRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak().second,
             begrunnelse = "Begrunnelse for hvorfor denne har blitt avsluttet",
-            fritekst = null,
+            brevvalg = null,
             tidspunktAvsluttet = fixedTidspunkt,
         ).shouldBeRight()
     }
@@ -41,7 +42,7 @@ internal class AvsluttetRevurderingTest {
         AvsluttetRevurdering.tryCreate(
             underliggendeRevurdering = simulertRevurderingOpphørtUføreFraInnvilgetSøknadsbehandlingsVedtak().second,
             begrunnelse = "Begrunnelse for hvorfor denne har blitt avsluttet",
-            fritekst = null,
+            brevvalg = null,
             tidspunktAvsluttet = fixedTidspunkt,
         ).shouldBeRight()
     }
@@ -53,7 +54,7 @@ internal class AvsluttetRevurderingTest {
                 forhåndsvarsel = Forhåndsvarsel.UnderBehandling.Sendt,
             ),
             begrunnelse = "Begrunnelse for hvorfor denne har blitt avsluttet",
-            fritekst = "en god, og fri tekst",
+            brevvalg = Brevvalg.SaksbehandlersValg.SkalSendeBrev.MedFritekst("en god, og fri tekst"),
             tidspunktAvsluttet = fixedTidspunkt,
         ).shouldBeRight()
     }
@@ -63,7 +64,7 @@ internal class AvsluttetRevurderingTest {
         AvsluttetRevurdering.tryCreate(
             underliggendeRevurdering = tilAttesteringRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak().second,
             begrunnelse = "Begrunnelse for hvorfor denne har blitt avsluttet",
-            fritekst = null,
+            brevvalg = null,
             tidspunktAvsluttet = fixedTidspunkt,
         ) shouldBe KunneIkkeLageAvsluttetRevurdering.RevurderingenErTilAttestering.left()
     }
@@ -74,7 +75,7 @@ internal class AvsluttetRevurderingTest {
         AvsluttetRevurdering.tryCreate(
             underliggendeRevurdering = iverksattRevurderingIngenEndringFraInnvilgetSøknadsbehandlingsVedtak().second,
             begrunnelse = "Begrunnelse for hvorfor denne har blitt avsluttet",
-            fritekst = null,
+            brevvalg = null,
             tidspunktAvsluttet = fixedTidspunkt,
         ) shouldBe KunneIkkeLageAvsluttetRevurdering.RevurderingenErIverksatt.left()
     }
@@ -83,10 +84,12 @@ internal class AvsluttetRevurderingTest {
     fun `får feil dersom man prøver å lage en avsluttet revurdering med avsluttet som underliggende`() {
         AvsluttetRevurdering.tryCreate(
             underliggendeRevurdering = simulertRevurderingOpphørtUføreFraInnvilgetSøknadsbehandlingsVedtak().second.avslutt(
-                begrunnelse = "begrunnelse", fritekst = null, tidspunktAvsluttet = fixedTidspunkt,
+                begrunnelse = "begrunnelse",
+                brevvalg = null,
+                tidspunktAvsluttet = fixedTidspunkt,
             ).getOrFail(),
             begrunnelse = "prøver å avslutte en revurdering som er i avsluttet tilstand",
-            fritekst = null,
+            brevvalg = null,
             tidspunktAvsluttet = fixedTidspunkt,
         ) shouldBe KunneIkkeLageAvsluttetRevurdering.RevurderingErAlleredeAvsluttet.left()
     }
@@ -98,9 +101,9 @@ internal class AvsluttetRevurderingTest {
                 assert(it.forhåndsvarsel == null)
             },
             begrunnelse = "Begrunnelse for hvorfor denne har blitt avsluttet",
-            fritekst = "forhåndsvarsel er null, men jeg er fyllt ut. dette skal ikke være lov",
+            brevvalg = Brevvalg.SaksbehandlersValg.SkalSendeBrev.MedFritekst("forhåndsvarsel er null, men jeg er fyllt ut. dette skal ikke være lov"),
             tidspunktAvsluttet = fixedTidspunkt,
-        ) shouldBe KunneIkkeLageAvsluttetRevurdering.FritekstErFylltUtUtenForhåndsvarsel.left()
+        ) shouldBe KunneIkkeLageAvsluttetRevurdering.BrevvalgUtenForhåndsvarsel.left()
     }
 
     @Test
@@ -112,8 +115,8 @@ internal class AvsluttetRevurderingTest {
                 assert(it.forhåndsvarsel == Forhåndsvarsel.Ferdigbehandlet.SkalIkkeForhåndsvarsles)
             },
             begrunnelse = "Begrunnelse for hvorfor denne har blitt avsluttet",
-            fritekst = "forhåndsvarsel er ingen forhåndsvarsel, men jeg er fyllt ut. dette skal ikke være lov",
+            brevvalg = Brevvalg.SaksbehandlersValg.SkalSendeBrev.MedFritekst("forhåndsvarsel er ingen forhåndsvarsel, men jeg er fyllt ut. dette skal ikke være lov"),
             tidspunktAvsluttet = fixedTidspunkt,
-        ) shouldBe KunneIkkeLageAvsluttetRevurdering.FritekstErFylltUtUtenForhåndsvarsel.left()
+        ) shouldBe KunneIkkeLageAvsluttetRevurdering.BrevvalgUtenForhåndsvarsel.left()
     }
 }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/ForhåndsvarselTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/ForhåndsvarselTest.kt
@@ -27,14 +27,6 @@ internal class ForhåndsvarselTest {
         }
 
         @Test
-        fun `Ugyldig overgang fra null til Avsluttet`() {
-            (null as Forhåndsvarsel?).prøvOvergangTilAvsluttet("a") shouldBe Forhåndsvarsel.UgyldigTilstandsovergang(
-                fra = Nothing::class,
-                til = Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.Avsluttet::class,
-            ).left()
-        }
-
-        @Test
         fun `Ugyldig overgang fra null til FortsettMedSammeGrunnlag`() {
             (null as Forhåndsvarsel?).prøvOvergangTilFortsettMedSammeGrunnlag("b") shouldBe Forhåndsvarsel.UgyldigTilstandsovergang(
                 fra = Nothing::class,
@@ -80,14 +72,6 @@ internal class ForhåndsvarselTest {
         @Test
         fun `Gyldig overgang fra SkalIkkeForhåndsvarsles til Sendt`() {
             Forhåndsvarsel.Ferdigbehandlet.SkalIkkeForhåndsvarsles.prøvOvergangTilSendt() shouldBe Forhåndsvarsel.UnderBehandling.Sendt.right()
-        }
-
-        @Test
-        fun `Ugyldig overgang fra SkalIkkeForhåndsvarsles til Avsluttet`() {
-            Forhåndsvarsel.Ferdigbehandlet.SkalIkkeForhåndsvarsles.prøvOvergangTilAvsluttet("d") shouldBe Forhåndsvarsel.UgyldigTilstandsovergang(
-                fra = Forhåndsvarsel.Ferdigbehandlet.SkalIkkeForhåndsvarsles::class,
-                til = Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.Avsluttet::class,
-            ).left()
         }
 
         @Test
@@ -145,13 +129,6 @@ internal class ForhåndsvarselTest {
         }
 
         @Test
-        fun `Gyldig overgang fra Sendt til Avsluttet`() {
-            Forhåndsvarsel.UnderBehandling.Sendt.prøvOvergangTilAvsluttet("g") shouldBe Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.Avsluttet(
-                "g",
-            ).right()
-        }
-
-        @Test
         fun `Gyldig overgang fra Sendt til FortsettMedSammeGrunnlag`() {
             Forhåndsvarsel.UnderBehandling.Sendt.prøvOvergangTilFortsettMedSammeGrunnlag("h") shouldBe Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.FortsettMedSammeGrunnlag(
                 "h",
@@ -203,15 +180,6 @@ internal class ForhåndsvarselTest {
         }
 
         @Test
-        fun `Ugyldig overgang fra Avsluttet til Avsluttet`() {
-            Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.Avsluttet("l")
-                .prøvOvergangTilAvsluttet("m") shouldBe Forhåndsvarsel.UgyldigTilstandsovergang(
-                fra = Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.Avsluttet::class,
-                til = Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.Avsluttet::class,
-            ).left()
-        }
-
-        @Test
         fun `Ugyldig overgang fra Avsluttet til FortsettMedSammeGrunnlag`() {
             Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.Avsluttet("n")
                 .prøvOvergangTilFortsettMedSammeGrunnlag("o") shouldBe Forhåndsvarsel.UgyldigTilstandsovergang(
@@ -252,15 +220,6 @@ internal class ForhåndsvarselTest {
         }
 
         @Test
-        fun `Ugyldig overgang fra FortsettMedSammeGrunnlag til Avsluttet`() {
-            Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.FortsettMedSammeGrunnlag("t")
-                .prøvOvergangTilAvsluttet("u") shouldBe Forhåndsvarsel.UgyldigTilstandsovergang(
-                fra = Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.FortsettMedSammeGrunnlag::class,
-                til = Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.Avsluttet::class,
-            ).left()
-        }
-
-        @Test
         fun `Ugyldig overgang fra FortsettMedSammeGrunnlag til FortsettMedSammeGrunnlag`() {
             Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.FortsettMedSammeGrunnlag("v")
                 .prøvOvergangTilFortsettMedSammeGrunnlag("w") shouldBe Forhåndsvarsel.UgyldigTilstandsovergang(
@@ -297,15 +256,6 @@ internal class ForhåndsvarselTest {
                 .prøvOvergangTilSendt() shouldBe Forhåndsvarsel.UgyldigTilstandsovergang(
                 fra = Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.EndreGrunnlaget::class,
                 til = Forhåndsvarsel.UnderBehandling.Sendt::class,
-            ).left()
-        }
-
-        @Test
-        fun `Ugyldig overgang fra EndreGrunnlaget til Avsluttet`() {
-            Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.EndreGrunnlaget("ø")
-                .prøvOvergangTilAvsluttet("å") shouldBe Forhåndsvarsel.UgyldigTilstandsovergang(
-                fra = Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.EndreGrunnlaget::class,
-                til = Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.Avsluttet::class,
             ).left()
         }
 

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
@@ -341,6 +341,11 @@ open class AccessCheckProxy(
                     return services.sak.hentSakForRevurdering(revurderingId)
                 }
 
+                override fun hentSakForSøknad(søknadId: UUID): Either<FantIkkeSak, Sak> {
+                    assertHarTilgangTilSøknad(søknadId)
+                    return services.sak.hentSakForSøknad(søknadId)
+                }
+
                 override fun opprettSak(sak: NySak) {
                     assertHarTilgangTilPerson(sak.fnr)
 

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
@@ -22,6 +22,7 @@ import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.behandling.Attestering
 import no.nav.su.se.bakover.domain.behandling.Behandling
 import no.nav.su.se.bakover.domain.behandling.avslag.AvslagManglendeDokumentasjon
+import no.nav.su.se.bakover.domain.brev.Brevvalg
 import no.nav.su.se.bakover.domain.brev.LagBrevRequest
 import no.nav.su.se.bakover.domain.dokument.Dokument
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
@@ -514,7 +515,7 @@ open class AccessCheckProxy(
                     return services.søknadsbehandling.iverksett(request)
                 }
 
-                override fun brev(request: SøknadsbehandlingService.BrevRequest): Either<SøknadsbehandlingService.KunneIkkeLageBrev, ByteArray> {
+                override fun brev(request: SøknadsbehandlingService.BrevRequest): Either<KunneIkkeLageDokument, ByteArray> {
                     assertHarTilgangTilBehandling(request.behandling.id)
                     return services.søknadsbehandling.brev(request)
                 }
@@ -771,10 +772,10 @@ open class AccessCheckProxy(
                 override fun avsluttRevurdering(
                     revurderingId: UUID,
                     begrunnelse: String,
-                    fritekst: String?,
+                    brevvalg: Brevvalg.SaksbehandlersValg?,
                 ): Either<KunneIkkeAvslutteRevurdering, AbstraktRevurdering> {
                     assertHarTilgangTilRevurdering(revurderingId)
-                    return services.revurdering.avsluttRevurdering(revurderingId, begrunnelse, fritekst)
+                    return services.revurdering.avsluttRevurdering(revurderingId, begrunnelse, brevvalg)
                 }
 
                 override fun leggTilOpplysningspliktVilkår(request: LeggTilOpplysningspliktRequest.Revurdering): Either<KunneIkkeLeggeTilOpplysningsplikt, RevurderingOgFeilmeldingerResponse> {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/ServiceBuilder.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/ServiceBuilder.kt
@@ -138,7 +138,6 @@ object ServiceBuilder {
             formuegrenserFactory = satsFactory.formuegrenserFactory,
             sakService = sakService,
             avkortingsvarselRepo = databaseRepos.avkortingsvarselRepo,
-            toggleService = toggleService,
             tilbakekrevingService = tilbakekrevingService,
             satsFactory = satsFactory,
         ).apply { addObserver(statistikkService) }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/brev/BrevService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/brev/BrevService.kt
@@ -40,6 +40,7 @@ sealed class KunneIkkeLageDokument {
     object KunneIkkeHenteNavnForSaksbehandlerEllerAttestant : KunneIkkeLageDokument()
     object KunneIkkeHentePerson : KunneIkkeLageDokument()
     object KunneIkkeGenererePDF : KunneIkkeLageDokument()
+    object DetSkalIkkeSendesBrev : KunneIkkeLageDokument()
 }
 
 sealed class KunneIkkeLageBrev {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/klage/KlageVurderingerRequest.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/klage/KlageVurderingerRequest.kt
@@ -74,6 +74,7 @@ data class KlageVurderingerRequest(
                     "SU_PARAGRAF_4" -> Hjemmel.SU_PARAGRAF_4
                     "SU_PARAGRAF_5" -> Hjemmel.SU_PARAGRAF_5
                     "SU_PARAGRAF_6" -> Hjemmel.SU_PARAGRAF_6
+                    "SU_PARAGRAF_7" -> Hjemmel.SU_PARAGRAF_7
                     "SU_PARAGRAF_8" -> Hjemmel.SU_PARAGRAF_8
                     "SU_PARAGRAF_9" -> Hjemmel.SU_PARAGRAF_9
                     "SU_PARAGRAF_10" -> Hjemmel.SU_PARAGRAF_10

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/FortsettEtterForhåndsvarslingRequest.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/FortsettEtterForhåndsvarslingRequest.kt
@@ -22,26 +22,15 @@ sealed interface FortsettEtterForhåndsvarslingRequest {
         override val saksbehandler: NavIdentBruker.Saksbehandler,
         override val begrunnelse: String,
     ) : FortsettEtterForhåndsvarslingRequest
-
-    data class AvsluttUtenEndringer(
-        override val revurderingId: UUID,
-        override val saksbehandler: NavIdentBruker.Saksbehandler,
-        override val begrunnelse: String,
-        val fritekstTilBrev: String?,
-    ) : FortsettEtterForhåndsvarslingRequest
 }
 
 sealed interface FortsettEtterForhåndsvarselFeil {
     object FantIkkeRevurdering : FortsettEtterForhåndsvarselFeil
     object MåVæreEnSimulertRevurdering : FortsettEtterForhåndsvarselFeil
-    object RevurderingErIkkeForhåndsvarslet : FortsettEtterForhåndsvarselFeil
     data class UgyldigTilstandsovergang(
         val fra: KClass<out Forhåndsvarsel>,
         val til: KClass<out Forhåndsvarsel>,
     ) : FortsettEtterForhåndsvarselFeil
 
     data class Attestering(val subError: KunneIkkeSendeRevurderingTilAttestering) : FortsettEtterForhåndsvarselFeil
-    data class KunneIkkeAvslutteRevurdering(
-        val subError: no.nav.su.se.bakover.domain.revurdering.KunneIkkeAvslutteRevurdering,
-    ) : FortsettEtterForhåndsvarselFeil
 }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingService.kt
@@ -11,6 +11,7 @@ import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Person
 import no.nav.su.se.bakover.domain.behandling.Attestering
+import no.nav.su.se.bakover.domain.brev.Brevvalg
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
 import no.nav.su.se.bakover.domain.grunnlag.Konsistensproblem
 import no.nav.su.se.bakover.domain.grunnlag.KunneIkkeLageGrunnlagsdata
@@ -155,7 +156,7 @@ interface RevurderingService {
     fun avsluttRevurdering(
         revurderingId: UUID,
         begrunnelse: String,
-        fritekst: String?,
+        brevvalg: Brevvalg.SaksbehandlersValg?,
     ): Either<KunneIkkeAvslutteRevurdering, AbstraktRevurdering>
 
     fun leggTilOpplysningspliktVilkår(
@@ -330,6 +331,7 @@ sealed class KunneIkkeLageBrevutkastForRevurdering {
     object FantIkkePerson : KunneIkkeLageBrevutkastForRevurdering()
     object KunneIkkeHenteNavnForSaksbehandlerEllerAttestant : KunneIkkeLageBrevutkastForRevurdering()
     object KunneIkkeFinneGjeldendeUtbetaling : KunneIkkeLageBrevutkastForRevurdering()
+    object DetSkalIkkeSendesBrev : KunneIkkeLageBrevutkastForRevurdering()
 }
 
 sealed class KunneIkkeHentePersonEllerSaksbehandlerNavn {
@@ -513,6 +515,7 @@ sealed class KunneIkkeLageBrevutkastForAvsluttingAvRevurdering {
     object KunneIkkeHenteNavnForSaksbehandlerEllerAttestant : KunneIkkeLageBrevutkastForAvsluttingAvRevurdering()
     object KunneIkkeGenererePDF : KunneIkkeLageBrevutkastForAvsluttingAvRevurdering()
     object KunneIkkeFinneGjeldendeUtbetaling : KunneIkkeLageBrevutkastForAvsluttingAvRevurdering()
+    object DetSkalIkkeSendesBrev : KunneIkkeLageBrevutkastForAvsluttingAvRevurdering()
 }
 
 data class LeggTilBosituasjonerRequest(

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -15,8 +15,6 @@ import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Person
 import no.nav.su.se.bakover.domain.Sak
-import no.nav.su.se.bakover.domain.avkorting.AvkortingVedRevurdering
-import no.nav.su.se.bakover.domain.avkorting.Avkortingsvarsel
 import no.nav.su.se.bakover.domain.avkorting.AvkortingsvarselRepo
 import no.nav.su.se.bakover.domain.behandling.Attestering
 import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
@@ -227,10 +225,23 @@ internal class RevurderingServiceImpl(
             return KunneIkkeOppretteRevurdering.FantIkkeAktørId.left()
         }
 
-        val uteståendeAvkorting = hentUteståendeAvkorting(opprettRevurderingRequest.sakId).let {
-            kontrollerPeriodeForUteståendeAvkorting(gjeldendeVedtaksdata.periodeFørsteTilOgMedSeneste(), it)
-                .getOrHandle { feil -> return feil.left() }
-        }
+        val uteståendeAvkorting = sak.hentUteståendeAvkortingForRevurdering()
+            .fold(
+                {
+                    it
+                },
+                { uteståendeAvkorting ->
+                    if (!gjeldendeVedtaksdata.periodeFørsteTilOgMedSeneste()
+                        .inneholder(uteståendeAvkorting.avkortingsvarsel.periode())
+                    ) {
+                        return KunneIkkeOppretteRevurdering.UteståendeAvkortingMåRevurderesEllerAvkortesINyPeriode(
+                            periode = uteståendeAvkorting.avkortingsvarsel.periode(),
+                        ).left()
+                    } else {
+                        uteståendeAvkorting
+                    }
+                },
+            )
 
         // Oppgaven skal egentligen ikke opprettes her. Den burde egentligen komma utifra melding av endring, som skal føres til revurdering.
         return oppgaveService.opprettOppgave(
@@ -267,56 +278,6 @@ internal class RevurderingServiceImpl(
                             it,
                         ),
                     )
-                }
-            }
-        }
-    }
-
-    private fun hentUteståendeAvkorting(sakId: UUID): AvkortingVedRevurdering.Uhåndtert {
-        // TODO jah: Bør flyttes til sak
-        return when (val utestående = avkortingsvarselRepo.hentUtestående(sakId)) {
-            is Avkortingsvarsel.Ingen -> {
-                AvkortingVedRevurdering.Uhåndtert.IngenUtestående
-            }
-
-            is Avkortingsvarsel.Utenlandsopphold.Annullert -> {
-                AvkortingVedRevurdering.Uhåndtert.IngenUtestående
-            }
-
-            is Avkortingsvarsel.Utenlandsopphold.Avkortet -> {
-                AvkortingVedRevurdering.Uhåndtert.IngenUtestående
-            }
-
-            is Avkortingsvarsel.Utenlandsopphold.Opprettet -> {
-                AvkortingVedRevurdering.Uhåndtert.IngenUtestående
-            }
-
-            is Avkortingsvarsel.Utenlandsopphold.SkalAvkortes -> {
-                AvkortingVedRevurdering.Uhåndtert.UteståendeAvkorting(utestående)
-            }
-        }
-    }
-
-    private fun kontrollerPeriodeForUteståendeAvkorting(
-        revurderingsperiode: Periode,
-        avkorting: AvkortingVedRevurdering.Uhåndtert,
-    ): Either<KunneIkkeOppretteRevurdering.UteståendeAvkortingMåRevurderesEllerAvkortesINyPeriode, AvkortingVedRevurdering.Uhåndtert> {
-        return when (avkorting) {
-            is AvkortingVedRevurdering.Uhåndtert.IngenUtestående -> {
-                avkorting.right()
-            }
-
-            is AvkortingVedRevurdering.Uhåndtert.KanIkkeHåndtere -> {
-                throw IllegalStateException("Denne situasjone kan ikke oppstå")
-            }
-
-            is AvkortingVedRevurdering.Uhåndtert.UteståendeAvkorting -> {
-                if (!revurderingsperiode.inneholder(avkorting.avkortingsvarsel.periode())) {
-                    return KunneIkkeOppretteRevurdering.UteståendeAvkortingMåRevurderesEllerAvkortesINyPeriode(
-                        periode = avkorting.avkortingsvarsel.periode(),
-                    ).left()
-                } else {
-                    avkorting.right()
                 }
             }
         }
@@ -672,14 +633,23 @@ internal class RevurderingServiceImpl(
             gjeldendeVedtaksdata.gjeldendeVedtakPåDato(oppdaterRevurderingRequest.fraOgMed)?.id
                 ?: return KunneIkkeOppdatereRevurdering.FantIngenVedtakSomKanRevurderes.left()
 
-        val avkorting = hentUteståendeAvkorting(revurdering.sakId).let {
-            kontrollerPeriodeForUteståendeAvkorting(gjeldendeVedtaksdata.periodeFørsteTilOgMedSeneste(), it)
-                .getOrHandle {
-                    return KunneIkkeOppdatereRevurdering.UteståendeAvkortingMåRevurderesEllerAvkortesINyPeriode(
-                        periode = it.periode,
-                    ).left()
-                }
-        }
+        val avkorting = sak.hentUteståendeAvkortingForRevurdering()
+            .fold(
+                {
+                    it
+                },
+                { uteståendeAvkorting ->
+                    if (!gjeldendeVedtaksdata.periodeFørsteTilOgMedSeneste()
+                        .inneholder(uteståendeAvkorting.avkortingsvarsel.periode())
+                    ) {
+                        return KunneIkkeOppdatereRevurdering.UteståendeAvkortingMåRevurderesEllerAvkortesINyPeriode(
+                            periode = uteståendeAvkorting.avkortingsvarsel.periode(),
+                        ).left()
+                    } else {
+                        uteståendeAvkorting
+                    }
+                },
+            )
 
         val periode = gjeldendeVedtaksdata.garantertSammenhengendePeriode()
 

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -15,6 +15,7 @@ import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Person
 import no.nav.su.se.bakover.domain.Sak
+import no.nav.su.se.bakover.domain.avkorting.AvkortingVedRevurdering
 import no.nav.su.se.bakover.domain.avkorting.AvkortingsvarselRepo
 import no.nav.su.se.bakover.domain.behandling.Attestering
 import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
@@ -230,15 +231,12 @@ internal class RevurderingServiceImpl(
                     it
                 },
                 { uteståendeAvkorting ->
-                    if (!gjeldendeVedtaksdata.periodeFørsteTilOgMedSeneste()
-                        .inneholder(uteståendeAvkorting.avkortingsvarsel.periode())
-                    ) {
-                        return KunneIkkeOppretteRevurdering.UteståendeAvkortingMåRevurderesEllerAvkortesINyPeriode(
-                            periode = uteståendeAvkorting.avkortingsvarsel.periode(),
-                        ).left()
-                    } else {
-                        uteståendeAvkorting
-                    }
+                    kontrollerAtUteståendeAvkortingRevurderes(gjeldendeVedtaksdata, uteståendeAvkorting)
+                        .getOrHandle {
+                            return KunneIkkeOppretteRevurdering.UteståendeAvkortingMåRevurderesEllerAvkortesINyPeriode(
+                                periode = uteståendeAvkorting.avkortingsvarsel.periode(),
+                            ).left()
+                        }
                 },
             )
 
@@ -280,6 +278,15 @@ internal class RevurderingServiceImpl(
                 }
             }
         }
+    }
+
+    private fun kontrollerAtUteståendeAvkortingRevurderes(
+        gjeldendeVedtaksdata: GjeldendeVedtaksdata,
+        uteståendeAvkorting: AvkortingVedRevurdering.Uhåndtert.UteståendeAvkorting,
+    ): Either<Unit, AvkortingVedRevurdering.Uhåndtert.UteståendeAvkorting> {
+        return if (!gjeldendeVedtaksdata.periodeFørsteTilOgMedSeneste()
+            .inneholder(uteståendeAvkorting.avkortingsvarsel.periode())
+        ) Unit.left() else uteståendeAvkorting.right()
     }
 
     override fun leggTilUførevilkår(
@@ -623,15 +630,12 @@ internal class RevurderingServiceImpl(
                     it
                 },
                 { uteståendeAvkorting ->
-                    if (!gjeldendeVedtaksdata.periodeFørsteTilOgMedSeneste()
-                        .inneholder(uteståendeAvkorting.avkortingsvarsel.periode())
-                    ) {
-                        return KunneIkkeOppdatereRevurdering.UteståendeAvkortingMåRevurderesEllerAvkortesINyPeriode(
-                            periode = uteståendeAvkorting.avkortingsvarsel.periode(),
-                        ).left()
-                    } else {
-                        uteståendeAvkorting
-                    }
+                    kontrollerAtUteståendeAvkortingRevurderes(gjeldendeVedtaksdata, uteståendeAvkorting)
+                        .getOrHandle {
+                            return KunneIkkeOppdatereRevurdering.UteståendeAvkortingMåRevurderesEllerAvkortesINyPeriode(
+                                periode = uteståendeAvkorting.avkortingsvarsel.periode(),
+                            ).left()
+                        }
                 },
             )
 

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -21,6 +21,7 @@ import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.avslag.Opphørsgrunn
 import no.nav.su.se.bakover.domain.beregning.Beregning
 import no.nav.su.se.bakover.domain.beregning.Månedsberegning
+import no.nav.su.se.bakover.domain.brev.Brevvalg
 import no.nav.su.se.bakover.domain.brev.LagBrevRequest
 import no.nav.su.se.bakover.domain.dokument.Dokument
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
@@ -73,7 +74,6 @@ import no.nav.su.se.bakover.service.statistikk.Event
 import no.nav.su.se.bakover.service.statistikk.Event.Statistikk.RevurderingStatistikk.RevurderingAvsluttet
 import no.nav.su.se.bakover.service.statistikk.EventObserver
 import no.nav.su.se.bakover.service.tilbakekreving.TilbakekrevingService
-import no.nav.su.se.bakover.service.toggles.ToggleService
 import no.nav.su.se.bakover.service.utbetaling.UtbetalingService
 import no.nav.su.se.bakover.service.vedtak.VedtakService
 import no.nav.su.se.bakover.service.vilkår.KunneIkkeLeggeFastOppholdINorgeVilkår
@@ -104,13 +104,12 @@ internal class RevurderingServiceImpl(
     private val brevService: BrevService,
     private val clock: Clock,
     private val vedtakRepo: VedtakRepo,
-    private val vedtakService: VedtakService,
+    vedtakService: VedtakService,
     private val kontrollsamtaleService: KontrollsamtaleService,
     private val sessionFactory: SessionFactory,
     private val formuegrenserFactory: FormuegrenserFactory,
     private val sakService: SakService,
     private val avkortingsvarselRepo: AvkortingsvarselRepo,
-    private val toggleService: ToggleService,
     private val tilbakekrevingService: TilbakekrevingService,
     private val satsFactory: SatsFactory,
 ) : RevurderingService {
@@ -286,8 +285,8 @@ internal class RevurderingServiceImpl(
     override fun leggTilUførevilkår(
         request: LeggTilUførevurderingerRequest,
     ): Either<KunneIkkeLeggeTilUføreVilkår, RevurderingOgFeilmeldingerResponse> {
-        val revurdering = hent(request.behandlingId)
-            .getOrHandle { return KunneIkkeLeggeTilUføreVilkår.FantIkkeBehandling.left() }
+        val revurdering =
+            hent(request.behandlingId).getOrHandle { return KunneIkkeLeggeTilUføreVilkår.FantIkkeBehandling.left() }
 
         val uførevilkår = request.toVilkår(
             behandlingsperiode = revurdering.periode,
@@ -306,20 +305,19 @@ internal class RevurderingServiceImpl(
     override fun leggTilUtenlandsopphold(
         request: LeggTilFlereUtenlandsoppholdRequest,
     ): Either<KunneIkkeLeggeTilUtenlandsopphold, RevurderingOgFeilmeldingerResponse> {
-        val revurdering = hent(request.behandlingId)
-            .getOrHandle { return KunneIkkeLeggeTilUtenlandsopphold.FantIkkeBehandling.left() }
+        val revurdering =
+            hent(request.behandlingId).getOrHandle { return KunneIkkeLeggeTilUtenlandsopphold.FantIkkeBehandling.left() }
 
         val utenlandsoppholdVilkår = request.tilVilkår(clock).getOrHandle {
             return it.tilService()
         }
 
-        return revurdering.oppdaterUtenlandsoppholdOgMarkerSomVurdert(utenlandsoppholdVilkår)
-            .mapLeft {
-                it.tilService()
-            }.map {
-                revurderingRepo.lagre(it)
-                identifiserFeilOgLagResponse(it)
-            }
+        return revurdering.oppdaterUtenlandsoppholdOgMarkerSomVurdert(utenlandsoppholdVilkår).mapLeft {
+            it.tilService()
+        }.map {
+            revurderingRepo.lagre(it)
+            identifiserFeilOgLagResponse(it)
+        }
     }
 
     private fun LeggTilFlereUtenlandsoppholdRequest.UgyldigUtenlandsopphold.tilService(): Either<KunneIkkeLeggeTilUtenlandsopphold, Nothing> {
@@ -358,14 +356,12 @@ internal class RevurderingServiceImpl(
         return hent(request.behandlingId).mapLeft {
             KunneIkkeLeggeTilOpplysningsplikt.FantIkkeBehandling
         }.flatMap { revurdering ->
-            revurdering.oppdaterOpplysningspliktOgMarkerSomVurdert(request.vilkår)
-                .mapLeft {
-                    KunneIkkeLeggeTilOpplysningsplikt.Revurdering(it)
-                }
-                .map {
-                    revurderingRepo.lagre(it)
-                    identifiserFeilOgLagResponse(it)
-                }
+            revurdering.oppdaterOpplysningspliktOgMarkerSomVurdert(request.vilkår).mapLeft {
+                KunneIkkeLeggeTilOpplysningsplikt.Revurdering(it)
+            }.map {
+                revurderingRepo.lagre(it)
+                identifiserFeilOgLagResponse(it)
+            }
         }
     }
 
@@ -373,14 +369,12 @@ internal class RevurderingServiceImpl(
         return hent(request.behandlingId).mapLeft {
             KunneIkkeLeggeTilPensjonsVilkår.FantIkkeBehandling
         }.flatMap { revurdering ->
-            revurdering.oppdaterPensjonsvilkårOgMarkerSomVurdert(request.vilkår)
-                .mapLeft {
-                    KunneIkkeLeggeTilPensjonsVilkår.Revurdering(it)
-                }
-                .map {
-                    revurderingRepo.lagre(it)
-                    identifiserFeilOgLagResponse(it)
-                }
+            revurdering.oppdaterPensjonsvilkårOgMarkerSomVurdert(request.vilkår).mapLeft {
+                KunneIkkeLeggeTilPensjonsVilkår.Revurdering(it)
+            }.map {
+                revurderingRepo.lagre(it)
+                identifiserFeilOgLagResponse(it)
+            }
         }
     }
 
@@ -403,14 +397,12 @@ internal class RevurderingServiceImpl(
         return hent(request.behandlingId).mapLeft {
             KunneIkkeLeggeTilFlyktningVilkår.FantIkkeBehandling
         }.flatMap { revurdering ->
-            revurdering.oppdaterFlyktningvilkårOgMarkerSomVurdert(request.vilkår)
-                .mapLeft {
-                    KunneIkkeLeggeTilFlyktningVilkår.Revurdering(it)
-                }
-                .map {
-                    revurderingRepo.lagre(it)
-                    identifiserFeilOgLagResponse(it)
-                }
+            revurdering.oppdaterFlyktningvilkårOgMarkerSomVurdert(request.vilkår).mapLeft {
+                KunneIkkeLeggeTilFlyktningVilkår.Revurdering(it)
+            }.map {
+                revurderingRepo.lagre(it)
+                identifiserFeilOgLagResponse(it)
+            }
         }
     }
 
@@ -418,20 +410,18 @@ internal class RevurderingServiceImpl(
         return hent(request.behandlingId).mapLeft {
             KunneIkkeLeggeFastOppholdINorgeVilkår.FantIkkeBehandling
         }.flatMap { revurdering ->
-            revurdering.oppdaterFastOppholdINorgeOgMarkerSomVurdert(request.vilkår)
-                .mapLeft {
-                    KunneIkkeLeggeFastOppholdINorgeVilkår.Revurdering(it)
-                }
-                .map {
-                    revurderingRepo.lagre(it)
-                    identifiserFeilOgLagResponse(it)
-                }
+            revurdering.oppdaterFastOppholdINorgeOgMarkerSomVurdert(request.vilkår).mapLeft {
+                KunneIkkeLeggeFastOppholdINorgeVilkår.Revurdering(it)
+            }.map {
+                revurderingRepo.lagre(it)
+                identifiserFeilOgLagResponse(it)
+            }
         }
     }
 
     override fun leggTilFradragsgrunnlag(request: LeggTilFradragsgrunnlagRequest): Either<KunneIkkeLeggeTilFradragsgrunnlag, RevurderingOgFeilmeldingerResponse> {
-        val revurdering = hent(request.behandlingId)
-            .getOrHandle { return KunneIkkeLeggeTilFradragsgrunnlag.FantIkkeBehandling.left() }
+        val revurdering =
+            hent(request.behandlingId).getOrHandle { return KunneIkkeLeggeTilFradragsgrunnlag.FantIkkeBehandling.left() }
 
         return revurdering.oppdaterFradragOgMarkerSomVurdert(request.fradragsgrunnlag).mapLeft {
             when (it) {
@@ -454,20 +444,18 @@ internal class RevurderingServiceImpl(
         return hent(request.behandlingId).mapLeft {
             KunneIkkeLeggeTilPersonligOppmøteVilkår.FantIkkeBehandling
         }.flatMap { revurdering ->
-            revurdering.oppdaterPersonligOppmøtevilkårOgMarkerSomVurdert(request.vilkår)
-                .mapLeft {
-                    KunneIkkeLeggeTilPersonligOppmøteVilkår.Revurdering(it)
-                }
-                .map {
-                    revurderingRepo.lagre(it)
-                    identifiserFeilOgLagResponse(it)
-                }
+            revurdering.oppdaterPersonligOppmøtevilkårOgMarkerSomVurdert(request.vilkår).mapLeft {
+                KunneIkkeLeggeTilPersonligOppmøteVilkår.Revurdering(it)
+            }.map {
+                revurderingRepo.lagre(it)
+                identifiserFeilOgLagResponse(it)
+            }
         }
     }
 
     override fun leggTilBosituasjongrunnlag(request: LeggTilBosituasjonerRequest): Either<KunneIkkeLeggeTilBosituasjongrunnlag, RevurderingOgFeilmeldingerResponse> {
-        val revurdering = hent(request.revurderingId)
-            .getOrHandle { return KunneIkkeLeggeTilBosituasjongrunnlag.FantIkkeBehandling.left() }
+        val revurdering =
+            hent(request.revurderingId).getOrHandle { return KunneIkkeLeggeTilBosituasjongrunnlag.FantIkkeBehandling.left() }
 
         val bosituasjongrunnlag = request.toDomain(
             clock = clock,
@@ -477,58 +465,55 @@ internal class RevurderingServiceImpl(
             return it.left()
         }
 
-        return revurdering.oppdaterBosituasjonOgMarkerSomVurdert(bosituasjongrunnlag)
-            .mapLeft {
-                KunneIkkeLeggeTilBosituasjongrunnlag.KunneIkkeLeggeTilBosituasjon(it)
-            }.map {
-                revurderingRepo.lagre(it)
-                identifiserFeilOgLagResponse(it)
-            }
+        return revurdering.oppdaterBosituasjonOgMarkerSomVurdert(bosituasjongrunnlag).mapLeft {
+            KunneIkkeLeggeTilBosituasjongrunnlag.KunneIkkeLeggeTilBosituasjon(it)
+        }.map {
+            revurderingRepo.lagre(it)
+            identifiserFeilOgLagResponse(it)
+        }
     }
 
     override fun leggTilFormuegrunnlag(
         request: LeggTilFormuevilkårRequest,
     ): Either<KunneIkkeLeggeTilFormuegrunnlag, RevurderingOgFeilmeldingerResponse> {
-        val revurdering = hent(request.behandlingId)
-            .getOrHandle { return KunneIkkeLeggeTilFormuegrunnlag.FantIkkeRevurdering.left() }
+        val revurdering =
+            hent(request.behandlingId).getOrHandle { return KunneIkkeLeggeTilFormuegrunnlag.FantIkkeRevurdering.left() }
 
         // TODO("flere_satser mulig å gjøre noe for å unngå casting?")
-        @Suppress("UNCHECKED_CAST")
-        val bosituasjon = revurdering.grunnlagsdata.bosituasjon as List<Grunnlag.Bosituasjon.Fullstendig>
+        @Suppress("UNCHECKED_CAST") val bosituasjon =
+            revurdering.grunnlagsdata.bosituasjon as List<Grunnlag.Bosituasjon.Fullstendig>
 
         val vilkår = request.toDomain(bosituasjon, revurdering.periode, clock, formuegrenserFactory).getOrHandle {
             return KunneIkkeLeggeTilFormuegrunnlag.KunneIkkeMappeTilDomenet(it).left()
         }
-        return revurdering.oppdaterFormueOgMarkerSomVurdert(vilkår)
-            .mapLeft {
-                when (it) {
-                    is Revurdering.KunneIkkeLeggeTilFormue.Konsistenssjekk -> {
-                        KunneIkkeLeggeTilFormuegrunnlag.Konsistenssjekk(it.feil)
-                    }
-
-                    is Revurdering.KunneIkkeLeggeTilFormue.UgyldigTilstand -> {
-                        KunneIkkeLeggeTilFormuegrunnlag.UgyldigTilstand(it.fra, it.til)
-                    }
+        return revurdering.oppdaterFormueOgMarkerSomVurdert(vilkår).mapLeft {
+            when (it) {
+                is Revurdering.KunneIkkeLeggeTilFormue.Konsistenssjekk -> {
+                    KunneIkkeLeggeTilFormuegrunnlag.Konsistenssjekk(it.feil)
                 }
-            }.map {
-                revurderingRepo.lagre(it)
-                identifiserFeilOgLagResponse(it)
+
+                is Revurdering.KunneIkkeLeggeTilFormue.UgyldigTilstand -> {
+                    KunneIkkeLeggeTilFormuegrunnlag.UgyldigTilstand(it.fra, it.til)
+                }
             }
+        }.map {
+            revurderingRepo.lagre(it)
+            identifiserFeilOgLagResponse(it)
+        }
     }
 
     override fun leggTilInstitusjonsoppholdVilkår(
         request: LeggTilInstitusjonsoppholdVilkårRequest,
     ): Either<KunneIkkeLeggeTilInstitusjonsoppholdVilkår, RevurderingOgFeilmeldingerResponse> {
-        val revurdering = hent(request.behandlingId)
-            .getOrElse { return KunneIkkeLeggeTilInstitusjonsoppholdVilkår.FantIkkeBehandling.left() }
+        val revurdering =
+            hent(request.behandlingId).getOrElse { return KunneIkkeLeggeTilInstitusjonsoppholdVilkår.FantIkkeBehandling.left() }
 
-        return revurdering.oppdaterInstitusjonsoppholdOgMarkerSomVurdert(request.vilkår)
-            .mapLeft {
-                KunneIkkeLeggeTilInstitusjonsoppholdVilkår.Revurdering(it)
-            }.map {
-                revurderingRepo.lagre(it)
-                identifiserFeilOgLagResponse(it)
-            }
+        return revurdering.oppdaterInstitusjonsoppholdOgMarkerSomVurdert(request.vilkår).mapLeft {
+            KunneIkkeLeggeTilInstitusjonsoppholdVilkår.Revurdering(it)
+        }.map {
+            revurderingRepo.lagre(it)
+            identifiserFeilOgLagResponse(it)
+        }
     }
 
     private fun identifiserFeilOgLagResponse(revurdering: Revurdering): RevurderingOgFeilmeldingerResponse {
@@ -580,13 +565,12 @@ internal class RevurderingServiceImpl(
         }
         val sak = sakService.hentSakForRevurdering(oppdaterRevurderingRequest.revurderingId)
 
-        val revurdering = sak.hentRevurdering(oppdaterRevurderingRequest.revurderingId)
-            .fold(
-                { return KunneIkkeOppdatereRevurdering.FantIkkeRevurdering.left() },
-                {
-                    if (it is Revurdering) it else return KunneIkkeOppdatereRevurdering.FantIkkeRevurdering.left()
-                },
-            )
+        val revurdering = sak.hentRevurdering(oppdaterRevurderingRequest.revurderingId).fold(
+            { return KunneIkkeOppdatereRevurdering.FantIkkeRevurdering.left() },
+            {
+                if (it is Revurdering) it else return KunneIkkeOppdatereRevurdering.FantIkkeRevurdering.left()
+            },
+        )
 
         // TODO jah: Flytt sjekker som dette inn i domenet
         if (revurdering.forhåndsvarsel.harSendtForhåndsvarsel()) {
@@ -757,19 +741,14 @@ internal class RevurderingServiceImpl(
                         ).resultat && !(beregnetRevurdering is BeregnetRevurdering.Opphørt && beregnetRevurdering.opphørSkyldesVilkår())
                         ) to Varselmelding.BeløpsendringUnder10Prosent,
                     gjeldendeVedtaksdata.let { gammel ->
-                        (
-                            gammel.grunnlagsdata.bosituasjon.any { it.harEPS() } &&
-                                beregnetRevurdering.grunnlagsdata.bosituasjon.none { it.harEPS() }
-                            ) to Varselmelding.FradragOgFormueForEPSErFjernet
+                        (gammel.grunnlagsdata.bosituasjon.any { it.harEPS() } && beregnetRevurdering.grunnlagsdata.bosituasjon.none { it.harEPS() }) to Varselmelding.FradragOgFormueForEPSErFjernet
                     },
                 )
 
                 when (beregnetRevurdering) {
                     is BeregnetRevurdering.IngenEndring -> {
                         revurderingRepo.lagre(beregnetRevurdering)
-                        identifiserFeilOgLagResponse(beregnetRevurdering)
-                            .leggTil(potensielleVarsel)
-                            .right()
+                        identifiserFeilOgLagResponse(beregnetRevurdering).leggTil(potensielleVarsel).right()
                     }
 
                     is BeregnetRevurdering.Innvilget -> {
@@ -796,8 +775,7 @@ internal class RevurderingServiceImpl(
                                 clock = clock,
                             ).let { simulert ->
                                 revurderingRepo.lagre(simulert)
-                                identifiserFeilOgLagResponse(simulert)
-                                    .leggTil(potensielleVarsel)
+                                identifiserFeilOgLagResponse(simulert).leggTil(potensielleVarsel)
                             }
                         }
                     }
@@ -812,12 +790,10 @@ internal class RevurderingServiceImpl(
                                     opphørsdato = opphørsdato,
                                 ),
                             )
-                        }.mapLeft { KunneIkkeBeregneOgSimulereRevurdering.KunneIkkeSimulere(it) }
-                            .map { simulert ->
-                                revurderingRepo.lagre(simulert)
-                                identifiserFeilOgLagResponse(simulert)
-                                    .leggTil(potensielleVarsel)
-                            }
+                        }.mapLeft { KunneIkkeBeregneOgSimulereRevurdering.KunneIkkeSimulere(it) }.map { simulert ->
+                            revurderingRepo.lagre(simulert)
+                            identifiserFeilOgLagResponse(simulert).leggTil(potensielleVarsel)
+                        }
                     }
                 }
             }
@@ -865,12 +841,11 @@ internal class RevurderingServiceImpl(
         }
         return when (forhåndsvarselhandling) {
             Forhåndsvarselhandling.INGEN_FORHÅNDSVARSEL -> {
-                revurdering.ikkeSendForhåndsvarsel()
-                    .mapLeft {
-                        KunneIkkeForhåndsvarsle.UgyldigTilstandsovergangForForhåndsvarsling
-                    }.tap {
-                        revurderingRepo.lagre(it)
-                    }
+                revurdering.ikkeSendForhåndsvarsel().mapLeft {
+                    KunneIkkeForhåndsvarsle.UgyldigTilstandsovergangForForhåndsvarsling
+                }.tap {
+                    revurderingRepo.lagre(it)
+                }
             }
 
             Forhåndsvarselhandling.FORHÅNDSVARSLE -> {
@@ -897,51 +872,48 @@ internal class RevurderingServiceImpl(
                         KunneIkkeForhåndsvarsle.UgyldigTilstandsovergangForForhåndsvarsling
                     }.flatMap { forhåndsvarselBrev ->
                         forhåndsvarselBrev.tilDokument {
-                            brevService.lagBrev(it)
-                                .mapLeft {
-                                    LagBrevRequest.KunneIkkeGenererePdf
-                                }
+                            brevService.lagBrev(it).mapLeft {
+                                LagBrevRequest.KunneIkkeGenererePdf
+                            }
                         }.mapLeft {
                             KunneIkkeForhåndsvarsle.KunneIkkeGenerereDokument
                         }.flatMap { dokumentUtenMetadata ->
-                            revurdering.markerForhåndsvarselSomSendt()
-                                .mapLeft {
-                                    KunneIkkeForhåndsvarsle.UgyldigTilstandsovergangForForhåndsvarsling
-                                }
-                                .flatMap { simulertRevurdering ->
-                                    Either.catch {
-                                        sessionFactory.withTransactionContext { tx ->
-                                            brevService.lagreDokument(
-                                                dokument = dokumentUtenMetadata.leggTilMetadata(
-                                                    Dokument.Metadata(
-                                                        sakId = simulertRevurdering.sakId,
-                                                        revurderingId = simulertRevurdering.id,
-                                                        bestillBrev = true,
-                                                    ),
+                            revurdering.markerForhåndsvarselSomSendt().mapLeft {
+                                KunneIkkeForhåndsvarsle.UgyldigTilstandsovergangForForhåndsvarsling
+                            }.flatMap { simulertRevurdering ->
+                                Either.catch {
+                                    sessionFactory.withTransactionContext { tx ->
+                                        brevService.lagreDokument(
+                                            dokument = dokumentUtenMetadata.leggTilMetadata(
+                                                Dokument.Metadata(
+                                                    sakId = simulertRevurdering.sakId,
+                                                    revurderingId = simulertRevurdering.id,
+                                                    bestillBrev = true,
                                                 ),
-                                                transactionContext = tx,
-                                            )
-                                            revurderingRepo.lagre(
-                                                revurdering = simulertRevurdering,
-                                                transactionContext = tx,
-                                            )
-                                            prøvÅOppdatereOppgaveEtterViHarSendtForhåndsvarsel(
-                                                revurderingId = simulertRevurdering.id,
-                                                oppgaveId = simulertRevurdering.oppgaveId,
-                                            ).tapLeft {
-                                                throw KunneIkkeOppdatereOppgave()
-                                            }
-                                            log.info("Forhåndsvarsel sendt for revurdering ${simulertRevurdering.id}")
-                                            simulertRevurdering
+                                            ),
+                                            transactionContext = tx,
+                                        )
+                                        revurderingRepo.lagre(
+                                            revurdering = simulertRevurdering,
+                                            transactionContext = tx,
+                                        )
+                                        prøvÅOppdatereOppgaveEtterViHarSendtForhåndsvarsel(
+                                            revurderingId = simulertRevurdering.id,
+                                            oppgaveId = simulertRevurdering.oppgaveId,
+                                        ).tapLeft {
+                                            throw KunneIkkeOppdatereOppgave()
                                         }
-                                    }.mapLeft {
-                                        if (it is KunneIkkeOppdatereOppgave) {
-                                            KunneIkkeForhåndsvarsle.KunneIkkeOppdatereOppgave
-                                        } else {
-                                            throw it
-                                        }
+                                        log.info("Forhåndsvarsel sendt for revurdering ${simulertRevurdering.id}")
+                                        simulertRevurdering
+                                    }
+                                }.mapLeft {
+                                    if (it is KunneIkkeOppdatereOppgave) {
+                                        KunneIkkeForhåndsvarsle.KunneIkkeOppdatereOppgave
+                                    } else {
+                                        throw it
                                     }
                                 }
+                            }
                         }
                     }
                 }
@@ -969,46 +941,44 @@ internal class RevurderingServiceImpl(
         revurderingId: UUID,
         fritekst: String,
     ): Either<KunneIkkeLageBrevutkastForRevurdering, ByteArray> {
-        return hent(revurderingId)
-            .mapLeft {
-                KunneIkkeLageBrevutkastForRevurdering.FantIkkeRevurdering
-            }
-            .flatMap { revurdering ->
-                if (revurdering !is SimulertRevurdering) return KunneIkkeLageBrevutkastForRevurdering.KunneIkkeLageBrevutkast.left()
+        return hent(revurderingId).mapLeft {
+            KunneIkkeLageBrevutkastForRevurdering.FantIkkeRevurdering
+        }.flatMap { revurdering ->
+            if (revurdering !is SimulertRevurdering) return KunneIkkeLageBrevutkastForRevurdering.KunneIkkeLageBrevutkast.left()
 
-                hentPersonOgSaksbehandlerNavn(
-                    fnr = revurdering.fnr,
-                    saksbehandler = revurdering.saksbehandler,
-                ).mapLeft {
-                    when (it) {
-                        KunneIkkeHentePersonEllerSaksbehandlerNavn.FantIkkePerson -> {
-                            KunneIkkeLageBrevutkastForRevurdering.FantIkkePerson
-                        }
-
-                        KunneIkkeHentePersonEllerSaksbehandlerNavn.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant -> {
-                            KunneIkkeLageBrevutkastForRevurdering.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant
-                        }
+            hentPersonOgSaksbehandlerNavn(
+                fnr = revurdering.fnr,
+                saksbehandler = revurdering.saksbehandler,
+            ).mapLeft {
+                when (it) {
+                    KunneIkkeHentePersonEllerSaksbehandlerNavn.FantIkkePerson -> {
+                        KunneIkkeLageBrevutkastForRevurdering.FantIkkePerson
                     }
-                }.flatMap { (person, saksbehandlerNavn) ->
-                    revurdering.lagForhåndsvarsel(
-                        person = person,
-                        saksbehandlerNavn = saksbehandlerNavn,
-                        fritekst = fritekst,
-                        clock = clock,
-                    ).mapLeft {
+
+                    KunneIkkeHentePersonEllerSaksbehandlerNavn.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant -> {
+                        KunneIkkeLageBrevutkastForRevurdering.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant
+                    }
+                }
+            }.flatMap { (person, saksbehandlerNavn) ->
+                revurdering.lagForhåndsvarsel(
+                    person = person,
+                    saksbehandlerNavn = saksbehandlerNavn,
+                    fritekst = fritekst,
+                    clock = clock,
+                ).mapLeft {
+                    KunneIkkeLageBrevutkastForRevurdering.KunneIkkeLageBrevutkast
+                }.flatMap {
+                    brevService.lagBrev(it).mapLeft {
                         KunneIkkeLageBrevutkastForRevurdering.KunneIkkeLageBrevutkast
-                    }.flatMap {
-                        brevService.lagBrev(it).mapLeft {
-                            KunneIkkeLageBrevutkastForRevurdering.KunneIkkeLageBrevutkast
-                        }
                     }
                 }
             }
+        }
     }
 
     override fun oppdaterTilbakekrevingsbehandling(request: OppdaterTilbakekrevingsbehandlingRequest): Either<KunneIkkeOppdatereTilbakekrevingsbehandling, SimulertRevurdering> {
-        val revurdering = hent(request.revurderingId)
-            .getOrHandle { return KunneIkkeOppdatereTilbakekrevingsbehandling.FantIkkeRevurdering.left() }
+        val revurdering =
+            hent(request.revurderingId).getOrHandle { return KunneIkkeOppdatereTilbakekrevingsbehandling.FantIkkeRevurdering.left() }
 
         if (revurdering !is SimulertRevurdering) {
             return KunneIkkeOppdatereTilbakekrevingsbehandling.UgyldigTilstand(fra = revurdering::class).left()
@@ -1042,8 +1012,7 @@ internal class RevurderingServiceImpl(
     override fun sendTilAttestering(
         request: SendTilAttesteringRequest,
     ): Either<KunneIkkeSendeRevurderingTilAttestering, Revurdering> {
-        return hent(request.revurderingId)
-            .mapLeft { return KunneIkkeSendeRevurderingTilAttestering.FantIkkeRevurdering.left() }
+        return hent(request.revurderingId).mapLeft { return KunneIkkeSendeRevurderingTilAttestering.FantIkkeRevurdering.left() }
             .flatMap {
                 sendTilAttestering(
                     revurdering = it,
@@ -1182,12 +1151,11 @@ internal class RevurderingServiceImpl(
             clock = clock,
         )
 
-        tilbakekrevingService.hentAvventerKravgrunnlag(revurdering.sakId)
-            .ifNotEmpty {
-                return KunneIkkeSendeRevurderingTilAttestering.SakHarRevurderingerMedÅpentKravgrunnlagForTilbakekreving(
-                    revurderingId = this.first().avgjort.revurderingId,
-                ).left()
-            }
+        tilbakekrevingService.hentAvventerKravgrunnlag(revurdering.sakId).ifNotEmpty {
+            return KunneIkkeSendeRevurderingTilAttestering.SakHarRevurderingerMedÅpentKravgrunnlagForTilbakekreving(
+                revurderingId = this.first().avgjort.revurderingId,
+            ).left()
+        }
 
         return when (revurdering) {
             is BeregnetRevurdering.IngenEndring -> {
@@ -1256,8 +1224,8 @@ internal class RevurderingServiceImpl(
         revurderingId: UUID,
         fritekst: String?,
     ): Either<KunneIkkeLageBrevutkastForRevurdering, ByteArray> {
-        val revurdering = hent(revurderingId)
-            .getOrHandle { return KunneIkkeLageBrevutkastForRevurdering.FantIkkeRevurdering.left() }
+        val revurdering =
+            hent(revurderingId).getOrHandle { return KunneIkkeLageBrevutkastForRevurdering.FantIkkeRevurdering.left() }
 
         val revurderingMedPotensiellFritekst = if (fritekst != null) {
             revurdering.medFritekst(fritekst)
@@ -1265,18 +1233,15 @@ internal class RevurderingServiceImpl(
             revurdering
         }
 
-        return brevService.lagDokument(revurderingMedPotensiellFritekst)
-            .mapLeft {
-                when (it) {
-                    KunneIkkeLageDokument.KunneIkkeFinneGjeldendeUtbetaling -> KunneIkkeLageBrevutkastForRevurdering.KunneIkkeFinneGjeldendeUtbetaling
-                    KunneIkkeLageDokument.KunneIkkeGenererePDF -> KunneIkkeLageBrevutkastForRevurdering.KunneIkkeLageBrevutkast
-                    KunneIkkeLageDokument.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant -> KunneIkkeLageBrevutkastForRevurdering.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant
-                    KunneIkkeLageDokument.KunneIkkeHentePerson -> KunneIkkeLageBrevutkastForRevurdering.FantIkkePerson
-                }
+        return brevService.lagDokument(revurderingMedPotensiellFritekst).mapLeft {
+            when (it) {
+                KunneIkkeLageDokument.KunneIkkeFinneGjeldendeUtbetaling -> KunneIkkeLageBrevutkastForRevurdering.KunneIkkeFinneGjeldendeUtbetaling
+                KunneIkkeLageDokument.KunneIkkeGenererePDF -> KunneIkkeLageBrevutkastForRevurdering.KunneIkkeLageBrevutkast
+                KunneIkkeLageDokument.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant -> KunneIkkeLageBrevutkastForRevurdering.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant
+                KunneIkkeLageDokument.KunneIkkeHentePerson -> KunneIkkeLageBrevutkastForRevurdering.FantIkkePerson
+                KunneIkkeLageDokument.DetSkalIkkeSendesBrev -> KunneIkkeLageBrevutkastForRevurdering.DetSkalIkkeSendesBrev
             }
-            .map {
-                it.generertDokument
-            }
+        }.map { it.generertDokument }
     }
 
     override fun iverksett(
@@ -1296,133 +1261,130 @@ internal class RevurderingServiceImpl(
                 KunneIkkeIverksetteRevurdering.IngenEndringErIkkeGyldig.left()
             }
 
-            is RevurderingTilAttestering.Innvilget ->
-                revurdering.tilIverksatt(
-                    attestant = attestant,
-                    hentOpprinneligAvkorting = { avkortingid -> avkortingsvarselRepo.hent(avkortingid) },
-                    clock = clock,
-                ).mapLeft {
-                    when (it) {
-                        RevurderingTilAttestering.KunneIkkeIverksetteRevurdering.AttestantOgSaksbehandlerKanIkkeVæreSammePerson -> KunneIkkeIverksetteRevurdering.AttestantOgSaksbehandlerKanIkkeVæreSammePerson
-                        RevurderingTilAttestering.KunneIkkeIverksetteRevurdering.HarAlleredeBlittAvkortetAvEnAnnen -> KunneIkkeIverksetteRevurdering.HarAlleredeBlittAvkortetAvEnAnnen
-                        RevurderingTilAttestering.KunneIkkeIverksetteRevurdering.HarBlittAnnullertAvEnAnnen -> KunneIkkeIverksetteRevurdering.HarAlleredeBlittAvkortetAvEnAnnen
-                        is RevurderingTilAttestering.KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale -> KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale(
-                            it.utbetalingFeilet,
-                        )
-                    }
-                }.flatMap { iverksattRevurdering ->
-                    utbetalingService.verifiserOgSimulerUtbetaling(
-                        request = UtbetalRequest.NyUtbetaling(
-                            request = SimulerUtbetalingRequest.NyUtbetaling.Uføre(
-                                sakId = revurdering.sakId,
-                                saksbehandler = attestant,
-                                beregning = revurdering.beregning,
-                                uføregrunnlag = revurdering.vilkårsvurderinger.uføreVilkår().fold(
-                                    {
-                                        TODO("vilkårsvurdering_alder utbetaling av alder ikke implementert")
-                                    },
-                                    {
-                                        it.grunnlag
-                                    },
-                                ),
-                                utbetalingsinstruksjonForEtterbetaling = UtbetalingsinstruksjonForEtterbetalinger.SåFortSomMulig,
-                            ),
-                            simulering = revurdering.simulering,
-                        ),
-                    ).mapLeft { KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale(it) }
-                        .flatMap { utbetaling ->
-                            val vedtak = VedtakSomKanRevurderes.from(iverksattRevurdering, utbetaling.id, clock)
-                            Either.catch {
-                                sessionFactory.withTransactionContext { tx ->
-                                    // OBS: Det er kun exceptions som vil føre til at transaksjonen ruller tilbake. Hvis funksjonene returnerer Left/null o.l. vil transaksjonen gå igjennom. De tilfellene må håndteres eksplisitt per funksjon.
-                                    // Det er også viktig at publiseringen av utbetalingen er det siste som skjer i blokka. Alt som ikke skal påvirke utfallet av iverksettingen skal flyttes ut av blokka. E.g. statistikk.
-                                    utbetalingService.lagreUtbetaling(utbetaling, tx)
-                                    vedtakRepo.lagre(vedtak, tx)
-                                    revurderingRepo.lagre(iverksattRevurdering, tx)
-                                    utbetalingService.publiserUtbetaling(utbetaling).mapLeft { feil ->
-                                        throw IverksettTransactionException(
-                                            "Kunne ikke publisere utbetaling på køen. Underliggende feil: $feil.",
-                                            KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale(feil),
-                                        )
-                                    }
-                                    vedtak
-                                }
-                            }.mapLeft {
-                                when (it) {
-                                    is IverksettTransactionException -> it.feil
-                                    else -> KunneIkkeIverksetteRevurdering.LagringFeilet
-                                }
-                            }
-                        }.map { Pair(iverksattRevurdering, it) }
+            is RevurderingTilAttestering.Innvilget -> revurdering.tilIverksatt(
+                attestant = attestant,
+                hentOpprinneligAvkorting = { avkortingid -> avkortingsvarselRepo.hent(avkortingid) },
+                clock = clock,
+            ).mapLeft {
+                when (it) {
+                    RevurderingTilAttestering.KunneIkkeIverksetteRevurdering.AttestantOgSaksbehandlerKanIkkeVæreSammePerson -> KunneIkkeIverksetteRevurdering.AttestantOgSaksbehandlerKanIkkeVæreSammePerson
+                    RevurderingTilAttestering.KunneIkkeIverksetteRevurdering.HarAlleredeBlittAvkortetAvEnAnnen -> KunneIkkeIverksetteRevurdering.HarAlleredeBlittAvkortetAvEnAnnen
+                    RevurderingTilAttestering.KunneIkkeIverksetteRevurdering.HarBlittAnnullertAvEnAnnen -> KunneIkkeIverksetteRevurdering.HarAlleredeBlittAvkortetAvEnAnnen
+                    is RevurderingTilAttestering.KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale -> KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale(
+                        it.utbetalingFeilet,
+                    )
                 }
-
-            is RevurderingTilAttestering.Opphørt ->
-                revurdering.tilIverksatt(
-                    attestant = attestant,
-                    clock = clock,
-                    hentOpprinneligAvkorting = { avkortingid -> avkortingsvarselRepo.hent(avkortingid) },
-                ).mapLeft {
-                    when (it) {
-                        RevurderingTilAttestering.KunneIkkeIverksetteRevurdering.AttestantOgSaksbehandlerKanIkkeVæreSammePerson -> KunneIkkeIverksetteRevurdering.AttestantOgSaksbehandlerKanIkkeVæreSammePerson
-                        RevurderingTilAttestering.KunneIkkeIverksetteRevurdering.HarAlleredeBlittAvkortetAvEnAnnen -> KunneIkkeIverksetteRevurdering.HarAlleredeBlittAvkortetAvEnAnnen
-                        RevurderingTilAttestering.KunneIkkeIverksetteRevurdering.HarBlittAnnullertAvEnAnnen -> KunneIkkeIverksetteRevurdering.HarAlleredeBlittAvkortetAvEnAnnen
-                        is RevurderingTilAttestering.KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale -> KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale(
-                            it.utbetalingFeilet,
-                        )
-                    }
-                }.flatMap { iverksattRevurdering ->
-                    utbetalingService.verifiserOgSimulerOpphør(
-                        request = UtbetalRequest.Opphør(
-                            request = SimulerUtbetalingRequest.Opphør(
-                                sakId = iverksattRevurdering.sakId,
-                                saksbehandler = attestant,
-                                opphørsdato = revurdering.opphørsdatoForUtbetalinger,
+            }.flatMap { iverksattRevurdering ->
+                utbetalingService.verifiserOgSimulerUtbetaling(
+                    request = UtbetalRequest.NyUtbetaling(
+                        request = SimulerUtbetalingRequest.NyUtbetaling.Uføre(
+                            sakId = revurdering.sakId,
+                            saksbehandler = attestant,
+                            beregning = revurdering.beregning,
+                            uføregrunnlag = revurdering.vilkårsvurderinger.uføreVilkår().fold(
+                                {
+                                    TODO("vilkårsvurdering_alder utbetaling av alder ikke implementert")
+                                },
+                                {
+                                    it.grunnlag
+                                },
                             ),
-                            simulering = iverksattRevurdering.simulering,
+                            utbetalingsinstruksjonForEtterbetaling = UtbetalingsinstruksjonForEtterbetalinger.SåFortSomMulig,
                         ),
-                    ).mapLeft {
-                        KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale(it)
-                    }.flatMap { utbetaling ->
-                        val opphørtVedtak = VedtakSomKanRevurderes.from(
-                            revurdering = iverksattRevurdering, utbetalingId = utbetaling.id,
-                            clock = clock,
-                        )
-                        Either.catch {
-                            sessionFactory.withTransactionContext { tx ->
-                                // OBS: Det er kun exceptions som vil føre til at transaksjonen ruller tilbake. Hvis funksjonene returnerer Left/null o.l. vil transaksjonen gå igjennom. De tilfellene må håndteres eksplisitt per funksjon.
-                                // Det er også viktig at publiseringen av utbetalingen er det siste som skjer i blokka. Alt som ikke skal påvirke utfallet av iverksettingen skal flyttes ut av blokka. E.g. statistikk.
-                                utbetalingService.lagreUtbetaling(utbetaling, tx)
-                                vedtakRepo.lagre(opphørtVedtak, tx)
-                                kontrollsamtaleService.annullerKontrollsamtale(opphørtVedtak.behandling.sakId, tx)
-                                    .mapLeft { feil ->
-                                        throw IverksettTransactionException(
-                                            "Kunne ikke annullere kontrollsamtale. Underliggende feil: $feil.",
-                                            KunneIkkeIverksetteRevurdering.KunneIkkeAnnulereKontrollsamtale,
-                                        )
-                                    }
-                                revurderingRepo.lagre(iverksattRevurdering, tx)
-                                utbetalingService.publiserUtbetaling(utbetaling).mapLeft { feil ->
+                        simulering = revurdering.simulering,
+                    ),
+                ).mapLeft { KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale(it) }.flatMap { utbetaling ->
+                    val vedtak = VedtakSomKanRevurderes.from(iverksattRevurdering, utbetaling.id, clock)
+                    Either.catch {
+                        sessionFactory.withTransactionContext { tx ->
+                            // OBS: Det er kun exceptions som vil føre til at transaksjonen ruller tilbake. Hvis funksjonene returnerer Left/null o.l. vil transaksjonen gå igjennom. De tilfellene må håndteres eksplisitt per funksjon.
+                            // Det er også viktig at publiseringen av utbetalingen er det siste som skjer i blokka. Alt som ikke skal påvirke utfallet av iverksettingen skal flyttes ut av blokka. E.g. statistikk.
+                            utbetalingService.lagreUtbetaling(utbetaling, tx)
+                            vedtakRepo.lagre(vedtak, tx)
+                            revurderingRepo.lagre(iverksattRevurdering, tx)
+                            utbetalingService.publiserUtbetaling(utbetaling).mapLeft { feil ->
+                                throw IverksettTransactionException(
+                                    "Kunne ikke publisere utbetaling på køen. Underliggende feil: $feil.",
+                                    KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale(feil),
+                                )
+                            }
+                            vedtak
+                        }
+                    }.mapLeft {
+                        when (it) {
+                            is IverksettTransactionException -> it.feil
+                            else -> KunneIkkeIverksetteRevurdering.LagringFeilet
+                        }
+                    }
+                }.map { Pair(iverksattRevurdering, it) }
+            }
+
+            is RevurderingTilAttestering.Opphørt -> revurdering.tilIverksatt(
+                attestant = attestant,
+                clock = clock,
+                hentOpprinneligAvkorting = { avkortingid -> avkortingsvarselRepo.hent(avkortingid) },
+            ).mapLeft {
+                when (it) {
+                    RevurderingTilAttestering.KunneIkkeIverksetteRevurdering.AttestantOgSaksbehandlerKanIkkeVæreSammePerson -> KunneIkkeIverksetteRevurdering.AttestantOgSaksbehandlerKanIkkeVæreSammePerson
+                    RevurderingTilAttestering.KunneIkkeIverksetteRevurdering.HarAlleredeBlittAvkortetAvEnAnnen -> KunneIkkeIverksetteRevurdering.HarAlleredeBlittAvkortetAvEnAnnen
+                    RevurderingTilAttestering.KunneIkkeIverksetteRevurdering.HarBlittAnnullertAvEnAnnen -> KunneIkkeIverksetteRevurdering.HarAlleredeBlittAvkortetAvEnAnnen
+                    is RevurderingTilAttestering.KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale -> KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale(
+                        it.utbetalingFeilet,
+                    )
+                }
+            }.flatMap { iverksattRevurdering ->
+                utbetalingService.verifiserOgSimulerOpphør(
+                    request = UtbetalRequest.Opphør(
+                        request = SimulerUtbetalingRequest.Opphør(
+                            sakId = iverksattRevurdering.sakId,
+                            saksbehandler = attestant,
+                            opphørsdato = revurdering.opphørsdatoForUtbetalinger,
+                        ),
+                        simulering = iverksattRevurdering.simulering,
+                    ),
+                ).mapLeft {
+                    KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale(it)
+                }.flatMap { utbetaling ->
+                    val opphørtVedtak = VedtakSomKanRevurderes.from(
+                        revurdering = iverksattRevurdering, utbetalingId = utbetaling.id,
+                        clock = clock,
+                    )
+                    Either.catch {
+                        sessionFactory.withTransactionContext { tx ->
+                            // OBS: Det er kun exceptions som vil føre til at transaksjonen ruller tilbake. Hvis funksjonene returnerer Left/null o.l. vil transaksjonen gå igjennom. De tilfellene må håndteres eksplisitt per funksjon.
+                            // Det er også viktig at publiseringen av utbetalingen er det siste som skjer i blokka. Alt som ikke skal påvirke utfallet av iverksettingen skal flyttes ut av blokka. E.g. statistikk.
+                            utbetalingService.lagreUtbetaling(utbetaling, tx)
+                            vedtakRepo.lagre(opphørtVedtak, tx)
+                            kontrollsamtaleService.annullerKontrollsamtale(opphørtVedtak.behandling.sakId, tx)
+                                .mapLeft { feil ->
                                     throw IverksettTransactionException(
-                                        "Kunne ikke publisere utbetaling på køen. Underliggende feil: $feil.",
-                                        KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale(feil),
+                                        "Kunne ikke annullere kontrollsamtale. Underliggende feil: $feil.",
+                                        KunneIkkeIverksetteRevurdering.KunneIkkeAnnulereKontrollsamtale,
                                     )
                                 }
-                                opphørtVedtak
+                            revurderingRepo.lagre(iverksattRevurdering, tx)
+                            utbetalingService.publiserUtbetaling(utbetaling).mapLeft { feil ->
+                                throw IverksettTransactionException(
+                                    "Kunne ikke publisere utbetaling på køen. Underliggende feil: $feil.",
+                                    KunneIkkeIverksetteRevurdering.KunneIkkeUtbetale(feil),
+                                )
                             }
-                        }.mapLeft {
-                            log.error(
-                                "Kunne ikke iverksette revurdering for sak ${iverksattRevurdering.sakId} og søknadsbehandling ${iverksattRevurdering.id}.",
-                                it,
-                            )
-                            when (it) {
-                                is IverksettTransactionException -> it.feil
-                                else -> KunneIkkeIverksetteRevurdering.LagringFeilet
-                            }
+                            opphørtVedtak
                         }
-                    }.map {
-                        Pair(iverksattRevurdering, it)
+                    }.mapLeft {
+                        log.error(
+                            "Kunne ikke iverksette revurdering for sak ${iverksattRevurdering.sakId} og søknadsbehandling ${iverksattRevurdering.id}.",
+                            it,
+                        )
+                        when (it) {
+                            is IverksettTransactionException -> it.feil
+                            else -> KunneIkkeIverksetteRevurdering.LagringFeilet
+                        }
                     }
+                }.map {
+                    Pair(iverksattRevurdering, it)
                 }
+            }
         }.map {
             Either.catch {
                 observers.forEach { observer ->
@@ -1448,8 +1410,8 @@ internal class RevurderingServiceImpl(
         revurderingId: UUID,
         attestering: Attestering.Underkjent,
     ): Either<KunneIkkeUnderkjenneRevurdering, UnderkjentRevurdering> {
-        val revurdering = hent(revurderingId)
-            .getOrHandle { return KunneIkkeUnderkjenneRevurdering.FantIkkeRevurdering.left() }
+        val revurdering =
+            hent(revurderingId).getOrHandle { return KunneIkkeUnderkjenneRevurdering.FantIkkeRevurdering.left() }
 
         if (revurdering !is RevurderingTilAttestering) {
             return KunneIkkeUnderkjenneRevurdering.UgyldigTilstand(
@@ -1485,12 +1447,11 @@ internal class RevurderingServiceImpl(
 
         val eksisterendeOppgaveId = revurdering.oppgaveId
 
-        oppgaveService.lukkOppgave(eksisterendeOppgaveId)
-            .mapLeft {
-                log.error("Kunne ikke lukke attesteringsoppgave $eksisterendeOppgaveId ved underkjenning av revurdering. Dette må gjøres manuelt.")
-            }.map {
-                log.info("Lukket attesteringsoppgave $eksisterendeOppgaveId ved underkjenning av revurdering")
-            }
+        oppgaveService.lukkOppgave(eksisterendeOppgaveId).mapLeft {
+            log.error("Kunne ikke lukke attesteringsoppgave $eksisterendeOppgaveId ved underkjenning av revurdering. Dette må gjøres manuelt.")
+        }.map {
+            log.info("Lukket attesteringsoppgave $eksisterendeOppgaveId ved underkjenning av revurdering")
+        }
 
         observers.forEach { observer ->
             observer.handle(
@@ -1503,12 +1464,10 @@ internal class RevurderingServiceImpl(
 
     override fun fortsettEtterForhåndsvarsling(request: FortsettEtterForhåndsvarslingRequest): Either<FortsettEtterForhåndsvarselFeil, Revurdering> {
         return Either.fromNullable(revurderingRepo.hent(request.revurderingId))
-            .mapLeft { FortsettEtterForhåndsvarselFeil.FantIkkeRevurdering }
-            .flatMap { revurdering ->
+            .mapLeft { FortsettEtterForhåndsvarselFeil.FantIkkeRevurdering }.flatMap { revurdering ->
                 (revurdering as? SimulertRevurdering)?.right()
                     ?: Either.Left(FortsettEtterForhåndsvarselFeil.MåVæreEnSimulertRevurdering)
-            }
-            .flatMap { simulertRevurdering ->
+            }.flatMap { simulertRevurdering ->
                 when (request) {
                     is FortsettEtterForhåndsvarslingRequest.FortsettMedSammeOpplysninger -> {
                         simulertRevurdering.prøvOvergangTilFortsettMedSammeGrunnlag(request.begrunnelse).mapLeft {
@@ -1531,21 +1490,6 @@ internal class RevurderingServiceImpl(
                             revurderingRepo.lagre(simulertRevurderingMedOppdatertForhåndsvarsel)
                         }
                     }
-
-                    is FortsettEtterForhåndsvarslingRequest.AvsluttUtenEndringer -> {
-                        simulertRevurdering.prøvOvergangTilAvsluttet(request.begrunnelse).mapLeft {
-                            FortsettEtterForhåndsvarselFeil.UgyldigTilstandsovergang(it.fra, it.til)
-                        }.flatMap { simulertRevurderingMedOppdatertForhåndsvarsel ->
-                            // avsluttRevurdering(...) persisterer forhåndsvarselet
-                            avsluttRevurdering(
-                                revurdering = simulertRevurderingMedOppdatertForhåndsvarsel,
-                                begrunnelse = request.begrunnelse,
-                                fritekst = request.fritekstTilBrev,
-                            ).mapLeft {
-                                FortsettEtterForhåndsvarselFeil.KunneIkkeAvslutteRevurdering(it)
-                            }.map { it as Revurdering }
-                        }
-                    }
                 }
             }
     }
@@ -1553,40 +1497,48 @@ internal class RevurderingServiceImpl(
     override fun avsluttRevurdering(
         revurderingId: UUID,
         begrunnelse: String,
-        fritekst: String?,
+        brevvalg: Brevvalg.SaksbehandlersValg?,
     ): Either<KunneIkkeAvslutteRevurdering, AbstraktRevurdering> {
         return revurderingRepo.hent(revurderingId)?.let {
             avsluttRevurdering(
                 revurdering = it,
                 begrunnelse = begrunnelse,
-                fritekst = fritekst,
+                brevvalg = brevvalg,
             )
         } ?: return KunneIkkeAvslutteRevurdering.FantIkkeRevurdering.left()
     }
 
     /**
      * Denne kan ikke returnere [KunneIkkeAvslutteRevurdering.FantIkkeRevurdering]
+     *
+     * @param brevvalg Kun dersom saksbehandler har forhåndsvarslet, må det tas et brevvalg. Dersom det ikke er forhåndsvarslet skal det ikke sendes brev.
      */
     private fun avsluttRevurdering(
         revurdering: AbstraktRevurdering,
         begrunnelse: String,
-        fritekst: String?,
+        brevvalg: Brevvalg.SaksbehandlersValg?,
     ): Either<KunneIkkeAvslutteRevurdering, AbstraktRevurdering> {
 
         val (avsluttetRevurdering, skalSendeAvslutningsbrev) = when (revurdering) {
-            is GjenopptaYtelseRevurdering -> revurdering.avslutt(begrunnelse, Tidspunkt.now(clock)).map {
-                it to it.skalSendeAvslutningsbrev()
-            }.getOrHandle {
-                return KunneIkkeAvslutteRevurdering.KunneIkkeLageAvsluttetGjenopptaAvYtelse(it).left()
+            is GjenopptaYtelseRevurdering -> {
+                if (brevvalg != null) return KunneIkkeAvslutteRevurdering.BrevvalgIkkeTillatt.left()
+                revurdering.avslutt(begrunnelse, Tidspunkt.now(clock)).map {
+                    it to it.skalSendeAvslutningsbrev()
+                }.getOrHandle {
+                    return KunneIkkeAvslutteRevurdering.KunneIkkeLageAvsluttetGjenopptaAvYtelse(it).left()
+                }
             }
 
-            is StansAvYtelseRevurdering -> revurdering.avslutt(begrunnelse, Tidspunkt.now(clock)).map {
-                it to it.skalSendeAvslutningsbrev()
-            }.getOrHandle {
-                return KunneIkkeAvslutteRevurdering.KunneIkkeLageAvsluttetStansAvYtelse(it).left()
+            is StansAvYtelseRevurdering -> {
+                if (brevvalg != null) return KunneIkkeAvslutteRevurdering.BrevvalgIkkeTillatt.left()
+                revurdering.avslutt(begrunnelse, Tidspunkt.now(clock)).map {
+                    it to it.skalSendeAvslutningsbrev()
+                }.getOrHandle {
+                    return KunneIkkeAvslutteRevurdering.KunneIkkeLageAvsluttetStansAvYtelse(it).left()
+                }
             }
 
-            is Revurdering -> revurdering.avslutt(begrunnelse, fritekst, Tidspunkt.now(clock)).map {
+            is Revurdering -> revurdering.avslutt(begrunnelse, brevvalg, Tidspunkt.now(clock)).map {
                 it to it.skalSendeAvslutningsbrev()
             }.getOrHandle {
                 return KunneIkkeAvslutteRevurdering.KunneIkkeLageAvsluttetRevurdering(it).left()
@@ -1594,12 +1546,11 @@ internal class RevurderingServiceImpl(
         }
 
         if (avsluttetRevurdering is Revurdering) {
-            oppgaveService.lukkOppgave(avsluttetRevurdering.oppgaveId)
-                .mapLeft {
-                    log.error("Kunne ikke lukke oppgave ${avsluttetRevurdering.oppgaveId} ved avslutting av revurdering. Dette må gjøres manuelt.")
-                }.map {
-                    log.info("Lukket oppgave ${avsluttetRevurdering.oppgaveId} ved avslutting av revurdering.")
-                }
+            oppgaveService.lukkOppgave(avsluttetRevurdering.oppgaveId).mapLeft {
+                log.error("Kunne ikke lukke oppgave ${avsluttetRevurdering.oppgaveId} ved avslutting av revurdering. Dette må gjøres manuelt.")
+            }.map {
+                log.info("Lukket oppgave ${avsluttetRevurdering.oppgaveId} ved avslutting av revurdering.")
+            }
         }
 
         val resultat = if (avsluttetRevurdering is Revurdering && skalSendeAvslutningsbrev) {
@@ -1642,8 +1593,8 @@ internal class RevurderingServiceImpl(
         revurderingId: UUID,
         fritekst: String?,
     ): Either<KunneIkkeLageBrevutkastForAvsluttingAvRevurdering, Pair<Fnr, ByteArray>> {
-        val revurdering = hent(revurderingId)
-            .getOrHandle { return KunneIkkeLageBrevutkastForAvsluttingAvRevurdering.FantIkkeRevurdering.left() }
+        val revurdering =
+            hent(revurderingId).getOrHandle { return KunneIkkeLageBrevutkastForAvsluttingAvRevurdering.FantIkkeRevurdering.left() }
 
         if (!revurdering.forhåndsvarsel.harSendtForhåndsvarsel()) {
             return KunneIkkeLageBrevutkastForAvsluttingAvRevurdering.RevurderingenErIkkeForhåndsvarslet.left()
@@ -1652,25 +1603,23 @@ internal class RevurderingServiceImpl(
         // Lager en midlertidig avsluttet revurdering for å konstruere brevet - denne skal ikke lagres
         val avsluttetRevurdering = revurdering.avslutt(
             begrunnelse = "",
-            fritekst = fritekst,
+            brevvalg = fritekst?.let { Brevvalg.SaksbehandlersValg.SkalSendeBrev.MedFritekst(it) },
             tidspunktAvsluttet = Tidspunkt.now(clock),
         ).getOrHandle {
             return KunneIkkeLageBrevutkastForAvsluttingAvRevurdering.KunneIkkeLageBrevutkast.left()
         }
 
-        return brevService.lagDokument(avsluttetRevurdering)
-            .mapLeft {
-                when (it) {
-                    KunneIkkeLageDokument.KunneIkkeFinneGjeldendeUtbetaling -> KunneIkkeLageBrevutkastForAvsluttingAvRevurdering.KunneIkkeFinneGjeldendeUtbetaling.left()
-                    KunneIkkeLageDokument.KunneIkkeGenererePDF -> KunneIkkeLageBrevutkastForAvsluttingAvRevurdering.KunneIkkeGenererePDF.left()
-                    KunneIkkeLageDokument.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant -> KunneIkkeLageBrevutkastForAvsluttingAvRevurdering.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant.left()
-                    KunneIkkeLageDokument.KunneIkkeHentePerson -> KunneIkkeLageBrevutkastForAvsluttingAvRevurdering.FantIkkePerson
-                }
-                return KunneIkkeLageBrevutkastForAvsluttingAvRevurdering.KunneIkkeLageBrevutkast.left()
+        return brevService.lagDokument(avsluttetRevurdering).mapLeft {
+            when (it) {
+                KunneIkkeLageDokument.KunneIkkeFinneGjeldendeUtbetaling -> KunneIkkeLageBrevutkastForAvsluttingAvRevurdering.KunneIkkeFinneGjeldendeUtbetaling
+                KunneIkkeLageDokument.KunneIkkeGenererePDF -> KunneIkkeLageBrevutkastForAvsluttingAvRevurdering.KunneIkkeGenererePDF
+                KunneIkkeLageDokument.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant -> KunneIkkeLageBrevutkastForAvsluttingAvRevurdering.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant
+                KunneIkkeLageDokument.KunneIkkeHentePerson -> KunneIkkeLageBrevutkastForAvsluttingAvRevurdering.FantIkkePerson
+                KunneIkkeLageDokument.DetSkalIkkeSendesBrev -> KunneIkkeLageBrevutkastForAvsluttingAvRevurdering.DetSkalIkkeSendesBrev
             }
-            .map {
-                return Pair(avsluttetRevurdering.fnr, it.generertDokument).right()
-            }
+        }.map {
+            Pair(avsluttetRevurdering.fnr, it.generertDokument)
+        }
     }
 
     private fun hentPersonOgSaksbehandlerNavn(

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/sak/SakService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/sak/SakService.kt
@@ -38,6 +38,8 @@ interface SakService {
     fun hentSakidOgSaksnummer(fnr: Fnr): Either<FantIkkeSak, SakInfo>
 
     fun hentSakForRevurdering(revurderingId: UUID): Sak
+
+    fun hentSakForSøknad(søknadId: UUID): Either<FantIkkeSak, Sak>
 }
 
 object FantIkkeSak

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/sak/SakServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/sak/SakServiceImpl.kt
@@ -83,6 +83,10 @@ internal class SakServiceImpl(
         return sakRepo.hentSakForRevurdering(revurderingId)
     }
 
+    override fun hentSakForSøknad(søknadId: UUID): Either<FantIkkeSak, Sak> {
+        return sakRepo.hentSakForSøknad(søknadId)?.right() ?: FantIkkeSak.left()
+    }
+
     override fun opprettSak(sak: NySak) {
         sakRepo.opprettSak(sak).also {
             hentSak(sak.id).fold(

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/AvslåSøknadManglendeDokumentasjonService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/AvslåSøknadManglendeDokumentasjonService.kt
@@ -3,6 +3,7 @@ package no.nav.su.se.bakover.service.søknad
 import arrow.core.Either
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Sak
+import no.nav.su.se.bakover.service.søknadsbehandling.SøknadsbehandlingService
 import java.util.UUID
 
 interface AvslåSøknadManglendeDokumentasjonService {
@@ -10,13 +11,8 @@ interface AvslåSøknadManglendeDokumentasjonService {
 }
 
 sealed class KunneIkkeAvslåSøknad {
-    sealed class KunneIkkeOppretteSøknadsbehandling : KunneIkkeAvslåSøknad() {
-        object HarAlleredeÅpenSøknadsbehandling : KunneIkkeOppretteSøknadsbehandling()
-        object FantIkkeSøknad : KunneIkkeOppretteSøknadsbehandling()
-        object SøknadErLukket : KunneIkkeOppretteSøknadsbehandling()
-        object SøknadHarAlleredeBehandling : KunneIkkeOppretteSøknadsbehandling()
-        object SøknadManglerOppgave : KunneIkkeOppretteSøknadsbehandling()
-    }
+    data class KunneIkkeOppretteSøknadsbehandling(val feil: SøknadsbehandlingService.KunneIkkeOpprette) :
+        KunneIkkeAvslåSøknad()
 
     object SøknadsbehandlingIUgyldigTilstandForAvslag : KunneIkkeAvslåSøknad()
     object KunneIkkeFinneGjeldendeUtbetaling : KunneIkkeAvslåSøknad()
@@ -24,6 +20,7 @@ sealed class KunneIkkeAvslåSøknad {
     object KunneIkkeHentePerson : KunneIkkeAvslåSøknad()
     object KunneIkkeGenererePDF : KunneIkkeAvslåSøknad()
     object FantIkkeSak : KunneIkkeAvslåSøknad()
+    object FantIkkeSøknad : KunneIkkeAvslåSøknad()
 }
 
 data class AvslåManglendeDokumentasjonRequest(

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/AvslåSøknadManglendeDokumentasjonService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/AvslåSøknadManglendeDokumentasjonService.kt
@@ -13,12 +13,7 @@ interface AvslåSøknadManglendeDokumentasjonService {
 sealed class KunneIkkeAvslåSøknad {
     data class KunneIkkeOppretteSøknadsbehandling(val feil: SøknadsbehandlingService.KunneIkkeOpprette) :
         KunneIkkeAvslåSøknad()
-
-    object SøknadsbehandlingIUgyldigTilstandForAvslag : KunneIkkeAvslåSøknad()
-    object KunneIkkeFinneGjeldendeUtbetaling : KunneIkkeAvslåSøknad()
-    object KunneIkkeHenteNavnForSaksbehandlerEllerAttestant : KunneIkkeAvslåSøknad()
-    object KunneIkkeHentePerson : KunneIkkeAvslåSøknad()
-    object KunneIkkeGenererePDF : KunneIkkeAvslåSøknad()
+    data class KunneIkkeLageDokument(val nested: no.nav.su.se.bakover.service.brev.KunneIkkeLageDokument) : KunneIkkeAvslåSøknad()
     object FantIkkeSak : KunneIkkeAvslåSøknad()
     object FantIkkeSøknad : KunneIkkeAvslåSøknad()
 }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/AvslåSøknadManglendeDokumentasjonServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/AvslåSøknadManglendeDokumentasjonServiceImpl.kt
@@ -24,7 +24,6 @@ import no.nav.su.se.bakover.domain.vedtak.Avslagsvedtak
 import no.nav.su.se.bakover.domain.vilkår.OpplysningspliktVilkår
 import no.nav.su.se.bakover.domain.vilkår.VurderingsperiodeOpplysningsplikt
 import no.nav.su.se.bakover.service.brev.BrevService
-import no.nav.su.se.bakover.service.brev.KunneIkkeLageDokument
 import no.nav.su.se.bakover.service.oppgave.OppgaveService
 import no.nav.su.se.bakover.service.sak.SakService
 import no.nav.su.se.bakover.service.søknadsbehandling.SøknadsbehandlingService
@@ -106,12 +105,7 @@ internal class AvslåSøknadManglendeDokumentasjonServiceImpl(
         )
 
         val dokument = brevService.lagDokument(avslagsvedtak).getOrHandle {
-            return when (it) {
-                KunneIkkeLageDokument.KunneIkkeFinneGjeldendeUtbetaling -> KunneIkkeAvslåSøknad.KunneIkkeFinneGjeldendeUtbetaling
-                KunneIkkeLageDokument.KunneIkkeGenererePDF -> KunneIkkeAvslåSøknad.KunneIkkeGenererePDF
-                KunneIkkeLageDokument.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant -> KunneIkkeAvslåSøknad.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant
-                KunneIkkeLageDokument.KunneIkkeHentePerson -> KunneIkkeAvslåSøknad.KunneIkkeHentePerson
-            }.left()
+            return KunneIkkeAvslåSøknad.KunneIkkeLageDokument(it).left()
         }.leggTilMetadata(
             metadata = Dokument.Metadata(
                 sakId = avslagsvedtak.behandling.sakId,

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingService.kt
@@ -14,6 +14,7 @@ import no.nav.su.se.bakover.domain.søknadsbehandling.LukketSøknadsbehandling
 import no.nav.su.se.bakover.domain.søknadsbehandling.Stønadsperiode
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
 import no.nav.su.se.bakover.domain.vilkår.UgyldigFamiliegjenforeningVilkår
+import no.nav.su.se.bakover.service.brev.KunneIkkeLageDokument
 import no.nav.su.se.bakover.service.grunnlag.LeggTilFradragsgrunnlagRequest
 import no.nav.su.se.bakover.service.revurdering.KunneIkkeLeggeTilOpplysningsplikt
 import no.nav.su.se.bakover.service.revurdering.LeggTilOpplysningspliktRequest
@@ -45,7 +46,7 @@ interface SøknadsbehandlingService {
     fun sendTilAttestering(request: SendTilAttesteringRequest): Either<KunneIkkeSendeTilAttestering, Søknadsbehandling.TilAttestering>
     fun underkjenn(request: UnderkjennRequest): Either<KunneIkkeUnderkjenne, Søknadsbehandling.Underkjent>
     fun iverksett(request: IverksettRequest): Either<KunneIkkeIverksette, Søknadsbehandling.Iverksatt>
-    fun brev(request: BrevRequest): Either<KunneIkkeLageBrev, ByteArray>
+    fun brev(request: BrevRequest): Either<KunneIkkeLageDokument, ByteArray>
     fun hent(request: HentRequest): Either<FantIkkeBehandling, Søknadsbehandling>
     fun oppdaterStønadsperiode(request: OppdaterStønadsperiodeRequest): Either<KunneIkkeOppdatereStønadsperiode, Søknadsbehandling>
     fun leggTilUførevilkår(request: LeggTilUførevurderingerRequest): Either<KunneIkkeLeggeTilUføreVilkår, Søknadsbehandling>

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingService.kt
@@ -69,6 +69,7 @@ interface SøknadsbehandlingService {
 
     data class OpprettRequest(
         val søknadId: UUID,
+        val sakId: UUID,
     )
 
     sealed class KunneIkkeOpprette {
@@ -77,6 +78,7 @@ interface SøknadsbehandlingService {
         object SøknadErLukket : KunneIkkeOpprette()
         object SøknadHarAlleredeBehandling : KunneIkkeOpprette()
         object HarAlleredeÅpenSøknadsbehandling : KunneIkkeOpprette()
+        object FantIkkeSak : KunneIkkeOpprette()
     }
 
     sealed class KunneIkkeVilkårsvurdere {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceImpl.kt
@@ -62,7 +62,6 @@ import no.nav.su.se.bakover.service.søknadsbehandling.SøknadsbehandlingService
 import no.nav.su.se.bakover.service.søknadsbehandling.SøknadsbehandlingService.IverksettRequest
 import no.nav.su.se.bakover.service.søknadsbehandling.SøknadsbehandlingService.KunneIkkeBeregne
 import no.nav.su.se.bakover.service.søknadsbehandling.SøknadsbehandlingService.KunneIkkeFullføreBosituasjonGrunnlag
-import no.nav.su.se.bakover.service.søknadsbehandling.SøknadsbehandlingService.KunneIkkeLageBrev
 import no.nav.su.se.bakover.service.søknadsbehandling.SøknadsbehandlingService.KunneIkkeLeggeTilBosituasjonEpsGrunnlag
 import no.nav.su.se.bakover.service.søknadsbehandling.SøknadsbehandlingService.KunneIkkeLeggeTilFamiliegjenforeningVilkårService
 import no.nav.su.se.bakover.service.søknadsbehandling.SøknadsbehandlingService.KunneIkkeLeggeTilFamiliegjenforeningVilkårService.FantIkkeBehandling.tilKunneIkkeLeggeTilFamiliegjenforeningVilkårService
@@ -527,7 +526,7 @@ internal class SøknadsbehandlingServiceImpl(
             }
         }
 
-    override fun brev(request: BrevRequest): Either<KunneIkkeLageBrev, ByteArray> {
+    override fun brev(request: BrevRequest): Either<KunneIkkeLageDokument, ByteArray> {
         val behandling = when (request) {
             is BrevRequest.MedFritekst ->
                 request.behandling.medFritekstTilBrev(request.fritekst)
@@ -537,17 +536,7 @@ internal class SøknadsbehandlingServiceImpl(
         }
 
         return brevService.lagDokument(behandling)
-            .mapLeft {
-                when (it) {
-                    KunneIkkeLageDokument.KunneIkkeFinneGjeldendeUtbetaling -> KunneIkkeLageBrev.KunneIkkeFinneGjeldendeUtbetaling
-                    KunneIkkeLageDokument.KunneIkkeGenererePDF -> KunneIkkeLageBrev.KunneIkkeLagePDF
-                    KunneIkkeLageDokument.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant -> KunneIkkeLageBrev.FikkIkkeHentetSaksbehandlerEllerAttestant
-                    KunneIkkeLageDokument.KunneIkkeHentePerson -> KunneIkkeLageBrev.FantIkkePerson
-                }
-            }
-            .map {
-                it.generertDokument
-            }
+            .map { it.generertDokument }
     }
 
     override fun hent(request: HentRequest): Either<FantIkkeBehandling, Søknadsbehandling> {

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/AccessCheckProxyTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/AccessCheckProxyTest.kt
@@ -9,6 +9,7 @@ import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Sakstype
+import no.nav.su.se.bakover.domain.avkorting.Avkortingsvarsel
 import no.nav.su.se.bakover.domain.person.KunneIkkeHentePerson
 import no.nav.su.se.bakover.domain.person.PersonRepo
 import no.nav.su.se.bakover.service.person.PersonService
@@ -74,7 +75,8 @@ internal class AccessCheckProxyTest {
                                 opprettet = fixedTidspunkt,
                                 fnr = fnr,
                                 utbetalinger = emptyList(),
-                                type = Sakstype.UFØRE
+                                type = Sakstype.UFØRE,
+                                uteståendeAvkorting = Avkortingsvarsel.Ingen
                             ),
                         )
                     },
@@ -212,11 +214,12 @@ internal class AccessCheckProxyTest {
                 } doReturn Either.Right(
                     Sak(
                         id = UUID.randomUUID(),
-                        opprettet = fixedTidspunkt,
                         saksnummer = Saksnummer(2021),
+                        opprettet = fixedTidspunkt,
                         fnr = fnr,
                         utbetalinger = emptyList(),
-                        type = Sakstype.UFØRE
+                        type = Sakstype.UFØRE,
+                        uteståendeAvkorting = Avkortingsvarsel.Ingen
                     ),
                 )
             },

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/SendPåminnelserOmNyStønadsperiodeServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/SendPåminnelserOmNyStønadsperiodeServiceImplTest.kt
@@ -20,6 +20,7 @@ import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Sakstype
 import no.nav.su.se.bakover.domain.SendPåminnelseNyStønadsperiodeContext
+import no.nav.su.se.bakover.domain.avkorting.Avkortingsvarsel
 import no.nav.su.se.bakover.domain.brev.BrevTemplate
 import no.nav.su.se.bakover.domain.brev.LagBrevRequest
 import no.nav.su.se.bakover.domain.dokument.Dokument
@@ -377,7 +378,8 @@ internal class SendPåminnelserOmNyStønadsperiodeServiceImplTest {
             opprettet = Tidspunkt.now(fixedClock),
             fnr = Fnr.generer(),
             utbetalinger = emptyList(),
-            type = Sakstype.UFØRE
+            type = Sakstype.UFØRE,
+            uteståendeAvkorting = Avkortingsvarsel.Ingen
         )
 
         SendPåminnelseNyStønadsperiodeServiceAndMocks(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/brev/BrevServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/brev/BrevServiceImplTest.kt
@@ -21,6 +21,7 @@ import no.nav.su.se.bakover.domain.Person
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Sakstype
+import no.nav.su.se.bakover.domain.avkorting.Avkortingsvarsel
 import no.nav.su.se.bakover.domain.brev.BrevInnhold
 import no.nav.su.se.bakover.domain.brev.BrevTemplate
 import no.nav.su.se.bakover.domain.brev.BrevbestillingId
@@ -599,6 +600,7 @@ internal class BrevServiceImplTest {
         utbetalinger = listOf(),
         revurderinger = listOf(),
         vedtakListe = listOf(),
-        type = Sakstype.UFØRE
+        type = Sakstype.UFØRE,
+        uteståendeAvkorting = Avkortingsvarsel.Ingen
     )
 }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/AvsluttRevurderingTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/AvsluttRevurderingTest.kt
@@ -5,6 +5,7 @@ import arrow.core.right
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.beOfType
+import no.nav.su.se.bakover.domain.brev.Brevvalg
 import no.nav.su.se.bakover.domain.dokument.Dokument
 import no.nav.su.se.bakover.domain.revurdering.AvsluttetRevurdering
 import no.nav.su.se.bakover.domain.revurdering.Forhåndsvarsel
@@ -59,13 +60,13 @@ internal class AvsluttRevurderingTest {
         val actual = revurderingService.avsluttRevurdering(
             revurderingId = opprettetRevurdering.id,
             begrunnelse = "opprettet revurderingen med en feil",
-            fritekst = null,
+            brevvalg = null,
         )
 
         actual shouldBe AvsluttetRevurdering.tryCreate(
             underliggendeRevurdering = opprettetRevurdering,
             begrunnelse = "opprettet revurderingen med en feil",
-            fritekst = null,
+            brevvalg = null,
             tidspunktAvsluttet = fixedTidspunkt,
         )
 
@@ -108,13 +109,13 @@ internal class AvsluttRevurderingTest {
         val actual = revurderingService.avsluttRevurdering(
             revurderingId = simulert.id,
             begrunnelse = "opprettet revurderingen med en feil",
-            fritekst = "en fri tekst",
+            brevvalg = Brevvalg.SaksbehandlersValg.SkalSendeBrev.MedFritekst("en fri tekst"),
         )
 
         val expectedAvsluttetRevurdering = AvsluttetRevurdering.tryCreate(
             underliggendeRevurdering = simulert,
             begrunnelse = "opprettet revurderingen med en feil",
-            fritekst = "en fri tekst",
+            brevvalg = Brevvalg.SaksbehandlersValg.SkalSendeBrev.MedFritekst("en fri tekst"),
             tidspunktAvsluttet = fixedTidspunkt,
         )
         actual shouldBe expectedAvsluttetRevurdering
@@ -156,7 +157,7 @@ internal class AvsluttRevurderingTest {
         revurderingService.avsluttRevurdering(
             revurderingId = id,
             begrunnelse = "hehe",
-            fritekst = null,
+            brevvalg = null,
         ) shouldBe KunneIkkeAvslutteRevurdering.FantIkkeRevurdering.left()
 
         verify(revurderingRepoMock).hent(argThat { it shouldBe id })
@@ -188,7 +189,7 @@ internal class AvsluttRevurderingTest {
         revurderingService.avsluttRevurdering(
             revurderingId = simulert.id,
             begrunnelse = "begrunnelse",
-            fritekst = null,
+            brevvalg = Brevvalg.SaksbehandlersValg.SkalSendeBrev.MedFritekst("medFritekst"),
         ) shouldBe KunneIkkeAvslutteRevurdering.KunneIkkeLageDokument.left()
 
         verify(oppgaveServiceMock).lukkOppgave(argThat { it shouldBe simulert.oppgaveId })
@@ -198,9 +199,9 @@ internal class AvsluttRevurderingTest {
                 it shouldBe AvsluttetRevurdering.tryCreate(
                     underliggendeRevurdering = simulert,
                     begrunnelse = "begrunnelse",
-                    fritekst = null,
+                    brevvalg = Brevvalg.SaksbehandlersValg.SkalSendeBrev.MedFritekst("medFritekst"),
                     tidspunktAvsluttet = fixedTidspunkt,
-                ).orNull()!!
+                ).getOrFail()
             },
         )
         verifyNoMoreInteractions(revurderingRepoMock, brevServiceMock, oppgaveServiceMock)
@@ -221,7 +222,7 @@ internal class AvsluttRevurderingTest {
         val actual = revurderingService.avsluttRevurdering(
             revurderingId = stansAvYtelse.id,
             begrunnelse = "skulle stanse ytelse, men så tenkte jeg 'neh'",
-            fritekst = null,
+            brevvalg = null,
         )
 
         actual shouldBe StansAvYtelseRevurdering.AvsluttetStansAvYtelse.tryCreate(
@@ -250,7 +251,7 @@ internal class AvsluttRevurderingTest {
         val actual = revurderingService.avsluttRevurdering(
             revurderingId = avsluttetStansAvYtelse.id,
             begrunnelse = "skulle stanse ytelse, men så tenkte jeg 'neh'",
-            fritekst = null,
+            brevvalg = null,
         )
 
         actual shouldBe KunneIkkeAvslutteRevurdering.KunneIkkeLageAvsluttetStansAvYtelse(StansAvYtelseRevurdering.KunneIkkeLageAvsluttetStansAvYtelse.RevurderingErAlleredeAvsluttet)
@@ -274,7 +275,7 @@ internal class AvsluttRevurderingTest {
         val actual = revurderingService.avsluttRevurdering(
             revurderingId = iverksattStansAvYtelse.id,
             begrunnelse = "skulle stanse ytelse, men så tenkte jeg 'neh'",
-            fritekst = null,
+            brevvalg = null,
         )
 
         actual shouldBe KunneIkkeAvslutteRevurdering.KunneIkkeLageAvsluttetStansAvYtelse(StansAvYtelseRevurdering.KunneIkkeLageAvsluttetStansAvYtelse.RevurderingenErIverksatt)
@@ -299,7 +300,7 @@ internal class AvsluttRevurderingTest {
         val actual = revurderingService.avsluttRevurdering(
             revurderingId = gjenopptaYtelse.id,
             begrunnelse = "skulle stanse ytelse, men så tenkte jeg 'neh'",
-            fritekst = null,
+            brevvalg = null,
         )
 
         actual shouldBe GjenopptaYtelseRevurdering.AvsluttetGjenoppta.tryCreate(
@@ -329,7 +330,7 @@ internal class AvsluttRevurderingTest {
         val actual = revurderingService.avsluttRevurdering(
             revurderingId = gjenopptaYtelse.id,
             begrunnelse = "skulle stanse ytelse, men så tenkte jeg 'neh'",
-            fritekst = null,
+            brevvalg = null,
         )
 
         actual shouldBe KunneIkkeAvslutteRevurdering.KunneIkkeLageAvsluttetGjenopptaAvYtelse(GjenopptaYtelseRevurdering.KunneIkkeLageAvsluttetGjenopptaAvYtelse.RevurderingErAlleredeAvsluttet)
@@ -353,7 +354,7 @@ internal class AvsluttRevurderingTest {
         val actual = revurderingService.avsluttRevurdering(
             revurderingId = gjenopptaYtelse.id,
             begrunnelse = "skulle stanse ytelse, men så tenkte jeg 'neh'",
-            fritekst = null,
+            brevvalg = null,
         )
 
         actual shouldBe KunneIkkeAvslutteRevurdering.KunneIkkeLageAvsluttetGjenopptaAvYtelse(GjenopptaYtelseRevurdering.KunneIkkeLageAvsluttetGjenopptaAvYtelse.RevurderingenErIverksatt)

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/FortsettEtterForhåndsvarslingTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/FortsettEtterForhåndsvarslingTest.kt
@@ -2,26 +2,18 @@ package no.nav.su.se.bakover.service.revurdering
 
 import arrow.core.left
 import arrow.core.right
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.beOfType
 import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.juli
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.NavIdentBruker
-import no.nav.su.se.bakover.domain.dokument.Dokument
 import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
-import no.nav.su.se.bakover.domain.revurdering.AvsluttetRevurdering
 import no.nav.su.se.bakover.domain.revurdering.Forhåndsvarsel
 import no.nav.su.se.bakover.domain.revurdering.RevurderingRepo
-import no.nav.su.se.bakover.domain.visitor.LagBrevRequestVisitor
-import no.nav.su.se.bakover.domain.visitor.Visitable
 import no.nav.su.se.bakover.service.argThat
 import no.nav.su.se.bakover.test.aktørId
 import no.nav.su.se.bakover.test.fixedClock
-import no.nav.su.se.bakover.test.fixedTidspunkt
-import no.nav.su.se.bakover.test.getOrFail
 import no.nav.su.se.bakover.test.revurderingId
 import no.nav.su.se.bakover.test.saksbehandler
 import no.nav.su.se.bakover.test.simulertRevurdering
@@ -138,79 +130,6 @@ internal class FortsettEtterForhåndsvarslingTest {
         )
         verify(mocks.sakService).hentSakForRevurdering(any())
         verify(mocks.tilbakekrevingService).hentAvventerKravgrunnlag(any<UUID>())
-        mocks.verifyNoMoreInteractions()
-    }
-
-    @Test
-    fun `avslutter en revurdering etter forhåndsvarsling`() {
-        val simulertMedForhåndsvarsel = simulertRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak(
-            forhåndsvarsel = Forhåndsvarsel.UnderBehandling.Sendt,
-        ).second
-
-        val mocks = RevurderingServiceMocks(
-            revurderingRepo = mock {
-                on { hent(any()) } doReturn simulertMedForhåndsvarsel
-            },
-            brevService = mock {
-                on { lagDokument(any<Visitable<LagBrevRequestVisitor>>()) } doReturn Dokument.UtenMetadata.Informasjon.Annet(
-                    opprettet = fixedTidspunkt,
-                    tittel = "tittel1",
-                    generertDokument = "brev".toByteArray(),
-                    generertDokumentJson = "brev",
-                ).right()
-            },
-            oppgaveService = mock {
-                on { lukkOppgave(any()) } doReturn Unit.right()
-            },
-        )
-
-        val actual = mocks.revurderingService.fortsettEtterForhåndsvarsling(
-            request = FortsettEtterForhåndsvarslingRequest.AvsluttUtenEndringer(
-                revurderingId = simulertMedForhåndsvarsel.id,
-                saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "navn"),
-                begrunnelse = "b e g r u n n e l s e",
-                fritekstTilBrev = null,
-            ),
-        )
-
-        val expected = AvsluttetRevurdering.tryCreate(
-            underliggendeRevurdering = simulertMedForhåndsvarsel.copy(
-                forhåndsvarsel = Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.Avsluttet("b e g r u n n e l s e"),
-            ),
-            begrunnelse = "b e g r u n n e l s e",
-            fritekst = null,
-            tidspunktAvsluttet = fixedTidspunkt,
-        ).getOrFail()
-
-        actual shouldBe expected.right()
-
-        verify(mocks.revurderingRepo).hent(argThat { it shouldBe simulertMedForhåndsvarsel.id })
-        verify(mocks.revurderingRepo).defaultTransactionContext()
-        verify(mocks.revurderingRepo).lagre(
-            argThat {
-                it shouldBe expected
-            },
-            anyOrNull(),
-        )
-        verify(mocks.oppgaveService).lukkOppgave(
-            argThat { it shouldBe simulertMedForhåndsvarsel.oppgaveId },
-        )
-        verify(mocks.brevService).lagDokument(
-            argThat<Visitable<LagBrevRequestVisitor>> {
-                it shouldBe expected
-            },
-        )
-        verify(mocks.brevService).lagreDokument(
-            argThat {
-                it should beOfType<Dokument.MedMetadata.Informasjon.Annet>()
-                it.generertDokument shouldBe "brev".toByteArray()
-                it.metadata shouldBe Dokument.Metadata(
-                    sakId = simulertMedForhåndsvarsel.sakId,
-                    revurderingId = simulertMedForhåndsvarsel.id,
-                    bestillBrev = true,
-                )
-            },
-        )
         mocks.verifyNoMoreInteractions()
     }
 

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceMocks.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceMocks.kt
@@ -60,7 +60,6 @@ internal data class RevurderingServiceMocks(
         formuegrenserFactory = formuegrenserFactoryTestPåDato(),
         sakService = sakService,
         avkortingsvarselRepo = avkortingsvarselRepo,
-        toggleService = toggleService,
         tilbakekrevingService = tilbakekrevingService,
         satsFactory = satsFactory
     ).apply { addObserver(observer) }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingTestUtils.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingTestUtils.kt
@@ -25,7 +25,6 @@ import no.nav.su.se.bakover.service.oppgave.OppgaveService
 import no.nav.su.se.bakover.service.person.PersonService
 import no.nav.su.se.bakover.service.sak.SakService
 import no.nav.su.se.bakover.service.tilbakekreving.TilbakekrevingService
-import no.nav.su.se.bakover.service.toggles.ToggleService
 import no.nav.su.se.bakover.service.utbetaling.UtbetalingService
 import no.nav.su.se.bakover.service.vedtak.VedtakService
 import no.nav.su.se.bakover.test.TestSessionFactory
@@ -106,7 +105,6 @@ internal object RevurderingTestUtils {
         kontrollsamtaleService: KontrollsamtaleService = mock(),
         sessionFactory: SessionFactory = TestSessionFactory(),
         avkortingsvarselRepo: AvkortingsvarselRepo = mock(),
-        toggleService: ToggleService = mock(),
         tilbakekrevingService: TilbakekrevingService = mock(),
         satsFactory: SatsFactory = satsFactoryTestPåDato(),
     ) =
@@ -125,7 +123,6 @@ internal object RevurderingTestUtils {
             formuegrenserFactory = formuegrenserFactoryTestPåDato(),
             sakService = sakService,
             avkortingsvarselRepo = avkortingsvarselRepo,
-            toggleService = toggleService,
             tilbakekrevingService = tilbakekrevingService,
             satsFactory = satsFactory,
         )

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/AvslåSøknadManglendeDokumentasjonServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/AvslåSøknadManglendeDokumentasjonServiceImplTest.kt
@@ -501,7 +501,7 @@ internal class AvslåSøknadManglendeDokumentasjonServiceImplTest {
                     saksbehandler = NavIdentBruker.Saksbehandler("saksemannen"),
                     fritekstTilBrev = "finfin tekst",
                 ),
-            ) shouldBe KunneIkkeAvslåSøknad.KunneIkkeGenererePDF.left()
+            ) shouldBe KunneIkkeAvslåSøknad.KunneIkkeLageDokument(no.nav.su.se.bakover.service.brev.KunneIkkeLageDokument.KunneIkkeGenererePDF).left()
 
             verify(serviceAndMocks.søknadsbehandlingService).hentForSøknad(søknadId)
             verify(serviceAndMocks.søknadsbehandlingService).opprett(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/AvslåSøknadManglendeDokumentasjonServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/AvslåSøknadManglendeDokumentasjonServiceImplTest.kt
@@ -5,6 +5,7 @@ import arrow.core.nonEmptyListOf
 import arrow.core.right
 import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
 import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.client.stubs.oppgave.OppgaveClientStub.lukkOppgave
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.endOfMonth
 import no.nav.su.se.bakover.common.periode.Periode
@@ -40,11 +41,13 @@ import no.nav.su.se.bakover.test.TestSessionFactory
 import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.getOrFail
+import no.nav.su.se.bakover.test.sakId
 import no.nav.su.se.bakover.test.satsFactoryTestPåDato
 import no.nav.su.se.bakover.test.søknadId
 import no.nav.su.se.bakover.test.søknadsbehandlingIverksattInnvilget
 import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertInnvilget
 import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertUavklart
+import no.nav.su.se.bakover.test.vilkårsvurdertSøknadsbehandlingUføre
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
@@ -82,6 +85,7 @@ internal class AvslåSøknadManglendeDokumentasjonServiceImplTest {
 
         val sakServiceMock = mock<SakService> {
             on { hentSak(any<UUID>()) } doReturn sak.right()
+            on { hentSakForSøknad(any()) } doReturn sak.right()
         }
 
         AvslåSøknadServiceAndMocks(
@@ -160,7 +164,12 @@ internal class AvslåSøknadManglendeDokumentasjonServiceImplTest {
             )
 
             verify(serviceAndMocks.søknadsbehandlingService).hentForSøknad(søknadId)
-            verify(serviceAndMocks.søknadsbehandlingService).opprett(SøknadsbehandlingService.OpprettRequest(søknadId = søknadId))
+            verify(serviceAndMocks.søknadsbehandlingService).opprett(
+                SøknadsbehandlingService.OpprettRequest(
+                    søknadId = søknadId,
+                    sakId = sakId,
+                ),
+            )
             verify(serviceAndMocks.søknadsbehandlingService).lagre(
                 argThat {
                     it.søknadsbehandling.shouldBeEqualToIgnoringFields(
@@ -378,24 +387,30 @@ internal class AvslåSøknadManglendeDokumentasjonServiceImplTest {
 
     @Test
     fun `svarer med feil dersom vi ikke får opprettet behandling`() {
-        val søknadsbehandlingServiceMock = mock<SøknadsbehandlingService> {
-            on { opprett(any()) } doReturn SøknadsbehandlingService.KunneIkkeOpprette.SøknadHarAlleredeBehandling.left()
-        }
+        val (sak, søknadsbehandling) = vilkårsvurdertSøknadsbehandlingUføre()
 
         AvslåSøknadServiceAndMocks(
-            søknadsbehandlingService = søknadsbehandlingServiceMock,
+            sakService = mock {
+                on { hentSakForSøknad(any()) } doReturn sak.right()
+            },
+            søknadsbehandlingService = mock {
+                on { hentForSøknad(any()) } doReturn null
+                on { opprett(any()) } doReturn SøknadsbehandlingService.KunneIkkeOpprette.SøknadHarAlleredeBehandling.left()
+            },
             clock = fixedClock,
         ).let {
             it.service.avslå(
                 AvslåManglendeDokumentasjonRequest(
-                    søknadId,
+                    søknadId = søknadsbehandling.søknad.id,
                     saksbehandler = NavIdentBruker.Saksbehandler("saksemannen"),
                     fritekstTilBrev = "finfin tekst",
                 ),
-            ) shouldBe KunneIkkeAvslåSøknad.KunneIkkeOppretteSøknadsbehandling.SøknadHarAlleredeBehandling.left()
+            ) shouldBe KunneIkkeAvslåSøknad.KunneIkkeOppretteSøknadsbehandling(SøknadsbehandlingService.KunneIkkeOpprette.SøknadHarAlleredeBehandling)
+                .left()
 
-            verify(søknadsbehandlingServiceMock).hentForSøknad(any())
-            verify(søknadsbehandlingServiceMock).opprett(any())
+            verify(it.sakService).hentSakForSøknad(any())
+            verify(it.søknadsbehandlingService).hentForSøknad(any())
+            verify(it.søknadsbehandlingService).opprett(any())
             it.verifyNoMoreInteractions()
         }
     }
@@ -412,6 +427,7 @@ internal class AvslåSøknadManglendeDokumentasjonServiceImplTest {
         }
         val sakServiceMock = mock<SakService> {
             on { hentSak(any<UUID>()) } doReturn sak.right()
+            on { hentSakForSøknad(any()) } doReturn sak.right()
         }
 
         val dokument = Dokument.UtenMetadata.Vedtak(
@@ -463,23 +479,20 @@ internal class AvslåSøknadManglendeDokumentasjonServiceImplTest {
 
     @Test
     fun `svarer med feil dersom opprettesle av dokument feiler`() {
-        val (_, uavklart) = søknadsbehandlingVilkårsvurdertUavklart()
-
-        val søknadsbehandlingServiceMock = mock<SøknadsbehandlingService> {
-            on { opprett(any()) } doReturn uavklart.right()
-        }
-        val oppgaveServiceMock = mock<OppgaveService> {
-            on { lukkOppgave(any()) } doReturn Unit.right()
-        }
-
-        val brevServiceMock = mock<BrevService> {
-            on { lagDokument(any<Visitable<LagBrevRequestVisitor>>()) } doReturn KunneIkkeLageDokument.KunneIkkeGenererePDF.left()
-        }
-
+        val (sak, uavklart) = søknadsbehandlingVilkårsvurdertUavklart()
         AvslåSøknadServiceAndMocks(
-            søknadsbehandlingService = søknadsbehandlingServiceMock,
-            oppgaveService = oppgaveServiceMock,
-            brevService = brevServiceMock,
+            søknadsbehandlingService = mock {
+                on { opprett(any()) } doReturn uavklart.right()
+            },
+            oppgaveService = mock {
+                on { lukkOppgave(any()) } doReturn Unit.right()
+            },
+            brevService = mock {
+                on { lagDokument(any<Visitable<LagBrevRequestVisitor>>()) } doReturn KunneIkkeLageDokument.KunneIkkeGenererePDF.left()
+            },
+            sakService = mock {
+                on { hentSakForSøknad(any()) } doReturn sak.right()
+            },
             clock = fixedClock,
         ).let { serviceAndMocks ->
             serviceAndMocks.service.avslå(
@@ -491,7 +504,12 @@ internal class AvslåSøknadManglendeDokumentasjonServiceImplTest {
             ) shouldBe KunneIkkeAvslåSøknad.KunneIkkeGenererePDF.left()
 
             verify(serviceAndMocks.søknadsbehandlingService).hentForSøknad(søknadId)
-            verify(serviceAndMocks.søknadsbehandlingService).opprett(SøknadsbehandlingService.OpprettRequest(søknadId = søknadId))
+            verify(serviceAndMocks.søknadsbehandlingService).opprett(
+                SøknadsbehandlingService.OpprettRequest(
+                    søknadId = søknadId,
+                    sakId = sakId,
+                ),
+            )
             verify(serviceAndMocks.brevService).lagDokument(any<Visitable<LagBrevRequestVisitor>>())
             serviceAndMocks.verifyNoMoreInteractions()
         }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/HentSøknadPdfTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/HentSøknadPdfTest.kt
@@ -15,6 +15,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Sakstype
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
+import no.nav.su.se.bakover.domain.avkorting.Avkortingsvarsel
 import no.nav.su.se.bakover.domain.søknad.SøknadPdfInnhold
 import no.nav.su.se.bakover.domain.søknad.SøknadRepo
 import no.nav.su.se.bakover.domain.søknadinnhold.SøknadsinnholdUføre
@@ -52,6 +53,7 @@ class HentSøknadPdfTest {
         søknader = listOf(søknad),
         utbetalinger = emptyList(),
         type = Sakstype.UFØRE,
+        uteståendeAvkorting = Avkortingsvarsel.Ingen,
     )
     private val person = Person(
         ident = Ident(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/OpprettManglendeJournalpostOgOppgaveTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/OpprettManglendeJournalpostOgOppgaveTest.kt
@@ -17,6 +17,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Sakstype
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
+import no.nav.su.se.bakover.domain.avkorting.Avkortingsvarsel
 import no.nav.su.se.bakover.domain.journal.JournalpostId
 import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
@@ -58,6 +59,7 @@ class OpprettManglendeJournalpostOgOppgaveTest {
         søknadsbehandlinger = emptyList(),
         utbetalinger = emptyList(),
         type = Sakstype.UFØRE,
+        uteståendeAvkorting = Avkortingsvarsel.Ingen,
     )
     private val person = Person(
         ident = Ident(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/SøknadTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/SøknadTest.kt
@@ -20,6 +20,7 @@ import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Sakstype
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
+import no.nav.su.se.bakover.domain.avkorting.Avkortingsvarsel
 import no.nav.su.se.bakover.domain.journal.JournalpostId
 import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
 import no.nav.su.se.bakover.domain.oppgave.OppgaveFeil.KunneIkkeOppretteOppgave
@@ -66,6 +67,7 @@ class SøknadTest {
         fnr = fnr,
         utbetalinger = emptyList(),
         type = Sakstype.UFØRE,
+        uteståendeAvkorting = Avkortingsvarsel.Ingen,
     )
     private val pdf = "pdf-data".toByteArray()
     private val journalpostId = JournalpostId("1")

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceBrevTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceBrevTest.kt
@@ -7,7 +7,6 @@ import no.nav.su.se.bakover.domain.dokument.Dokument
 import no.nav.su.se.bakover.domain.visitor.LagBrevRequestVisitor
 import no.nav.su.se.bakover.domain.visitor.Visitable
 import no.nav.su.se.bakover.service.brev.BrevService
-import no.nav.su.se.bakover.service.brev.BrevServiceImplTest.DummyRequest.person
 import no.nav.su.se.bakover.service.brev.KunneIkkeLageDokument
 import no.nav.su.se.bakover.service.person.PersonService
 import no.nav.su.se.bakover.test.aktørId
@@ -37,7 +36,7 @@ internal class SøknadsbehandlingServiceBrevTest {
         SøknadsbehandlingServiceAndMocks(
             brevService = brevServiceMock,
         ).let {
-            it.søknadsbehandlingService.brev(SøknadsbehandlingService.BrevRequest.UtenFritekst(tilAttesteringInnvilget)) shouldBe SøknadsbehandlingService.KunneIkkeLageBrev.FantIkkePerson.left()
+            it.søknadsbehandlingService.brev(SøknadsbehandlingService.BrevRequest.UtenFritekst(tilAttesteringInnvilget)) shouldBe KunneIkkeLageDokument.KunneIkkeHentePerson.left()
             verify(it.brevService).lagDokument(tilAttesteringInnvilget)
             it.verifyNoMoreInteractions()
         }
@@ -57,7 +56,7 @@ internal class SøknadsbehandlingServiceBrevTest {
             personService = personServiceMock,
             brevService = brevServiceMock,
         ).let {
-            it.søknadsbehandlingService.brev(SøknadsbehandlingService.BrevRequest.UtenFritekst(tilAttesteringInnvilget)) shouldBe SøknadsbehandlingService.KunneIkkeLageBrev.FikkIkkeHentetSaksbehandlerEllerAttestant.left()
+            it.søknadsbehandlingService.brev(SøknadsbehandlingService.BrevRequest.UtenFritekst(tilAttesteringInnvilget)) shouldBe KunneIkkeLageDokument.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant.left()
             verify(it.brevService).lagDokument(tilAttesteringInnvilget)
             it.verifyNoMoreInteractions()
         }
@@ -77,7 +76,7 @@ internal class SøknadsbehandlingServiceBrevTest {
             personService = personServiceMock,
             brevService = brevServiceMock,
         ).let {
-            it.søknadsbehandlingService.brev(SøknadsbehandlingService.BrevRequest.UtenFritekst(tilAttesteringInnvilget)) shouldBe SøknadsbehandlingService.KunneIkkeLageBrev.KunneIkkeLagePDF.left()
+            it.søknadsbehandlingService.brev(SøknadsbehandlingService.BrevRequest.UtenFritekst(tilAttesteringInnvilget)) shouldBe KunneIkkeLageDokument.KunneIkkeGenererePDF.left()
             verify(it.brevService).lagDokument(tilAttesteringInnvilget)
             it.verifyNoMoreInteractions()
         }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/utbetaling/StansUtbetalingServiceTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/utbetaling/StansUtbetalingServiceTest.kt
@@ -20,6 +20,7 @@ import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Sakstype
+import no.nav.su.se.bakover.domain.avkorting.Avkortingsvarsel
 import no.nav.su.se.bakover.domain.oppdrag.SimulerUtbetalingRequest
 import no.nav.su.se.bakover.domain.oppdrag.UtbetalRequest
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
@@ -109,7 +110,6 @@ internal class StansUtbetalingServiceTest {
         saksnummer = saksnummer,
         opprettet = Tidspunkt.EPOCH,
         fnr = fnr,
-        type = Sakstype.UFØRE,
         utbetalinger = listOf(
             Utbetaling.UtbetalingForSimulering(
                 id = UUID30.randomUUID(),
@@ -130,6 +130,8 @@ internal class StansUtbetalingServiceTest {
                 oppdragsmelding,
             ),
         ),
+        type = Sakstype.UFØRE,
+        uteståendeAvkorting = Avkortingsvarsel.Ingen,
     )
 
     private fun expectedUtbetalingslinje(opprettet: Tidspunkt) = Utbetalingslinje.Endring.Stans(

--- a/test-common/src/main/kotlin/RevurderingTestData.kt
+++ b/test-common/src/main/kotlin/RevurderingTestData.kt
@@ -19,6 +19,7 @@ import no.nav.su.se.bakover.domain.beregning.fradrag.FradragFactory
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragTilhører
 import no.nav.su.se.bakover.domain.beregning.fradrag.Fradragstype
 import no.nav.su.se.bakover.domain.beregning.fradrag.UtenlandskInntekt
+import no.nav.su.se.bakover.domain.brev.Brevvalg
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
 import no.nav.su.se.bakover.domain.grunnlag.GrunnlagsdataOgVilkårsvurderinger
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
@@ -1054,8 +1055,7 @@ private fun <T : SimulertRevurdering> T.prøvÅLeggTilForhåndsvarselPåSimulert
     @Suppress("UNCHECKED_CAST")
     return when (forhåndsvarsel) {
         is Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.Avsluttet -> {
-            this.markerForhåndsvarselSomSendt().orNull()!!.prøvOvergangTilAvsluttet(forhåndsvarsel.begrunnelse)
-                .orNull()!!
+            throw IllegalArgumentException("Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.Avsluttet skal ikke brukes på denne måten lenger.")
         }
 
         is Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.EndreGrunnlaget -> {
@@ -1065,7 +1065,7 @@ private fun <T : SimulertRevurdering> T.prøvÅLeggTilForhåndsvarselPåSimulert
 
         is Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.FortsettMedSammeGrunnlag -> {
             this.markerForhåndsvarselSomSendt().orNull()!!
-                .prøvOvergangTilAvsluttet(forhåndsvarsel.begrunnelse)
+                .prøvOvergangTilFortsettMedSammeGrunnlag(forhåndsvarsel.begrunnelse)
                 .orNull()!!
         }
 
@@ -1442,7 +1442,7 @@ fun avsluttetRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak(
     return simulertRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak().let { (sak, simulert) ->
         val avsluttet = simulert.avslutt(
             begrunnelse = begrunnelse,
-            fritekst = fritekst,
+            brevvalg = fritekst?.let { Brevvalg.SaksbehandlersValg.SkalSendeBrev.MedFritekst(it) },
             tidspunktAvsluttet = tidspunktAvsluttet,
         ).getOrFail()
 

--- a/test-common/src/main/kotlin/RevurderingTestData.kt
+++ b/test-common/src/main/kotlin/RevurderingTestData.kt
@@ -12,6 +12,7 @@ import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.avkorting.AvkortingVedRevurdering
+import no.nav.su.se.bakover.domain.avkorting.Avkortingsvarsel
 import no.nav.su.se.bakover.domain.behandling.Attestering
 import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragFactory
@@ -151,9 +152,11 @@ fun opprettRevurderingFraSaksopplysninger(
                     is Grunnlag.Bosituasjon -> {
                         acc.copy(bosituasjon = (acc.bosituasjon + grunnlag) - it.grunnlagsdata.bosituasjon.toSet())
                     }
+
                     is Grunnlag.Fradragsgrunnlag -> {
                         acc.copy(fradragsgrunnlag = (acc.fradragsgrunnlag + grunnlag) - it.grunnlagsdata.fradragsgrunnlag.toSet())
                     }
+
                     else -> {
                         // andre grunnlag legges til via sine respektive vilkår
                         acc
@@ -288,6 +291,7 @@ fun simulertRevurdering(
             is BeregnetRevurdering.IngenEndring -> {
                 throw IllegalStateException("Kan ikke simulere for:${beregnet::class}, overstyr vilkår/grunnlag for et annet resultat.")
             }
+
             is BeregnetRevurdering.Innvilget -> {
                 val simulert = beregnet.toSimulert(
                     simuleringNy(
@@ -311,6 +315,7 @@ fun simulertRevurdering(
 
                 oppdaterTilbakekrevingsbehandling(simulert)
             }
+
             is BeregnetRevurdering.Opphørt -> {
                 val simulert = beregnet.toSimulert { _, _, opphørsdato ->
                     opphørUtbetalingSimulert(
@@ -368,6 +373,7 @@ fun revurderingTilAttestering(
                     fritekstTilBrev = simulert.fritekstTilBrev,
                 ).getOrFail()
             }
+
             is SimulertRevurdering.Opphørt -> {
                 val oppdatertTilbakekreving =
                     (oppdaterTilbakekrevingsbehandling(simulert) as SimulertRevurdering.Opphørt)
@@ -436,6 +442,7 @@ private fun oppdaterTilbakekrevingsbehandling(revurdering: SimulertRevurdering):
                 ),
             )
         }
+
         false -> {
             revurdering.oppdaterTilbakekrevingsbehandling(
                 tilbakekrevingsbehandling = IkkeBehovForTilbakekrevingUnderBehandling,
@@ -480,6 +487,7 @@ fun iverksattRevurdering(
                     clock = clock,
                 ).getOrFail() to null
             }
+
             is RevurderingTilAttestering.Innvilget -> {
                 val utbetaling = nyUtbetalingOversendUtenKvittering(
                     sakOgBehandling = sak to tilAttestering,
@@ -495,15 +503,19 @@ fun iverksattRevurdering(
                             is AvkortingVedRevurdering.Håndtert.AnnullerUtestående -> {
                                 opprinnelig.avkortingsvarsel
                             }
+
                             AvkortingVedRevurdering.Håndtert.IngenNyEllerUtestående -> {
                                 null
                             }
+
                             is AvkortingVedRevurdering.Håndtert.KanIkkeHåndteres -> {
                                 null
                             }
+
                             is AvkortingVedRevurdering.Håndtert.OpprettNyttAvkortingsvarsel -> {
                                 null
                             }
+
                             is AvkortingVedRevurdering.Håndtert.OpprettNyttAvkortingsvarselOgAnnullerUtestående -> {
                                 opprinnelig.annullerUtestående
                             }
@@ -511,6 +523,7 @@ fun iverksattRevurdering(
                     },
                 ).getOrFail() to utbetaling
             }
+
             is RevurderingTilAttestering.Opphørt -> {
                 val utbetaling = opphørUtbetalingOversendUtenKvittering(
                     sakOgBehandling = sak to tilAttestering,
@@ -525,15 +538,19 @@ fun iverksattRevurdering(
                             is AvkortingVedRevurdering.Håndtert.AnnullerUtestående -> {
                                 opprinnelig.avkortingsvarsel
                             }
+
                             AvkortingVedRevurdering.Håndtert.IngenNyEllerUtestående -> {
                                 null
                             }
+
                             is AvkortingVedRevurdering.Håndtert.KanIkkeHåndteres -> {
                                 null
                             }
+
                             is AvkortingVedRevurdering.Håndtert.OpprettNyttAvkortingsvarsel -> {
                                 null
                             }
+
                             is AvkortingVedRevurdering.Håndtert.OpprettNyttAvkortingsvarselOgAnnullerUtestående -> {
                                 opprinnelig.annullerUtestående
                             }
@@ -546,6 +563,13 @@ fun iverksattRevurdering(
             first = sak.copy(
                 revurderinger = sak.revurderinger.filterNot { it.id == iverksatt.id } + iverksatt,
                 utbetalinger = if (utbetaling != null) sak.utbetalinger + utbetaling else sak.utbetalinger,
+                uteståendeAvkorting = when (val avkorting = iverksatt.avkorting) {
+                    is AvkortingVedRevurdering.Iverksatt.AnnullerUtestående -> Avkortingsvarsel.Ingen
+                    is AvkortingVedRevurdering.Iverksatt.IngenNyEllerUtestående -> Avkortingsvarsel.Ingen
+                    is AvkortingVedRevurdering.Iverksatt.KanIkkeHåndteres -> Avkortingsvarsel.Ingen
+                    is AvkortingVedRevurdering.Iverksatt.OpprettNyttAvkortingsvarsel -> avkorting.avkortingsvarsel
+                    is AvkortingVedRevurdering.Iverksatt.OpprettNyttAvkortingsvarselOgAnnullerUtestående -> avkorting.avkortingsvarsel
+                },
             ),
             second = iverksatt,
             third = utbetaling,
@@ -589,9 +613,11 @@ fun vedtakRevurdering(
             is IverksattRevurdering.IngenEndring -> {
                 VedtakSomKanRevurderes.from(iverksatt, clockPlusOneTick)
             }
+
             is IverksattRevurdering.Innvilget -> {
                 VedtakSomKanRevurderes.from(iverksatt, utbetaling!!.id, clockPlusOneTick)
             }
+
             is IverksattRevurdering.Opphørt -> {
                 VedtakSomKanRevurderes.from(iverksatt, utbetaling!!.id, clockPlusOneTick)
             }
@@ -1031,21 +1057,26 @@ private fun <T : SimulertRevurdering> T.prøvÅLeggTilForhåndsvarselPåSimulert
             this.markerForhåndsvarselSomSendt().orNull()!!.prøvOvergangTilAvsluttet(forhåndsvarsel.begrunnelse)
                 .orNull()!!
         }
+
         is Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.EndreGrunnlaget -> {
             this.markerForhåndsvarselSomSendt().orNull()!!
                 .prøvOvergangTilEndreGrunnlaget(forhåndsvarsel.begrunnelse).orNull()!!
         }
+
         is Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.FortsettMedSammeGrunnlag -> {
             this.markerForhåndsvarselSomSendt().orNull()!!
                 .prøvOvergangTilAvsluttet(forhåndsvarsel.begrunnelse)
                 .orNull()!!
         }
+
         Forhåndsvarsel.Ferdigbehandlet.SkalIkkeForhåndsvarsles -> {
             this.ikkeSendForhåndsvarsel().orNull()!!
         }
+
         Forhåndsvarsel.UnderBehandling.Sendt -> {
             this.markerForhåndsvarselSomSendt().orNull()!!
         }
+
         null -> this
     } as T
 }

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/komponenttest/SøknadsbehandlingAlder.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/komponenttest/SøknadsbehandlingAlder.kt
@@ -70,7 +70,10 @@ internal class SøknadsbehandlingAlder {
             søknad.type shouldBe Sakstype.ALDER
 
             val søknadsbehandling = appComponents.services.søknadsbehandling.opprett(
-                request = SøknadsbehandlingService.OpprettRequest(søknadId = søknad.id),
+                request = SøknadsbehandlingService.OpprettRequest(
+                    søknadId = søknad.id,
+                    sakId = sak.id,
+                ),
             ).getOrFail()
 
             appComponents.services.søknadsbehandling.oppdaterStønadsperiode(

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/Feilresponser.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/Feilresponser.kt
@@ -301,10 +301,13 @@ internal object Feilresponser {
             "Kunne ikke generere brev",
             "kunne_ikke_generere_brev",
         )
-
         val kunneIkkeLageBrevutkast = InternalServerError.errorJson(
             "Kunne ikke lage brevutkast",
             "kunne_ikke_lage_brevutkast",
+        )
+        val kanIkkeSendeBrevIDenneTilstanden = InternalServerError.errorJson(
+            "Kan ikke sende brev i denne tilstanden",
+            "kan_ikke_sende_brev_i_denne_tilstanden",
         )
     }
 

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/brev/SaksbehandlerBrevvalgJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/brev/SaksbehandlerBrevvalgJson.kt
@@ -1,0 +1,9 @@
+package no.nav.su.se.bakover.web.routes.brev
+
+/**
+ * Inputparametre fra frontend-laget aka. brevvalgene saksbehandler har.
+ */
+enum class SaksbehandlerBrevvalgJson {
+    SKAL_SENDE_BREV_MED_FRITEKST,
+    SKAL_IKKE_SENDE_BREV,
+}

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/RevurderingRoutes.kt
@@ -4,6 +4,7 @@ import io.ktor.server.routing.Route
 import no.nav.su.se.bakover.domain.satser.SatsFactory
 import no.nav.su.se.bakover.service.revurdering.RevurderingService
 import no.nav.su.se.bakover.service.sak.SakService
+import no.nav.su.se.bakover.web.routes.revurdering.avslutt.avsluttRevurderingRoute
 import no.nav.su.se.bakover.web.routes.revurdering.forhåndsvarsel.forhåndsvarslingRoute
 import no.nav.su.se.bakover.web.routes.sak.sakPath
 import no.nav.su.se.bakover.web.routes.vilkår.lovligopphold.leggTilLovligOppholdRoute

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/Revurderingsfeilresponser.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/Revurderingsfeilresponser.kt
@@ -16,6 +16,7 @@ import no.nav.su.se.bakover.web.routes.Feilresponser.Brev.kunneIkkeLageBrevutkas
 import no.nav.su.se.bakover.web.routes.Feilresponser.fantIkkePerson
 import no.nav.su.se.bakover.web.routes.Feilresponser.feilVedGenereringAvDokument
 import no.nav.su.se.bakover.web.routes.Feilresponser.kunneIkkeOppretteOppgave
+import no.nav.su.se.bakover.web.routes.revurdering.Revurderingsfeilresponser.Brev.brevvalgIkkeTillatt
 import no.nav.su.se.bakover.web.routes.revurdering.Revurderingsfeilresponser.Brev.fantIkkeGjeldendeUtbetaling
 import no.nav.su.se.bakover.web.routes.revurdering.Revurderingsfeilresponser.Brev.navneoppslagSaksbehandlerAttesttantFeilet
 
@@ -63,7 +64,7 @@ internal object Revurderingsfeilresponser {
         )
         val utenlandsoppholdSomFørerTilOpphørMåRevurderes = BadRequest.errorJson(
             "Utenlandsopphold som fører til opphør må revurderes",
-            "utenlandsopphold_som_fører_til_opphør_må_revurderes"
+            "utenlandsopphold_som_fører_til_opphør_må_revurderes",
         )
 
         val epsFormueMedFlereBosituasjonsperioderMåRevurderes = BadRequest.errorJson(
@@ -86,6 +87,14 @@ internal object Revurderingsfeilresponser {
         val fantIkkeGjeldendeUtbetaling = InternalServerError.errorJson(
             "Kunne ikke hente gjeldende utbetaling",
             "kunne_ikke_hente_gjeldende_utbetaling",
+        )
+        val brevvalgIkkeTillatt = BadRequest.errorJson(
+            "Brevvalg ikke tillatt",
+            "brevvalg_ikke_tillatt",
+        )
+        val manglerBrevvalg = BadRequest.errorJson(
+            "Mangler brevvalg",
+            "mangler_brevvalg",
         )
     }
 
@@ -120,6 +129,7 @@ internal object Revurderingsfeilresponser {
             KunneIkkeLageBrevutkastForRevurdering.FantIkkePerson -> fantIkkePerson
             KunneIkkeLageBrevutkastForRevurdering.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant -> navneoppslagSaksbehandlerAttesttantFeilet
             KunneIkkeLageBrevutkastForRevurdering.KunneIkkeFinneGjeldendeUtbetaling -> fantIkkeGjeldendeUtbetaling
+            KunneIkkeLageBrevutkastForRevurdering.DetSkalIkkeSendesBrev -> brevvalgIkkeTillatt
         }
     }
 

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/avslutt/AvsluttRevurderingRequestJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/avslutt/AvsluttRevurderingRequestJson.kt
@@ -1,0 +1,40 @@
+package no.nav.su.se.bakover.web.routes.revurdering.avslutt
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import io.ktor.http.HttpStatusCode.Companion.BadRequest
+import no.nav.su.se.bakover.domain.brev.Brevvalg
+import no.nav.su.se.bakover.web.Resultat
+import no.nav.su.se.bakover.web.errorJson
+import no.nav.su.se.bakover.web.routes.brev.SaksbehandlerBrevvalgJson
+
+/**
+ * Dersom
+ *
+ * @param fritekst null dersom SKAL_IKKE_SENDE_BREV og utfylt dersom SKAL_SENDE_BREV_MED_FRITEKST.
+ * @param begrunnelse Skal inneholde informasjon om hvorfor saksbehandler valgte å avslutte revurderingen. Dersom saksbehandler velger at det ikke skal sendes brev, skal dette og begrunnes her.
+ */
+internal data class AvsluttRevurderingRequestJson(
+    val begrunnelse: String,
+    val fritekst: String?,
+    val brevvalg: SaksbehandlerBrevvalgJson?,
+) {
+    fun toBrevvalg(): Either<Resultat, Brevvalg.SaksbehandlersValg?> {
+        // Så lenge avslutt revurdering er 1-1 med brevvalg, kan vi ta denne snarveien her.
+        return when (brevvalg) {
+            SaksbehandlerBrevvalgJson.SKAL_SENDE_BREV_MED_FRITEKST -> {
+                fritekst?.let {
+                    Brevvalg.SaksbehandlersValg.SkalSendeBrev.MedFritekst(it).right()
+                } ?: BadRequest.errorJson(
+                    message = "Mangler fritekst",
+                    code = "mangler_fritekst",
+                ).left()
+            }
+            SaksbehandlerBrevvalgJson.SKAL_IKKE_SENDE_BREV -> {
+                Brevvalg.SaksbehandlersValg.SkalIkkeSendeBrev(begrunnelse).right()
+            }
+            null -> null.right()
+        }
+    }
+}

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/forhåndsvarsel/FortsettEtterForhåndsvarslingBody.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/forhåndsvarsel/FortsettEtterForhåndsvarslingBody.kt
@@ -1,0 +1,15 @@
+package no.nav.su.se.bakover.web.routes.revurdering.forhåndsvarsel
+
+data class FortsettEtterForhåndsvarslingBody(
+    /** Dette er begrunnelsen til beslutningen om man skal fortsette med samme eller andre opplysninger */
+    val begrunnelse: String,
+    /** @see BeslutningEtterForhåndsvarsling . Må ikke sammenlignes med brevvalg. */
+    val valg: BeslutningEtterForhåndsvarsling,
+    /** Må være utfylt dersom man skal fortsette med samme opplysninger. Skal ikke være utfylt dersom man skal fortsette med andre opplysninger */
+    val fritekstTilBrev: String?,
+) {
+    enum class BeslutningEtterForhåndsvarsling {
+        FORTSETT_MED_SAMME_OPPLYSNINGER,
+        FORTSETT_MED_ANDRE_OPPLYSNINGER;
+    }
+}

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutes.kt
@@ -24,6 +24,7 @@ import no.nav.su.se.bakover.domain.søknadinnhold.FeilVedOpprettelseAvSøknadinn
 import no.nav.su.se.bakover.domain.søknadinnhold.FeilVedValideringAvBoforholdOgEktefelle
 import no.nav.su.se.bakover.domain.søknadinnhold.FeilVedValideringAvOppholdstillatelseOgOppholdstillatelseAlder
 import no.nav.su.se.bakover.domain.søknadinnhold.ForNav
+import no.nav.su.se.bakover.service.brev.KunneIkkeLageDokument
 import no.nav.su.se.bakover.service.søknad.AvslåManglendeDokumentasjonRequest
 import no.nav.su.se.bakover.service.søknad.AvslåSøknadManglendeDokumentasjonService
 import no.nav.su.se.bakover.service.søknad.KunneIkkeAvslåSøknad
@@ -181,11 +182,14 @@ internal fun Route.søknadRoutes(
                     ).mapLeft {
                         call.svar(
                             when (it) {
-                                KunneIkkeAvslåSøknad.SøknadsbehandlingIUgyldigTilstandForAvslag -> Feilresponser.behandlingErIUgyldigTilstand
-                                KunneIkkeAvslåSøknad.KunneIkkeFinneGjeldendeUtbetaling -> Feilresponser.fantIkkeGjeldendeUtbetaling
-                                KunneIkkeAvslåSøknad.KunneIkkeGenererePDF -> Feilresponser.Brev.kunneIkkeGenerereBrev
-                                KunneIkkeAvslåSøknad.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant -> Feilresponser.fantIkkeSaksbehandlerEllerAttestant
-                                KunneIkkeAvslåSøknad.KunneIkkeHentePerson -> Feilresponser.fantIkkePerson
+                                is KunneIkkeAvslåSøknad.KunneIkkeLageDokument -> when (it.nested) {
+                                    // KunneIkkeAvslåSøknad.SøknadsbehandlingIUgyldigTilstandForAvslag -> Feilresponser.behandlingErIUgyldigTilstand
+                                    KunneIkkeLageDokument.DetSkalIkkeSendesBrev -> TODO()
+                                    KunneIkkeLageDokument.KunneIkkeFinneGjeldendeUtbetaling -> Feilresponser.fantIkkeGjeldendeUtbetaling
+                                    KunneIkkeLageDokument.KunneIkkeGenererePDF -> Feilresponser.Brev.kunneIkkeGenerereBrev
+                                    KunneIkkeLageDokument.KunneIkkeHenteNavnForSaksbehandlerEllerAttestant -> Feilresponser.fantIkkeSaksbehandlerEllerAttestant
+                                    KunneIkkeLageDokument.KunneIkkeHentePerson -> Feilresponser.fantIkkePerson
+                                }
                                 KunneIkkeAvslåSøknad.FantIkkeSak -> Feilresponser.fantIkkeSak
                                 is KunneIkkeAvslåSøknad.KunneIkkeOppretteSøknadsbehandling -> {
                                     when (it.feil) {

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutes.kt
@@ -96,7 +96,12 @@ internal fun Route.søknadsbehandlingRoutes(
                     body.soknadId.toUUID().mapLeft {
                         call.svar(BadRequest.errorJson("soknadId er ikke en gyldig uuid", "ikke_gyldig_uuid"))
                     }.map { søknadId ->
-                        søknadsbehandlingService.opprett(OpprettRequest(søknadId)).fold(
+                        søknadsbehandlingService.opprett(
+                            OpprettRequest(
+                                søknadId = søknadId,
+                                sakId = sakId,
+                            )
+                        ).fold(
                             {
                                 call.svar(
                                     when (it) {
@@ -129,6 +134,10 @@ internal fun Route.søknadsbehandlingRoutes(
                                                 "Har allerede en åpen søknadsbehandling",
                                                 "har_allerede_en_åpen_søknadsbehandling",
                                             )
+                                        }
+
+                                        KunneIkkeOpprette.FantIkkeSak -> {
+                                            fantIkkeSak
                                         }
                                     },
                                 )

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/ForhåndsvarslingRouteTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/revurdering/ForhåndsvarslingRouteTest.kt
@@ -77,11 +77,10 @@ internal class ForhåndsvarslingRouteTest {
 
         @Test
         fun `lagrer valget`() {
-            val simulertRevurdering = simulertRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak()
-                .second.copy(
-                    forhåndsvarsel = Forhåndsvarsel.Ferdigbehandlet.SkalIkkeForhåndsvarsles,
-                    fritekstTilBrev = "",
-                )
+            val simulertRevurdering = simulertRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak().second.copy(
+                forhåndsvarsel = Forhåndsvarsel.Ferdigbehandlet.SkalIkkeForhåndsvarsles,
+                fritekstTilBrev = "",
+            )
 
             val revurderingServiceMock = mock<RevurderingService> {
                 on {
@@ -262,75 +261,6 @@ internal class ForhåndsvarslingRouteTest {
                     actualResponse.forhåndsvarsel shouldBe ForhåndsvarselJson.SkalVarslesBesluttet(
                         begrunnelse = "begrunnelse",
                         beslutningEtterForhåndsvarsling = BeslutningEtterForhåndsvarsling.FortsettSammeOpplysninger,
-                    )
-                }
-            }
-        }
-
-        @Test
-        fun `avslutter uten endring`() {
-            val simulertRevurdering = SimulertRevurdering.Innvilget(
-                id = UUID.randomUUID(),
-                periode = RevurderingRoutesTestData.periode,
-                opprettet = fixedTidspunkt,
-                tilRevurdering = vedtak.id,
-                saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "saksbehandler"),
-                beregning = TestBeregning,
-                simulering = Simulering(
-                    gjelderId = Fnr(fnr = "12345678901"),
-                    gjelderNavn = "navn",
-                    datoBeregnet = fixedLocalDate,
-                    nettoBeløp = 0,
-                    periodeList = listOf(),
-                ),
-                oppgaveId = OppgaveId("OppgaveId"),
-                fritekstTilBrev = "Friteksten",
-                revurderingsårsak = Revurderingsårsak(
-                    Revurderingsårsak.Årsak.MELDING_FRA_BRUKER,
-                    Revurderingsårsak.Begrunnelse.create("Ny informasjon"),
-                ),
-                forhåndsvarsel = Forhåndsvarsel.Ferdigbehandlet.Forhåndsvarslet.Avsluttet("begrunnelse"),
-                grunnlagsdata = Grunnlagsdata.IkkeVurdert,
-                vilkårsvurderinger = vilkårsvurderingRevurderingIkkeVurdert(),
-                informasjonSomRevurderes = InformasjonSomRevurderes.create(listOf(Revurderingsteg.Inntekt)),
-                attesteringer = Attesteringshistorikk.empty(),
-                avkorting = AvkortingVedRevurdering.Håndtert.IngenNyEllerUtestående,
-                tilbakekrevingsbehandling = IkkeBehovForTilbakekrevingUnderBehandling,
-                sakinfo = vedtak.sakinfo(),
-            )
-
-            val revurderingServiceMock = mock<RevurderingService> {
-                on { fortsettEtterForhåndsvarsling(any()) } doReturn simulertRevurdering.right()
-            }
-
-            testApplication {
-                application {
-                    testSusebakover(services = RevurderingRoutesTestData.testServices.copy(revurdering = revurderingServiceMock))
-                }
-                defaultRequest(
-                    HttpMethod.Post,
-                    "${RevurderingRoutesTestData.requestPath}/${simulertRevurdering.id}/fortsettEtterForhåndsvarsel",
-                    listOf(Brukerrolle.Saksbehandler),
-                ) {
-                    setBody(
-                        //language=json
-                        """
-                        {
-                          "fritekstTilBrev": "Friteksten",
-                          "valg": "AVSLUTT_UTEN_ENDRINGER",
-                          "begrunnelse": "begrunnelse"
-                        }
-                        """.trimIndent(),
-                    )
-                }.apply {
-                    status shouldBe HttpStatusCode.OK
-                    val actualResponse = objectMapper.readValue<SimulertRevurderingJson>(bodyAsText())
-                    actualResponse.id shouldBe simulertRevurdering.id.toString()
-                    actualResponse.status shouldBe RevurderingsStatus.SIMULERT_INNVILGET
-                    actualResponse.fritekstTilBrev shouldBe "Friteksten"
-                    actualResponse.forhåndsvarsel shouldBe ForhåndsvarselJson.SkalVarslesBesluttet(
-                        begrunnelse = "begrunnelse",
-                        beslutningEtterForhåndsvarsling = BeslutningEtterForhåndsvarsling.AvsluttUtenEndringer,
                     )
                 }
             }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/sak/SakJsonTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/sak/SakJsonTest.kt
@@ -14,6 +14,7 @@ import no.nav.su.se.bakover.domain.Fnr
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Sakstype
+import no.nav.su.se.bakover.domain.avkorting.Avkortingsvarsel
 import no.nav.su.se.bakover.domain.grunnlag.Uføregrad
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppdrag.Utbetalingslinje
@@ -43,6 +44,7 @@ internal class SakJsonTest {
         utbetalinger = emptyList(),
         klager = emptyList(),
         type = Sakstype.UFØRE,
+        uteståendeAvkorting = Avkortingsvarsel.Ingen,
     )
 
     //language=JSON

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutesKtTest.kt
@@ -38,6 +38,7 @@ import no.nav.su.se.bakover.domain.Sakstype
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder.build
+import no.nav.su.se.bakover.domain.avkorting.Avkortingsvarsel
 import no.nav.su.se.bakover.domain.journal.JournalpostId
 import no.nav.su.se.bakover.domain.oppgave.OppgaveClient
 import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
@@ -98,6 +99,7 @@ internal class SøknadRoutesKtTest {
         fnr = Fnr.generer(),
         utbetalinger = emptyList(),
         type = Sakstype.UFØRE,
+        uteståendeAvkorting = Avkortingsvarsel.Ingen,
     )
     private val søknadId = UUID.randomUUID()
 


### PR DESCRIPTION
Forberedende refaktorering for å gjøre klar for at sak skal kunne eie større deler av opprettelse/oppdatering av søknadsbehandling og revurderinger. En del av opprett/oppdater funksjonene kan refaktoreres videre slik at sak håndterer mange av de aktuelle sjekkene, men har spart dette i første omgang for å begrense scopet noe.