### PR TITLE
Bump io.confluent:kafka-avro-serializer to 7.2.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ subprojects {
         implementation("no.finn.unleash:unleash-client-java:4.4.1")
 
         implementation("com.ibm.mq:com.ibm.mq.allclient:9.3.0.0")
-        implementation("io.confluent:kafka-avro-serializer:7.1.3")
+        implementation("io.confluent:kafka-avro-serializer:7.2.0")
         implementation("org.apache.avro:avro:1.11.1")
         implementation("com.github.ben-manes.caffeine:caffeine:3.1.1")
         implementation("io.micrometer:micrometer-core:1.9.3")


### PR DESCRIPTION
Det brekker fra denne minor versjonen. Vi må finne på noe annet for å serdes'e avro-strenger.