### PR TITLE
Ta vare på innsender av søknad ved første innsending på sak

### DIFF
--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepo.kt
@@ -135,7 +135,7 @@ internal class SakPostgresRepo(
             sessionFactory.withSession { session ->
                 """
                 with inserted_sak as (insert into sak (id, fnr, opprettet, type) values (:sakId, :fnr, :opprettet, :type))
-                insert into søknad (id, sakId, søknadInnhold, opprettet) values (:soknadId, :sakId, to_json(:soknad::json), :opprettet)
+                insert into søknad (id, sakId, søknadInnhold, opprettet, ident) values (:soknadId, :sakId, to_json(:soknad::json), :opprettet, :ident)
                 """.insert(
                     mapOf(
                         "sakId" to sak.id,
@@ -144,6 +144,7 @@ internal class SakPostgresRepo(
                         "soknadId" to sak.søknad.id,
                         "soknad" to serialize(sak.søknad.søknadInnhold),
                         "type" to sak.søknad.type.value,
+                        "ident" to sak.søknad.innsendtAv.navIdent
                     ),
                     session,
                 )

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/søknad/SøknadPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/søknad/SøknadPostgresRepo.kt
@@ -10,7 +10,6 @@ import no.nav.su.se.bakover.database.insert
 import no.nav.su.se.bakover.database.oppdatering
 import no.nav.su.se.bakover.database.søknad.LukketJson.Companion.toLukketJson
 import no.nav.su.se.bakover.database.søknad.SøknadRepoInternal.hentSøknadInternal
-import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.søknad.SøknadRepo
 import java.util.UUID
@@ -26,7 +25,7 @@ internal class SøknadPostgresRepo(
         }
     }
 
-    override fun opprettSøknad(søknad: Søknad.Ny, identBruker: NavIdentBruker) {
+    override fun opprettSøknad(søknad: Søknad.Ny) {
         dbMetrics.timeQuery("opprettSøknad") {
             sessionFactory.withSession { session ->
                 """
@@ -48,7 +47,7 @@ internal class SøknadPostgresRepo(
                         "sakId" to søknad.sakId,
                         "soknad" to serialize(søknad.søknadInnhold),
                         "opprettet" to søknad.opprettet,
-                        "ident" to identBruker.navIdent,
+                        "ident" to søknad.innsendtAv.navIdent,
                     ),
                     session,
                 )

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/TestDataHelper.kt
@@ -170,6 +170,7 @@ internal fun simulering(fnr: Fnr) = Simulering(
 )
 
 internal val saksbehandler = NavIdentBruker.Saksbehandler("saksbehandler")
+internal val veileder = NavIdentBruker.Veileder("veileder")
 internal val underkjentAttestering =
     Attestering.Underkjent(
         attestant = attestant,
@@ -420,6 +421,7 @@ internal class TestDataHelper(
         søknadId: UUID = UUID.randomUUID(),
         fnr: Fnr = Fnr.generer(),
         søknadInnhold: SøknadsinnholdUføre = SøknadInnholdTestdataBuilder.build(),
+        søknadInnsendtAv: NavIdentBruker = veileder
     ): NySak {
         return SakFactory(
             clock = clock,
@@ -429,7 +431,11 @@ internal class TestDataHelper(
                     return ids.pop()
                 }
             },
-        ).nySakMedNySøknad(fnr, søknadInnhold).also {
+        ).nySakMedNySøknad(
+            fnr = fnr,
+            søknadInnhold = søknadInnhold,
+            innsendtAv = søknadInnsendtAv,
+        ).also {
             sakRepo.opprettSak(it)
         }
     }
@@ -449,7 +455,8 @@ internal class TestDataHelper(
             id = søknadId,
             søknadInnhold = søknadInnhold,
             opprettet = fixedTidspunkt,
-        ).also { søknadRepo.opprettSøknad(it, identBruker) }
+            innsendtAv = identBruker,
+        ).also { søknadRepo.opprettSøknad(it) }
     }
 
     /**

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Sak.kt
@@ -869,6 +869,7 @@ class SakFactory(
     fun nySakMedNySøknad(
         fnr: Fnr,
         søknadInnhold: SøknadInnhold,
+        innsendtAv: NavIdentBruker,
     ): NySak {
         val opprettet = Tidspunkt.now(clock)
         val sakId = uuidFactory.newUUID()
@@ -881,6 +882,7 @@ class SakFactory(
                 opprettet = opprettet,
                 sakId = sakId,
                 søknadInnhold = søknadInnhold,
+                innsendtAv = innsendtAv,
             ),
         )
     }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Søknad.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/Søknad.kt
@@ -33,6 +33,7 @@ sealed class Søknad {
     abstract val opprettet: Tidspunkt
     abstract val sakId: UUID
     abstract val søknadInnhold: SøknadInnhold
+    abstract val innsendtAv: NavIdentBruker
 
     val type: Sakstype by lazy {
         when (søknadInnhold) {
@@ -59,6 +60,7 @@ sealed class Søknad {
         override val opprettet: Tidspunkt,
         override val sakId: UUID,
         override val søknadInnhold: SøknadInnhold,
+        override val innsendtAv: NavIdentBruker,
     ) : Søknad() {
 
         fun journalfør(
@@ -69,6 +71,7 @@ sealed class Søknad {
                 opprettet = opprettet,
                 sakId = sakId,
                 søknadInnhold = søknadInnhold,
+                innsendtAv = innsendtAv,
                 journalpostId = journalpostId,
             )
         }
@@ -82,6 +85,7 @@ sealed class Søknad {
             override val opprettet: Tidspunkt,
             override val sakId: UUID,
             override val søknadInnhold: SøknadInnhold,
+            override val innsendtAv: NavIdentBruker,
             override val journalpostId: JournalpostId,
         ) : Journalført() {
 
@@ -93,6 +97,7 @@ sealed class Søknad {
                     opprettet = opprettet,
                     sakId = sakId,
                     søknadInnhold = søknadInnhold,
+                    innsendtAv = innsendtAv,
                     journalpostId = journalpostId,
                     oppgaveId = oppgaveId,
                 )
@@ -107,6 +112,7 @@ sealed class Søknad {
                 override val opprettet: Tidspunkt,
                 override val sakId: UUID,
                 override val søknadInnhold: SøknadInnhold,
+                override val innsendtAv: NavIdentBruker,
                 override val journalpostId: JournalpostId,
                 override val oppgaveId: OppgaveId,
             ) : MedOppgave() {
@@ -121,6 +127,7 @@ sealed class Søknad {
                         opprettet = opprettet,
                         sakId = sakId,
                         søknadInnhold = søknadInnhold,
+                        innsendtAv = innsendtAv,
                         journalpostId = journalpostId,
                         oppgaveId = oppgaveId,
                         lukketTidspunkt = lukketTidspunkt,
@@ -135,6 +142,7 @@ sealed class Søknad {
                 override val opprettet: Tidspunkt,
                 override val sakId: UUID,
                 override val søknadInnhold: SøknadInnhold,
+                override val innsendtAv: NavIdentBruker,
                 override val journalpostId: JournalpostId,
                 override val oppgaveId: OppgaveId,
                 val lukketTidspunkt: Tidspunkt,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknad/SøknadRepo.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknad/SøknadRepo.kt
@@ -1,13 +1,12 @@
 package no.nav.su.se.bakover.domain.søknad
 
 import no.nav.su.se.bakover.common.persistence.SessionContext
-import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Søknad
 import java.util.UUID
 
 interface SøknadRepo {
     fun hentSøknad(søknadId: UUID): Søknad?
-    fun opprettSøknad(søknad: Søknad.Ny, identBruker: NavIdentBruker)
+    fun opprettSøknad(søknad: Søknad.Ny)
     fun lukkSøknad(søknad: Søknad.Journalført.MedOppgave.Lukket, sessionContext: SessionContext = defaultSessionContext())
     fun oppdaterjournalpostId(søknad: Søknad.Journalført.UtenOppgave)
     fun oppdaterOppgaveId(søknad: Søknad.Journalført.MedOppgave)

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadinnhold/ForNav.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadinnhold/ForNav.kt
@@ -14,12 +14,19 @@ import java.time.LocalDate
     JsonSubTypes.Type(value = ForNav.Papirsøknad::class, name = "Papirsøknad"),
 )
 sealed class ForNav {
+
+    abstract fun erPapirsøknad(): Boolean
+
     data class DigitalSøknad(
         val harFullmektigEllerVerge: Vergemål? = null
     ) : ForNav() {
         enum class Vergemål() {
             FULLMEKTIG,
             VERGE;
+        }
+
+        override fun erPapirsøknad(): Boolean {
+            return false
         }
     }
 
@@ -28,6 +35,9 @@ sealed class ForNav {
         val grunnForPapirinnsending: GrunnForPapirinnsending,
         val annenGrunn: String?
     ) : ForNav() {
+        override fun erPapirsøknad(): Boolean {
+            return true
+        }
         enum class GrunnForPapirinnsending() {
             VergeHarSøktPåVegneAvBruker,
             MidlertidigUnntakFraOppmøteplikt,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadinnhold/Søknadsinnhold.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadinnhold/Søknadsinnhold.kt
@@ -43,6 +43,10 @@ sealed interface SøknadInnhold {
         is SøknadsinnholdUføre -> Sakstype.UFØRE
     }
 
+    fun erPapirsøknad(): Boolean {
+        return forNav.erPapirsøknad()
+    }
+
     // slipper å måtte ha den 2 steder
     companion object {
         internal fun validerBoforholdOgEktefelle(

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknad/SøknadTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknad/SøknadTest.kt
@@ -6,6 +6,7 @@ import no.nav.su.se.bakover.domain.søknadinnhold.ForNav
 import no.nav.su.se.bakover.test.fixedLocalDate
 import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.søknadinnhold
+import no.nav.su.se.bakover.test.veileder
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
@@ -21,6 +22,7 @@ internal class SøknadTest {
             søknadInnhold = søknadinnhold(
                 forNav = ForNav.DigitalSøknad(),
             ),
+            innsendtAv = veileder
         )
         søknad.mottaksdato shouldBe fixedLocalDate
     }
@@ -39,6 +41,7 @@ internal class SøknadTest {
                     annenGrunn = null,
                 ),
             ),
+            innsendtAv = veileder
         )
         søknad.mottaksdato shouldBe dato
     }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/SøknadServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/SøknadServiceImpl.kt
@@ -75,11 +75,15 @@ internal class SøknadServiceImpl(
         val (saksnummer: Saksnummer, søknad: Søknad.Ny) = sakService.hentSakidOgSaksnummer(fnr).fold(
             {
                 log.info("Ny søknad: Fant ikke sak for fødselsnummmer. Oppretter ny søknad og ny sak.")
-                val nySak = sakFactory.nySakMedNySøknad(fnr, søknadsinnholdMedNyesteFødselsnummer).also {
+                val nySak = sakFactory.nySakMedNySøknad(
+                    fnr = fnr,
+                    søknadInnhold = søknadsinnholdMedNyesteFødselsnummer,
+                    innsendtAv = identBruker
+                ).also {
                     sakService.opprettSak(it)
                 }
-                val sakIdSaksnummerFnr =
-                    sakService.hentSakidOgSaksnummer(fnr).getOrElse { throw RuntimeException("Feil ved henting av sak") }
+                val sakIdSaksnummerFnr = sakService.hentSakidOgSaksnummer(fnr)
+                    .getOrElse { throw RuntimeException("Feil ved henting av sak") }
                 Pair(sakIdSaksnummerFnr.saksnummer, nySak.søknad)
             },
             {
@@ -89,8 +93,9 @@ internal class SøknadServiceImpl(
                     id = UUID.randomUUID(),
                     opprettet = Tidspunkt.now(clock),
                     søknadInnhold = søknadsinnholdMedNyesteFødselsnummer,
+                    innsendtAv = identBruker
                 )
-                søknadRepo.opprettSøknad(søknad, identBruker)
+                søknadRepo.opprettSøknad(søknad)
 
                 Pair(it.saksnummer, søknad)
             },

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/BehandlingStatistikkMapperTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/BehandlingStatistikkMapperTest.kt
@@ -44,6 +44,7 @@ import no.nav.su.se.bakover.test.søknadsbehandlingUnderkjentInnvilget
 import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertAvslag
 import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertInnvilget
 import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertUavklart
+import no.nav.su.se.bakover.test.veileder
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -60,6 +61,7 @@ internal class BehandlingStatistikkMapperTest {
             opprettet = fixedTidspunkt,
             sakId = UUID.randomUUID(),
             søknadInnhold = SøknadInnholdTestdataBuilder.build(),
+            innsendtAv = veileder
         )
 
         BehandlingStatistikkMapper(fixedClock).map(
@@ -113,6 +115,7 @@ internal class BehandlingStatistikkMapperTest {
             opprettet = fixedTidspunkt,
             sakId = UUID.randomUUID(),
             søknadInnhold = SøknadInnholdTestdataBuilder.build(),
+            innsendtAv = veileder,
             journalpostId = JournalpostId("journalpostid"),
             oppgaveId = OppgaveId("oppgaveid"),
             lukketTidspunkt = fixedTidspunkt,
@@ -666,6 +669,7 @@ internal class BehandlingStatistikkMapperTest {
         opprettet = fixedTidspunkt,
         sakId = UUID.randomUUID(),
         søknadInnhold = SøknadInnholdTestdataBuilder.build(),
+        innsendtAv = veileder,
         journalpostId = JournalpostId(""),
         oppgaveId = OppgaveId(""),
     )

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/StatistikkServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/StatistikkServiceImplTest.kt
@@ -23,12 +23,14 @@ import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.iverksattRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak
 import no.nav.su.se.bakover.test.nySakMedNySøknad
 import no.nav.su.se.bakover.test.opprettetRevurderingFraInnvilgetSøknadsbehandlingsVedtak
+import no.nav.su.se.bakover.test.saksbehandler
 import no.nav.su.se.bakover.test.søknadsbehandlingIverksattAvslagUtenBeregning
 import no.nav.su.se.bakover.test.søknadsbehandlingIverksattInnvilget
 import no.nav.su.se.bakover.test.søknadsbehandlingTilAttesteringAvslagUtenBeregning
 import no.nav.su.se.bakover.test.søknadsbehandlingUnderkjentInnvilget
 import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertUavklart
 import no.nav.su.se.bakover.test.tilAttesteringRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak
+import no.nav.su.se.bakover.test.veileder
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
@@ -468,6 +470,7 @@ internal class StatistikkServiceImplTest {
             opprettet = Tidspunkt.now(clock),
             sakId = UUID.randomUUID(),
             søknadInnhold = SøknadInnholdTestdataBuilder.build(),
+            innsendtAv = veileder,
             journalpostId = JournalpostId("journalpostid"),
             oppgaveId = OppgaveId("oppgaveid"),
             lukketTidspunkt = fixedTidspunkt,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/HentSøknadTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/HentSøknadTest.kt
@@ -3,79 +3,43 @@ package no.nav.su.se.bakover.service.søknad
 import arrow.core.left
 import arrow.core.right
 import io.kotest.matchers.shouldBe
-import no.nav.su.se.bakover.common.Tidspunkt
-import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.SøknadInnholdTestdataBuilder
-import no.nav.su.se.bakover.domain.søknad.SøknadRepo
-import no.nav.su.se.bakover.domain.søknadinnhold.SøknadsinnholdUføre
-import no.nav.su.se.bakover.service.argThat
 import no.nav.su.se.bakover.test.fixedClock
+import no.nav.su.se.bakover.test.nySøknad
+import no.nav.su.se.bakover.test.veileder
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoMoreInteractions
 import java.util.UUID
 
 class HentSøknadTest {
     @Test
     fun `fant ikke søknad`() {
-
-        val søknadId = UUID.randomUUID()
-
-        val søknadRepoMock = mock<SøknadRepo> {
-            on { hentSøknad(any()) } doReturn null
+        SøknadServiceOgMocks(
+            søknadRepo = mock {
+                on { hentSøknad(any()) } doReturn null
+            }
+        ).also {
+            it.service.hentSøknad(UUID.randomUUID()) shouldBe FantIkkeSøknad.left()
         }
-
-        val søknadService = SøknadServiceImpl(
-            søknadRepo = søknadRepoMock,
-            sakService = mock(),
-            sakFactory = mock(),
-            pdfGenerator = mock(),
-            dokArkiv = mock(),
-            personService = mock(),
-            oppgaveService = mock(),
-            søknadMetrics = mock(),
-            toggleService = mock(),
-            clock = fixedClock
-        )
-
-        val actual = søknadService.hentSøknad(søknadId)
-        actual shouldBe FantIkkeSøknad.left()
     }
 
     @Test
     fun `fant søknad`() {
-        val søknadInnhold: SøknadsinnholdUføre = SøknadInnholdTestdataBuilder.build()
-        val søknadId = UUID.randomUUID()
-        val søknad = Søknad.Ny(
-            id = søknadId,
-            opprettet = Tidspunkt.EPOCH,
-            sakId = UUID.randomUUID(),
-            søknadInnhold = søknadInnhold,
-        )
-        val søknadRepoMock = mock<SøknadRepo> {
-            on { hentSøknad(any()) } doReturn søknad
-        }
-
-        val søknadService = SøknadServiceImpl(
-            søknadRepo = søknadRepoMock,
-            sakService = mock(),
-            sakFactory = mock(),
-            pdfGenerator = mock(),
-            dokArkiv = mock(),
-            personService = mock(),
-            oppgaveService = mock(),
-            søknadMetrics = mock(),
-            toggleService = mock(),
+        val søknad = nySøknad(
             clock = fixedClock,
+            sakId = UUID.randomUUID(),
+            søknadInnhold = SøknadInnholdTestdataBuilder.build(),
+            søknadInnsendtAv = veileder
         )
 
-        val actual = søknadService.hentSøknad(søknadId)
-        actual shouldBe søknad.right()
-
-        verify(søknadRepoMock).hentSøknad(argThat { it shouldBe søknadId })
-        verifyNoMoreInteractions(søknadRepoMock)
+        SøknadServiceOgMocks(
+            søknadRepo = mock {
+                on { hentSøknad(any()) } doReturn søknad
+            }
+        ).also {
+            it.service.hentSøknad(UUID.randomUUID()) shouldBe søknad.right()
+        }
     }
 }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/OpprettManglendeJournalpostOgOppgaveTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/OpprettManglendeJournalpostOgOppgaveTest.kt
@@ -4,9 +4,7 @@ import arrow.core.left
 import arrow.core.right
 import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.client.ClientError
-import no.nav.su.se.bakover.client.dokarkiv.DokArkiv
 import no.nav.su.se.bakover.client.dokarkiv.Journalpost
-import no.nav.su.se.bakover.client.pdf.PdfGenerator
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.domain.AktørId
 import no.nav.su.se.bakover.domain.Fnr
@@ -22,15 +20,13 @@ import no.nav.su.se.bakover.domain.journal.JournalpostId
 import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.domain.person.KunneIkkeHentePerson
+import no.nav.su.se.bakover.domain.søknad.SøknadMetrics
 import no.nav.su.se.bakover.domain.søknad.SøknadPdfInnhold
-import no.nav.su.se.bakover.domain.søknad.SøknadRepo
 import no.nav.su.se.bakover.service.argThat
-import no.nav.su.se.bakover.service.oppgave.OppgaveService
-import no.nav.su.se.bakover.service.person.PersonService
 import no.nav.su.se.bakover.service.sak.FantIkkeSak
-import no.nav.su.se.bakover.service.sak.SakService
 import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.generer
+import no.nav.su.se.bakover.test.veileder
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
@@ -47,6 +43,7 @@ class OpprettManglendeJournalpostOgOppgaveTest {
         id = UUID.randomUUID(),
         opprettet = Tidspunkt.EPOCH,
         søknadInnhold = søknadInnhold,
+        innsendtAv = veileder,
     )
     private val fnr = Fnr.generer()
     private val journalførtSøknad = nySøknad.journalfør(JournalpostId("1"))
@@ -71,252 +68,162 @@ class OpprettManglendeJournalpostOgOppgaveTest {
 
     @Test
     fun `ingen søknader`() {
-        val søknadRepoMock = mock<SøknadRepo> {
-            on { hentSøknaderUtenJournalpost() } doReturn emptyList()
-            on { hentSøknaderMedJournalpostMenUtenOppgave() } doReturn emptyList()
+        SøknadServiceOgMocks(
+            mock {
+                on { hentSøknaderUtenJournalpost() } doReturn emptyList()
+                on { hentSøknaderMedJournalpostMenUtenOppgave() } doReturn emptyList()
+            }
+        ).also {
+            it.service.opprettManglendeJournalpostOgOppgave() shouldBe OpprettManglendeJournalpostOgOppgaveResultat(emptyList(), emptyList())
+            inOrder(*it.allMocks()) {
+                verify(it.søknadRepo).hentSøknaderUtenJournalpost()
+                verify(it.søknadRepo).hentSøknaderMedJournalpostMenUtenOppgave()
+            }
+            it.verifyNoMoreInteractions()
         }
-
-        val søknadService = SøknadServiceImpl(
-            søknadRepo = søknadRepoMock,
-            sakService = mock(),
-            sakFactory = mock(),
-            pdfGenerator = mock(),
-            dokArkiv = mock(),
-            personService = mock(),
-            oppgaveService = mock(),
-            søknadMetrics = mock(),
-            toggleService = mock(),
-            clock = fixedClock,
-        )
-
-        val actual = søknadService.opprettManglendeJournalpostOgOppgave()
-        actual shouldBe OpprettManglendeJournalpostOgOppgaveResultat(emptyList(), emptyList())
-        inOrder(
-            søknadRepoMock
-        ) {
-            verify(søknadRepoMock).hentSøknaderUtenJournalpost()
-            verify(søknadRepoMock).hentSøknaderMedJournalpostMenUtenOppgave()
-        }
-        verifyNoMoreInteractions(søknadRepoMock)
     }
 
     @Test
     fun `finner ikke saken`() {
-        val journalførtSøknad = nySøknad.journalfør(JournalpostId("1"))
+        SøknadServiceOgMocks(
+            søknadRepo = mock {
+                on { hentSøknaderUtenJournalpost() } doReturn listOf(nySøknad)
+                on { hentSøknaderMedJournalpostMenUtenOppgave() } doReturn listOf(journalførtSøknad)
+            },
+            sakService = mock {
+                on { hentSak(sakId) } doReturn FantIkkeSak.left()
+            }
+        ).also {
+            it.service.opprettManglendeJournalpostOgOppgave() shouldBe OpprettManglendeJournalpostOgOppgaveResultat(
+                journalpostResultat = listOf(KunneIkkeOppretteJournalpost(sakId, nySøknad.id, "Fant ikke sak").left()),
+                oppgaveResultat = listOf(KunneIkkeOppretteOppgave(sakId, nySøknad.id, journalførtSøknad.journalpostId, "Fant ikke sak").left())
+            )
 
-        val søknadRepoMock = mock<SøknadRepo> {
-            on { hentSøknaderUtenJournalpost() } doReturn listOf(nySøknad)
-            on { hentSøknaderMedJournalpostMenUtenOppgave() } doReturn listOf(journalførtSøknad)
+            inOrder(*it.allMocks()) {
+                verify(it.søknadRepo).hentSøknaderUtenJournalpost()
+                verify(it.sakService).hentSak(argThat<UUID> { it shouldBe sakId })
+                verify(it.søknadRepo).hentSøknaderMedJournalpostMenUtenOppgave()
+                verify(it.sakService).hentSak(argThat<UUID> { it shouldBe sakId })
+            }
+            it.verifyNoMoreInteractions()
         }
-
-        val sakServiceMock = mock<SakService> {
-            on { hentSak(sakId) } doReturn FantIkkeSak.left()
-        }
-
-        val søknadService = SøknadServiceImpl(
-            søknadRepo = søknadRepoMock,
-            sakService = sakServiceMock,
-            sakFactory = mock(),
-            pdfGenerator = mock(),
-            dokArkiv = mock(),
-            personService = mock(),
-            oppgaveService = mock(),
-            søknadMetrics = mock(),
-            toggleService = mock(),
-            clock = fixedClock,
-        )
-
-        val actual = søknadService.opprettManglendeJournalpostOgOppgave()
-        actual shouldBe OpprettManglendeJournalpostOgOppgaveResultat(
-            journalpostResultat = listOf(KunneIkkeOppretteJournalpost(sakId, nySøknad.id, "Fant ikke sak").left()),
-            oppgaveResultat = listOf(KunneIkkeOppretteOppgave(sakId, nySøknad.id, journalførtSøknad.journalpostId, "Fant ikke sak").left())
-        )
-
-        inOrder(
-            sakServiceMock,
-            søknadRepoMock
-        ) {
-            verify(søknadRepoMock).hentSøknaderUtenJournalpost()
-            verify(sakServiceMock).hentSak(argThat<UUID> { it shouldBe sakId })
-            verify(søknadRepoMock).hentSøknaderMedJournalpostMenUtenOppgave()
-            verify(sakServiceMock).hentSak(argThat<UUID> { it shouldBe sakId })
-        }
-        verifyNoMoreInteractions(søknadRepoMock, sakServiceMock)
     }
 
     @Test
     fun `finner ikke person`() {
-        val søknadRepoMock = mock<SøknadRepo> {
-            on { hentSøknaderUtenJournalpost() } doReturn listOf(nySøknad)
-            on { hentSøknaderMedJournalpostMenUtenOppgave() } doReturn listOf(journalførtSøknad)
+        SøknadServiceOgMocks(
+            søknadRepo = mock {
+                on { hentSøknaderUtenJournalpost() } doReturn listOf(nySøknad)
+                on { hentSøknaderMedJournalpostMenUtenOppgave() } doReturn listOf(journalførtSøknad)
+            },
+            sakService = mock {
+                on { hentSak(sakId) } doReturn sak.right()
+            },
+            personService = mock {
+                on { hentPersonMedSystembruker(fnr) } doReturn KunneIkkeHentePerson.FantIkkePerson.left()
+            }
+        ).also {
+            it.service.opprettManglendeJournalpostOgOppgave() shouldBe OpprettManglendeJournalpostOgOppgaveResultat(
+                journalpostResultat = listOf(KunneIkkeOppretteJournalpost(sakId, nySøknad.id, "Fant ikke person").left()),
+                oppgaveResultat = listOf(KunneIkkeOppretteOppgave(sakId, journalførtSøknad.id, journalførtSøknad.journalpostId, "Fant ikke person").left())
+            )
+            inOrder(*it.allMocks()) {
+                verify(it.søknadRepo).hentSøknaderUtenJournalpost()
+                verify(it.sakService).hentSak(argThat<UUID> { it shouldBe sakId })
+                verify(it.personService).hentPersonMedSystembruker(argThat { it shouldBe fnr })
+                verify(it.søknadRepo).hentSøknaderMedJournalpostMenUtenOppgave()
+                verify(it.sakService).hentSak(argThat<UUID> { it shouldBe sakId })
+                verify(it.personService).hentPersonMedSystembruker(argThat { it shouldBe fnr })
+            }
+            it.verifyNoMoreInteractions()
         }
-
-        val sakServiceMock = mock<SakService> {
-            on { hentSak(sakId) } doReturn sak.right()
-        }
-
-        val personServiceMock = mock<PersonService> {
-            on { hentPersonMedSystembruker(fnr) } doReturn KunneIkkeHentePerson.FantIkkePerson.left()
-        }
-
-        val søknadService = SøknadServiceImpl(
-            søknadRepo = søknadRepoMock,
-            sakService = sakServiceMock,
-            sakFactory = mock(),
-            pdfGenerator = mock(),
-            dokArkiv = mock(),
-            personService = personServiceMock,
-            oppgaveService = mock(),
-            søknadMetrics = mock(),
-            toggleService = mock(),
-            clock = fixedClock,
-        )
-
-        val actual = søknadService.opprettManglendeJournalpostOgOppgave()
-        actual shouldBe OpprettManglendeJournalpostOgOppgaveResultat(
-            journalpostResultat = listOf(KunneIkkeOppretteJournalpost(sakId, nySøknad.id, "Fant ikke person").left()),
-            oppgaveResultat = listOf(KunneIkkeOppretteOppgave(sakId, journalførtSøknad.id, journalførtSøknad.journalpostId, "Fant ikke person").left())
-        )
-        inOrder(
-            personServiceMock,
-            sakServiceMock,
-            søknadRepoMock
-        ) {
-            verify(søknadRepoMock).hentSøknaderUtenJournalpost()
-            verify(sakServiceMock).hentSak(argThat<UUID> { it shouldBe sakId })
-            verify(personServiceMock).hentPersonMedSystembruker(argThat { it shouldBe fnr })
-            verify(søknadRepoMock).hentSøknaderMedJournalpostMenUtenOppgave()
-            verify(sakServiceMock).hentSak(argThat<UUID> { it shouldBe sakId })
-            verify(personServiceMock).hentPersonMedSystembruker(argThat { it shouldBe fnr })
-        }
-        verifyNoMoreInteractions(personServiceMock, sakServiceMock, søknadRepoMock)
     }
 
     @Test
     fun `opprett journalpost feiler`() {
-        val søknadRepoMock = mock<SøknadRepo> {
-            on { hentSøknaderUtenJournalpost() } doReturn listOf(nySøknad)
-            on { hentSøknaderMedJournalpostMenUtenOppgave() } doReturn emptyList()
-        }
-
-        val sakServiceMock = mock<SakService> {
-            on { hentSak(sakId) } doReturn sak.right()
-        }
-
-        val personServiceMock = mock<PersonService> {
-            on { hentPersonMedSystembruker(fnr) } doReturn person.right()
-        }
-
-        val pdfGeneratorMock = mock<PdfGenerator> {
-            on { genererPdf(any<SøknadPdfInnhold>()) } doReturn ClientError(0, "").left()
-        }
-
-        val søknadService = SøknadServiceImpl(
-            søknadRepo = søknadRepoMock,
-            sakService = sakServiceMock,
-            sakFactory = mock(),
-            pdfGenerator = pdfGeneratorMock,
-            dokArkiv = mock(),
-            personService = personServiceMock,
-            oppgaveService = mock(),
-            søknadMetrics = mock(),
-            toggleService = mock(),
-            clock = fixedClock,
-        )
-
-        val actual = søknadService.opprettManglendeJournalpostOgOppgave()
-        actual shouldBe OpprettManglendeJournalpostOgOppgaveResultat(
-            journalpostResultat = listOf(KunneIkkeOppretteJournalpost(sakId, nySøknad.id, "Kunne ikke generere PDF").left()),
-            oppgaveResultat = emptyList()
-        )
-        inOrder(
-            personServiceMock,
-            sakServiceMock,
-            søknadRepoMock,
-            pdfGeneratorMock
-        ) {
-            verify(søknadRepoMock).hentSøknaderUtenJournalpost()
-            verify(sakServiceMock).hentSak(argThat<UUID> { it shouldBe sakId })
-            verify(personServiceMock).hentPersonMedSystembruker(argThat { it shouldBe fnr })
-            verify(pdfGeneratorMock).genererPdf(
-                argThat<SøknadPdfInnhold> {
-                    it shouldBe SøknadPdfInnhold.create(
-                        saksnummer = sak.saksnummer,
-                        søknadsId = it.søknadsId,
-                        navn = person.navn,
-                        søknadOpprettet = nySøknad.opprettet,
-                        søknadInnhold = søknadInnhold,
-                        clock = fixedClock,
-                    )
-                }
+        SøknadServiceOgMocks(
+            søknadRepo = mock {
+                on { hentSøknaderUtenJournalpost() } doReturn listOf(nySøknad)
+                on { hentSøknaderMedJournalpostMenUtenOppgave() } doReturn emptyList()
+            },
+            sakService = mock {
+                on { hentSak(sakId) } doReturn sak.right()
+            },
+            personService = mock {
+                on { hentPersonMedSystembruker(fnr) } doReturn person.right()
+            },
+            pdfGenerator = mock {
+                on { genererPdf(any<SøknadPdfInnhold>()) } doReturn ClientError(0, "").left()
+            }
+        ).also {
+            it.service.opprettManglendeJournalpostOgOppgave() shouldBe OpprettManglendeJournalpostOgOppgaveResultat(
+                journalpostResultat = listOf(KunneIkkeOppretteJournalpost(sakId, nySøknad.id, "Kunne ikke generere PDF").left()),
+                oppgaveResultat = emptyList()
             )
-            verify(søknadRepoMock).hentSøknaderMedJournalpostMenUtenOppgave()
+            inOrder(*it.allMocks()) {
+                verify(it.søknadRepo).hentSøknaderUtenJournalpost()
+                verify(it.sakService).hentSak(argThat<UUID> { it shouldBe sakId })
+                verify(it.personService).hentPersonMedSystembruker(argThat { it shouldBe fnr })
+                verify(it.pdfGenerator).genererPdf(
+                    argThat<SøknadPdfInnhold> {
+                        it shouldBe SøknadPdfInnhold.create(
+                            saksnummer = sak.saksnummer,
+                            søknadsId = it.søknadsId,
+                            navn = person.navn,
+                            søknadOpprettet = nySøknad.opprettet,
+                            søknadInnhold = søknadInnhold,
+                            clock = fixedClock,
+                        )
+                    }
+                )
+                verify(it.søknadRepo).hentSøknaderMedJournalpostMenUtenOppgave()
+            }
+            it.verifyNoMoreInteractions()
         }
-        verifyNoMoreInteractions(personServiceMock, sakServiceMock, søknadRepoMock, pdfGeneratorMock)
     }
 
     @Test
     fun `opprett oppgave feiler`() {
-        val søknadRepoMock = mock<SøknadRepo> {
-            on { hentSøknaderUtenJournalpost() } doReturn emptyList()
-            on { hentSøknaderMedJournalpostMenUtenOppgave() } doReturn listOf(journalførtSøknad)
-        }
-
-        val sakServiceMock = mock<SakService> {
-            on { hentSak(sakId) } doReturn sak.right()
-        }
-
-        val personServiceMock = mock<PersonService> {
-            on { hentPersonMedSystembruker(fnr) } doReturn person.right()
-        }
-
-        val oppgaveServiceMock = mock<OppgaveService> {
-            on { opprettOppgaveMedSystembruker(any()) } doReturn no.nav.su.se.bakover.domain.oppgave.OppgaveFeil.KunneIkkeOppretteOppgave.left()
-        }
-
-        val søknadService = SøknadServiceImpl(
-            søknadRepo = søknadRepoMock,
-            sakService = sakServiceMock,
-            sakFactory = mock(),
-            pdfGenerator = mock(),
-            dokArkiv = mock(),
-            personService = personServiceMock,
-            oppgaveService = oppgaveServiceMock,
-            søknadMetrics = mock(),
-            toggleService = mock(),
-            clock = fixedClock,
-        )
-
-        val actual = søknadService.opprettManglendeJournalpostOgOppgave()
-        actual shouldBe OpprettManglendeJournalpostOgOppgaveResultat(
-            journalpostResultat = emptyList(),
-            oppgaveResultat = listOf(KunneIkkeOppretteOppgave(sakId, journalførtSøknad.id, journalførtSøknad.journalpostId, "Kunne ikke opprette oppgave").left())
-        )
-
-        inOrder(
-            personServiceMock,
-            sakServiceMock,
-            søknadRepoMock,
-            oppgaveServiceMock
-        ) {
-            verify(søknadRepoMock).hentSøknaderUtenJournalpost()
-            verify(søknadRepoMock).hentSøknaderMedJournalpostMenUtenOppgave()
-            verify(sakServiceMock).hentSak(argThat<UUID> { it shouldBe sakId })
-            verify(personServiceMock).hentPersonMedSystembruker(argThat { it shouldBe fnr })
-            verify(oppgaveServiceMock).opprettOppgaveMedSystembruker(
-                argThat {
-                    it shouldBe OppgaveConfig.Søknad(
-                        sakstype = Sakstype.UFØRE,
-                        journalpostId = journalførtSøknad.journalpostId,
-                        søknadId = journalførtSøknad.id,
-                        aktørId = person.ident.aktørId,
-                        clock = fixedClock,
-                        tilordnetRessurs = null,
-                    )
-                },
+        SøknadServiceOgMocks(
+            søknadRepo = mock {
+                on { hentSøknaderUtenJournalpost() } doReturn emptyList()
+                on { hentSøknaderMedJournalpostMenUtenOppgave() } doReturn listOf(journalførtSøknad)
+            },
+            sakService = mock {
+                on { hentSak(sakId) } doReturn sak.right()
+            },
+            personService = mock {
+                on { hentPersonMedSystembruker(fnr) } doReturn person.right()
+            },
+            oppgaveService = mock {
+                on { opprettOppgaveMedSystembruker(any()) } doReturn no.nav.su.se.bakover.domain.oppgave.OppgaveFeil.KunneIkkeOppretteOppgave.left()
+            }
+        ).also {
+            it.service.opprettManglendeJournalpostOgOppgave() shouldBe OpprettManglendeJournalpostOgOppgaveResultat(
+                journalpostResultat = emptyList(),
+                oppgaveResultat = listOf(KunneIkkeOppretteOppgave(sakId, journalførtSøknad.id, journalførtSøknad.journalpostId, "Kunne ikke opprette oppgave").left())
             )
+
+            inOrder(*it.allMocks()) {
+                verify(it.søknadRepo).hentSøknaderUtenJournalpost()
+                verify(it.søknadRepo).hentSøknaderMedJournalpostMenUtenOppgave()
+                verify(it.sakService).hentSak(argThat<UUID> { it shouldBe sakId })
+                verify(it.personService).hentPersonMedSystembruker(argThat { it shouldBe fnr })
+                verify(it.oppgaveService).opprettOppgaveMedSystembruker(
+                    argThat {
+                        it shouldBe OppgaveConfig.Søknad(
+                            sakstype = Sakstype.UFØRE,
+                            journalpostId = journalførtSøknad.journalpostId,
+                            søknadId = journalførtSøknad.id,
+                            aktørId = person.ident.aktørId,
+                            clock = fixedClock,
+                            tilordnetRessurs = null,
+                        )
+                    },
+                )
+            }
+            it.verifyNoMoreInteractions()
         }
-        verifyNoMoreInteractions(personServiceMock, sakServiceMock, søknadRepoMock, oppgaveServiceMock)
     }
 
     @Test
@@ -324,112 +231,92 @@ class OpprettManglendeJournalpostOgOppgaveTest {
         val oppgaveId = OppgaveId("1")
         val pdf = "pdf-data".toByteArray()
 
-        val søknadRepoMock = mock<SøknadRepo> {
-            on { hentSøknaderUtenJournalpost() } doReturn listOf(nySøknad)
-            on { hentSøknaderMedJournalpostMenUtenOppgave() } doReturn listOf(journalførtSøknad)
-        }
-
-        val sakServiceMock = mock<SakService> {
-            on { hentSak(sakId) } doReturn sak.right()
-        }
-
-        val personServiceMock = mock<PersonService> {
-            on { hentPersonMedSystembruker(fnr) } doReturn person.right()
-        }
-
-        val oppgaveServiceMock = mock<OppgaveService> {
-            on { opprettOppgaveMedSystembruker(any()) } doReturn oppgaveId.right()
-        }
-
-        val pdfGeneratorMock: PdfGenerator = mock {
-            on { genererPdf(any<SøknadPdfInnhold>()) } doReturn pdf.right()
-        }
-
-        val dokArkivMock: DokArkiv = mock {
-            on { opprettJournalpost(any()) } doReturn journalførtSøknad.journalpostId.right()
-        }
-
-        val søknadService = SøknadServiceImpl(
-            søknadRepo = søknadRepoMock,
-            sakService = sakServiceMock,
-            sakFactory = mock(),
-            pdfGenerator = pdfGeneratorMock,
-            dokArkiv = dokArkivMock,
-            personService = personServiceMock,
-            oppgaveService = oppgaveServiceMock,
-            søknadMetrics = mock(),
-            toggleService = mock(),
-            clock = fixedClock,
-        )
-
-        val actual = søknadService.opprettManglendeJournalpostOgOppgave()
-        actual shouldBe OpprettManglendeJournalpostOgOppgaveResultat(
-            journalpostResultat = listOf(journalførtSøknad.right()),
-            oppgaveResultat = listOf(journalførtSøknad.medOppgave(oppgaveId).right())
-        )
-
-        inOrder(
-            personServiceMock,
-            sakServiceMock,
-            søknadRepoMock,
-            pdfGeneratorMock,
-            dokArkivMock,
-            oppgaveServiceMock
-        ) {
-            verify(søknadRepoMock).hentSøknaderUtenJournalpost()
-            verify(sakServiceMock).hentSak(argThat<UUID> { it shouldBe sakId })
-            verify(personServiceMock).hentPersonMedSystembruker(argThat { it shouldBe fnr })
-            verify(pdfGeneratorMock).genererPdf(
-                argThat<SøknadPdfInnhold> {
-                    it shouldBe SøknadPdfInnhold.create(
-                        saksnummer = sak.saksnummer,
-                        søknadsId = it.søknadsId,
-                        navn = person.navn,
-                        søknadOpprettet = nySøknad.opprettet,
-                        søknadInnhold = søknadInnhold,
-                        clock = fixedClock,
-                    )
-                }
+        SøknadServiceOgMocks(
+            søknadRepo = mock {
+                on { hentSøknaderUtenJournalpost() } doReturn listOf(nySøknad)
+                on { hentSøknaderMedJournalpostMenUtenOppgave() } doReturn listOf(journalførtSøknad)
+            },
+            sakService = mock {
+                on { hentSak(sakId) } doReturn sak.right()
+            },
+            personService = mock {
+                on { hentPersonMedSystembruker(fnr) } doReturn person.right()
+            },
+            oppgaveService = mock {
+                on { opprettOppgaveMedSystembruker(any()) } doReturn oppgaveId.right()
+            },
+            pdfGenerator = mock {
+                on { genererPdf(any<SøknadPdfInnhold>()) } doReturn pdf.right()
+            },
+            dokArkiv = mock {
+                on { opprettJournalpost(any()) } doReturn journalførtSøknad.journalpostId.right()
+            },
+            søknadMetrics = mock()
+        ).also {
+            it.service.opprettManglendeJournalpostOgOppgave() shouldBe OpprettManglendeJournalpostOgOppgaveResultat(
+                journalpostResultat = listOf(journalførtSøknad.right()),
+                oppgaveResultat = listOf(journalførtSøknad.medOppgave(oppgaveId).right())
             )
-            verify(dokArkivMock).opprettJournalpost(
-                argThat {
-                    it shouldBe Journalpost.Søknadspost.from(
-                        person = person,
-                        saksnummer = Saksnummer(2021),
-                        søknadInnhold = søknadInnhold,
-                        pdf = pdf,
-                    )
-                },
-            )
-            verify(søknadRepoMock).oppdaterjournalpostId(argThat { journalførtSøknad.id })
-            verify(søknadRepoMock).hentSøknaderMedJournalpostMenUtenOppgave()
-            verify(sakServiceMock).hentSak(argThat<UUID> { it shouldBe sakId })
-            verify(personServiceMock).hentPersonMedSystembruker(argThat { it shouldBe fnr })
-            verify(oppgaveServiceMock).opprettOppgaveMedSystembruker(
-                argThat {
-                    it shouldBe OppgaveConfig.Søknad(
-                        sakstype = Sakstype.UFØRE,
-                        journalpostId = journalførtSøknad.journalpostId,
-                        søknadId = journalførtSøknad.id,
-                        aktørId = person.ident.aktørId,
-                        clock = fixedClock,
-                        tilordnetRessurs = null,
-                    )
-                },
-            )
-            verify(søknadRepoMock).oppdaterOppgaveId(
-                argThat {
-                    it shouldBe Søknad.Journalført.MedOppgave.IkkeLukket(
-                        id = journalførtSøknad.id,
-                        opprettet = journalførtSøknad.opprettet,
-                        sakId = sakId,
-                        søknadInnhold = søknadInnhold,
-                        journalpostId = journalførtSøknad.journalpostId,
-                        oppgaveId = oppgaveId
-                    )
-                }
-            )
+
+            inOrder(*it.allMocks()) {
+                verify(it.søknadRepo).hentSøknaderUtenJournalpost()
+                verify(it.sakService).hentSak(argThat<UUID> { it shouldBe sakId })
+                verify(it.personService).hentPersonMedSystembruker(argThat { it shouldBe fnr })
+                verify(it.pdfGenerator).genererPdf(
+                    argThat<SøknadPdfInnhold> {
+                        it shouldBe SøknadPdfInnhold.create(
+                            saksnummer = sak.saksnummer,
+                            søknadsId = it.søknadsId,
+                            navn = person.navn,
+                            søknadOpprettet = nySøknad.opprettet,
+                            søknadInnhold = søknadInnhold,
+                            clock = fixedClock,
+                        )
+                    }
+                )
+                verify(it.dokArkiv).opprettJournalpost(
+                    argThat {
+                        it shouldBe Journalpost.Søknadspost.from(
+                            person = person,
+                            saksnummer = Saksnummer(2021),
+                            søknadInnhold = søknadInnhold,
+                            pdf = pdf,
+                        )
+                    },
+                )
+                verify(it.søknadRepo).oppdaterjournalpostId(argThat { journalførtSøknad.id })
+                verify(it.søknadMetrics).incrementNyCounter(SøknadMetrics.NyHandlinger.JOURNALFØRT)
+                verify(it.søknadRepo).hentSøknaderMedJournalpostMenUtenOppgave()
+                verify(it.sakService).hentSak(argThat<UUID> { it shouldBe sakId })
+                verify(it.personService).hentPersonMedSystembruker(argThat { it shouldBe fnr })
+                verify(it.oppgaveService).opprettOppgaveMedSystembruker(
+                    argThat {
+                        it shouldBe OppgaveConfig.Søknad(
+                            sakstype = Sakstype.UFØRE,
+                            journalpostId = journalførtSøknad.journalpostId,
+                            søknadId = journalførtSøknad.id,
+                            aktørId = person.ident.aktørId,
+                            clock = fixedClock,
+                            tilordnetRessurs = null,
+                        )
+                    },
+                )
+                verify(it.søknadRepo).oppdaterOppgaveId(
+                    argThat {
+                        it shouldBe Søknad.Journalført.MedOppgave.IkkeLukket(
+                            id = journalførtSøknad.id,
+                            opprettet = journalførtSøknad.opprettet,
+                            sakId = sakId,
+                            søknadInnhold = søknadInnhold,
+                            innsendtAv = veileder,
+                            journalpostId = journalførtSøknad.journalpostId,
+                            oppgaveId = oppgaveId
+                        )
+                    }
+                )
+                verify(it.søknadMetrics).incrementNyCounter(SøknadMetrics.NyHandlinger.OPPRETTET_OPPGAVE)
+            }
+            it.verifyNoMoreInteractions()
         }
-        verifyNoMoreInteractions(personServiceMock, sakServiceMock, søknadRepoMock, pdfGeneratorMock, dokArkivMock, oppgaveServiceMock)
     }
 }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/SøknadServiceOgMocks.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/SøknadServiceOgMocks.kt
@@ -9,25 +9,24 @@ import no.nav.su.se.bakover.service.oppgave.OppgaveService
 import no.nav.su.se.bakover.service.person.PersonService
 import no.nav.su.se.bakover.service.sak.SakService
 import no.nav.su.se.bakover.service.toggles.ToggleService
+import no.nav.su.se.bakover.test.defaultMock
 import no.nav.su.se.bakover.test.fixedClock
-import org.mockito.kotlin.mock
 import java.time.Clock
 
 /**
  * Kjører verifyNoMoreInteractions() etter runTest
  */
-internal data class SøknadserviceOgMocks(
-    val søknadRepo: SøknadRepo = mock(),
-    val sakService: SakService = mock(),
+internal data class SøknadServiceOgMocks(
+    val søknadRepo: SøknadRepo = defaultMock(),
+    val sakService: SakService = defaultMock(),
     val sakFactory: SakFactory = SakFactory(clock = fixedClock),
-    val pdfGenerator: PdfGenerator = mock(),
-    val dokArkiv: DokArkiv = mock(),
-    val personService: PersonService = mock(),
-    val oppgaveService: OppgaveService = mock(),
-    val søknadMetrics: SøknadMetrics = mock(),
-    val toggleService: ToggleService = mock(),
+    val pdfGenerator: PdfGenerator = defaultMock(),
+    val dokArkiv: DokArkiv = defaultMock(),
+    val personService: PersonService = defaultMock(),
+    val oppgaveService: OppgaveService = defaultMock(),
+    val søknadMetrics: SøknadMetrics = defaultMock(),
+    val toggleService: ToggleService = defaultMock(),
     val clock: Clock = fixedClock,
-    val runTest: SøknadserviceOgMocks.() -> Unit,
 ) {
     val service = SøknadServiceImpl(
         søknadRepo = søknadRepo,
@@ -42,11 +41,6 @@ internal data class SøknadserviceOgMocks(
         clock = fixedClock,
     )
 
-    init {
-        runTest()
-        verifyNoMoreInteractions()
-    }
-
     fun allMocks() = listOf(
         søknadRepo,
         sakService,
@@ -55,9 +49,10 @@ internal data class SøknadserviceOgMocks(
         personService,
         oppgaveService,
         søknadMetrics,
+        toggleService,
     ).toTypedArray()
 
-    private fun verifyNoMoreInteractions() {
+    fun verifyNoMoreInteractions() {
         org.mockito.kotlin.verifyNoMoreInteractions(
             *allMocks(),
         )

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/SøknadTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/SøknadTest.kt
@@ -4,18 +4,15 @@ import arrow.core.left
 import arrow.core.right
 import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import no.nav.su.se.bakover.client.ClientError
-import no.nav.su.se.bakover.client.dokarkiv.DokArkiv
 import no.nav.su.se.bakover.client.dokarkiv.Journalpost
-import no.nav.su.se.bakover.client.pdf.PdfGenerator
+import no.nav.su.se.bakover.client.stubs.pdf.PdfGeneratorStub.genererPdf
 import no.nav.su.se.bakover.client.stubs.person.PersonOppslagStub
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.NySak
 import no.nav.su.se.bakover.domain.Person
 import no.nav.su.se.bakover.domain.Sak
-import no.nav.su.se.bakover.domain.SakFactory
 import no.nav.su.se.bakover.domain.Saksnummer
 import no.nav.su.se.bakover.domain.Sakstype
 import no.nav.su.se.bakover.domain.Søknad
@@ -29,18 +26,13 @@ import no.nav.su.se.bakover.domain.person.KunneIkkeHentePerson
 import no.nav.su.se.bakover.domain.sak.SakInfo
 import no.nav.su.se.bakover.domain.søknad.SøknadMetrics
 import no.nav.su.se.bakover.domain.søknad.SøknadPdfInnhold
-import no.nav.su.se.bakover.domain.søknad.SøknadRepo
 import no.nav.su.se.bakover.domain.søknadinnhold.Personopplysninger
 import no.nav.su.se.bakover.domain.søknadinnhold.SøknadsinnholdUføre
 import no.nav.su.se.bakover.service.argThat
-import no.nav.su.se.bakover.service.oppgave.OppgaveService
-import no.nav.su.se.bakover.service.person.PersonService
 import no.nav.su.se.bakover.service.sak.FantIkkeSak
-import no.nav.su.se.bakover.service.sak.SakService
-import no.nav.su.se.bakover.service.statistikk.Event
-import no.nav.su.se.bakover.service.statistikk.EventObserver
 import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.fixedTidspunkt
+import no.nav.su.se.bakover.test.getOrFail
 import no.nav.su.se.bakover.test.søknadsbehandlingIverksattInnvilget
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -48,7 +40,6 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
 import java.util.UUID
 
@@ -57,7 +48,6 @@ class SøknadTest {
     private val søknadInnhold: SøknadsinnholdUføre = SøknadInnholdTestdataBuilder.build()
     private val fnr = søknadInnhold.personopplysninger.fnr
     private val person: Person = PersonOppslagStub.person(fnr).orNull()!!
-    private val sakFactory: SakFactory = SakFactory(clock = fixedClock)
     private val sakId = UUID.randomUUID()
     private val saksnummer = Saksnummer(2021)
     private val sak: Sak = Sak(
@@ -76,333 +66,169 @@ class SøknadTest {
 
     @Test
     fun `Fant ikke person`() {
-        val personServiceMock = mock<PersonService> {
-            on { hentPerson(any()) } doReturn KunneIkkeHentePerson.FantIkkePerson.left()
+        SøknadServiceOgMocks(
+            personService = mock {
+                on { hentPerson(any()) } doReturn KunneIkkeHentePerson.FantIkkePerson.left()
+            }
+        ).also {
+            it.service.nySøknad(søknadInnhold, innsender) shouldBe KunneIkkeOppretteSøknad.FantIkkePerson.left()
         }
-        val søknadRepoMock: SøknadRepo = mock()
-        val sakServiceMock: SakService = mock()
-        val pdfGeneratorMock: PdfGenerator = mock()
-        val dokArkivMock: DokArkiv = mock()
-        val oppgaveServiceMock: OppgaveService = mock()
-        val observerMock: EventObserver = mock()
-
-        val søknadService = SøknadServiceImpl(
-            søknadRepo = søknadRepoMock,
-            sakService = sakServiceMock,
-            sakFactory = sakFactory,
-            pdfGenerator = pdfGeneratorMock,
-            dokArkiv = dokArkivMock,
-            personService = personServiceMock,
-            oppgaveService = oppgaveServiceMock,
-            søknadMetrics = mock(),
-            toggleService = mock(),
-            clock = fixedClock,
-        ).apply { addObserver(observerMock) }
-
-        søknadService.nySøknad(søknadInnhold, innsender) shouldBe KunneIkkeOppretteSøknad.FantIkkePerson.left()
-        verify(personServiceMock).hentPerson(argThat { it shouldBe fnr })
-        verifyNoMoreInteractions(
-            personServiceMock,
-            søknadRepoMock,
-            sakServiceMock,
-            pdfGeneratorMock,
-            dokArkivMock,
-            oppgaveServiceMock
-        )
-        verifyNoInteractions(observerMock)
     }
 
     @Test
     fun `ny sak med søknad hvor pdf-generering feilet`() {
-        val personServiceMock = mock<PersonService> {
-            on { hentPerson(any()) } doReturn person.right()
-        }
-        val sakServiceMock: SakService = mock {
-            on { hentSakidOgSaksnummer(any()) } doReturn FantIkkeSak.left() doReturn SakInfo(sak.id, sak.saksnummer, fnr, Sakstype.UFØRE).right()
-        }
+        SøknadServiceOgMocks(
+            personService = mock {
+                on { hentPerson(any()) } doReturn person.right()
+            },
+            sakService = mock {
+                on { hentSakidOgSaksnummer(any()) } doReturn FantIkkeSak.left() doReturn SakInfo(sak.id, sak.saksnummer, fnr, Sakstype.UFØRE).right()
+            },
+            pdfGenerator = mock {
+                on { genererPdf(any<SøknadPdfInnhold>()) } doReturn ClientError(1, "").left()
+            },
+            søknadMetrics = mock()
+        ).also {
+            val actual = it.service.nySøknad(søknadInnhold, innsender)
 
-        val pdfGeneratorMock: PdfGenerator = mock {
-            on { genererPdf(any<SøknadPdfInnhold>()) } doReturn ClientError(1, "").left()
-        }
-        val dokArkivMock: DokArkiv = mock()
-        val søknadRepoMock: SøknadRepo = mock()
-        val oppgaveServiceMock: OppgaveService = mock()
-        val søknadService = SøknadServiceImpl(
-            søknadRepo = søknadRepoMock,
-            sakService = sakServiceMock,
-            sakFactory = sakFactory,
-            pdfGenerator = pdfGeneratorMock,
-            dokArkiv = dokArkivMock,
-            personService = personServiceMock,
-            oppgaveService = oppgaveServiceMock,
-            søknadMetrics = mock(),
-            toggleService = mock(),
-            clock = fixedClock,
-        )
-
-        val actual = søknadService.nySøknad(søknadInnhold, innsender)
-
-        inOrder(
-            personServiceMock,
-            sakServiceMock,
-            pdfGeneratorMock
-        ) {
-            verify(personServiceMock).hentPerson(argThat { it shouldBe fnr })
-            verify(sakServiceMock).hentSakidOgSaksnummer(argThat { it shouldBe fnr })
-            verify(sakServiceMock).opprettSak(
-                argThat {
-                    it shouldBe NySak(
-                        id = it.id,
-                        opprettet = it.opprettet,
-                        fnr = fnr,
-                        søknad = Søknad.Ny(
-                            id = it.søknad.id,
-                            opprettet = it.søknad.opprettet,
-                            sakId = it.id,
-                            søknadInnhold = søknadInnhold,
-                        ),
-                    )
-                }
-            )
-            verify(sakServiceMock).hentSakidOgSaksnummer(argThat { it shouldBe fnr })
-            verify(pdfGeneratorMock).genererPdf(
-                argThat<SøknadPdfInnhold> {
-                    it shouldBe SøknadPdfInnhold.create(
-                        saksnummer = sak.saksnummer,
-                        søknadsId = it.søknadsId,
-                        navn = person.navn,
-                        søknadOpprettet = actual.orNull()!!.second.opprettet,
-                        søknadInnhold = søknadInnhold,
-                        clock = fixedClock,
-                    )
-                }
-            )
-        }
-        verifyNoMoreInteractions(
-            personServiceMock,
-            søknadRepoMock,
-            sakServiceMock,
-            pdfGeneratorMock,
-            dokArkivMock,
-            oppgaveServiceMock
-        )
-        actual.orNull()!!.apply {
-            first shouldBe sak.saksnummer
-            second.shouldBeEqualToIgnoringFields(
-                Søknad.Ny(
-                    id = UUID.randomUUID(), // ignored
-                    opprettet = fixedTidspunkt,
-                    sakId = UUID.randomUUID(), // ignored
-                    søknadInnhold = søknadInnhold,
-                ),
-                Søknad.Ny::id, Søknad.Ny::sakId
-            )
-        }
-    }
-
-    @Test
-    fun `nye søknader bortsett fra den første skal ha en annerledes opprettet tidspunkt`() {
-        val sak = sak.copy(
-            søknader = listOf<Søknad>(
-                Søknad.Ny(
-                    id = UUID.randomUUID(),
-                    opprettet = Tidspunkt.EPOCH,
-                    sakId = sak.id,
-                    søknadInnhold = søknadInnhold
+            inOrder(
+                it.personService,
+                it.sakService,
+                it.pdfGenerator
+            ) {
+                verify(it.personService).hentPerson(argThat { it shouldBe fnr })
+                verify(it.sakService).hentSakidOgSaksnummer(argThat { it shouldBe fnr })
+                verify(it.sakService).opprettSak(
+                    argThat {
+                        it shouldBe NySak(
+                            id = it.id,
+                            opprettet = it.opprettet,
+                            fnr = fnr,
+                            søknad = Søknad.Ny(
+                                id = it.søknad.id,
+                                opprettet = it.søknad.opprettet,
+                                sakId = it.id,
+                                søknadInnhold = søknadInnhold,
+                                innsendtAv = innsender,
+                            ),
+                        )
+                    }
                 )
-            )
-        )
-        val personServiceMock = mock<PersonService> {
-            on { hentPerson(any()) } doReturn person.right()
-        }
-        val sakServiceMock: SakService = mock {
-            on { hentSakidOgSaksnummer(any()) } doReturn SakInfo(sak.id, sak.saksnummer, fnr, Sakstype.UFØRE).right()
-        }
-        val søknadRepoMock: SøknadRepo = mock()
-        val pdfGeneratorMock: PdfGenerator = mock {
-            on { genererPdf(any<SøknadPdfInnhold>()) } doReturn pdf.right()
-        }
-        val dokArkivMock: DokArkiv = mock {
-            on { opprettJournalpost(any()) } doReturn journalpostId.right()
-        }
-
-        val oppgaveServiceMock: OppgaveService = mock {
-            on { opprettOppgave(any()) } doReturn oppgaveId.right()
-        }
-        val observerMock = mock<EventObserver>()
-
-        val søknadService = SøknadServiceImpl(
-            søknadRepo = søknadRepoMock,
-            sakService = sakServiceMock,
-            sakFactory = sakFactory,
-            pdfGenerator = pdfGeneratorMock,
-            dokArkiv = dokArkivMock,
-            personService = personServiceMock,
-            oppgaveService = oppgaveServiceMock,
-            søknadMetrics = mock(),
-            toggleService = mock(),
-            clock = fixedClock,
-        ).apply { addObserver(observerMock) }
-
-        val nySøknad = søknadService.nySøknad(søknadInnhold, innsender)
-
-        inOrder(
-            personServiceMock,
-            sakServiceMock,
-            søknadRepoMock,
-            pdfGeneratorMock,
-            dokArkivMock,
-            observerMock
-        ) {
-            verify(personServiceMock).hentPerson(argThat { it shouldBe fnr })
-            verify(sakServiceMock).hentSakidOgSaksnummer(argThat { it shouldBe fnr })
-            verify(søknadRepoMock).opprettSøknad(
-                argThat {
-                    it shouldBe Søknad.Ny(
-                        id = it.id,
-                        opprettet = it.opprettet,
-                        sakId = sakId,
+                verify(it.sakService).hentSakidOgSaksnummer(argThat { it shouldBe fnr })
+                verify(it.pdfGenerator).genererPdf(
+                    argThat<SøknadPdfInnhold> {
+                        it shouldBe SøknadPdfInnhold.create(
+                            saksnummer = sak.saksnummer,
+                            søknadsId = it.søknadsId,
+                            navn = person.navn,
+                            søknadOpprettet = actual.getOrFail().second.opprettet,
+                            søknadInnhold = søknadInnhold,
+                            clock = fixedClock,
+                        )
+                    }
+                )
+            }
+            actual.getOrFail().apply {
+                first shouldBe sak.saksnummer
+                second.shouldBeEqualToIgnoringFields(
+                    Søknad.Ny(
+                        id = UUID.randomUUID(), // ignored
+                        opprettet = fixedTidspunkt,
+                        sakId = UUID.randomUUID(), // ignored
                         søknadInnhold = søknadInnhold,
-                    )
-                },
-                argThat { it shouldBe innsender }
-            )
-            verify(pdfGeneratorMock).genererPdf(
-                argThat<SøknadPdfInnhold> {
-                    it shouldBe SøknadPdfInnhold.create(
-                        saksnummer = sak.saksnummer,
-                        søknadsId = it.søknadsId,
-                        navn = person.navn,
-                        søknadOpprettet = nySøknad.orNull()!!.second.opprettet,
-                        søknadInnhold = søknadInnhold,
-                        clock = fixedClock,
-                    )
-                }
-            )
-            verify(dokArkivMock).opprettJournalpost(
-                argThat {
-                    it shouldBe Journalpost.Søknadspost.from(
-                        person = person,
-                        saksnummer = saksnummer,
-                        søknadInnhold = søknadInnhold,
-                        pdf = pdf,
-                    )
-                },
-            )
-        }
-        verify(observerMock).handle(argThat { it shouldBe Event.Statistikk.SøknadStatistikk.SøknadMottatt(nySøknad.orNull()!!.second, sak.saksnummer) })
-
-        nySøknad.map { (_, søknad) ->
-            søknad.opprettet shouldNotBe sak.søknader.first().opprettet
+                        innsendtAv = innsender,
+                    ),
+                    Søknad.Ny::id, Søknad.Ny::sakId
+                )
+            }
         }
     }
 
     @Test
     fun `eksisterende sak med søknad hvor journalføring feiler`() {
-        val personServiceMock = mock<PersonService> {
-            on { hentPerson(any()) } doReturn person.right()
-        }
-        val sakServiceMock: SakService = mock {
-            on { hentSakidOgSaksnummer(any()) } doReturn SakInfo(sak.id, sak.saksnummer, fnr, Sakstype.UFØRE).right()
-        }
-        val søknadRepoMock: SøknadRepo = mock()
-        val pdfGeneratorMock: PdfGenerator = mock {
-            on { genererPdf(any<SøknadPdfInnhold>()) } doReturn pdf.right()
-        }
-        val dokArkivMock: DokArkiv = mock {
-            on { opprettJournalpost(any()) } doReturn ClientError(1, "").left()
-        }
-
-        val oppgaveServiceMock: OppgaveService = mock()
-
-        val søknadService = SøknadServiceImpl(
-            søknadRepo = søknadRepoMock,
-            sakService = sakServiceMock,
-            sakFactory = sakFactory,
-            pdfGenerator = pdfGeneratorMock,
-            dokArkiv = dokArkivMock,
-            personService = personServiceMock,
-            oppgaveService = oppgaveServiceMock,
+        SøknadServiceOgMocks(
+            personService = mock {
+                on { hentPerson(any()) } doReturn person.right()
+            },
+            sakService = mock {
+                on { hentSakidOgSaksnummer(any()) } doReturn SakInfo(sak.id, sak.saksnummer, fnr, Sakstype.UFØRE).right()
+            },
+            pdfGenerator = mock {
+                on { genererPdf(any<SøknadPdfInnhold>()) } doReturn pdf.right()
+            },
             søknadMetrics = mock(),
-            toggleService = mock(),
-            clock = fixedClock,
-        )
+            dokArkiv = mock {
+                on { opprettJournalpost(any()) } doReturn ClientError(1, "").left()
+            },
+            søknadRepo = mock()
+        ).also {
+            val actual = it.service.nySøknad(søknadInnhold, innsender)
 
-        val actual = søknadService.nySøknad(søknadInnhold, innsender)
-
-        inOrder(
-            personServiceMock,
-            sakServiceMock,
-            søknadRepoMock,
-            pdfGeneratorMock,
-            dokArkivMock
-        ) {
-            verify(personServiceMock).hentPerson(argThat { it shouldBe fnr })
-            verify(sakServiceMock).hentSakidOgSaksnummer(argThat { it shouldBe fnr })
-            verify(søknadRepoMock).opprettSøknad(
-                argThat {
-                    it shouldBe Søknad.Ny(
-                        id = it.id,
-                        opprettet = it.opprettet,
-                        sakId = sakId,
+            inOrder(
+                it.personService,
+                it.sakService,
+                it.søknadRepo,
+                it.pdfGenerator,
+                it.dokArkiv
+            ) {
+                verify(it.personService).hentPerson(argThat { it shouldBe fnr })
+                verify(it.sakService).hentSakidOgSaksnummer(argThat { it shouldBe fnr })
+                verify(it.søknadRepo).opprettSøknad(
+                    argThat {
+                        it shouldBe Søknad.Ny(
+                            id = it.id,
+                            opprettet = it.opprettet,
+                            sakId = sakId,
+                            søknadInnhold = søknadInnhold,
+                            innsendtAv = innsender,
+                        )
+                    }
+                )
+                verify(it.pdfGenerator).genererPdf(
+                    argThat<SøknadPdfInnhold> {
+                        it shouldBe SøknadPdfInnhold.create(
+                            saksnummer = sak.saksnummer,
+                            søknadsId = it.søknadsId,
+                            navn = person.navn,
+                            søknadOpprettet = actual.getOrFail().second.opprettet,
+                            søknadInnhold = søknadInnhold,
+                            clock = fixedClock,
+                        )
+                    }
+                )
+                verify(it.dokArkiv).opprettJournalpost(
+                    argThat {
+                        it shouldBe Journalpost.Søknadspost.from(
+                            person = person,
+                            saksnummer = saksnummer,
+                            søknadInnhold = søknadInnhold,
+                            pdf = pdf,
+                        )
+                    },
+                )
+            }
+            actual.getOrFail().apply {
+                first shouldBe sak.saksnummer
+                second.shouldBeEqualToIgnoringFields(
+                    Søknad.Ny(
+                        id = UUID.randomUUID(), // ignored
+                        opprettet = fixedTidspunkt,
+                        sakId = UUID.randomUUID(), // ignored
                         søknadInnhold = søknadInnhold,
-                    )
-                },
-                argThat { it shouldBe innsender }
-            )
-            verify(pdfGeneratorMock).genererPdf(
-                argThat<SøknadPdfInnhold> {
-                    it shouldBe SøknadPdfInnhold.create(
-                        saksnummer = sak.saksnummer,
-                        søknadsId = it.søknadsId,
-                        navn = person.navn,
-                        søknadOpprettet = actual.orNull()!!.second.opprettet,
-                        søknadInnhold = søknadInnhold,
-                        clock = fixedClock,
-                    )
-                }
-            )
-            verify(dokArkivMock).opprettJournalpost(
-                argThat {
-                    it shouldBe Journalpost.Søknadspost.from(
-                        person = person,
-                        saksnummer = saksnummer,
-                        søknadInnhold = søknadInnhold,
-                        pdf = pdf,
-                    )
-                },
-            )
-        }
-        verifyNoMoreInteractions(
-            personServiceMock,
-            søknadRepoMock,
-            sakServiceMock,
-            pdfGeneratorMock,
-            dokArkivMock,
-            oppgaveServiceMock
-        )
-
-        actual.orNull()!!.apply {
-            first shouldBe sak.saksnummer
-            second.shouldBeEqualToIgnoringFields(
-                Søknad.Ny(
-                    id = UUID.randomUUID(), // ignored
-                    opprettet = fixedTidspunkt,
-                    sakId = UUID.randomUUID(), // ignored
-                    søknadInnhold = søknadInnhold,
-                ),
-                Søknad.Ny::id, Søknad.Ny::sakId
-            )
+                        innsendtAv = innsender,
+                    ),
+                    Søknad.Ny::id, Søknad.Ny::sakId
+                )
+            }
         }
     }
 
     @Test
     fun `eksisterende sak med søknad hvor oppgave feiler`() {
-
         val (sak, _) = søknadsbehandlingIverksattInnvilget()
-        val person = PersonOppslagStub.person(sak.fnr).orNull()!!
+        val person = PersonOppslagStub.person(sak.fnr).getOrFail()
 
-        SøknadserviceOgMocks(
+        SøknadServiceOgMocks(
             sakService = mock {
                 on { hentSakidOgSaksnummer(any()) } doReturn SakInfo(sak.id, sak.saksnummer, fnr, Sakstype.UFØRE).right()
             },
@@ -418,37 +244,40 @@ class SøknadTest {
             oppgaveService = mock {
                 on { opprettOppgave(any()) } doReturn KunneIkkeOppretteOppgave.left()
             },
-        ) {
+            søknadRepo = mock(),
+            søknadMetrics = mock(),
+            toggleService = mock(),
+        ).also {
             val søknadInnhold = SøknadInnholdTestdataBuilder.build(personopplysninger = Personopplysninger(sak.fnr))
-            val actual = service.nySøknad(søknadInnhold, innsender)
-            inOrder(*allMocks()) {
-                verify(personService).hentPerson(argThat { it shouldBe sak.fnr })
-                verify(sakService).hentSakidOgSaksnummer(argThat { it shouldBe sak.fnr })
-                verify(søknadRepo).opprettSøknad(
+            val actual = it.service.nySøknad(søknadInnhold, innsender)
+            inOrder(*it.allMocks()) {
+                verify(it.personService).hentPerson(argThat { it shouldBe sak.fnr })
+                verify(it.sakService).hentSakidOgSaksnummer(argThat { it shouldBe sak.fnr })
+                verify(it.søknadRepo).opprettSøknad(
                     argThat {
                         it shouldBe Søknad.Ny(
                             id = it.id,
                             opprettet = it.opprettet,
                             sakId = sak.id,
                             søknadInnhold = søknadInnhold,
+                            innsendtAv = innsender,
                         )
-                    },
-                    argThat { it shouldBe innsender }
+                    }
                 )
-                verify(søknadMetrics).incrementNyCounter(SøknadMetrics.NyHandlinger.PERSISTERT)
-                verify(pdfGenerator).genererPdf(
+                verify(it.søknadMetrics).incrementNyCounter(SøknadMetrics.NyHandlinger.PERSISTERT)
+                verify(it.pdfGenerator).genererPdf(
                     argThat<SøknadPdfInnhold> {
                         it shouldBe SøknadPdfInnhold.create(
                             saksnummer = sak.saksnummer,
                             søknadsId = it.søknadsId,
                             navn = person.navn,
-                            søknadOpprettet = actual.orNull()!!.second.opprettet,
+                            søknadOpprettet = actual.getOrFail().second.opprettet,
                             søknadInnhold = søknadInnhold,
                             clock = fixedClock,
                         )
                     },
                 )
-                verify(dokArkiv).opprettJournalpost(
+                verify(it.dokArkiv).opprettJournalpost(
                     argThat {
                         it shouldBe Journalpost.Søknadspost.from(
                             person = person,
@@ -458,7 +287,7 @@ class SøknadTest {
                         )
                     },
                 )
-                verify(søknadRepo).oppdaterjournalpostId(
+                verify(it.søknadRepo).oppdaterjournalpostId(
                     argThat {
                         it.shouldBeEqualToIgnoringFields(
                             Søknad.Journalført.UtenOppgave(
@@ -466,14 +295,15 @@ class SøknadTest {
                                 opprettet = fixedTidspunkt,
                                 sakId = sak.id,
                                 søknadInnhold = søknadInnhold,
+                                innsendtAv = innsender,
                                 journalpostId = journalpostId,
                             ),
                             Søknad.Journalført.UtenOppgave::id,
                         )
                     },
                 )
-                verify(søknadMetrics).incrementNyCounter(SøknadMetrics.NyHandlinger.JOURNALFØRT)
-                verify(oppgaveService).opprettOppgave(
+                verify(it.søknadMetrics).incrementNyCounter(SøknadMetrics.NyHandlinger.JOURNALFØRT)
+                verify(it.oppgaveService).opprettOppgave(
                     argThat {
                         it.shouldBeEqualToIgnoringFields(
                             OppgaveConfig.Søknad(
@@ -490,7 +320,7 @@ class SøknadTest {
                     },
                 )
             }
-            actual.orNull()!!.apply {
+            actual.getOrFail().apply {
                 first shouldBe sak.saksnummer
                 second.shouldBeEqualToIgnoringFields(
                     Søknad.Ny(
@@ -498,6 +328,7 @@ class SøknadTest {
                         opprettet = fixedTidspunkt,
                         sakId = UUID.randomUUID(), // ignored
                         søknadInnhold = søknadInnhold,
+                        innsendtAv = innsender,
                     ),
                     Søknad.Ny::id, Søknad.Ny::sakId,
                 )
@@ -507,147 +338,140 @@ class SøknadTest {
 
     @Test
     fun `eksisterende sak med søknad hvor oppgavekallet går bra`() {
-        val personServiceMock = mock<PersonService> {
-            on { hentPerson(any()) } doReturn person.right()
-        }
-        val sakServiceMock: SakService = mock {
-            on { hentSakidOgSaksnummer(any()) } doReturn SakInfo(sak.id, sak.saksnummer, fnr, Sakstype.UFØRE).right()
-        }
-        val søknadRepoMock: SøknadRepo = mock()
-        val pdfGeneratorMock: PdfGenerator = mock {
-            on { genererPdf(any<SøknadPdfInnhold>()) } doReturn pdf.right()
-        }
-        val dokArkivMock: DokArkiv = mock {
-            on { opprettJournalpost(any()) } doReturn journalpostId.right()
-        }
+        SøknadServiceOgMocks(
+            personService = mock {
+                on { hentPerson(any()) } doReturn person.right()
+            },
+            sakService = mock {
+                on { hentSakidOgSaksnummer(any()) } doReturn SakInfo(sak.id, sak.saksnummer, fnr, Sakstype.UFØRE).right()
+            },
+            pdfGenerator = mock {
+                on { genererPdf(any<SøknadPdfInnhold>()) } doReturn pdf.right()
+            },
+            dokArkiv = mock {
+                on { opprettJournalpost(any()) } doReturn journalpostId.right()
+            },
+            oppgaveService = mock {
+                on { opprettOppgave(any()) } doReturn oppgaveId.right()
+            },
+            søknadRepo = mock(),
+            søknadMetrics = mock()
+        ).also {
+            val actual = it.service.nySøknad(søknadInnhold, innsender)
 
-        val oppgaveServiceMock: OppgaveService = mock {
-            on { opprettOppgave(any()) } doReturn oppgaveId.right()
-        }
-
-        val søknadService = SøknadServiceImpl(
-            søknadRepo = søknadRepoMock,
-            sakService = sakServiceMock,
-            sakFactory = sakFactory,
-            pdfGenerator = pdfGeneratorMock,
-            dokArkiv = dokArkivMock,
-            personService = personServiceMock,
-            oppgaveService = oppgaveServiceMock,
-            søknadMetrics = mock(),
-            toggleService = mock(),
-            clock = fixedClock,
-        )
-
-        val actual = søknadService.nySøknad(søknadInnhold, innsender)
-        inOrder(
-            personServiceMock,
-            sakServiceMock,
-            søknadRepoMock,
-            pdfGeneratorMock,
-            dokArkivMock,
-            oppgaveServiceMock
-        ) {
-            verify(personServiceMock).hentPerson(argThat { it shouldBe fnr })
-            verify(sakServiceMock).hentSakidOgSaksnummer(argThat { it shouldBe fnr })
-            verify(søknadRepoMock).opprettSøknad(
-                argThat {
-                    it shouldBe Søknad.Ny(
-                        id = it.id,
-                        opprettet = it.opprettet,
-                        sakId = sakId,
-                        søknadInnhold = søknadInnhold,
-                    )
-                },
-                argThat { it shouldBe innsender }
-            )
-            verify(pdfGeneratorMock).genererPdf(
-                argThat<SøknadPdfInnhold> {
-                    it shouldBe SøknadPdfInnhold.create(
-                        saksnummer = sak.saksnummer,
-                        søknadsId = it.søknadsId,
-                        navn = person.navn,
-                        søknadOpprettet = actual.orNull()!!.second.opprettet,
-                        søknadInnhold = søknadInnhold,
-                        clock = fixedClock,
-                    )
-                }
-            )
-            verify(dokArkivMock).opprettJournalpost(
-                argThat {
-                    it shouldBe Journalpost.Søknadspost.from(
-                        person = person,
-                        saksnummer = saksnummer,
-                        søknadInnhold = søknadInnhold,
-                        pdf = pdf,
-                    )
-                },
-            )
-            verify(søknadRepoMock).oppdaterjournalpostId(
-                argThat {
-                    it.shouldBeEqualToIgnoringFields(
-                        Søknad.Journalført.UtenOppgave(
-                            id = UUID.randomUUID(), // ignored
-                            opprettet = fixedTidspunkt,
+            inOrder(
+                it.personService,
+                it.sakService,
+                it.søknadRepo,
+                it.pdfGenerator,
+                it.dokArkiv,
+                it.oppgaveService
+            ) {
+                verify(it.personService).hentPerson(argThat { it shouldBe fnr })
+                verify(it.sakService).hentSakidOgSaksnummer(argThat { it shouldBe fnr })
+                verify(it.søknadRepo).opprettSøknad(
+                    argThat {
+                        it shouldBe Søknad.Ny(
+                            id = it.id,
+                            opprettet = it.opprettet,
                             sakId = sakId,
                             søknadInnhold = søknadInnhold,
-                            journalpostId = journalpostId,
-                        ),
-                        Søknad.Journalført.MedOppgave::id
-                    )
-                }
-            )
-            verify(oppgaveServiceMock).opprettOppgave(
-                argThat {
-                    it.shouldBeEqualToIgnoringFields(
-                        OppgaveConfig.Søknad(
-                            sakstype = Sakstype.UFØRE,
-                            journalpostId = journalpostId,
-                            søknadId = UUID.randomUUID(), // ignored
-                            aktørId = person.ident.aktørId,
-                            tilordnetRessurs = null,
+                            innsendtAv = innsender,
+                        )
+                    }
+                )
+                verify(it.pdfGenerator).genererPdf(
+                    argThat<SøknadPdfInnhold> {
+                        it shouldBe SøknadPdfInnhold.create(
+                            saksnummer = sak.saksnummer,
+                            søknadsId = it.søknadsId,
+                            navn = person.navn,
+                            søknadOpprettet = actual.getOrFail().second.opprettet,
+                            søknadInnhold = søknadInnhold,
                             clock = fixedClock,
-                        ),
-                        OppgaveConfig.Søknad::søknadId,
-                        OppgaveConfig.Søknad::saksreferanse,
-                    )
-                },
-            )
-            verify(søknadRepoMock).oppdaterOppgaveId(
-                argThat {
-                    it.shouldBeEqualToIgnoringFields(
-                        Søknad.Journalført.MedOppgave.IkkeLukket(
-                            id = UUID.randomUUID(), // ignored
-                            opprettet = fixedTidspunkt,
-                            sakId = sakId,
+                        )
+                    }
+                )
+                verify(it.dokArkiv).opprettJournalpost(
+                    argThat {
+                        it shouldBe Journalpost.Søknadspost.from(
+                            person = person,
+                            saksnummer = saksnummer,
                             søknadInnhold = søknadInnhold,
-                            journalpostId = journalpostId,
-                            oppgaveId = oppgaveId
-                        ),
-                        Søknad.Journalført.MedOppgave::id
-                    )
-                }
+                            pdf = pdf,
+                        )
+                    },
+                )
+                verify(it.søknadRepo).oppdaterjournalpostId(
+                    argThat {
+                        it.shouldBeEqualToIgnoringFields(
+                            Søknad.Journalført.UtenOppgave(
+                                id = UUID.randomUUID(), // ignored
+                                opprettet = fixedTidspunkt,
+                                sakId = sakId,
+                                søknadInnhold = søknadInnhold,
+                                innsendtAv = innsender,
+                                journalpostId = journalpostId,
+                            ),
+                            Søknad.Journalført.MedOppgave::id
+                        )
+                    }
+                )
+                verify(it.oppgaveService).opprettOppgave(
+                    argThat {
+                        it.shouldBeEqualToIgnoringFields(
+                            OppgaveConfig.Søknad(
+                                sakstype = Sakstype.UFØRE,
+                                journalpostId = journalpostId,
+                                søknadId = UUID.randomUUID(), // ignored
+                                aktørId = person.ident.aktørId,
+                                tilordnetRessurs = null,
+                                clock = fixedClock,
+                            ),
+                            OppgaveConfig.Søknad::søknadId,
+                            OppgaveConfig.Søknad::saksreferanse,
+                        )
+                    },
+                )
+                verify(it.søknadRepo).oppdaterOppgaveId(
+                    argThat {
+                        it.shouldBeEqualToIgnoringFields(
+                            Søknad.Journalført.MedOppgave.IkkeLukket(
+                                id = UUID.randomUUID(), // ignored
+                                opprettet = fixedTidspunkt,
+                                sakId = sakId,
+                                søknadInnhold = søknadInnhold,
+                                innsendtAv = innsender,
+                                journalpostId = journalpostId,
+                                oppgaveId = oppgaveId
+                            ),
+                            Søknad.Journalført.MedOppgave::id
+                        )
+                    }
+                )
+            }
+            verifyNoMoreInteractions(
+                it.personService,
+                it.søknadRepo,
+                it.sakService,
+                it.pdfGenerator,
+                it.dokArkiv,
+                it.oppgaveService
             )
-        }
-        verifyNoMoreInteractions(
-            personServiceMock,
-            søknadRepoMock,
-            sakServiceMock,
-            pdfGeneratorMock,
-            dokArkivMock,
-            oppgaveServiceMock
-        )
 
-        actual.orNull()!!.apply {
-            first shouldBe sak.saksnummer
-            second.shouldBeEqualToIgnoringFields(
-                Søknad.Ny(
-                    id = UUID.randomUUID(), // ignored
-                    opprettet = fixedTidspunkt,
-                    sakId = UUID.randomUUID(), // ignored
-                    søknadInnhold = søknadInnhold,
-                ),
-                Søknad.Ny::id, Søknad.Ny::sakId
-            )
+            actual.getOrFail().apply {
+                first shouldBe sak.saksnummer
+                second.shouldBeEqualToIgnoringFields(
+                    Søknad.Ny(
+                        id = UUID.randomUUID(), // ignored
+                        opprettet = fixedTidspunkt,
+                        sakId = UUID.randomUUID(), // ignored
+                        søknadInnhold = søknadInnhold,
+                        innsendtAv = innsender,
+                    ),
+                    Søknad.Ny::id, Søknad.Ny::sakId
+                )
+            }
         }
     }
 }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/lukk/LukkSøknadServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/lukk/LukkSøknadServiceImplTest.kt
@@ -52,6 +52,7 @@ import no.nav.su.se.bakover.test.søknadsbehandlingLukket
 import no.nav.su.se.bakover.test.søknadsbehandlingTilAttesteringInnvilget
 import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertUavklart
 import no.nav.su.se.bakover.test.trukketSøknad
+import no.nav.su.se.bakover.test.veileder
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
@@ -198,6 +199,7 @@ internal class LukkSøknadServiceImplTest {
                             opprettet = søknad.opprettet,
                             sakId = søknad.sakId,
                             søknadInnhold = søknad.søknadInnhold,
+                            innsendtAv = søknad.innsendtAv,
                             journalpostId = søknad.journalpostId,
                             oppgaveId = søknad.oppgaveId,
                             lukketAv = saksbehandler,
@@ -232,6 +234,7 @@ internal class LukkSøknadServiceImplTest {
                                 opprettet = søknad.opprettet,
                                 sakId = søknad.sakId,
                                 søknadInnhold = søknad.søknadInnhold,
+                                innsendtAv = søknad.innsendtAv,
                                 journalpostId = søknad.journalpostId,
                                 oppgaveId = søknad.oppgaveId,
                                 lukketAv = saksbehandler,
@@ -399,6 +402,7 @@ internal class LukkSøknadServiceImplTest {
                             opprettet = søknad.opprettet,
                             sakId = søknad.sakId,
                             søknadInnhold = søknad.søknadInnhold,
+                            innsendtAv = søknad.innsendtAv,
                             journalpostId = søknad.journalpostId,
                             oppgaveId = søknad.oppgaveId,
                             lukketAv = saksbehandler,
@@ -433,6 +437,7 @@ internal class LukkSøknadServiceImplTest {
                                 opprettet = søknad.opprettet,
                                 sakId = søknad.sakId,
                                 søknadInnhold = søknad.søknadInnhold,
+                                innsendtAv = søknad.innsendtAv,
                                 journalpostId = søknad.journalpostId,
                                 oppgaveId = søknad.oppgaveId,
                                 lukketAv = saksbehandler,
@@ -455,6 +460,7 @@ internal class LukkSøknadServiceImplTest {
             id = UUID.randomUUID(),
             opprettet = LocalDateTime.now().minusDays(3).toTidspunkt(zoneIdOslo),
             søknadInnhold = søknadinnhold(),
+            innsendtAv = veileder
         )
         val søknadServiceMock = mock<SøknadService> {
             on { hentSøknad(any()) } doReturn treDagerGammelSøknad.right()
@@ -930,6 +936,7 @@ internal class LukkSøknadServiceImplTest {
                             opprettet = søknad.opprettet,
                             sakId = søknad.sakId,
                             søknadInnhold = søknad.søknadInnhold,
+                            innsendtAv = søknad.innsendtAv,
                             journalpostId = søknad.journalpostId,
                             oppgaveId = søknad.oppgaveId,
                             lukketAv = saksbehandler,
@@ -964,6 +971,7 @@ internal class LukkSøknadServiceImplTest {
                                 opprettet = søknad.opprettet,
                                 sakId = søknad.sakId,
                                 søknadInnhold = søknad.søknadInnhold,
+                                innsendtAv = søknad.innsendtAv,
                                 journalpostId = søknad.journalpostId,
                                 oppgaveId = søknad.oppgaveId,
                                 lukketAv = saksbehandler,

--- a/test-common/src/main/kotlin/GenerelleTestData.kt
+++ b/test-common/src/main/kotlin/GenerelleTestData.kt
@@ -62,6 +62,7 @@ val enUkeEtterFixedTidspunkt: Tidspunkt = Tidspunkt.now(enUkeEtterFixedClock)
 val fixedLocalDate: LocalDate = 1.januar(2021)
 
 val saksbehandler = NavIdentBruker.Saksbehandler("saksbehandler")
+val veileder = NavIdentBruker.Veileder("veileder")
 
 const val saksbehandlerNavn = "Sak S. Behandler"
 

--- a/test-common/src/main/kotlin/SakTestData.kt
+++ b/test-common/src/main/kotlin/SakTestData.kt
@@ -2,6 +2,7 @@ package no.nav.su.se.bakover.test
 
 import no.nav.su.se.bakover.common.UUIDFactory
 import no.nav.su.se.bakover.common.periode.Periode
+import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.SakFactory
 import no.nav.su.se.bakover.domain.Sakstype
@@ -52,11 +53,13 @@ fun nySakUføre(
         type = Sakstype.UFØRE,
     ),
     søknadsInnhold: SøknadsinnholdUføre = søknadinnhold(sakInfo.fnr),
+    søknadInnsendtAv: NavIdentBruker = veileder,
 ): Pair<Sak, Søknad.Journalført.MedOppgave> {
     return nySak(
         clock = clock,
         sakInfo = sakInfo,
         søknadsinnhold = søknadsInnhold,
+        søknadInnsendtAv = søknadInnsendtAv,
     )
 }
 
@@ -69,11 +72,13 @@ fun nySakAlder(
         type = Sakstype.ALDER,
     ),
     søknadsInnhold: SøknadsinnholdAlder = søknadsinnholdAlder(),
+    søknadInnsendtAv: NavIdentBruker = veileder,
 ): Pair<Sak, Søknad.Journalført.MedOppgave> {
     return nySak(
         clock = clock,
         sakInfo = sakInfo,
         søknadsinnhold = søknadsInnhold,
+        søknadInnsendtAv = søknadInnsendtAv,
     )
 }
 
@@ -81,6 +86,7 @@ fun nySak(
     clock: Clock = fixedClock,
     sakInfo: SakInfo,
     søknadsinnhold: SøknadInnhold,
+    søknadInnsendtAv: NavIdentBruker = veileder,
 ): Pair<Sak, Søknad.Journalført.MedOppgave> {
     return SakFactory(
         clock = clock,
@@ -94,6 +100,7 @@ fun nySak(
         sakFactory.nySakMedNySøknad(
             fnr = sakInfo.fnr,
             søknadInnhold = søknadsinnhold,
+            innsendtAv = søknadInnsendtAv,
         ).let {
             val søknad = it.søknad.journalfør(journalpostIdSøknad).medOppgave(oppgaveIdSøknad)
             val sak = it.toSak(sakInfo.saksnummer)

--- a/test-common/src/main/kotlin/SøknadTestData.kt
+++ b/test-common/src/main/kotlin/SøknadTestData.kt
@@ -37,6 +37,7 @@ fun nySakMedNySøknad(
     sakId: UUID = no.nav.su.se.bakover.test.sakId,
     søknadId: UUID = no.nav.su.se.bakover.test.søknadId,
     fnr: Fnr = no.nav.su.se.bakover.test.fnr,
+    søknadInnsendtAv: NavIdentBruker = veileder,
 ): Pair<Sak, Søknad.Ny> = SakFactory(
     uuidFactory = object : UUIDFactory() {
         val ids = LinkedList(listOf(sakId, søknadId))
@@ -48,6 +49,7 @@ fun nySakMedNySøknad(
 ).nySakMedNySøknad(
     fnr = fnr,
     søknadInnhold = søknadinnhold(fnr),
+    innsendtAv = søknadInnsendtAv,
 ).let {
     assert(it.id == sakId)
     assert(it.søknad.id == søknadId)
@@ -118,12 +120,14 @@ fun nySøknad(
     clock: Clock = fixedClock,
     sakId: UUID,
     søknadInnhold: SøknadInnhold,
+    søknadInnsendtAv: NavIdentBruker = veileder,
 ): Søknad.Ny {
     return Søknad.Ny(
         id = UUID.randomUUID(),
         opprettet = Tidspunkt.now(clock),
         sakId = sakId,
         søknadInnhold = søknadInnhold,
+        innsendtAv = søknadInnsendtAv,
     )
 }
 

--- a/test-common/src/main/kotlin/SøknadsbehandlingTestData.kt
+++ b/test-common/src/main/kotlin/SøknadsbehandlingTestData.kt
@@ -538,6 +538,7 @@ fun søknadsbehandlingLukket(
                 opprettet = it.opprettet,
                 sakId = it.sakId,
                 søknadInnhold = it.søknadInnhold,
+                innsendtAv = it.innsendtAv,
                 journalpostId = it.journalpostId,
                 oppgaveId = it.oppgaveId,
                 lukketTidspunkt = fixedTidspunkt,

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/drift/FixSøknaderTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/drift/FixSøknaderTest.kt
@@ -17,6 +17,7 @@ import no.nav.su.se.bakover.service.søknad.KunneIkkeOppretteJournalpost
 import no.nav.su.se.bakover.service.søknad.KunneIkkeOppretteOppgave
 import no.nav.su.se.bakover.service.søknad.OpprettManglendeJournalpostOgOppgaveResultat
 import no.nav.su.se.bakover.service.søknad.SøknadService
+import no.nav.su.se.bakover.test.veileder
 import no.nav.su.se.bakover.web.TestServicesBuilder
 import no.nav.su.se.bakover.web.defaultRequest
 import no.nav.su.se.bakover.web.testSusebakover
@@ -95,7 +96,8 @@ internal class FixSøknaderTest {
             sakId = sakId,
             journalpostId = JournalpostId("1"),
             opprettet = Tidspunkt.EPOCH,
-            søknadInnhold = SøknadInnholdTestdataBuilder.build()
+            søknadInnhold = SøknadInnholdTestdataBuilder.build(),
+            innsendtAv = veileder,
         )
         val journalførtSøknadMedOppgave = Søknad.Journalført.MedOppgave.IkkeLukket(
             id = UUID.fromString("e38df38a-c3fc-48d1-adca-0a9264024a2e"),
@@ -103,6 +105,7 @@ internal class FixSøknaderTest {
             journalpostId = JournalpostId("2"),
             opprettet = Tidspunkt.EPOCH,
             søknadInnhold = SøknadInnholdTestdataBuilder.build(),
+            innsendtAv = veileder,
             oppgaveId = OppgaveId("2")
         )
 

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/sak/SakRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/sak/SakRoutesKtTest.kt
@@ -32,6 +32,7 @@ import no.nav.su.se.bakover.test.satsFactoryTest
 import no.nav.su.se.bakover.test.satsFactoryTestPåDato
 import no.nav.su.se.bakover.test.stønadsperiode2021
 import no.nav.su.se.bakover.test.vedtakSøknadsbehandlingIverksattInnvilget
+import no.nav.su.se.bakover.test.veileder
 import no.nav.su.se.bakover.web.TestClientsBuilder
 import no.nav.su.se.bakover.web.dbMetricsStub
 import no.nav.su.se.bakover.web.defaultRequest
@@ -73,7 +74,11 @@ internal class SakRoutesKtTest {
             testApplication {
                 application { testSusebakover(databaseRepos = repos) }
 
-                SakFactory(clock = fixedClock).nySakMedNySøknad(Fnr(sakFnr01), søknadInnhold).also {
+                SakFactory(clock = fixedClock).nySakMedNySøknad(
+                    fnr = Fnr(sakFnr01),
+                    søknadInnhold = søknadInnhold,
+                    innsendtAv = veileder,
+                ).also {
                     repos.sak.opprettSak(it)
                 }
                 val opprettetSakId: Sak = repos.sak.hentSak(Fnr(sakFnr01), Sakstype.UFØRE)!!
@@ -97,7 +102,13 @@ internal class SakRoutesKtTest {
             testApplication {
                 application { testSusebakover(databaseRepos = repos) }
 
-                repos.sak.opprettSak(SakFactory(clock = fixedClock).nySakMedNySøknad(Fnr(sakFnr01), søknadInnhold))
+                repos.sak.opprettSak(
+                    SakFactory(clock = fixedClock).nySakMedNySøknad(
+                        fnr = Fnr(sakFnr01),
+                        søknadInnhold = søknadInnhold,
+                        innsendtAv = veileder,
+                    )
+                )
 
                 defaultRequest(HttpMethod.Post, "$sakPath/søk", listOf(Brukerrolle.Saksbehandler)) {
                     setBody("""{"fnr":"$sakFnr01", "type": "uføre"}""")
@@ -148,7 +159,11 @@ internal class SakRoutesKtTest {
 
                 testApplication {
                     application { testSusebakover(databaseRepos = repos) }
-                    SakFactory(clock = fixedClock).nySakMedNySøknad(Fnr(sakFnr01), søknadInnhold).also {
+                    SakFactory(clock = fixedClock).nySakMedNySøknad(
+                        fnr = Fnr(sakFnr01),
+                        søknadInnhold = søknadInnhold,
+                        innsendtAv = veileder
+                    ).also {
                         repos.sak.opprettSak(it)
 
                         defaultRequest(

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknad/UføresøknadJsonTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknad/UføresøknadJsonTest.kt
@@ -6,10 +6,11 @@ import no.nav.su.se.bakover.common.deserialize
 import no.nav.su.se.bakover.common.oktober
 import no.nav.su.se.bakover.common.serialize
 import no.nav.su.se.bakover.common.startOfDay
-import no.nav.su.se.bakover.domain.NavIdentBruker
 import no.nav.su.se.bakover.domain.Søknad
 import no.nav.su.se.bakover.domain.fnrUnder67
 import no.nav.su.se.bakover.test.nySakMedjournalførtSøknadOgOppgave
+import no.nav.su.se.bakover.test.saksbehandler
+import no.nav.su.se.bakover.test.veileder
 import no.nav.su.se.bakover.web.routes.søknadsbehandling.BehandlingTestUtils.sakId
 import no.nav.su.se.bakover.web.routes.søknadsbehandling.BehandlingTestUtils.søknadId
 import no.nav.su.se.bakover.web.routes.søknadsbehandling.BehandlingTestUtils.søknadInnhold
@@ -25,9 +26,9 @@ internal class UføresøknadJsonTest {
             opprettet = Tidspunkt.EPOCH,
             id = søknadId,
             søknadInnhold = søknadInnhold,
+            innsendtAv = veileder,
         )
         private val opprettetTidspunkt: String = DateTimeFormatter.ISO_INSTANT.format(søknad.opprettet)
-        private val saksbehandler = NavIdentBruker.Saksbehandler("saksbehandler")
 
         //language=JSON
         val søknadJsonString =

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutesKtTest.kt
@@ -86,6 +86,7 @@ import no.nav.su.se.bakover.test.lagFradragsgrunnlag
 import no.nav.su.se.bakover.test.satsFactoryTest
 import no.nav.su.se.bakover.test.satsFactoryTestPåDato
 import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertInnvilget
+import no.nav.su.se.bakover.test.veileder
 import no.nav.su.se.bakover.test.vilkår.fastOppholdVilkårInnvilget
 import no.nav.su.se.bakover.test.vilkår.flyktningVilkårInnvilget
 import no.nav.su.se.bakover.test.vilkår.institusjonsoppholdvilkårInnvilget
@@ -834,7 +835,11 @@ internal class SøknadsbehandlingRoutesKtTest {
     ): UavklartVilkårsvurdertSøknadsbehandling {
         val søknadInnhold = SøknadInnholdTestdataBuilder.build()
         val fnr: Fnr = Fnr.generer()
-        SakFactory(clock = fixedClock).nySakMedNySøknad(fnr, søknadInnhold).also {
+        SakFactory(clock = fixedClock).nySakMedNySøknad(
+            fnr = fnr,
+            søknadInnhold = søknadInnhold,
+            innsendtAv = veileder
+        ).also {
             repos.sak.opprettSak(it)
         }
         val sak: Sak = repos.sak.hentSak(fnr, Sakstype.UFØRE)!!

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/beregning/BeregnRoutesKtTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/beregning/BeregnRoutesKtTest.kt
@@ -57,6 +57,7 @@ import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.generer
 import no.nav.su.se.bakover.test.satsFactoryTest
 import no.nav.su.se.bakover.test.satsFactoryTestPåDato
+import no.nav.su.se.bakover.test.veileder
 import no.nav.su.se.bakover.test.vilkår.fastOppholdVilkårInnvilget
 import no.nav.su.se.bakover.test.vilkår.flyktningVilkårInnvilget
 import no.nav.su.se.bakover.test.vilkår.institusjonsoppholdvilkårInnvilget
@@ -230,7 +231,11 @@ internal class BeregnRoutesKtTest {
     private fun setup(services: Services, repos: DatabaseRepos): UavklartVilkårsvurdertSøknadsbehandling {
         val søknadInnhold = SøknadInnholdTestdataBuilder.build()
         val fnr: Fnr = Fnr.generer()
-        SakFactory(clock = fixedClock).nySakMedNySøknad(fnr, søknadInnhold).also {
+        SakFactory(clock = fixedClock).nySakMedNySøknad(
+            fnr = fnr,
+            søknadInnhold = søknadInnhold,
+            innsendtAv = veileder,
+        ).also {
             repos.sak.opprettSak(it)
         }
         val sak: Sak = repos.sak.hentSak(fnr, Sakstype.UFØRE)!!


### PR DESCRIPTION
Usikker på om det hensiktsmessig å bruke `NavIdentBruker` her, eller om det er like greit å bare pakke det ut til en string - retrospektivt heller jeg mot dette. Tanker @hestad ?