### PR TITLE
Fix genertDokumentJson dobbel serdes

### DIFF
--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/dokument/DokumentPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/dokument/DokumentPostgresRepo.kt
@@ -2,9 +2,7 @@ package no.nav.su.se.bakover.database.dokument
 
 import kotliquery.Row
 import no.nav.su.se.bakover.common.Tidspunkt
-import no.nav.su.se.bakover.common.deserialize
 import no.nav.su.se.bakover.common.persistence.TransactionContext
-import no.nav.su.se.bakover.common.serialize
 import no.nav.su.se.bakover.database.DbMetrics
 import no.nav.su.se.bakover.database.PostgresSessionFactory
 import no.nav.su.se.bakover.database.PostgresTransactionContext.Companion.withTransaction
@@ -41,7 +39,8 @@ internal class DokumentPostgresRepo(
                             "opprettet" to dokument.opprettet,
                             "sakId" to dokument.metadata.sakId,
                             "generertDokument" to dokument.generertDokument,
-                            "generertDokumentJson" to serialize(dokument.generertDokumentJson),
+                            // Dette er allerede gyldig json lagret som en String.
+                            "generertDokumentJson" to dokument.generertDokumentJson,
                             "type" to when (dokument) {
                                 is Dokument.MedMetadata.Informasjon.Viktig -> DokumentKategori.INFORMASJON_VIKTIG
                                 is Dokument.MedMetadata.Informasjon.Annet -> DokumentKategori.INFORMASJON_ANNET
@@ -239,7 +238,7 @@ internal class DokumentPostgresRepo(
         val id = uuid("id")
         val opprettet = tidspunkt("opprettet")
         val innhold = bytes("generertDokument")
-        val request = deserialize<String>(string("generertDokumentJson"))
+        val request = string("generertDokumentJson")
         val sakId = uuid("sakid")
         val søknadId = uuidOrNull("søknadId")
         val vedtakId = uuidOrNull("vedtakId")

--- a/database/src/main/resources/db/migration/V158__dokument_generertdokumentjson_fjern_dobbel_serialisering.sql
+++ b/database/src/main/resources/db/migration/V158__dokument_generertdokumentjson_fjern_dobbel_serialisering.sql
@@ -1,0 +1,3 @@
+update dokument d
+set generertdokumentjson = (d.generertdokumentjson #>> '{}')::jsonb
+where "left"(d.generertdokumentjson::text, 1) = '"';

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/dokument/DokumentPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/dokument/DokumentPostgresRepoTest.kt
@@ -32,13 +32,13 @@ internal class DokumentPostgresRepoTest {
                 oppgaveId = oppgaveId,
             )
 
-            // Dette er en snarvei for å teste alle referasene til et dokument og ikke noe som vil oppstå naturlig.
+            // Dette er en snarvei for å teste alle referansene til et dokument og ikke noe som vil oppstå naturlig.
             val original = Dokument.MedMetadata.Vedtak(
                 id = UUID.randomUUID(),
                 opprettet = fixedTidspunkt,
                 tittel = "tittel",
                 generertDokument = "".toByteArray(),
-                generertDokumentJson = """{"some":"json"}""",
+                generertDokumentJson = """{"some": "json"}""",
                 metadata = Dokument.Metadata(
                     sakId = sak.id,
                     søknadId = sak.søknader.first().id,

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/komponenttest/AvslagManglendeDokumentasjonKomponentTest.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/komponenttest/AvslagManglendeDokumentasjonKomponentTest.kt
@@ -91,7 +91,7 @@ class AvslagManglendeDokumentasjonKomponentTest {
                         .let { dokumenter ->
                             dokumenter.single().let {
                                 it.tittel shouldBe "Vedtaksbrev for søknad om supplerende stønad"
-                                it.generertDokumentJson shouldContain """"avslagsgrunner":["MANGLENDE_DOKUMENTASJON"]"""
+                                it.generertDokumentJson shouldContain """"avslagsgrunner": ["MANGLENDE_DOKUMENTASJON"]"""
                             }
                         }
                 }
@@ -176,7 +176,7 @@ class AvslagManglendeDokumentasjonKomponentTest {
                             .let { dokumenter ->
                                 dokumenter.single().let {
                                     it.tittel shouldBe "Vedtaksbrev for søknad om supplerende stønad"
-                                    it.generertDokumentJson shouldContain """"avslagsgrunner":["MANGLENDE_DOKUMENTASJON"]"""
+                                    it.generertDokumentJson shouldContain """"avslagsgrunner": ["MANGLENDE_DOKUMENTASJON"]"""
                                 }
                             }
                     }


### PR DESCRIPTION
Denne har blitt lagret i basen som "{\"...\"}" som gjør den vanskelig å gjøre json-spørringer på