### PR TITLE
Fjern oppdater revurdering sperre etter forhåndsvarsel

### DIFF
--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OppdaterRevurderingsperiodeRoute.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/revurdering/OppdaterRevurderingsperiodeRoute.kt
@@ -111,10 +111,10 @@ private fun KunneIkkeOppdatereRevurdering.tilResultat(): Resultat {
                 }
                 is Sak.KunneIkkeOppdatereRevurdering.KunneIkkeOppdatere -> {
                     when (val nested = inner.feil) {
-                        Revurdering.KunneIkkeOppdatereRevurdering.KanIkkeOppdatereRevurderingSomErForhåndsvarslet -> {
+                        Revurdering.KunneIkkeOppdatereRevurdering.KanIkkeEndreÅrsakTilReguleringVedForhåndsvarsletRevurdering -> {
                             HttpStatusCode.BadRequest.errorJson(
-                                "Kan ikke oppdatere revurdering som er forhåndsvarslet",
-                                "kan_ikke_oppdatere_revurdering_som_er_forhåndsvarslet",
+                                "Kan ikke oppdatere revurdering med årsak `REGULER_GRUNNBELØP` som er forhåndsvarslet",
+                                "kan_ikke_oppdatere_revurdering_med_årsak_reguler_grunnbeløp_som_er_forhåndsvarslet",
                             )
                         }
                         is Revurdering.KunneIkkeOppdatereRevurdering.UgyldigTilstand -> {


### PR DESCRIPTION
Beholder sperren dersom man endrer årsak til REGULER_GRUNNBELØP og det har blitt forhåndsvarslet. Siden vi ikke støtter forhåndsvarsler i denne tilstanden. Dersom det senere blir et krav, må man gjøre litt større endringer.