### PR TITLE
Unngå nested session ved stans

### DIFF
--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepo.kt
@@ -97,6 +97,15 @@ internal class SakPostgresRepo(
         }
     }
 
+    override fun hentSakForRevurdering(revurderingId: UUID, sessionContext: SessionContext): Sak {
+        return dbMetrics.timeQuery("hentSakForRevurdering") {
+            sessionContext.withSession { session ->
+                "select s.* from sak s join revurdering r on r.sakid = s.id where r.id =:revurderingid"
+                    .hent(mapOf("revurderingid" to revurderingId), session) { it.toSak(sessionContext) }
+            }
+        }!!
+    }
+
     override fun hentSakForSøknad(søknadId: UUID): Sak? {
         return dbMetrics.timeQuery("hentSakForSøknad") {
             sessionFactory.withSessionContext { sessionContext ->

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/SimulerUtbetalingRequest.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/SimulerUtbetalingRequest.kt
@@ -6,7 +6,6 @@ import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.beregning.Beregning
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
-import java.time.LocalDate
 import java.util.UUID
 
 sealed interface SimulerUtbetalingRequest {
@@ -20,10 +19,6 @@ sealed interface SimulerUtbetalingRequest {
 
     interface OpphørRequest : SimulerUtbetalingRequest {
         val opphørsperiode: Periode
-    }
-
-    interface StansRequest : SimulerUtbetalingRequest {
-        val stansdato: LocalDate
     }
 
     interface GjenopptakRequest : SimulerUtbetalingRequest {
@@ -53,12 +48,6 @@ sealed interface SimulerUtbetalingRequest {
         override val opphørsperiode: Periode,
     ) : OpphørRequest
 
-    data class Stans(
-        override val sakId: UUID,
-        override val saksbehandler: NavIdentBruker,
-        override val stansdato: LocalDate,
-    ) : StansRequest
-
     data class Gjenopptak(
         override val saksbehandler: NavIdentBruker,
         override val sak: Sak,
@@ -81,12 +70,6 @@ sealed interface UtbetalRequest : SimulerUtbetalingRequest {
         override val simulering: Simulering,
     ) : UtbetalRequest,
         SimulerUtbetalingRequest.OpphørRequest by request
-
-    data class Stans(
-        private val request: SimulerUtbetalingRequest.StansRequest,
-        override val simulering: Simulering,
-    ) : UtbetalRequest,
-        SimulerUtbetalingRequest.StansRequest by request
 
     data class Gjenopptak(
         override val sakId: UUID,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakRepo.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakRepo.kt
@@ -24,5 +24,7 @@ interface SakRepo {
     fun hentSaker(fnr: Fnr): List<Sak>
 
     fun hentSakForRevurdering(revurderingId: UUID): Sak
+
+    fun hentSakForRevurdering(revurderingId: UUID, sessionContext: SessionContext): Sak
     fun hentSakForSøknad(søknadId: UUID): Sak?
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/Utbetaling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/Utbetaling.kt
@@ -1,0 +1,26 @@
+package no.nav.su.se.bakover.domain.sak
+
+import arrow.core.Either
+import no.nav.su.se.bakover.common.NavIdentBruker
+import no.nav.su.se.bakover.domain.Sak
+import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
+import no.nav.su.se.bakover.domain.oppdrag.Utbetalingsstrategi
+import java.time.Clock
+import java.time.LocalDate
+
+fun Sak.lagUtbetalingForStans(
+    stansdato: LocalDate,
+    behandler: NavIdentBruker,
+    clock: Clock,
+): Either<Utbetalingsstrategi.Stans.Feil, Utbetaling.UtbetalingForSimulering> {
+    return Utbetalingsstrategi.Stans(
+        sakId = id,
+        saksnummer = saksnummer,
+        fnr = fnr,
+        eksisterendeUtbetalinger = utbetalinger,
+        behandler = behandler,
+        stansDato = stansdato,
+        clock = clock,
+        sakstype = type,
+    ).generer()
+}

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
@@ -58,6 +58,7 @@ import no.nav.su.se.bakover.domain.oppdrag.UtbetalingFeilet
 import no.nav.su.se.bakover.domain.oppdrag.UtbetalingKlargjortForOversendelse
 import no.nav.su.se.bakover.domain.oppdrag.avstemming.Avstemming
 import no.nav.su.se.bakover.domain.oppdrag.avstemming.Fagområde
+import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimuleringFeilet
 import no.nav.su.se.bakover.domain.oppdrag.tilbakekreving.Kravgrunnlag
 import no.nav.su.se.bakover.domain.oppdrag.tilbakekreving.RåttKravgrunnlag
@@ -167,6 +168,8 @@ import no.nav.su.se.bakover.service.søknad.lukk.LukkSøknadService
 import no.nav.su.se.bakover.service.søknadsbehandling.SøknadsbehandlingService
 import no.nav.su.se.bakover.service.tilbakekreving.TilbakekrevingService
 import no.nav.su.se.bakover.service.utbetaling.FantIkkeUtbetaling
+import no.nav.su.se.bakover.service.utbetaling.SimulerStansFeilet
+import no.nav.su.se.bakover.service.utbetaling.UtbetalStansFeil
 import no.nav.su.se.bakover.service.utbetaling.UtbetalingService
 import no.nav.su.se.bakover.service.vedtak.FerdigstillVedtakService
 import no.nav.su.se.bakover.service.vedtak.VedtakService
@@ -254,14 +257,17 @@ open class AccessCheckProxy(
                     kastKanKunKallesFraAnnenService()
                 }
 
-                override fun simulerStans(
-                    request: SimulerUtbetalingRequest.StansRequest,
-                ) = kastKanKunKallesFraAnnenService()
+                override fun simulerStans(utbetaling: Utbetaling.UtbetalingForSimulering): Either<SimulerStansFeilet, Utbetaling.SimulertUtbetaling> {
+                    kastKanKunKallesFraAnnenService()
+                }
 
                 override fun klargjørStans(
-                    request: UtbetalRequest.Stans,
+                    utbetaling: Utbetaling.UtbetalingForSimulering,
+                    saksbehandlersSimulering: Simulering,
                     transactionContext: TransactionContext,
-                ) = kastKanKunKallesFraAnnenService()
+                ): Either<UtbetalStansFeil, UtbetalingKlargjortForOversendelse<UtbetalStansFeil.KunneIkkeUtbetale>> {
+                    kastKanKunKallesFraAnnenService()
+                }
 
                 override fun simulerGjenopptak(
                     request: SimulerUtbetalingRequest.GjenopptakRequest,
@@ -345,6 +351,10 @@ open class AccessCheckProxy(
                 override fun hentSakForRevurdering(revurderingId: UUID): Sak {
                     assertHarTilgangTilRevurdering(revurderingId)
                     return services.sak.hentSakForRevurdering(revurderingId)
+                }
+
+                override fun hentSakForRevurdering(revurderingId: UUID, sessionContext: SessionContext): Sak {
+                    kastKanKunKallesFraAnnenService()
                 }
 
                 override fun hentSakForSøknad(søknadId: UUID): Either<FantIkkeSak, Sak> {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/sak/SakService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/sak/SakService.kt
@@ -42,6 +42,8 @@ interface SakService {
 
     fun hentSakForRevurdering(revurderingId: UUID): Sak
 
+    fun hentSakForRevurdering(revurderingId: UUID, sessionContext: SessionContext): Sak
+
     fun hentSakForSøknad(søknadId: UUID): Either<FantIkkeSak, Sak>
 }
 

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/sak/SakServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/sak/SakServiceImpl.kt
@@ -99,6 +99,10 @@ internal class SakServiceImpl(
         return sakRepo.hentSakForRevurdering(revurderingId)
     }
 
+    override fun hentSakForRevurdering(revurderingId: UUID, sessionContext: SessionContext): Sak {
+        return sakRepo.hentSakForRevurdering(revurderingId, sessionContext)
+    }
+
     override fun hentSakForSøknad(søknadId: UUID): Either<FantIkkeSak, Sak> {
         return sakRepo.hentSakForSøknad(søknadId)?.right() ?: FantIkkeSak.left()
     }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingService.kt
@@ -13,6 +13,7 @@ import no.nav.su.se.bakover.domain.oppdrag.UtbetalingFeilet
 import no.nav.su.se.bakover.domain.oppdrag.UtbetalingKlargjortForOversendelse
 import no.nav.su.se.bakover.domain.oppdrag.UtbetalingslinjePåTidslinje
 import no.nav.su.se.bakover.domain.oppdrag.Utbetalingsstrategi
+import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimuleringFeilet
 import java.time.LocalDate
 import java.util.UUID
@@ -49,7 +50,7 @@ interface UtbetalingService {
     ): Either<UtbetalingFeilet, UtbetalingKlargjortForOversendelse<UtbetalingFeilet.Protokollfeil>>
 
     fun simulerStans(
-        request: SimulerUtbetalingRequest.StansRequest,
+        utbetaling: Utbetaling.UtbetalingForSimulering,
     ): Either<SimulerStansFeilet, Utbetaling.SimulertUtbetaling>
 
     /**
@@ -62,7 +63,8 @@ interface UtbetalingService {
      * som det siste steget i [transactionContext], slik at eventuelle feil her kan rulle tilbake hele transaksjonen.
      */
     fun klargjørStans(
-        request: UtbetalRequest.Stans,
+        utbetaling: Utbetaling.UtbetalingForSimulering,
+        saksbehandlersSimulering: Simulering,
         transactionContext: TransactionContext,
     ): Either<UtbetalStansFeil, UtbetalingKlargjortForOversendelse<UtbetalStansFeil.KunneIkkeUtbetale>>
 

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingServiceImplTest.kt
@@ -19,7 +19,9 @@ import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppdrag.UtbetalingslinjePåTidslinje
 import no.nav.su.se.bakover.domain.oppdrag.avstemming.Avstemmingsnøkkel
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimulerUtbetalingForPeriode
+import no.nav.su.se.bakover.domain.sak.lagUtbetalingForStans
 import no.nav.su.se.bakover.service.argThat
+import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.fradragsgrunnlagArbeidsinntekt
 import no.nav.su.se.bakover.test.getOrFail
 import no.nav.su.se.bakover.test.iverksattSøknadsbehandlingUføre
@@ -180,11 +182,12 @@ internal class UtbetalingServiceImplTest {
                 clock = tikkendeFixedClock,
             ).let {
                 it.service.simulerStans(
-                    request = SimulerUtbetalingRequest.Stans(
-                        sakId = sak.id,
-                        saksbehandler = saksbehandler,
+                    utbetaling = sak.lagUtbetalingForStans(
                         stansdato = 1.februar(2021),
-                    ),
+                        behandler = saksbehandler,
+                        clock = fixedClock,
+                    ).getOrFail(),
+
                 ).getOrFail() shouldBe beOfType<Utbetaling.SimulertUtbetaling>()
 
                 verify(it.simuleringClient).simulerUtbetaling(


### PR DESCRIPTION
La saken opprette utbetalingen som skal simuleres. Med dette unngår at vi oppretter en ny session for å hente sak ved simulering, og åpner for videre refaktorering for å la saken opprette hele stansen.