### PR TITLE
Unngå nested session opphør

### DIFF
--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/Utbetaling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/Utbetaling.kt
@@ -2,6 +2,7 @@ package no.nav.su.se.bakover.domain.sak
 
 import arrow.core.Either
 import no.nav.su.se.bakover.common.NavIdentBruker
+import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppdrag.Utbetalingsstrategi
@@ -38,4 +39,21 @@ fun Sak.lagUtbetalingForGjenopptak(
         clock = clock,
         sakstype = type,
     ).generer()
+}
+
+fun Sak.lagUtbetalingForOpphør(
+    opphørsperiode: Periode,
+    behandler: NavIdentBruker,
+    clock: Clock,
+): Utbetaling.UtbetalingForSimulering {
+    return Utbetalingsstrategi.Opphør(
+        sakId = id,
+        saksnummer = saksnummer,
+        fnr = fnr,
+        eksisterendeUtbetalinger = utbetalinger,
+        behandler = behandler,
+        periode = opphørsperiode,
+        clock = clock,
+        sakstype = type,
+    ).generate()
 }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/OpphørsperiodeForUtbetalingerTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/OpphørsperiodeForUtbetalingerTest.kt
@@ -10,9 +10,9 @@ import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.common.startOfMonth
 import no.nav.su.se.bakover.domain.avkorting.AvkortingVedRevurdering
 import no.nav.su.se.bakover.test.nåtidForSimuleringStub
-import no.nav.su.se.bakover.test.simulertRevurderingOpphørtPgaVilkårFraInnvilgetSøknadsbehandlingsVedtak
-import no.nav.su.se.bakover.test.simulertRevurderingOpphørtUføreFraInnvilgetSøknadsbehandlingsVedtak
+import no.nav.su.se.bakover.test.simulertRevurdering
 import no.nav.su.se.bakover.test.vilkår.utenlandsoppholdAvslag
+import no.nav.su.se.bakover.test.vilkårsvurderinger.avslåttUførevilkårUtenGrunnlag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
@@ -23,9 +23,11 @@ internal class OpphørsperiodeForUtbetalingerTest {
     fun `opphørsdato er lik revurdering fra og med hvis ingen avkortingsvarsel`() {
         val revurderingsperiode =
             Periode.create(LocalDate.now(nåtidForSimuleringStub).startOfMonth(), 31.desember(2021))
-        val simulert = simulertRevurderingOpphørtUføreFraInnvilgetSøknadsbehandlingsVedtak(
+        val simulert = simulertRevurdering(
             revurderingsperiode = revurderingsperiode,
-        ).second
+            vilkårOverrides = listOf(avslåttUførevilkårUtenGrunnlag(periode = revurderingsperiode)),
+        ).second as SimulertRevurdering.Opphørt
+
         OpphørsperiodeForUtbetalinger(simulert).value shouldBe revurderingsperiode
         simulert.avkorting shouldBe beOfType<AvkortingVedRevurdering.Håndtert.IngenNyEllerUtestående>()
     }
@@ -33,20 +35,24 @@ internal class OpphørsperiodeForUtbetalingerTest {
     @Test
     fun `opphørsdato er lik første måned uten utbetalte beløp hvis feilutbetalinger kan avkortes`() {
         val tidligsteFraOgMedSomIkkeErUtbetalt = LocalDate.now(nåtidForSimuleringStub).startOfMonth()
-        val simulert = simulertRevurderingOpphørtPgaVilkårFraInnvilgetSøknadsbehandlingsVedtak(
-            vilkårSomFørerTilOpphør = utenlandsoppholdAvslag(),
-        ).second
-        OpphørsperiodeForUtbetalinger(simulert).value shouldBe Periode.create(tidligsteFraOgMedSomIkkeErUtbetalt, simulert.periode.tilOgMed)
+        val simulert = simulertRevurdering(
+            vilkårOverrides = listOf(utenlandsoppholdAvslag()),
+        ).second as SimulertRevurdering.Opphørt
+        OpphørsperiodeForUtbetalinger(simulert).value shouldBe Periode.create(
+            tidligsteFraOgMedSomIkkeErUtbetalt,
+            simulert.periode.tilOgMed,
+        )
         simulert.avkorting shouldBe beOfType<AvkortingVedRevurdering.Håndtert.OpprettNyttAvkortingsvarsel>()
     }
 
     @Test
     fun `kaster exception hvis opphørsdato for utbetalinger er utenfor revurderingsperioden`() {
         assertThrows<IllegalStateException> {
-            simulertRevurderingOpphørtPgaVilkårFraInnvilgetSøknadsbehandlingsVedtak(
-                revurderingsperiode = Periode.create(1.januar(2021), 31.mars(2021)),
-                vilkårSomFørerTilOpphør = utenlandsoppholdAvslag(periode = Periode.create(1.januar(2021), 31.mars(2021))),
-            ).second
+            val revurderingsperiode = Periode.create(1.januar(2021), 31.mars(2021))
+            simulertRevurdering(
+                revurderingsperiode = revurderingsperiode,
+                vilkårOverrides = listOf(utenlandsoppholdAvslag(periode = revurderingsperiode)),
+            ).second as SimulertRevurdering.Opphørt
         }.also {
             it.message shouldContain "Opphørsdato er utenfor revurderingsperioden"
         }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/RevurderingSimulerTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/RevurderingSimulerTest.kt
@@ -2,7 +2,6 @@ package no.nav.su.se.bakover.domain.revurdering
 
 import arrow.core.right
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.common.periode.mars
@@ -59,8 +58,7 @@ class RevurderingSimulerTest {
                         clock = fixedClock,
                         lagUtbetaling = sak::lagUtbetalingForOpphør,
                         eksisterendeUtbetalinger = sak::utbetalinger,
-                    ) { utbetaling, eksisterende, opphørsperiode ->
-                        beregnet.periode shouldNotBe opphørsperiode
+                    ) { utbetaling, eksisterende, _ ->
                         utbetaling.toSimulertUtbetaling(
                             simuleringOpphørt(
                                 opphørsperiode = beregnet.periode, // bruk feil periode

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/RevurderingSimulerTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/RevurderingSimulerTest.kt
@@ -2,6 +2,7 @@ package no.nav.su.se.bakover.domain.revurdering
 
 import arrow.core.right
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.common.periode.mars
@@ -10,16 +11,16 @@ import no.nav.su.se.bakover.domain.avkorting.AvkortingVedRevurdering
 import no.nav.su.se.bakover.domain.avkorting.Avkortingsvarsel
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragTilhører
 import no.nav.su.se.bakover.domain.oppdrag.tilbakekreving.IkkeAvgjort
+import no.nav.su.se.bakover.domain.sak.lagUtbetalingForOpphør
 import no.nav.su.se.bakover.test.beregnetRevurdering
 import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.fradragsgrunnlagArbeidsinntekt
 import no.nav.su.se.bakover.test.getOrFail
 import no.nav.su.se.bakover.test.nyUtbetalingSimulert
-import no.nav.su.se.bakover.test.opphørUtbetalingSimulert
-import no.nav.su.se.bakover.test.opprettetRevurderingAvslagSpesifiktVilkår
-import no.nav.su.se.bakover.test.opprettetRevurderingFraInnvilgetSøknadsbehandlingsVedtak
 import no.nav.su.se.bakover.test.saksbehandler
-import no.nav.su.se.bakover.test.satsFactoryTestPåDato
+import no.nav.su.se.bakover.test.shouldBeType
+import no.nav.su.se.bakover.test.simuleringOpphørt
+import no.nav.su.se.bakover.test.simulertRevurdering
 import no.nav.su.se.bakover.test.vilkår.utenlandsoppholdAvslag
 import no.nav.su.se.bakover.test.vilkårsvurderinger.avslåttUførevilkårUtenGrunnlag
 import org.junit.jupiter.api.Test
@@ -29,42 +30,19 @@ import org.junit.jupiter.api.fail
 class RevurderingSimulerTest {
     @Test
     fun `avkortingsvarsel dersom opphør skyldes utenlandsopphold og simulering inneholder feilutbetaling`() {
-        opprettetRevurderingAvslagSpesifiktVilkår(
-            avslåttVilkår = utenlandsoppholdAvslag(),
-        ).let { (sak, revurdering) ->
-            revurdering.beregn(
-                eksisterendeUtbetalinger = sak.utbetalinger,
-                clock = fixedClock,
-                gjeldendeVedtaksdata = sak.kopierGjeldendeVedtaksdata(
-                    fraOgMed = revurdering.periode.fraOgMed,
-                    clock = fixedClock,
-                ).getOrFail(),
-                satsFactory = satsFactoryTestPåDato(),
-            ).getOrFail().let { beregnet ->
-                (beregnet as BeregnetRevurdering.Opphørt)
-                    .simuler(
-                        saksbehandler = saksbehandler,
-                        clock = fixedClock,
-                    ) {
-                        opphørUtbetalingSimulert(
-                            sakOgBehandling = sak to beregnet,
-                            opphørsperiode = it.opphørsperiode,
-                            clock = fixedClock,
-                        ).right()
-                    }.getOrFail()
-                    .let { simulert ->
-                        simulert.avkorting.let {
-                            (it as AvkortingVedRevurdering.Håndtert.OpprettNyttAvkortingsvarsel).let { avkorting ->
-                                avkorting.avkortingsvarsel shouldBe Avkortingsvarsel.Utenlandsopphold.Opprettet(
-                                    id = avkorting.avkortingsvarsel.id,
-                                    sakId = revurdering.sakId,
-                                    revurderingId = revurdering.id,
-                                    opprettet = avkorting.avkortingsvarsel.opprettet,
-                                    simulering = avkorting.avkortingsvarsel.simulering,
-                                ).skalAvkortes()
-                            }
-                        }
-                    }
+        simulertRevurdering(
+            vilkårOverrides = listOf(utenlandsoppholdAvslag()),
+        ).let { (_, revurdering) ->
+            revurdering.avkorting.let {
+                (it as AvkortingVedRevurdering.Håndtert.OpprettNyttAvkortingsvarsel).let { avkorting ->
+                    avkorting.avkortingsvarsel shouldBe Avkortingsvarsel.Utenlandsopphold.Opprettet(
+                        id = avkorting.avkortingsvarsel.id,
+                        sakId = revurdering.sakId,
+                        revurderingId = revurdering.id,
+                        opprettet = avkorting.avkortingsvarsel.opprettet,
+                        simulering = avkorting.avkortingsvarsel.simulering,
+                    ).skalAvkortes()
+                }
             }
         }
     }
@@ -72,29 +50,28 @@ class RevurderingSimulerTest {
     @Test
     fun `kaster exception dersom simulering med justert opphørsdato for utbetaling inneholder feilutbetalinger`() {
         assertThrows<IllegalStateException> {
-            opprettetRevurderingAvslagSpesifiktVilkår(
-                avslåttVilkår = utenlandsoppholdAvslag(),
+            beregnetRevurdering(
+                vilkårOverrides = listOf(utenlandsoppholdAvslag()),
             ).let { (sak, revurdering) ->
-                revurdering.beregn(
-                    eksisterendeUtbetalinger = sak.utbetalinger,
-                    clock = fixedClock,
-                    gjeldendeVedtaksdata = sak.kopierGjeldendeVedtaksdata(
-                        fraOgMed = revurdering.periode.fraOgMed,
+                revurdering.shouldBeType<BeregnetRevurdering.Opphørt>().let { beregnet ->
+                    beregnet.simuler(
+                        saksbehandler = saksbehandler,
                         clock = fixedClock,
-                    ).getOrFail(),
-                    satsFactory = satsFactoryTestPåDato(),
-                ).getOrFail().let { beregnet ->
-                    (beregnet as BeregnetRevurdering.Opphørt)
-                        .simuler(
-                            saksbehandler = saksbehandler,
-                            clock = fixedClock,
-                        ) {
-                            opphørUtbetalingSimulert(
-                                sakOgBehandling = sak to beregnet,
-                                opphørsperiode = beregnet.periode,
+                        lagUtbetaling = sak::lagUtbetalingForOpphør,
+                        eksisterendeUtbetalinger = sak::utbetalinger,
+                    ) { utbetaling, eksisterende, opphørsperiode ->
+                        beregnet.periode shouldNotBe opphørsperiode
+                        utbetaling.toSimulertUtbetaling(
+                            simuleringOpphørt(
+                                opphørsperiode = beregnet.periode, // bruk feil periode
+                                eksisterendeUtbetalinger = eksisterende,
+                                fnr = beregnet.fnr,
+                                sakId = beregnet.sakId,
+                                saksnummer = beregnet.saksnummer,
                                 clock = fixedClock,
-                            ).right()
-                        }.getOrFail()
+                            ),
+                        ).right()
+                    }.getOrFail()
                 }
             }
         }
@@ -102,75 +79,23 @@ class RevurderingSimulerTest {
 
     @Test
     fun `ingen avkortingsvarsel dersom opphør ikke skyldes utenlandsopphold og simulering inneholder feilutbetaling`() {
-        opprettetRevurderingAvslagSpesifiktVilkår(
-            avslåttVilkår = avslåttUførevilkårUtenGrunnlag(),
-        ).let { (sak, revurdering) ->
-            revurdering.beregn(
-                eksisterendeUtbetalinger = sak.utbetalinger,
-                clock = fixedClock,
-                gjeldendeVedtaksdata = sak.kopierGjeldendeVedtaksdata(
-                    fraOgMed = revurdering.periode.fraOgMed,
-                    clock = fixedClock,
-                ).getOrFail(),
-                satsFactory = satsFactoryTestPåDato(),
-            ).getOrFail().let { beregnet ->
-                (beregnet as BeregnetRevurdering.Opphørt)
-                    .simuler(
-                        saksbehandler = saksbehandler,
-                        clock = fixedClock,
-                    ) {
-                        opphørUtbetalingSimulert(
-                            sakOgBehandling = sak to beregnet,
-                            opphørsperiode = it.opphørsperiode,
-                            clock = fixedClock,
-                        ).right()
-                    }.getOrFail()
-                    .let {
-                        it.avkorting shouldBe AvkortingVedRevurdering.Håndtert.IngenNyEllerUtestående
-                    }
-            }
+        simulertRevurdering(
+            vilkårOverrides = listOf(avslåttUførevilkårUtenGrunnlag()),
+        ).let { (_, revurdering) ->
+            revurdering.simulering.harFeilutbetalinger() shouldBe true
+            revurdering.avkorting shouldBe AvkortingVedRevurdering.Håndtert.IngenNyEllerUtestående
         }
     }
 
     @Test
     fun `ingen avkortingsvarsel dersom opphør ikke fører til feilutbetaling`() {
-        opprettetRevurderingFraInnvilgetSøknadsbehandlingsVedtak(
-            revurderingsperiode = Periode.create(1.september(2021), 31.desember(2021)),
-        ).let { (sak, revurdering) ->
-            revurdering.oppdaterFradragOgMarkerSomVurdert(
-                fradragsgrunnlag = listOf(
-                    fradragsgrunnlagArbeidsinntekt(
-                        periode = Periode.create(1.september(2021), 31.desember(2021)),
-                        arbeidsinntekt = 35000.0,
-                        tilhører = FradragTilhører.BRUKER,
-                    ),
-                ),
-            ).getOrFail().let {
-                it.beregn(
-                    eksisterendeUtbetalinger = sak.utbetalinger,
-                    clock = fixedClock,
-                    gjeldendeVedtaksdata = sak.kopierGjeldendeVedtaksdata(
-                        fraOgMed = revurdering.periode.fraOgMed,
-                        clock = fixedClock,
-                    ).getOrFail(),
-                    satsFactory = satsFactoryTestPåDato(),
-                ).getOrFail().let { beregnet ->
-                    (beregnet as BeregnetRevurdering.Opphørt)
-                        .simuler(
-                            saksbehandler = saksbehandler,
-                            clock = fixedClock,
-                        ) {
-                            opphørUtbetalingSimulert(
-                                sakOgBehandling = sak to beregnet,
-                                opphørsperiode = it.opphørsperiode,
-                                clock = fixedClock,
-                            ).right()
-                        }.getOrFail()
-                        .let {
-                            it.avkorting shouldBe AvkortingVedRevurdering.Håndtert.IngenNyEllerUtestående
-                        }
-                }
-            }
+        val revurderingsperiode = Periode.create(1.september(2021), 31.desember(2021))
+        simulertRevurdering(
+            revurderingsperiode = revurderingsperiode,
+            vilkårOverrides = listOf(utenlandsoppholdAvslag(periode = revurderingsperiode)),
+        ).let { (_, revurdering) ->
+            revurdering.simulering.harFeilutbetalinger() shouldBe false
+            revurdering.avkorting shouldBe AvkortingVedRevurdering.Håndtert.IngenNyEllerUtestående
         }
     }
 

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitorTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitorTest.kt
@@ -15,6 +15,7 @@ import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.juni
 import no.nav.su.se.bakover.common.periode.Periode
+import no.nav.su.se.bakover.common.periode.august
 import no.nav.su.se.bakover.common.periode.desember
 import no.nav.su.se.bakover.common.periode.juni
 import no.nav.su.se.bakover.common.periode.mai
@@ -1350,15 +1351,17 @@ internal class LagBrevRequestVisitorTest {
 
     @Test
     fun `lager opphørsvedtak med opphørsgrunn for høy inntekt`() {
-        val opphørsperiode = år(2021)
+        val opphørsperiode = august(2021)..desember(2021)
 
         val (_, revurdering, opphørsvedtak) = vedtakRevurdering(
+            revurderingsperiode = opphørsperiode,
             grunnlagsdataOverrides = listOf(
                 fradragsgrunnlagArbeidsinntekt(
                     arbeidsinntekt = 150000.0,
                     periode = opphørsperiode,
                 ),
             ),
+            fritekstTilBrev = "FRITEKST REVURDERING",
         ).let {
             Triple(sak, it.second.behandling as IverksattRevurdering, it.second)
         }
@@ -1393,7 +1396,17 @@ internal class LagBrevRequestVisitorTest {
             saksnummer = revurdering.saksnummer,
             opphørsperiode = revurdering.periode,
             avkortingsBeløp = null,
-            satsoversikt = `satsoversikt2021EnsligPr01-01-21`,
+            satsoversikt = Satsoversikt(
+                perioder = listOf(
+                    Satsoversikt.Satsperiode(
+                        fraOgMed = "01.08.2021",
+                        tilOgMed = "31.12.2021",
+                        sats = "høy",
+                        satsBeløp = 20946,
+                        satsGrunn = "ENSLIG",
+                    ),
+                ),
+            ),
             halvtGrunnbeløp = 50676, // halvparten av grunnbeløp for 2020-05-01 som er 101351 avrundet
         ).right()
     }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitorTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/visitor/LagBrevRequestVisitorTest.kt
@@ -46,13 +46,10 @@ import no.nav.su.se.bakover.domain.grunnlag.Formuegrunnlag
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlag.Bosituasjon.Companion.harEPS
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
-import no.nav.su.se.bakover.domain.grunnlag.GrunnlagsdataOgVilkårsvurderinger
 import no.nav.su.se.bakover.domain.grunnlag.firstOrThrowIfMultipleOrEmpty
 import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
 import no.nav.su.se.bakover.domain.oppdrag.tilbakekreving.IkkeBehovForTilbakekrevingFerdigbehandlet
-import no.nav.su.se.bakover.domain.oppdrag.tilbakekreving.IkkeBehovForTilbakekrevingUnderBehandling
 import no.nav.su.se.bakover.domain.oppgave.OppgaveId
-import no.nav.su.se.bakover.domain.revurdering.BeregnetRevurdering
 import no.nav.su.se.bakover.domain.revurdering.Forhåndsvarsel
 import no.nav.su.se.bakover.domain.revurdering.InformasjonSomRevurderes
 import no.nav.su.se.bakover.domain.revurdering.IverksattRevurdering
@@ -65,7 +62,6 @@ import no.nav.su.se.bakover.domain.vilkår.UføreVilkår
 import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
 import no.nav.su.se.bakover.domain.vilkår.Vurdering
 import no.nav.su.se.bakover.domain.vilkår.VurderingsperiodeUføre
-import no.nav.su.se.bakover.test.bosituasjongrunnlagEnslig
 import no.nav.su.se.bakover.test.create
 import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.fixedLocalDate
@@ -74,9 +70,6 @@ import no.nav.su.se.bakover.test.fradragsgrunnlagArbeidsinntekt
 import no.nav.su.se.bakover.test.generer
 import no.nav.su.se.bakover.test.getOrFail
 import no.nav.su.se.bakover.test.iverksattRevurderingOpphørtUføreFraInnvilgetSøknadsbehandlingsVedtak
-import no.nav.su.se.bakover.test.oppgaveIdRevurdering
-import no.nav.su.se.bakover.test.opphørUtbetalingSimulert
-import no.nav.su.se.bakover.test.opprettetRevurderingFraInnvilgetSøknadsbehandlingsVedtak
 import no.nav.su.se.bakover.test.satsFactoryTestPåDato
 import no.nav.su.se.bakover.test.shouldBeType
 import no.nav.su.se.bakover.test.simulerNyUtbetaling
@@ -94,7 +87,6 @@ import no.nav.su.se.bakover.test.vilkår.tilstrekkeligDokumentert
 import no.nav.su.se.bakover.test.vilkår.utenlandsoppholdInnvilget
 import no.nav.su.se.bakover.test.vilkårsvurderingRevurderingIkkeVurdert
 import no.nav.su.se.bakover.test.vilkårsvurderinger.avslåttUførevilkårUtenGrunnlag
-import no.nav.su.se.bakover.test.vilkårsvurderingerSøknadsbehandlingInnvilget
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.fail
@@ -1358,65 +1350,18 @@ internal class LagBrevRequestVisitorTest {
 
     @Test
     fun `lager opphørsvedtak med opphørsgrunn for høy inntekt`() {
-        val utbetalingId = UUID30.randomUUID()
         val opphørsperiode = år(2021)
 
-        val (sak, revurdering) = opprettetRevurderingFraInnvilgetSøknadsbehandlingsVedtak(
-            revurderingsperiode = opphørsperiode,
-            grunnlagsdataOgVilkårsvurderinger = GrunnlagsdataOgVilkårsvurderinger.Søknadsbehandling(
-                grunnlagsdata = Grunnlagsdata.create(
-                    fradragsgrunnlag = listOf(
-                        fradragsgrunnlagArbeidsinntekt(
-                            arbeidsinntekt = 150000.0,
-                            periode = opphørsperiode,
-                        ),
-                    ),
-                    bosituasjon = listOf(
-                        bosituasjongrunnlagEnslig(periode = opphørsperiode),
-                    ),
-                ),
-                vilkårsvurderinger = vilkårsvurderingerSøknadsbehandlingInnvilget(
+        val (_, revurdering, opphørsvedtak) = vedtakRevurdering(
+            grunnlagsdataOverrides = listOf(
+                fradragsgrunnlagArbeidsinntekt(
+                    arbeidsinntekt = 150000.0,
                     periode = opphørsperiode,
                 ),
             ),
-        )
-
-        val attestert = revurdering.beregn(
-            eksisterendeUtbetalinger = sak.utbetalinger,
-            clock = fixedClock,
-            gjeldendeVedtaksdata = sak.kopierGjeldendeVedtaksdata(
-                fraOgMed = revurdering.periode.fraOgMed,
-                clock = fixedClock,
-            ).getOrFail(),
-            satsFactory = satsFactoryTestPåDato(),
-        ).getOrFail().let { beregnet ->
-            (beregnet as BeregnetRevurdering.Opphørt).simuler(
-                saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
-                clock = fixedClock,
-            ) {
-                opphørUtbetalingSimulert(
-                    sakOgBehandling = sak to beregnet,
-                    opphørsperiode = it.opphørsperiode,
-                    clock = fixedClock,
-                ).right()
-            }.getOrFail()
-        }.ikkeSendForhåndsvarsel().getOrFail()
-            .oppdaterTilbakekrevingsbehandling(
-                tilbakekrevingsbehandling = IkkeBehovForTilbakekrevingUnderBehandling,
-            )
-            .tilAttestering(
-                attesteringsoppgaveId = oppgaveIdRevurdering,
-                saksbehandler = saksbehandler,
-                fritekstTilBrev = "FRITEKST REVURDERING",
-            ).getOrFail()
-            .tilIverksatt(
-                attestant = attestant,
-                hentOpprinneligAvkorting = { null },
-                clock = fixedClock,
-            )
-            .getOrFail()
-
-        val opphørsvedtak = VedtakSomKanRevurderes.from(attestert, utbetalingId, fixedClock)
+        ).let {
+            Triple(sak, it.second.behandling as IverksattRevurdering, it.second)
+        }
 
         val brevRevurdering = LagBrevRequestVisitor(
             hentPerson = { person.right() },
@@ -1424,7 +1369,7 @@ internal class LagBrevRequestVisitorTest {
             hentGjeldendeUtbetaling = { _, _ -> 0.right() },
             clock = fixedClock,
             satsFactory = satsFactoryTestPåDato(),
-        ).apply { attestert.accept(this) }
+        ).apply { revurdering.accept(this) }
 
         val brevVedtak = LagBrevRequestVisitor(
             hentPerson = { person.right() },
@@ -1437,8 +1382,8 @@ internal class LagBrevRequestVisitorTest {
         brevRevurdering.brevRequest shouldBe brevVedtak.brevRequest
         brevRevurdering.brevRequest shouldBe LagBrevRequest.Opphørsvedtak(
             person = person,
-            beregning = attestert.beregning,
-            harEktefelle = attestert.grunnlagsdata.bosituasjon.harEPS(),
+            beregning = revurdering.beregning,
+            harEktefelle = revurdering.grunnlagsdata.bosituasjon.harEPS(),
             saksbehandlerNavn = saksbehandlerNavn,
             attestantNavn = attestantNavn,
             fritekst = "FRITEKST REVURDERING",

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/AccessCheckProxy.kt
@@ -248,11 +248,11 @@ open class AccessCheckProxy(
                 }
 
                 override fun simulerOpphør(
-                    request: SimulerUtbetalingRequest.OpphørRequest,
+                    utbetaling: Utbetaling.UtbetalingForSimulering,
+                    eksisterendeUtbetalinger: List<Utbetaling>,
+                    opphørsperiode: Periode,
                 ): Either<SimuleringFeilet, Utbetaling.SimulertUtbetaling> {
-                    assertHarTilgangTilSak(request.sakId)
-
-                    return services.utbetaling.simulerOpphør(request)
+                    kastKanKunKallesFraAnnenService()
                 }
 
                 override fun klargjørNyUtbetaling(request: UtbetalRequest.NyUtbetaling, transactionContext: TransactionContext): Either<UtbetalingFeilet, UtbetalingKlargjortForOversendelse<UtbetalingFeilet.Protokollfeil>> {
@@ -280,7 +280,10 @@ open class AccessCheckProxy(
                 }
 
                 override fun klargjørOpphør(
-                    request: UtbetalRequest.Opphør,
+                    utbetaling: Utbetaling.UtbetalingForSimulering,
+                    eksisterendeUtbetalinger: List<Utbetaling>,
+                    opphørsperiode: Periode,
+                    saksbehandlersSimulering: Simulering,
                     transactionContext: TransactionContext,
                 ): Either<UtbetalingFeilet, UtbetalingKlargjortForOversendelse<UtbetalingFeilet.Protokollfeil>> {
                     kastKanKunKallesFraAnnenService()

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingService.kt
@@ -2,6 +2,7 @@ package no.nav.su.se.bakover.service.utbetaling
 
 import arrow.core.Either
 import no.nav.su.se.bakover.common.UUID30
+import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.common.persistence.TransactionContext
 import no.nav.su.se.bakover.domain.oppdrag.FantIkkeGjeldendeUtbetaling
 import no.nav.su.se.bakover.domain.oppdrag.FeilVedKryssjekkAvTidslinjerOgSimulering
@@ -30,9 +31,10 @@ interface UtbetalingService {
     fun simulerUtbetaling(
         request: SimulerUtbetalingRequest.NyUtbetalingRequest,
     ): Either<SimuleringFeilet, Utbetaling.SimulertUtbetaling>
-
     fun simulerOpphør(
-        request: SimulerUtbetalingRequest.OpphørRequest,
+        utbetaling: Utbetaling.UtbetalingForSimulering,
+        eksisterendeUtbetalinger: List<Utbetaling>,
+        opphørsperiode: Periode,
     ): Either<SimuleringFeilet, Utbetaling.SimulertUtbetaling>
 
     /**
@@ -98,8 +100,12 @@ interface UtbetalingService {
      * i tillegg til [UtbetalingKlargjortForOversendelse.callback] for å publisere utbetalingen på kø mot OS. Kall til denne funksjonen bør gjennomføres
      * som det siste steget i [transactionContext], slik at eventuelle feil her kan rulle tilbake hele transaksjonen.
      */
+
     fun klargjørOpphør(
-        request: UtbetalRequest.Opphør,
+        utbetaling: Utbetaling.UtbetalingForSimulering,
+        eksisterendeUtbetalinger: List<Utbetaling>,
+        opphørsperiode: Periode,
+        saksbehandlersSimulering: Simulering,
         transactionContext: TransactionContext,
     ): Either<UtbetalingFeilet, UtbetalingKlargjortForOversendelse<UtbetalingFeilet.Protokollfeil>>
 

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingBeregnOgSimulerTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingBeregnOgSimulerTest.kt
@@ -72,7 +72,7 @@ internal class RevurderingBeregnOgSimulerTest {
         val serviceAndMocks = RevurderingServiceMocks(
             revurderingRepo = mock(),
             utbetalingService = mock {
-                on { simulerOpphør(any()) } doReturn opphørUtbetalingSimulert(
+                on { simulerOpphør(any(), any(), any()) } doReturn opphørUtbetalingSimulert(
                     sakOgBehandling = sak to opprettet,
                     opphørsperiode = opprettet.periode,
                     clock = fixedClock,
@@ -142,7 +142,7 @@ internal class RevurderingBeregnOgSimulerTest {
         RevurderingServiceMocks(
             revurderingRepo = mock(),
             utbetalingService = mock {
-                on { simulerOpphør(any()) } doReturn opphørUtbetalingSimulert(
+                on { simulerOpphør(any(), any(), any()) } doReturn opphørUtbetalingSimulert(
                     sakOgBehandling = sak to revurdering,
                     opphørsperiode = revurdering.periode,
                     clock = fixedClock,
@@ -393,7 +393,7 @@ internal class RevurderingBeregnOgSimulerTest {
         val serviceAndMocks = RevurderingServiceMocks(
             revurderingRepo = mock(),
             utbetalingService = mock {
-                on { simulerOpphør(any()) } doReturn opphørUtbetalingSimulert(
+                on { simulerOpphør(any(), any(), any()) } doReturn opphørUtbetalingSimulert(
                     sakOgBehandling = sak to opprettet,
                     opphørsperiode = opprettet.periode,
                     clock = fixedClock,
@@ -416,11 +416,15 @@ internal class RevurderingBeregnOgSimulerTest {
             verify(serviceAndMocks.sakService).hentSakForRevurdering(opprettet.id)
             verify(serviceAndMocks.utbetalingService).simulerOpphør(
                 argThat {
-                    it shouldBe SimulerUtbetalingRequest.Opphør(
-                        sakId = sakId,
-                        saksbehandler = NavIdentBruker.Saksbehandler("s1"),
-                        opphørsperiode = opprettet.periode,
-                    )
+                    it.tidligsteDato() shouldBe opprettet.periode.fraOgMed
+                    it.senesteDato() shouldBe opprettet.periode.tilOgMed
+                    it.behandler shouldBe NavIdentBruker.Saksbehandler("s1")
+                },
+                argThat {
+                    it shouldBe sak.utbetalinger
+                },
+                argThat {
+                    it shouldBe opprettet.periode
                 },
             )
             verify(serviceAndMocks.revurderingRepo).defaultTransactionContext()

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/utbetaling/UtbetalingServiceImplTest.kt
@@ -14,12 +14,12 @@ import no.nav.su.se.bakover.common.periode.februar
 import no.nav.su.se.bakover.common.periode.januar
 import no.nav.su.se.bakover.common.periode.mars
 import no.nav.su.se.bakover.common.toPeriode
-import no.nav.su.se.bakover.domain.oppdrag.SimulerUtbetalingRequest
 import no.nav.su.se.bakover.domain.oppdrag.Utbetaling
 import no.nav.su.se.bakover.domain.oppdrag.UtbetalingslinjePåTidslinje
 import no.nav.su.se.bakover.domain.oppdrag.avstemming.Avstemmingsnøkkel
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimulerUtbetalingForPeriode
 import no.nav.su.se.bakover.domain.sak.lagUtbetalingForGjenopptak
+import no.nav.su.se.bakover.domain.sak.lagUtbetalingForOpphør
 import no.nav.su.se.bakover.domain.sak.lagUtbetalingForStans
 import no.nav.su.se.bakover.service.argThat
 import no.nav.su.se.bakover.test.fixedClock
@@ -221,11 +221,13 @@ internal class UtbetalingServiceImplTest {
                 clock = tikkendeFixedClock,
             ).let {
                 it.service.simulerOpphør(
-                    request = SimulerUtbetalingRequest.Opphør(
-                        sakId = sak.id,
-                        saksbehandler = saksbehandler,
+                    utbetaling = sak.lagUtbetalingForOpphør(
                         opphørsperiode = 1.februar(2021).rangeTo(vedtak.periode.tilOgMed).toPeriode(),
+                        behandler = saksbehandler,
+                        clock = tikkendeFixedClock,
                     ),
+                    eksisterendeUtbetalinger = sak.utbetalinger,
+                    opphørsperiode = 1.februar(2021).rangeTo(vedtak.periode.tilOgMed).toPeriode(),
                 ).getOrFail() shouldBe beOfType<Utbetaling.SimulertUtbetaling>()
 
                 verify(it.simuleringClient, times(2)).simulerUtbetaling(

--- a/test-common/src/main/kotlin/RevurderingTestData.kt
+++ b/test-common/src/main/kotlin/RevurderingTestData.kt
@@ -387,8 +387,8 @@ fun revurderingTilAttestering(
 
                 oppdatertTilbakekreving.tilAttestering(
                     attesteringsoppgaveId = attesteringsoppgaveId,
-                    saksbehandler = simulert.saksbehandler,
-                    fritekstTilBrev = simulert.fritekstTilBrev,
+                    saksbehandler = saksbehandler,
+                    fritekstTilBrev = fritekstTilBrev,
                 ).getOrFail()
             }
         }

--- a/test-common/src/main/kotlin/SimuleringTestData.kt
+++ b/test-common/src/main/kotlin/SimuleringTestData.kt
@@ -225,7 +225,6 @@ fun simuleringOpphørt(
         eksisterendeUtbetalinger = eksisterendeUtbetalinger,
         behandler = saksbehandler,
         clock = clock,
-        // TODO send med periode
         periode = opphørsperiode,
         sakstype = Sakstype.UFØRE, // TODO("simulering_utbetaling_alder utled fra sak/behandling")
     ).generate().let {


### PR DESCRIPTION
Føles som det kan være potensial for videre refaktorering, f.eks trekke ut sjekkene mot tidslinje/tidligere attesteringer fra servicen og inn i domenet. Det vil gi et litt mer behagelig og clean api mot servicen.