### PR TITLE
Begrens utplukk fra gjeldende vedtaksdata for beregning til revurderingens periode

### DIFF
--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurdering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/Revurdering.kt
@@ -502,6 +502,7 @@ sealed class Revurdering :
     }
 
     protected fun oppdaterFradragInternal(fradragsgrunnlag: List<Grunnlag.Fradragsgrunnlag>): Either<KunneIkkeLeggeTilFradrag, OpprettetRevurdering> {
+        require(fradragsgrunnlag.all { periode inneholder it.periode })
         return Grunnlagsdata.tryCreate(
             bosituasjon = grunnlagsdata.bosituasjon,
             fradragsgrunnlag = fradragsgrunnlag,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/beregning/BeregnRevurderingStrategyDecider.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/beregning/BeregnRevurderingStrategyDecider.kt
@@ -16,6 +16,9 @@ internal class BeregnRevurderingStrategyDecider(
     private val clock: Clock,
     private val beregningStrategyFactory: BeregningStrategyFactory,
 ) {
+    init {
+        require(revurdering.periode == gjeldendeVedtaksdata.garantertSammenhengendePeriode()) { "Periode for revurdering:${revurdering.periode} og gjeldende vedtaksdata:${gjeldendeVedtaksdata.garantertSammenhengendePeriode()} er forskjellig" }
+    }
     fun decide(): BeregnRevurderingStrategy {
         /**
          * Lurer typesystemet til å snevre inn valgmulighetene for avkorting ved å forsøke en vanlig beregning først.

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/LeggTilFradragTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/LeggTilFradragTest.kt
@@ -1,0 +1,98 @@
+package no.nav.su.se.bakover.domain.revurdering
+
+import arrow.core.left
+import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.domain.beregning.fradrag.FradragTilhører
+import no.nav.su.se.bakover.domain.beregning.fradrag.Fradragstype
+import no.nav.su.se.bakover.domain.grunnlag.Konsistensproblem
+import no.nav.su.se.bakover.domain.grunnlag.KunneIkkeLageGrunnlagsdata
+import no.nav.su.se.bakover.test.bosituasjongrunnlagEnslig
+import no.nav.su.se.bakover.test.lagFradragsgrunnlag
+import no.nav.su.se.bakover.test.opprettetRevurdering
+import no.nav.su.se.bakover.test.revurderingTilAttestering
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class LeggTilFradragTest {
+
+    @Test
+    fun `ugyldig status for å legge til fradrag`() {
+        val (_, tilAttestering) = revurderingTilAttestering()
+
+        lagFradragsgrunnlag(
+            type = Fradragstype.Arbeidsinntekt,
+            månedsbeløp = 100.0,
+            periode = tilAttestering.periode,
+            utenlandskInntekt = null,
+            tilhører = FradragTilhører.BRUKER,
+        ).let {
+            tilAttestering.oppdaterFradrag(listOf(it)) shouldBe Revurdering.KunneIkkeLeggeTilFradrag.UgyldigTilstand(
+                tilAttestering::class,
+                OpprettetRevurdering::class,
+            ).left()
+
+            tilAttestering.oppdaterFradragOgMarkerSomVurdert(listOf(it)) shouldBe Revurdering.KunneIkkeLeggeTilFradrag.UgyldigTilstand(
+                tilAttestering::class,
+                OpprettetRevurdering::class,
+            ).left()
+        }
+    }
+
+    @Test
+    fun `kryssvaliderer fradrag og bosituasjon`() {
+        val (_, opprettetRevurdering) = opprettetRevurdering(
+            grunnlagsdataOverrides = listOf(
+                bosituasjongrunnlagEnslig(),
+            ),
+        )
+
+        lagFradragsgrunnlag(
+            type = Fradragstype.Arbeidsinntekt,
+            månedsbeløp = 0.0,
+            periode = opprettetRevurdering.periode,
+            utenlandskInntekt = null,
+            tilhører = FradragTilhører.EPS,
+        ).let {
+            opprettetRevurdering.oppdaterFradrag(listOf(it)) shouldBe Revurdering.KunneIkkeLeggeTilFradrag.Valideringsfeil(
+                KunneIkkeLageGrunnlagsdata.Konsistenssjekk(Konsistensproblem.BosituasjonOgFradrag.KombinasjonAvBosituasjonOgFradragErUgyldig),
+            ).left()
+
+            opprettetRevurdering.oppdaterFradragOgMarkerSomVurdert(listOf(it)) shouldBe Revurdering.KunneIkkeLeggeTilFradrag.Valideringsfeil(
+                KunneIkkeLageGrunnlagsdata.Konsistenssjekk(Konsistensproblem.BosituasjonOgFradrag.KombinasjonAvBosituasjonOgFradragErUgyldig),
+            ).left()
+        }
+    }
+
+    @Test
+    fun `tryner hvis perioden for alle fradrag ikke er innenfor revurderingens periode`() {
+        val (_, opprettetRevurdering) = opprettetRevurdering(
+            grunnlagsdataOverrides = listOf(
+                bosituasjongrunnlagEnslig(),
+            ),
+        )
+
+        listOf(
+            lagFradragsgrunnlag(
+                type = Fradragstype.Arbeidsinntekt,
+                månedsbeløp = 0.0,
+                periode = opprettetRevurdering.periode,
+                utenlandskInntekt = null,
+                tilhører = FradragTilhører.EPS,
+            ),
+            lagFradragsgrunnlag(
+                type = Fradragstype.Arbeidsinntekt,
+                månedsbeløp = 0.0,
+                periode = opprettetRevurdering.periode.forskyv(1),
+                utenlandskInntekt = null,
+                tilhører = FradragTilhører.EPS,
+            ),
+        ).let {
+            assertThrows<IllegalArgumentException> {
+                opprettetRevurdering.oppdaterFradrag(it)
+            }
+            assertThrows<IllegalArgumentException> {
+                opprettetRevurdering.oppdaterFradragOgMarkerSomVurdert(it)
+            }
+        }
+    }
+}

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -589,8 +589,8 @@ internal class RevurderingServiceImpl(
         return when (originalRevurdering) {
             is BeregnetRevurdering, is OpprettetRevurdering, is SimulertRevurdering, is UnderkjentRevurdering -> {
                 val eksisterendeUtbetalinger = sak.utbetalinger
-                val gjeldendeVedtaksdata = sak.kopierGjeldendeVedtaksdata(
-                    fraOgMed = originalRevurdering.periode.fraOgMed,
+                val gjeldendeVedtaksdata = sak.hentGjeldendeVedtaksdata(
+                    periode = originalRevurdering.periode,
                     clock = clock,
                 ).getOrHandle {
                     throw IllegalStateException("Fant ikke gjeldende vedtaksdata for sak:${originalRevurdering.sakId}")

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/LeggTilFradragsgrunnlagTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/LeggTilFradragsgrunnlagTest.kt
@@ -4,29 +4,15 @@ import arrow.core.getOrHandle
 import arrow.core.left
 import io.kotest.assertions.fail
 import io.kotest.matchers.shouldBe
-import no.nav.su.se.bakover.common.desember
-import no.nav.su.se.bakover.common.januar
-import no.nav.su.se.bakover.common.juli
-import no.nav.su.se.bakover.common.mai
-import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.common.periode.år
 import no.nav.su.se.bakover.domain.beregning.fradrag.FradragTilhører
 import no.nav.su.se.bakover.domain.beregning.fradrag.Fradragstype
-import no.nav.su.se.bakover.domain.grunnlag.Grunnlag
-import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
-import no.nav.su.se.bakover.domain.grunnlag.GrunnlagsdataOgVilkårsvurderinger
-import no.nav.su.se.bakover.domain.grunnlag.Konsistensproblem
-import no.nav.su.se.bakover.domain.grunnlag.KunneIkkeLageGrunnlagsdata
-import no.nav.su.se.bakover.domain.revurdering.OpprettetRevurdering
 import no.nav.su.se.bakover.domain.revurdering.RevurderingRepo
 import no.nav.su.se.bakover.service.argThat
 import no.nav.su.se.bakover.service.grunnlag.LeggTilFradragsgrunnlagRequest
-import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.lagFradragsgrunnlag
 import no.nav.su.se.bakover.test.opprettetRevurderingFraInnvilgetSøknadsbehandlingsVedtak
 import no.nav.su.se.bakover.test.revurderingId
-import no.nav.su.se.bakover.test.tilAttesteringRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak
-import no.nav.su.se.bakover.test.vilkårsvurderingerSøknadsbehandlingInnvilget
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -34,7 +20,6 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verifyNoMoreInteractions
-import java.util.UUID
 
 internal class LeggTilFradragsgrunnlagTest {
 
@@ -114,99 +99,5 @@ internal class LeggTilFradragsgrunnlagTest {
         }
 
         verifyNoMoreInteractions(revurderingRepoMock)
-    }
-
-    @Test
-    fun `leggTilFradragsgrunnlag - lagreFradrag har en status som gjør at man ikke kan legge til fradrag`() {
-        val eksisterendeRevurdering = tilAttesteringRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak().second
-
-        val revurderingRepoMock = mock<RevurderingRepo> {
-            on { hent(any()) } doReturn eksisterendeRevurdering
-        }
-
-        val revurderingService = RevurderingTestUtils.createRevurderingService(
-            revurderingRepo = revurderingRepoMock,
-        )
-
-        val request = LeggTilFradragsgrunnlagRequest(
-            behandlingId = eksisterendeRevurdering.id,
-            fradragsgrunnlag = listOf(
-                lagFradragsgrunnlag(
-                    type = Fradragstype.Arbeidsinntekt,
-                    månedsbeløp = 0.0,
-                    periode = år(2021),
-                    utenlandskInntekt = null,
-                    tilhører = FradragTilhører.BRUKER,
-                ),
-            ),
-        )
-
-        revurderingService.leggTilFradragsgrunnlag(
-            request,
-        ) shouldBe
-            KunneIkkeLeggeTilFradragsgrunnlag.UgyldigTilstand(
-                fra = eksisterendeRevurdering::class,
-                til = OpprettetRevurdering::class,
-            ).left()
-
-        inOrder(
-            revurderingRepoMock,
-        ) {
-            verify(revurderingRepoMock).hent(argThat { it shouldBe eksisterendeRevurdering.id })
-        }
-
-        verifyNoMoreInteractions(revurderingRepoMock)
-    }
-
-    @Test
-    fun `validerer fradragsgrunnlag`() {
-        val revurderingsperiode = Periode.create(1.mai(2021), 31.desember(2021))
-        val opprettetRevurdering = opprettetRevurderingFraInnvilgetSøknadsbehandlingsVedtak(
-            revurderingsperiode = revurderingsperiode,
-            grunnlagsdataOgVilkårsvurderinger = GrunnlagsdataOgVilkårsvurderinger.Søknadsbehandling(
-                vilkårsvurderinger = vilkårsvurderingerSøknadsbehandlingInnvilget(periode = revurderingsperiode),
-                grunnlagsdata = Grunnlagsdata.create(
-                    bosituasjon = listOf(
-                        Grunnlag.Bosituasjon.Fullstendig.Enslig(
-                            id = UUID.randomUUID(),
-                            opprettet = fixedTidspunkt,
-                            periode = revurderingsperiode,
-                        ),
-                    ),
-                ),
-            ),
-        )
-
-        val revurderingRepoMock = mock<RevurderingRepo> {
-            on { hent(any()) } doReturn opprettetRevurdering.second
-        }
-
-        val revurderingService = RevurderingTestUtils.createRevurderingService(
-            revurderingRepo = revurderingRepoMock,
-        )
-
-        val request = LeggTilFradragsgrunnlagRequest(
-            behandlingId = revurderingId,
-            fradragsgrunnlag = listOf(
-                lagFradragsgrunnlag(
-                    type = Fradragstype.Arbeidsinntekt,
-                    månedsbeløp = 0.0,
-                    periode = revurderingsperiode,
-                    utenlandskInntekt = null,
-                    tilhører = FradragTilhører.BRUKER,
-                ),
-                lagFradragsgrunnlag(
-                    type = Fradragstype.Kontantstøtte,
-                    månedsbeløp = 0.0,
-                    periode = Periode.create(fraOgMed = 1.januar(2021), tilOgMed = 31.juli(2021)),
-                    utenlandskInntekt = null,
-                    tilhører = FradragTilhører.BRUKER,
-                ),
-            ),
-        )
-
-        revurderingService.leggTilFradragsgrunnlag(request) shouldBe KunneIkkeLeggeTilFradragsgrunnlag.KunneIkkeEndreFradragsgrunnlag(
-            KunneIkkeLageGrunnlagsdata.Konsistenssjekk(Konsistensproblem.BosituasjonOgFradrag.IngenBosituasjonForFradragsperiode),
-        ).left()
     }
 }

--- a/test-common/src/main/kotlin/RevurderingTestData.kt
+++ b/test-common/src/main/kotlin/RevurderingTestData.kt
@@ -248,8 +248,8 @@ fun beregnetRevurdering(
         val beregnet = opprettet.beregn(
             eksisterendeUtbetalinger = sak.utbetalinger,
             clock = clock,
-            gjeldendeVedtaksdata = sak.kopierGjeldendeVedtaksdata(
-                fraOgMed = revurderingsperiode.fraOgMed,
+            gjeldendeVedtaksdata = sak.hentGjeldendeVedtaksdata(
+                periode = opprettet.periode,
                 clock = clock,
             ).getOrFail(),
             satsFactory = satsFactoryTestPåDato(),
@@ -662,8 +662,8 @@ fun beregnetRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak(
         val innvilgetBeregnetRevurdering = revurdering.beregn(
             eksisterendeUtbetalinger = sak.utbetalinger,
             clock = clock,
-            gjeldendeVedtaksdata = sak.kopierGjeldendeVedtaksdata(
-                fraOgMed = revurderingsperiode.fraOgMed,
+            gjeldendeVedtaksdata = sak.hentGjeldendeVedtaksdata(
+                periode = revurdering.periode,
                 clock = clock,
             ).getOrFail(),
             satsFactory = satsFactoryTestPåDato(),


### PR DESCRIPTION
Obskur liten detalj som kan føre til at data fra fremtiden "blør tilbake" til revurderinger som gjøres for tidligere perioder men på senere tidspunkt. Erfart case, fradrag for avkorting i fremtidig stønadsperiode ble propagert til en revurdering for en tidligere og helt urelatert periode.