### PR TITLE
Oppdater og iverksett søknadsbehandling - valider overlappende stønadsperioder

### DIFF
--- a/common/src/main/kotlin/no/nav/su/se/bakover/common/application/MånedBeløp.kt
+++ b/common/src/main/kotlin/no/nav/su/se/bakover/common/application/MånedBeløp.kt
@@ -35,6 +35,7 @@ data class Månedsbeløp(
 }
 
 data class MånedBeløp(
+    /** TODO jah; Burde vært renamet til 'måned', men usikker på om den serialiseres til json i database etc. */
     val periode: Måned,
     val beløp: Beløp,
 ) {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/Simulering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/Simulering.kt
@@ -22,6 +22,10 @@ data class Simulering(
         return tolkning.harFeilutbetalinger()
     }
 
+    fun harFeilutbetalinger(periode: Periode): Boolean {
+        return tolkning.harFeilutbetalinger(periode)
+    }
+
     /**
      * Beløp som tidligere har vært utbetalt for denne perioden.
      */

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/TolketSimulering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/simulering/TolketSimulering.kt
@@ -38,6 +38,10 @@ internal data class TolketSimulering(
 
     fun harFeilutbetalinger() = hentFeilutbetalteBeløp().sum() > 0
 
+    fun harFeilutbetalinger(periode: Periode): Boolean {
+        return hentFeilutbetalteBeløp().filter { periode.overlapper(it.periode) }.sumOf { it.beløp.sum() } > 0
+    }
+
     /**
      * Sjekk for spesialtilfelle hvor vi har mottatt tom respons (indikerer ingen posteringer/utbetalinger).
      * Her vil [no.nav.su.se.bakover.client.oppdrag.simulering.SimuleringResponseMapper] lage en "fiktiv" periode

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/Sak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/Sak.kt
@@ -45,6 +45,7 @@ import no.nav.su.se.bakover.domain.statistikk.StatistikkEvent
 import no.nav.su.se.bakover.domain.søknad.LukkSøknadCommand
 import no.nav.su.se.bakover.domain.søknad.Søknad
 import no.nav.su.se.bakover.domain.søknadsbehandling.LukketSøknadsbehandling
+import no.nav.su.se.bakover.domain.søknadsbehandling.StøtterIkkeOverlappendeStønadsperioder
 import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
 import no.nav.su.se.bakover.domain.tidslinje.Tidslinje
 import no.nav.su.se.bakover.domain.tidslinje.TidslinjeForUtbetalinger
@@ -249,7 +250,7 @@ data class Sak(
     }
 
     /**
-     * Identifiser alle perioder hvor ytelsen har vært eller vil være løpende.
+     * Henter minste antall sammenhengende perioder hvor vedtakene ikke er av typen opphør.
      */
     fun hentIkkeOpphørtePerioder(
         periode: Periode = Periode.create(
@@ -577,20 +578,21 @@ data class Sak(
 
     object FantIkkeSøknadsbehandlingForSøknad
 
-    sealed class KunneIkkeOppdatereStønadsperiode {
-        object FantIkkeBehandling : KunneIkkeOppdatereStønadsperiode()
-        object StønadsperiodeOverlapperMedLøpendeStønadsperiode : KunneIkkeOppdatereStønadsperiode()
-        object StønadsperiodeForSenerePeriodeEksisterer : KunneIkkeOppdatereStønadsperiode()
-        data class KunneIkkeOppdatereGrunnlagsdata(val feil: no.nav.su.se.bakover.domain.søknadsbehandling.KunneIkkeOppdatereStønadsperiode) :
-            KunneIkkeOppdatereStønadsperiode()
+    sealed interface KunneIkkeOppdatereStønadsperiode {
+        object FantIkkeBehandling : KunneIkkeOppdatereStønadsperiode
 
-        data class KunneIkkeHenteGjeldendeVedtaksdata(val feil: Sak.KunneIkkeHenteGjeldendeVedtaksdata) :
-            KunneIkkeOppdatereStønadsperiode()
+        data class KunneIkkeOppdatereGrunnlagsdata(
+            val feil: no.nav.su.se.bakover.domain.søknadsbehandling.KunneIkkeOppdatereStønadsperiode,
+        ) : KunneIkkeOppdatereStønadsperiode
 
-        object StønadsperiodeInneholderAvkortingPgaUtenlandsopphold : KunneIkkeOppdatereStønadsperiode()
+        data class KunneIkkeHenteGjeldendeVedtaksdata(
+            val feil: Sak.KunneIkkeHenteGjeldendeVedtaksdata,
+        ) : KunneIkkeOppdatereStønadsperiode
 
         /** Dette kan være en søknadsbehandling, revurdering eller regulering. Kan utvides til en per dersom, dersom saksbehandlerne har behov for dette. */
-        object FinnesOverlappendeÅpenBehandling : KunneIkkeOppdatereStønadsperiode()
+        object FinnesOverlappendeÅpenBehandling : KunneIkkeOppdatereStønadsperiode
+
+        data class OverlappendeStønadsperiode(val feil: StøtterIkkeOverlappendeStønadsperioder) : KunneIkkeOppdatereStønadsperiode
     }
 
     fun avventerKravgrunnlag(): Boolean {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/ValiderOverlappendeStønadsperioder.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/ValiderOverlappendeStønadsperioder.kt
@@ -1,0 +1,86 @@
+package no.nav.su.se.bakover.domain.søknadsbehandling
+
+import arrow.core.Either
+import arrow.core.continuations.either
+import arrow.core.left
+import arrow.core.right
+import no.nav.su.se.bakover.common.periode.Periode
+import no.nav.su.se.bakover.domain.Sak
+import java.time.Clock
+
+/**
+ * Tar kun utgangspunkt i vedtak (ikke pågående behandlinger).
+ * Begrensninger:
+ * - Støtter ikke overlapp med ikke-opphørte måneder.
+ * - Støtter ikke overlapp med opphørte måneder som førte til avkorting.
+ * - Støtter ikke overlapp med opphørte måneder som førte til feilutbetaling.
+ */
+internal fun Sak.validerOverlappendeStønadsperioder(
+    periode: Periode,
+    clock: Clock,
+): Either<StøtterIkkeOverlappendeStønadsperioder, Unit> {
+    return either.eager {
+        validerOverlappendeIkkeOpphørtePerioder(periode).bind()
+        validerOpphørFørtTilAvkorting(periode, clock).bind()
+        validerOpphørMedFeilutbetaling(periode, clock).bind()
+    }
+}
+
+private fun Sak.validerOverlappendeIkkeOpphørtePerioder(
+    periode: Periode,
+): Either<StøtterIkkeOverlappendeStønadsperioder, Unit> {
+    hentIkkeOpphørtePerioder().let { stønadsperioder ->
+        if (stønadsperioder.any { it overlapper periode }) {
+            return StøtterIkkeOverlappendeStønadsperioder.StønadsperiodeOverlapperMedIkkeOpphørtStønadsperiode.left()
+        }
+        if (stønadsperioder.any { it.starterSamtidigEllerSenere(periode) }) {
+            return StøtterIkkeOverlappendeStønadsperioder.StønadsperiodeForSenerePeriodeEksisterer.left()
+        }
+    }
+    return Unit.right()
+}
+
+private fun Sak.validerOpphørFørtTilAvkorting(
+    periode: Periode,
+    clock: Clock,
+): Either<StøtterIkkeOverlappendeStønadsperioder.StønadsperiodeInneholderAvkortingPgaUtenlandsopphold, Unit> {
+    return hentGjeldendeVedtaksdata(
+        periode = periode,
+        clock = clock,
+    ).fold(
+        { Unit.right() },
+        {
+            if (it.inneholderOpphørsvedtakMedAvkortingUtenlandsopphold()) {
+                StøtterIkkeOverlappendeStønadsperioder.StønadsperiodeInneholderAvkortingPgaUtenlandsopphold.left()
+            } else {
+                Unit.right()
+            }
+        },
+    )
+}
+
+private fun Sak.validerOpphørMedFeilutbetaling(
+    periode: Periode,
+    clock: Clock,
+): Either<StøtterIkkeOverlappendeStønadsperioder.StønadsperiodeInneholderFeilutbetaling, Unit> {
+    return hentGjeldendeVedtaksdata(
+        periode = periode,
+        clock = clock,
+    ).fold(
+        { Unit.right() },
+        {
+            if (it.inneholderOpphørsvedtakMedFeilutbetaling()) {
+                StøtterIkkeOverlappendeStønadsperioder.StønadsperiodeInneholderFeilutbetaling.left()
+            } else {
+                Unit.right()
+            }
+        },
+    )
+}
+
+sealed interface StøtterIkkeOverlappendeStønadsperioder {
+    object StønadsperiodeOverlapperMedIkkeOpphørtStønadsperiode : StøtterIkkeOverlappendeStønadsperioder
+    object StønadsperiodeForSenerePeriodeEksisterer : StøtterIkkeOverlappendeStønadsperioder
+    object StønadsperiodeInneholderAvkortingPgaUtenlandsopphold : StøtterIkkeOverlappendeStønadsperioder
+    object StønadsperiodeInneholderFeilutbetaling : StøtterIkkeOverlappendeStønadsperioder
+}

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/iverksett/KunneIkkeIverksetteSøknadsbehandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/iverksett/KunneIkkeIverksetteSøknadsbehandling.kt
@@ -2,19 +2,24 @@ package no.nav.su.se.bakover.domain.søknadsbehandling.iverksett
 
 import no.nav.su.se.bakover.domain.dokument.KunneIkkeLageDokument
 import no.nav.su.se.bakover.domain.oppdrag.UtbetalingFeilet
+import no.nav.su.se.bakover.domain.søknadsbehandling.StøtterIkkeOverlappendeStønadsperioder
 
 sealed interface KunneIkkeIverksetteSøknadsbehandling {
     object AttestantOgSaksbehandlerKanIkkeVæreSammePerson : KunneIkkeIverksetteSøknadsbehandling
     data class KunneIkkeUtbetale(val utbetalingFeilet: UtbetalingFeilet) : KunneIkkeIverksetteSøknadsbehandling
-    data class KunneIkkeGenerereVedtaksbrev(val underliggendeFeil: KunneIkkeLageDokument) : KunneIkkeIverksetteSøknadsbehandling
+    data class KunneIkkeGenerereVedtaksbrev(val underliggendeFeil: KunneIkkeLageDokument) :
+        KunneIkkeIverksetteSøknadsbehandling
+
     object AvkortingErUfullstendig : KunneIkkeIverksetteSøknadsbehandling
     object SakHarRevurderingerMedÅpentKravgrunnlagForTilbakekreving : KunneIkkeIverksetteSøknadsbehandling
     object SimuleringFørerTilFeilutbetaling : KunneIkkeIverksetteSøknadsbehandling
 
     /**
-     * En stønadsperiode kan ikke overskrive utbetalte måneder eller måneder som kommer til å bli utbetalt.
-     * I utgangspunk
-     * Et unntak er utbetalte måneder som er tilbakekrevd i sin helhet.
+     * En stønadsperiode kan ikke overlappe tidligere stønadsperioder som har utbetalte måneder eller måneder som kommer til å bli utbetalt.
+     * I.e. Kan kun overlappe opphørte måneder som ikke førte til feilutbetaling eller avkorting.
+     * Mulig utvidelse på sikt kan f.eks. være: Utbetalte måneder som er tilbakekrevd i sin helhet, men det støttes ikke per tidspunkt.
      */
-    object OverskriverVedtak : KunneIkkeIverksetteSøknadsbehandling
+    data class OverlappendeStønadsperiode(
+        val underliggendeFeil: StøtterIkkeOverlappendeStønadsperioder,
+    ) : KunneIkkeIverksetteSøknadsbehandling
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/GjeldendeVedtaksdata.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/GjeldendeVedtaksdata.kt
@@ -131,11 +131,16 @@ data class GjeldendeVedtaksdata(
             periode == garantertSammenhengendePeriode()
     }
 
+    /** Tar kun høyde for månedene i [periode]. */
     fun inneholderOpphørsvedtakMedAvkortingUtenlandsopphold(): Boolean {
-        return periode.måneder()
-            .mapNotNull { gjeldendeVedtakPåDato(it.fraOgMed) }
-            .filterIsInstance<VedtakSomKanRevurderes.EndringIYtelse.OpphørtRevurdering>()
-            .any { it.harIdentifisertBehovForFremtidigAvkorting() }
+        return tidslinje.tidslinje.map { it.originaltVedtak }.filterIsInstance<VedtakSomKanRevurderes.EndringIYtelse.OpphørtRevurdering>()
+            .any { it.harIdentifisertBehovForFremtidigAvkorting(periode) }
+    }
+
+    /** Tar kun høyde for månedene i [periode]. */
+    fun inneholderOpphørsvedtakMedFeilutbetaling(): Boolean {
+        return tidslinje.tidslinje.map { it.originaltVedtak }.filterIsInstance<VedtakSomKanRevurderes.EndringIYtelse.OpphørtRevurdering>()
+            .any { it.førteTilFeilutbetaling(periode) }
     }
 
     fun vedtaksperioder(): List<Periode> {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/Stønadsvedtak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/Stønadsvedtak.kt
@@ -270,6 +270,12 @@ sealed interface VedtakSomKanRevurderes : Stønadsvedtak {
             override fun harIdentifisertBehovForFremtidigAvkorting() =
                 behandling.avkorting is AvkortingVedRevurdering.Iverksatt.HarProdusertNyttAvkortingsvarsel
 
+            fun harIdentifisertBehovForFremtidigAvkorting(periode: Periode) =
+                behandling.avkorting is AvkortingVedRevurdering.Iverksatt.HarProdusertNyttAvkortingsvarsel && behandling.avkorting.periode().overlapper(periode)
+
+            /** Sjekker både saksbehandlers og attestants simulering. */
+            fun førteTilFeilutbetaling(periode: Periode): Boolean = behandling.simulering.harFeilutbetalinger(periode) || simulering.harFeilutbetalinger(periode)
+
             override fun accept(visitor: VedtakVisitor) {
                 visitor.visit(this)
             }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/SakTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/SakTest.kt
@@ -7,11 +7,9 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.beOfType
 import no.nav.su.se.bakover.common.Fnr
 import no.nav.su.se.bakover.common.april
-import no.nav.su.se.bakover.common.august
 import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.februar
 import no.nav.su.se.bakover.common.januar
@@ -20,7 +18,6 @@ import no.nav.su.se.bakover.common.juni
 import no.nav.su.se.bakover.common.mai
 import no.nav.su.se.bakover.common.mars
 import no.nav.su.se.bakover.common.november
-import no.nav.su.se.bakover.common.oktober
 import no.nav.su.se.bakover.common.periode.Periode
 import no.nav.su.se.bakover.common.periode.desember
 import no.nav.su.se.bakover.common.periode.januar
@@ -29,29 +26,16 @@ import no.nav.su.se.bakover.common.periode.mai
 import no.nav.su.se.bakover.common.periode.mars
 import no.nav.su.se.bakover.common.periode.november
 import no.nav.su.se.bakover.common.periode.år
-import no.nav.su.se.bakover.common.september
 import no.nav.su.se.bakover.domain.avkorting.Avkortingsvarsel
 import no.nav.su.se.bakover.domain.sak.Sakstype
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.Personopplysninger
-import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
 import no.nav.su.se.bakover.domain.søknadsbehandling.stønadsperiode.Stønadsperiode
-import no.nav.su.se.bakover.domain.søknadsbehandling.stønadsperiode.oppdaterStønadsperiodeForSøknadsbehandling
 import no.nav.su.se.bakover.domain.vedtak.GjeldendeVedtaksdata
 import no.nav.su.se.bakover.domain.vedtak.VedtakSomKanRevurderes
-import no.nav.su.se.bakover.domain.vilkår.FastOppholdINorgeVilkår
-import no.nav.su.se.bakover.domain.vilkår.FlyktningVilkår
-import no.nav.su.se.bakover.domain.vilkår.FormueVilkår
-import no.nav.su.se.bakover.domain.vilkår.InstitusjonsoppholdVilkår
-import no.nav.su.se.bakover.domain.vilkår.LovligOppholdVilkår
-import no.nav.su.se.bakover.domain.vilkår.PersonligOppmøteVilkår
-import no.nav.su.se.bakover.domain.vilkår.UføreVilkår
-import no.nav.su.se.bakover.domain.vilkår.UtenlandsoppholdVilkår
-import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
 import no.nav.su.se.bakover.hendelse.domain.Hendelsesversjon
 import no.nav.su.se.bakover.test.TikkendeKlokke
 import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.fixedTidspunkt
-import no.nav.su.se.bakover.test.formuegrenserFactoryTestPåDato
 import no.nav.su.se.bakover.test.generer
 import no.nav.su.se.bakover.test.getOrFail
 import no.nav.su.se.bakover.test.innvilgetSøknadsbehandlingMedIverksattRegulering
@@ -60,13 +44,11 @@ import no.nav.su.se.bakover.test.iverksattRevurdering
 import no.nav.su.se.bakover.test.iverksattSøknadsbehandling
 import no.nav.su.se.bakover.test.iverksattSøknadsbehandlingUføre
 import no.nav.su.se.bakover.test.opprettetRevurdering
-import no.nav.su.se.bakover.test.saksbehandler
 import no.nav.su.se.bakover.test.saksnummer
 import no.nav.su.se.bakover.test.shouldBeType
 import no.nav.su.se.bakover.test.stønadsperiode2021
 import no.nav.su.se.bakover.test.søknad.nySøknadJournalførtMedOppgave
 import no.nav.su.se.bakover.test.søknad.søknadinnholdUføre
-import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertInnvilget
 import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertUavklart
 import no.nav.su.se.bakover.test.tikkendeFixedClock
 import no.nav.su.se.bakover.test.vedtakIverksattGjenopptakAvYtelseFraIverksattStans
@@ -74,8 +56,6 @@ import no.nav.su.se.bakover.test.vedtakIverksattStansAvYtelseFraIverksattSøknad
 import no.nav.su.se.bakover.test.vedtakRevurdering
 import no.nav.su.se.bakover.test.vedtakRevurderingIverksattInnvilget
 import no.nav.su.se.bakover.test.vedtakSøknadsbehandlingIverksattInnvilget
-import no.nav.su.se.bakover.test.vilkår.tilstrekkeligDokumentert
-import no.nav.su.se.bakover.test.vilkår.utenlandsoppholdAvslag
 import no.nav.su.se.bakover.test.vilkårsvurderinger.avslåttUførevilkårUtenGrunnlag
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -438,165 +418,7 @@ internal class SakTest {
     }
 
     @Nested
-    inner class OppdaterStønadsperiodeForSøknadsbehandling {
-
-        @Test
-        fun `oppdaterer perioden riktig`() {
-            val (_, vilkårsvurdert) = søknadsbehandlingVilkårsvurdertInnvilget()
-
-            val nyPeriode = Periode.create(1.februar(2022), 31.mars(2022))
-            val actual = vilkårsvurdert.oppdaterStønadsperiode(
-                oppdatertStønadsperiode = Stønadsperiode.create(nyPeriode),
-                formuegrenserFactory = formuegrenserFactoryTestPåDato(),
-                clock = fixedClock,
-                saksbehandler = saksbehandler,
-            ).getOrFail()
-
-            vilkårsvurdert.periode shouldNotBe nyPeriode
-            actual.periode shouldBe nyPeriode
-            actual.vilkårsvurderinger.uføreVilkår().getOrFail().grunnlag.first().periode shouldBe nyPeriode
-            actual.vilkårsvurderinger.formue.grunnlag.first().periode shouldBe nyPeriode
-            actual.grunnlagsdata.bosituasjon.first().periode shouldBe nyPeriode
-        }
-
-        @Test
-        fun `stønadsperioder skal ikke kunne overlappe`() {
-            val (sak, _) = vedtakSøknadsbehandlingIverksattInnvilget(
-                stønadsperiode = Stønadsperiode.create(periode = år(2021)),
-            )
-
-            val opprettetSøknadsbehandling = søknadsbehandlingVilkårsvurdertUavklart().second
-
-            sak.copy(
-                søknadsbehandlinger = sak.søknadsbehandlinger + opprettetSøknadsbehandling,
-            ).let {
-                val nyPeriode = Periode.create(1.desember(2021), 31.mars(2022))
-
-                it.oppdaterStønadsperiodeForSøknadsbehandling(
-                    søknadsbehandlingId = opprettetSøknadsbehandling.id,
-                    stønadsperiode = Stønadsperiode.create(nyPeriode),
-                    clock = fixedClock,
-                    formuegrenserFactory = formuegrenserFactoryTestPåDato(),
-                    saksbehandler = saksbehandler,
-                ) shouldBe Sak.KunneIkkeOppdatereStønadsperiode.StønadsperiodeOverlapperMedLøpendeStønadsperiode.left()
-            }
-        }
-
-        @Test
-        fun `stønadsperioder skal ikke kunne legges forut for eksisterende stønadsperioder`() {
-            val (sak, _) = vedtakSøknadsbehandlingIverksattInnvilget()
-            val (_, andreStønadsperiode) = vedtakSøknadsbehandlingIverksattInnvilget(
-                stønadsperiode = Stønadsperiode.create(periode = år(2023)),
-            )
-            val mellomToAndrePerioder = søknadsbehandlingVilkårsvurdertUavklart().second
-
-            sak.copy(
-                søknadsbehandlinger = sak.søknadsbehandlinger + andreStønadsperiode.behandling + mellomToAndrePerioder,
-                vedtakListe = sak.vedtakListe + andreStønadsperiode,
-            ).let {
-                val nyPeriode = Stønadsperiode.create(periode = år(2022))
-
-                it.oppdaterStønadsperiodeForSøknadsbehandling(
-                    søknadsbehandlingId = mellomToAndrePerioder.id,
-                    stønadsperiode = nyPeriode,
-                    clock = fixedClock,
-                    formuegrenserFactory = formuegrenserFactoryTestPåDato(),
-                    saksbehandler = saksbehandler,
-                ) shouldBe Sak.KunneIkkeOppdatereStønadsperiode.StønadsperiodeForSenerePeriodeEksisterer.left()
-            }
-        }
-
-        @Test
-        fun `stønadsperioder skal ikke kunne overlappe med perioder som skal avkortes`() {
-            val tikkendeKlokke = TikkendeKlokke()
-
-            val (sakMedSøknadVedtak, søknadsbehandlingVedtak) = vedtakSøknadsbehandlingIverksattInnvilget(
-                clock = tikkendeKlokke,
-            )
-            val revurderingsperiode = Periode.create(1.mai(2021), 31.desember(2021))
-            val (sakMedRevurderingOgSøknadVedtak, _) = vedtakRevurdering(
-                clock = tikkendeKlokke,
-                revurderingsperiode = revurderingsperiode,
-                sakOgVedtakSomKanRevurderes = sakMedSøknadVedtak to søknadsbehandlingVedtak,
-                vilkårOverrides = listOf(
-                    utenlandsoppholdAvslag(
-                        periode = revurderingsperiode,
-                    ),
-                ),
-                utbetalingerKjørtTilOgMed = 1.juli(2021),
-            )
-
-            val nyPeriode = år(2022)
-            val nyStønadsperiode = Stønadsperiode.create(nyPeriode)
-            val (_, nySøknadsbehandling) = søknadsbehandlingVilkårsvurdertUavklart(
-                clock = tikkendeKlokke,
-                stønadsperiode = nyStønadsperiode,
-            )
-
-            val nySøknadsbehandlingMedOpplysningsplikt = nySøknadsbehandling.leggTilOpplysningspliktVilkår(
-                saksbehandler = nySøknadsbehandling.saksbehandler!!,
-                opplysningspliktVilkår = tilstrekkeligDokumentert(periode = nyPeriode),
-            ).getOrFail() as Søknadsbehandling.Vilkårsvurdert.Uavklart
-
-            sakMedRevurderingOgSøknadVedtak.copy(
-                søknadsbehandlinger = sakMedRevurderingOgSøknadVedtak.søknadsbehandlinger + nySøknadsbehandling,
-            ).let { sak ->
-                sak.oppdaterStønadsperiodeForSøknadsbehandling(
-                    søknadsbehandlingId = nySøknadsbehandlingMedOpplysningsplikt.id,
-                    stønadsperiode = nyStønadsperiode,
-                    clock = tikkendeKlokke,
-                    formuegrenserFactory = formuegrenserFactoryTestPåDato(),
-                    saksbehandler = saksbehandler,
-                ).getOrFail().second shouldBe nySøknadsbehandlingMedOpplysningsplikt
-
-                listOf(
-                    1.mai(2021),
-                    1.juni(2021),
-                ).map {
-                    Stønadsperiode.create(Periode.create(fraOgMed = it, tilOgMed = 31.desember(2021)))
-                }.forEach { stønadsperiode ->
-                    sak.oppdaterStønadsperiodeForSøknadsbehandling(
-                        søknadsbehandlingId = nySøknadsbehandlingMedOpplysningsplikt.id,
-                        stønadsperiode = stønadsperiode,
-                        clock = tikkendeKlokke,
-                        formuegrenserFactory = formuegrenserFactoryTestPåDato(),
-                        saksbehandler = saksbehandler,
-                    ) shouldBe Sak.KunneIkkeOppdatereStønadsperiode.StønadsperiodeInneholderAvkortingPgaUtenlandsopphold.left()
-                }
-
-                listOf(
-                    1.juli(2021),
-                    1.august(2021),
-                    1.september(2021),
-                    1.oktober(2021),
-                    1.november(2021),
-                    1.desember(2021),
-                ).map {
-                    Stønadsperiode.create(Periode.create(fraOgMed = it, tilOgMed = 31.desember(2021)))
-                }.forEach { stønadsperiode ->
-                    sak.oppdaterStønadsperiodeForSøknadsbehandling(
-                        søknadsbehandlingId = nySøknadsbehandlingMedOpplysningsplikt.id,
-                        stønadsperiode = stønadsperiode,
-                        clock = tikkendeKlokke,
-                        formuegrenserFactory = formuegrenserFactoryTestPåDato(),
-                        saksbehandler = saksbehandler,
-                    ).getOrFail().second shouldBe nySøknadsbehandlingMedOpplysningsplikt.copy(
-                        stønadsperiode = stønadsperiode,
-                        vilkårsvurderinger = Vilkårsvurderinger.Søknadsbehandling.Uføre(
-                            formue = FormueVilkår.IkkeVurdert,
-                            utenlandsopphold = UtenlandsoppholdVilkår.IkkeVurdert,
-                            opplysningsplikt = tilstrekkeligDokumentert(periode = stønadsperiode.periode),
-                            lovligOpphold = LovligOppholdVilkår.IkkeVurdert,
-                            fastOpphold = FastOppholdINorgeVilkår.IkkeVurdert,
-                            institusjonsopphold = InstitusjonsoppholdVilkår.IkkeVurdert,
-                            personligOppmøte = PersonligOppmøteVilkår.IkkeVurdert,
-                            flyktning = FlyktningVilkår.IkkeVurdert,
-                            uføre = UføreVilkår.IkkeVurdert,
-                        ),
-                    )
-                }
-            }
-        }
+    inner class YtelseUtløperVedUtløpAv {
 
         @Test
         fun `utløp av ytelse`() {

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/stønadsperiode/OppdaterStønadsperiodeTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/stønadsperiode/OppdaterStønadsperiodeTest.kt
@@ -1,0 +1,309 @@
+package no.nav.su.se.bakover.domain.søknadsbehandling.stønadsperiode
+
+import arrow.core.left
+import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import no.nav.su.se.bakover.common.Tidspunkt
+import no.nav.su.se.bakover.common.august
+import no.nav.su.se.bakover.common.desember
+import no.nav.su.se.bakover.common.februar
+import no.nav.su.se.bakover.common.juli
+import no.nav.su.se.bakover.common.juni
+import no.nav.su.se.bakover.common.mai
+import no.nav.su.se.bakover.common.mars
+import no.nav.su.se.bakover.common.november
+import no.nav.su.se.bakover.common.oktober
+import no.nav.su.se.bakover.common.periode.Periode
+import no.nav.su.se.bakover.common.periode.april
+import no.nav.su.se.bakover.common.periode.august
+import no.nav.su.se.bakover.common.periode.desember
+import no.nav.su.se.bakover.common.periode.februar
+import no.nav.su.se.bakover.common.periode.januar
+import no.nav.su.se.bakover.common.periode.juli
+import no.nav.su.se.bakover.common.periode.juni
+import no.nav.su.se.bakover.common.periode.mai
+import no.nav.su.se.bakover.common.periode.mars
+import no.nav.su.se.bakover.common.periode.november
+import no.nav.su.se.bakover.common.periode.oktober
+import no.nav.su.se.bakover.common.periode.september
+import no.nav.su.se.bakover.common.periode.år
+import no.nav.su.se.bakover.common.september
+import no.nav.su.se.bakover.domain.Sak
+import no.nav.su.se.bakover.domain.søknadsbehandling.StøtterIkkeOverlappendeStønadsperioder
+import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
+import no.nav.su.se.bakover.domain.vilkår.FastOppholdINorgeVilkår
+import no.nav.su.se.bakover.domain.vilkår.FlyktningVilkår
+import no.nav.su.se.bakover.domain.vilkår.FormueVilkår
+import no.nav.su.se.bakover.domain.vilkår.InstitusjonsoppholdVilkår
+import no.nav.su.se.bakover.domain.vilkår.LovligOppholdVilkår
+import no.nav.su.se.bakover.domain.vilkår.PersonligOppmøteVilkår
+import no.nav.su.se.bakover.domain.vilkår.UføreVilkår
+import no.nav.su.se.bakover.domain.vilkår.UtenlandsoppholdVilkår
+import no.nav.su.se.bakover.domain.vilkår.Vilkårsvurderinger
+import no.nav.su.se.bakover.test.TikkendeKlokke
+import no.nav.su.se.bakover.test.fixedClock
+import no.nav.su.se.bakover.test.formuegrenserFactoryTestPåDato
+import no.nav.su.se.bakover.test.getOrFail
+import no.nav.su.se.bakover.test.saksbehandler
+import no.nav.su.se.bakover.test.stønadsperiode2021
+import no.nav.su.se.bakover.test.søknad.nySøknadJournalførtMedOppgave
+import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertInnvilget
+import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertUavklart
+import no.nav.su.se.bakover.test.vedtakRevurdering
+import no.nav.su.se.bakover.test.vedtakSøknadsbehandlingIverksattInnvilget
+import no.nav.su.se.bakover.test.vilkår.tilstrekkeligDokumentert
+import no.nav.su.se.bakover.test.vilkår.utenlandsoppholdAvslag
+import no.nav.su.se.bakover.test.vilkårsvurderinger.avslåttUførevilkårUtenGrunnlag
+import no.nav.su.se.bakover.test.vilkårsvurdertSøknadsbehandling
+import org.junit.jupiter.api.Test
+
+internal class OppdaterStønadsperiodeTest {
+
+    @Test
+    fun `oppdaterer perioden riktig`() {
+        val (_, vilkårsvurdert) = søknadsbehandlingVilkårsvurdertInnvilget()
+
+        val nyPeriode = Periode.create(1.februar(2022), 31.mars(2022))
+        val actual = vilkårsvurdert.oppdaterStønadsperiode(
+            oppdatertStønadsperiode = Stønadsperiode.create(nyPeriode),
+            formuegrenserFactory = formuegrenserFactoryTestPåDato(),
+            clock = fixedClock,
+            saksbehandler = saksbehandler,
+        ).getOrFail()
+
+        vilkårsvurdert.periode shouldNotBe nyPeriode
+        actual.periode shouldBe nyPeriode
+        actual.vilkårsvurderinger.uføreVilkår().getOrFail().grunnlag.first().periode shouldBe nyPeriode
+        actual.vilkårsvurderinger.formue.grunnlag.first().periode shouldBe nyPeriode
+        actual.grunnlagsdata.bosituasjon.first().periode shouldBe nyPeriode
+    }
+
+    @Test
+    fun `innvilget stønadsperioder skal ikke kunne overlappe`() {
+        val (sak, _) = vedtakSøknadsbehandlingIverksattInnvilget(
+            stønadsperiode = Stønadsperiode.create(periode = år(2021)),
+        )
+
+        val opprettetSøknadsbehandling = søknadsbehandlingVilkårsvurdertUavklart().second
+
+        sak.copy(
+            søknadsbehandlinger = sak.søknadsbehandlinger + opprettetSøknadsbehandling,
+        ).let {
+            val nyPeriode = Periode.create(1.desember(2021), 31.mars(2022))
+
+            it.oppdaterStønadsperiodeForSøknadsbehandling(
+                søknadsbehandlingId = opprettetSøknadsbehandling.id,
+                stønadsperiode = Stønadsperiode.create(nyPeriode),
+                clock = fixedClock,
+                formuegrenserFactory = formuegrenserFactoryTestPåDato(),
+                saksbehandler = saksbehandler,
+            ) shouldBe Sak.KunneIkkeOppdatereStønadsperiode.OverlappendeStønadsperiode(
+                StøtterIkkeOverlappendeStønadsperioder.StønadsperiodeOverlapperMedIkkeOpphørtStønadsperiode,
+            ).left()
+        }
+    }
+
+    @Test
+    fun `stønadsperioder skal ikke kunne legges forut for eksisterende stønadsperioder`() {
+        val (sak, _) = vedtakSøknadsbehandlingIverksattInnvilget()
+        val (_, andreStønadsperiode) = vedtakSøknadsbehandlingIverksattInnvilget(
+            stønadsperiode = Stønadsperiode.create(periode = år(2023)),
+        )
+        val mellomToAndrePerioder = søknadsbehandlingVilkårsvurdertUavklart().second
+
+        sak.copy(
+            søknadsbehandlinger = sak.søknadsbehandlinger + andreStønadsperiode.behandling + mellomToAndrePerioder,
+            vedtakListe = sak.vedtakListe + andreStønadsperiode,
+        ).let {
+            val nyPeriode = Stønadsperiode.create(periode = år(2022))
+
+            it.oppdaterStønadsperiodeForSøknadsbehandling(
+                søknadsbehandlingId = mellomToAndrePerioder.id,
+                stønadsperiode = nyPeriode,
+                clock = fixedClock,
+                formuegrenserFactory = formuegrenserFactoryTestPåDato(),
+                saksbehandler = saksbehandler,
+            ) shouldBe Sak.KunneIkkeOppdatereStønadsperiode.OverlappendeStønadsperiode(
+                StøtterIkkeOverlappendeStønadsperioder.StønadsperiodeForSenerePeriodeEksisterer,
+            ).left()
+        }
+    }
+
+    @Test
+    fun `stønadsperioder skal ikke kunne overlappe med perioder som førte til avkorting`() {
+        val tikkendeKlokke = TikkendeKlokke()
+
+        val (sakMedSøknadVedtak, søknadsbehandlingVedtak) = vedtakSøknadsbehandlingIverksattInnvilget(
+            clock = tikkendeKlokke,
+        )
+        val revurderingsperiode = Periode.create(1.mai(2021), 31.desember(2021))
+        val (sakMedRevurderingOgSøknadVedtak, _) = vedtakRevurdering(
+            clock = tikkendeKlokke,
+            revurderingsperiode = revurderingsperiode,
+            sakOgVedtakSomKanRevurderes = sakMedSøknadVedtak to søknadsbehandlingVedtak,
+            vilkårOverrides = listOf(
+                utenlandsoppholdAvslag(
+                    periode = revurderingsperiode,
+                ),
+            ),
+            utbetalingerKjørtTilOgMed = 1.juli(2021),
+        )
+
+        val nyPeriode = år(2022)
+        val nyStønadsperiode = Stønadsperiode.create(nyPeriode)
+        val (_, nySøknadsbehandling) = søknadsbehandlingVilkårsvurdertUavklart(
+            clock = tikkendeKlokke,
+            stønadsperiode = nyStønadsperiode,
+        )
+
+        val nySøknadsbehandlingMedOpplysningsplikt = nySøknadsbehandling.leggTilOpplysningspliktVilkår(
+            saksbehandler = nySøknadsbehandling.saksbehandler!!,
+            opplysningspliktVilkår = tilstrekkeligDokumentert(periode = nyPeriode),
+        ).getOrFail() as Søknadsbehandling.Vilkårsvurdert.Uavklart
+
+        sakMedRevurderingOgSøknadVedtak.copy(
+            søknadsbehandlinger = sakMedRevurderingOgSøknadVedtak.søknadsbehandlinger + nySøknadsbehandling,
+        ).let { sak ->
+            sak.oppdaterStønadsperiodeForSøknadsbehandling(
+                søknadsbehandlingId = nySøknadsbehandlingMedOpplysningsplikt.id,
+                stønadsperiode = nyStønadsperiode,
+                clock = tikkendeKlokke,
+                formuegrenserFactory = formuegrenserFactoryTestPåDato(),
+                saksbehandler = saksbehandler,
+            ).getOrFail().second shouldBe nySøknadsbehandlingMedOpplysningsplikt
+
+            listOf(
+                1.mai(2021),
+                1.juni(2021),
+            ).map {
+                Stønadsperiode.create(Periode.create(fraOgMed = it, tilOgMed = 31.desember(2021)))
+            }.forEach { stønadsperiode ->
+                sak.oppdaterStønadsperiodeForSøknadsbehandling(
+                    søknadsbehandlingId = nySøknadsbehandlingMedOpplysningsplikt.id,
+                    stønadsperiode = stønadsperiode,
+                    clock = tikkendeKlokke,
+                    formuegrenserFactory = formuegrenserFactoryTestPåDato(),
+                    saksbehandler = saksbehandler,
+                ) shouldBe Sak.KunneIkkeOppdatereStønadsperiode.OverlappendeStønadsperiode(
+                    StøtterIkkeOverlappendeStønadsperioder.StønadsperiodeInneholderAvkortingPgaUtenlandsopphold,
+                ).left()
+            }
+
+            listOf(
+                1.juli(2021),
+                1.august(2021),
+                1.september(2021),
+                1.oktober(2021),
+                1.november(2021),
+                1.desember(2021),
+            ).map {
+                Stønadsperiode.create(Periode.create(fraOgMed = it, tilOgMed = 31.desember(2021)))
+            }.forEach { stønadsperiode ->
+                sak.oppdaterStønadsperiodeForSøknadsbehandling(
+                    søknadsbehandlingId = nySøknadsbehandlingMedOpplysningsplikt.id,
+                    stønadsperiode = stønadsperiode,
+                    clock = tikkendeKlokke,
+                    formuegrenserFactory = formuegrenserFactoryTestPåDato(),
+                    saksbehandler = saksbehandler,
+                ).getOrFail().second shouldBe nySøknadsbehandlingMedOpplysningsplikt.copy(
+                    stønadsperiode = stønadsperiode,
+                    vilkårsvurderinger = Vilkårsvurderinger.Søknadsbehandling.Uføre(
+                        formue = FormueVilkår.IkkeVurdert,
+                        utenlandsopphold = UtenlandsoppholdVilkår.IkkeVurdert,
+                        opplysningsplikt = tilstrekkeligDokumentert(periode = stønadsperiode.periode),
+                        lovligOpphold = LovligOppholdVilkår.IkkeVurdert,
+                        fastOpphold = FastOppholdINorgeVilkår.IkkeVurdert,
+                        institusjonsopphold = InstitusjonsoppholdVilkår.IkkeVurdert,
+                        personligOppmøte = PersonligOppmøteVilkår.IkkeVurdert,
+                        flyktning = FlyktningVilkår.IkkeVurdert,
+                        uføre = UføreVilkår.IkkeVurdert,
+                    ),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `stønadsperioder skal ikke kunne overlappe med perioder som førte til feilutbetaling `() {
+        val tikkendeKlokke = TikkendeKlokke()
+        val (sakMedSøknadVedtak, søknadsbehandlingVedtak) = vedtakSøknadsbehandlingIverksattInnvilget(
+            clock = tikkendeKlokke,
+            stønadsperiode = stønadsperiode2021,
+        )
+        val sakId = sakMedSøknadVedtak.id
+        val revurderingsperiode = Periode.create(1.mai(2021), 31.desember(2021))
+        val (sakMedRevurderingOgSøknadVedtak, _) = vedtakRevurdering(
+            clock = tikkendeKlokke,
+            revurderingsperiode = revurderingsperiode,
+            sakOgVedtakSomKanRevurderes = sakMedSøknadVedtak to søknadsbehandlingVedtak,
+            vilkårOverrides = listOf(
+                avslåttUførevilkårUtenGrunnlag(
+                    opprettet = Tidspunkt.now(tikkendeKlokke),
+                    periode = revurderingsperiode,
+                ),
+            ),
+            // Genererer feiltutbetaling for mai og juni.
+            utbetalingerKjørtTilOgMed = 1.juli(2021),
+        )
+
+        val nyPeriode = år(2022)
+        val nyStønadsperiode = Stønadsperiode.create(nyPeriode)
+        val (sakMedNySøknadsbehandling, nySøknadsbehandling) = vilkårsvurdertSøknadsbehandling(
+            clock = tikkendeKlokke,
+            sakOgSøknad = sakMedRevurderingOgSøknadVedtak to nySøknadJournalførtMedOppgave(
+                sakId = sakId,
+                clock = tikkendeKlokke,
+            ),
+            stønadsperiode = nyStønadsperiode,
+        )
+        listOf(
+            mai(2021),
+            juni(2021),
+        ).forEach { periode ->
+            sakMedNySøknadsbehandling.oppdaterStønadsperiodeForSøknadsbehandling(
+                søknadsbehandlingId = nySøknadsbehandling.id,
+                stønadsperiode = Stønadsperiode.create(periode),
+                clock = tikkendeKlokke.copy(),
+                formuegrenserFactory = formuegrenserFactoryTestPåDato(),
+                saksbehandler = saksbehandler,
+            ) shouldBe Sak.KunneIkkeOppdatereStønadsperiode.OverlappendeStønadsperiode(
+                StøtterIkkeOverlappendeStønadsperioder.StønadsperiodeInneholderFeilutbetaling,
+            ).left()
+        }
+
+        listOf(
+            januar(2021),
+            februar(2021),
+            mars(2021),
+            april(2021),
+        ).forEach { periode ->
+            sakMedNySøknadsbehandling.oppdaterStønadsperiodeForSøknadsbehandling(
+                søknadsbehandlingId = nySøknadsbehandling.id,
+                stønadsperiode = Stønadsperiode.create(periode),
+                clock = tikkendeKlokke.copy(),
+                formuegrenserFactory = formuegrenserFactoryTestPåDato(),
+                saksbehandler = saksbehandler,
+            ) shouldBe Sak.KunneIkkeOppdatereStønadsperiode.OverlappendeStønadsperiode(
+                StøtterIkkeOverlappendeStønadsperioder.StønadsperiodeOverlapperMedIkkeOpphørtStønadsperiode,
+            ).left()
+        }
+
+        listOf(
+            juli(2021),
+            august(2021),
+            september(2021),
+            oktober(2021),
+            november(2021),
+            desember(2021),
+        ).forEach { periode ->
+            sakMedNySøknadsbehandling.oppdaterStønadsperiodeForSøknadsbehandling(
+                søknadsbehandlingId = nySøknadsbehandling.id,
+                stønadsperiode = Stønadsperiode.create(periode),
+                clock = tikkendeKlokke.copy(),
+                formuegrenserFactory = formuegrenserFactoryTestPåDato(),
+                saksbehandler = saksbehandler,
+            ).shouldBeRight()
+        }
+    }
+}

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceIverksettTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceIverksettTest.kt
@@ -63,6 +63,7 @@ import no.nav.su.se.bakover.test.søknadsbehandlingVilkårsvurdertInnvilget
 import no.nav.su.se.bakover.test.tilAttesteringSøknadsbehandling
 import no.nav.su.se.bakover.test.utbetalingsRequest
 import no.nav.su.se.bakover.test.vedtakRevurdering
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -615,6 +616,8 @@ internal class SøknadsbehandlingServiceIverksettTest {
         }
     }
 
+    // TODO jah: Denne kan tilpasses og enables etter vi har åpnet for parallelle behandlinger.
+    @Disabled("Dette er ikke et case vi kan provosere frem lenger, siden oppdaterStønadsperiode(...) vil stoppe oss.")
     @Test
     fun `feil ved åpent kravgrunnlag`() {
         val clock: Clock = TikkendeKlokke()

--- a/test-common/src/main/kotlin/TikkendeKlokke.kt
+++ b/test-common/src/main/kotlin/TikkendeKlokke.kt
@@ -33,4 +33,6 @@ class TikkendeKlokke(
         } while (nextInstant < dato.startOfDay(zone).instant)
         return nextInstant
     }
+
+    fun copy(): TikkendeKlokke = TikkendeKlokke(initialClock)
 }

--- a/test-common/src/main/kotlin/no/nav/su/se/bakover/test/søknad/SøknadTestData.kt
+++ b/test-common/src/main/kotlin/no/nav/su/se/bakover/test/søknad/SøknadTestData.kt
@@ -21,6 +21,7 @@ import no.nav.su.se.bakover.test.avvisSøknadUtenBrev
 import no.nav.su.se.bakover.test.bortfallSøknad
 import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.fixedTidspunkt
+import no.nav.su.se.bakover.test.generer
 import no.nav.su.se.bakover.test.saksbehandler
 import no.nav.su.se.bakover.test.trekkSøknad
 import no.nav.su.se.bakover.test.veileder
@@ -251,10 +252,14 @@ fun nySøknadJournalført(
     ).journalfør(journalpostIdSøknad)
 }
 
+/**
+ * @param fnr brukes kun dersom [søknadInnhold] ikke sendes inn.
+ */
 fun nySøknadJournalførtMedOppgave(
     clock: Clock = fixedClock,
     sakId: UUID,
-    søknadInnhold: SøknadInnhold,
+    fnr: Fnr = Fnr.generer(),
+    søknadInnhold: SøknadInnhold = søknadinnholdUføre(personopplysninger = personopplysninger(fnr)),
     søknadId: UUID = UUID.randomUUID(),
     søknadInnsendtAv: NavIdentBruker = veileder,
 ): Søknad.Journalført.MedOppgave.IkkeLukket {

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/ResultatMappers.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/ResultatMappers.kt
@@ -11,6 +11,7 @@ import no.nav.su.se.bakover.domain.oppdrag.UtbetalingFeilet
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimuleringFeilet
 import no.nav.su.se.bakover.domain.sak.SimulerUtbetalingFeilet
 import no.nav.su.se.bakover.domain.søknadsbehandling.KunneIkkeSimulereBehandling
+import no.nav.su.se.bakover.domain.søknadsbehandling.StøtterIkkeOverlappendeStønadsperioder
 import no.nav.su.se.bakover.domain.søknadsbehandling.SøknadsbehandlingService
 
 internal fun UtbetalingFeilet.tilResultat(): Resultat {
@@ -165,4 +166,23 @@ internal fun KryssjekkAvTidslinjeOgSimuleringFeilet.tilResultat(): Resultat {
             this.feil.tilResultat()
         }
     }
+}
+
+internal fun StøtterIkkeOverlappendeStønadsperioder.tilResultat() = when (this) {
+    StøtterIkkeOverlappendeStønadsperioder.StønadsperiodeForSenerePeriodeEksisterer -> HttpStatusCode.BadRequest.errorJson(
+        message = "Kan ikke opprette stønadsperiode som er før en tidligere stønadsperiode.",
+        code = "senere_stønadsperiode",
+    )
+    StøtterIkkeOverlappendeStønadsperioder.StønadsperiodeOverlapperMedIkkeOpphørtStønadsperiode -> HttpStatusCode.BadRequest.errorJson(
+        message = "Kan ikke overlappe med tidligere utbetalte stønadsperioder eller ikke-opphørte stønadsperioder.",
+        code = "overlappende_stønadsperiode",
+    )
+    StøtterIkkeOverlappendeStønadsperioder.StønadsperiodeInneholderAvkortingPgaUtenlandsopphold -> HttpStatusCode.BadRequest.errorJson(
+        message = "Kan ikke overlappe med stønadsmåned som har blitt opphørt og ført til avkortingsvarsel.",
+        code = "overlappende_stønadsperiode",
+    )
+    StøtterIkkeOverlappendeStønadsperioder.StønadsperiodeInneholderFeilutbetaling -> HttpStatusCode.BadRequest.errorJson(
+        message = "Kan ikke overlappe med stønadsmåned som har blitt opphørt og ført til feilutbetaling.",
+        code = "overlappende_stønadsperiode",
+    )
 }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/SøknadsbehandlingRoutes.kt
@@ -150,20 +150,6 @@ internal fun Route.søknadsbehandlingRoutes(
                                                     )
                                                 }
 
-                                                Sak.KunneIkkeOppdatereStønadsperiode.StønadsperiodeForSenerePeriodeEksisterer -> {
-                                                    BadRequest.errorJson(
-                                                        "Kan ikke legge til ny stønadsperiode forut for eksisterende stønadsperioder",
-                                                        "senere_stønadsperioder_eksisterer",
-                                                    )
-                                                }
-
-                                                Sak.KunneIkkeOppdatereStønadsperiode.StønadsperiodeOverlapperMedLøpendeStønadsperiode -> {
-                                                    BadRequest.errorJson(
-                                                        "Stønadsperioden overlapper med eksisterende stønadsperiode",
-                                                        "stønadsperioden_overlapper_med_eksisterende_søknadsbehandling",
-                                                    )
-                                                }
-
                                                 is Sak.KunneIkkeOppdatereStønadsperiode.KunneIkkeHenteGjeldendeVedtaksdata -> {
                                                     InternalServerError.errorJson(
                                                         "Kunne ikke hente gjeldende vedtaksdata",
@@ -171,16 +157,11 @@ internal fun Route.søknadsbehandlingRoutes(
                                                     )
                                                 }
 
-                                                Sak.KunneIkkeOppdatereStønadsperiode.StønadsperiodeInneholderAvkortingPgaUtenlandsopphold -> {
-                                                    BadRequest.errorJson(
-                                                        "Stønadsperioden inneholder utbetalinger som skal avkortes pga utenlandsopphold. Dette støttes ikke.",
-                                                        "stønadsperiode_inneholder_avkorting_utenlandsopphold",
-                                                    )
-                                                }
                                                 is Sak.KunneIkkeOppdatereStønadsperiode.FinnesOverlappendeÅpenBehandling -> BadRequest.errorJson(
                                                     "Stønadsperioden overlapper en annen åpen behandling.",
                                                     "stønadsperiode_overlapper_åpen_behandling",
                                                 )
+                                                is Sak.KunneIkkeOppdatereStønadsperiode.OverlappendeStønadsperiode -> feil.feil.tilResultat()
                                             }
                                         }
                                     },

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/iverksett/IverksettSøknadsbehandlingRoute.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/iverksett/IverksettSøknadsbehandlingRoute.kt
@@ -74,13 +74,10 @@ internal fun KunneIkkeIverksetteSøknadsbehandling.tilResultat(): Resultat {
         is KunneIkkeIverksetteSøknadsbehandling.KunneIkkeGenerereVedtaksbrev -> Feilresponser.Brev.kunneIkkeGenerereBrev
         KunneIkkeIverksetteSøknadsbehandling.AvkortingErUfullstendig -> Feilresponser.avkortingErUfullstendig
         KunneIkkeIverksetteSøknadsbehandling.SakHarRevurderingerMedÅpentKravgrunnlagForTilbakekreving -> Feilresponser.sakAvventerKravgrunnlagForTilbakekreving
-        KunneIkkeIverksetteSøknadsbehandling.OverskriverVedtak -> HttpStatusCode.InternalServerError.errorJson(
-            message = "Overskriver andre vedtak som førte til utbetaling eller vil føre til utbetaling",
-            code = "kan_ikke_overskrive_utbetalinger",
-        )
         KunneIkkeIverksetteSøknadsbehandling.SimuleringFørerTilFeilutbetaling -> HttpStatusCode.BadRequest.errorJson(
             message = "Simulering fører til feilutbetaling.",
             code = "simulering_fører_til_feilutbetaling",
         )
+        is KunneIkkeIverksetteSøknadsbehandling.OverlappendeStønadsperiode -> this.underliggendeFeil.tilResultat()
     }
 }


### PR DESCRIPTION
Et skritt nærmere parallelle behandlinger. Må gjøre tilsvarende for revurdering og regulering. Vi bør også persistere original saksbehandler+attestants simulerings xml. Bør finne algoritme for å finne ut om et opphør tidligere har vært utbetalt for å sperre de tilfellene.