### PR TITLE
Bytt ut microsoftGraphFilter med onPremisesSamAccountName

### DIFF
--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/person/MicrosoftGraphApiClientTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/person/MicrosoftGraphApiClientTest.kt
@@ -1,0 +1,62 @@
+package no.nav.su.se.bakover.client.person
+
+import arrow.core.right
+import com.github.tomakehurst.wiremock.client.WireMock
+import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.client.WiremockBase
+import no.nav.su.se.bakover.client.azure.AzureAd
+import no.nav.su.se.bakover.client.stubs.sts.TokenOppslagStub
+import no.nav.su.se.bakover.common.NavIdentBruker
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+class MicrosoftGraphApiClientTest : WiremockBase {
+
+    @Test
+    fun hentNavnForNavIdent() {
+        //language=JSON
+        val suksessResponseJson =
+            """
+            {
+              "value":[
+                {
+                  "displayName":"displayName",
+                  "givenName":"givenName",
+                  "mail":"mail",
+                  "officeLocation":"officeLocation",
+                  "surname":"surname",
+                  "userPrincipalName":"userPrincipalName",
+                  "id":"id",
+                  "jobTitle":"jobTitle"
+                }
+              ]
+            }
+            """.trimIndent()
+        val azureAdMock = mock<AzureAd> {
+            on { getSystemToken(any()) } doReturn tokenOppslag.token().value
+        }
+
+        WiremockBase.wireMockServer.stubFor(
+            wiremockBuilderSystembruker("Bearer ${tokenOppslag.token().value}")
+                .willReturn(WireMock.ok(suksessResponseJson)),
+        )
+
+        val client = MicrosoftGraphApiClient(
+            exchange = azureAdMock,
+            baseUrl = WiremockBase.wireMockServer.baseUrl(),
+        )
+        client.hentNavnForNavIdent(NavIdentBruker.Saksbehandler("saksbehandler")) shouldBe "displayName".right()
+    }
+
+    private val tokenOppslag = TokenOppslagStub
+
+    private fun wiremockBuilderSystembruker(authorization: String) = WireMock.get(
+        WireMock.urlEqualTo(
+            "/users?%24select=onPremisesSamAccountName%2CdisplayName%2CgivenName%2Cmail%2CofficeLocation%2Csurname%2CuserPrincipalName%2Cid%2CjobTitle&%24filter=onPremisesSamAccountName+eq+%27saksbehandler%27&%24count=true",
+        ),
+    )
+        .withHeader("Authorization", WireMock.equalTo(authorization))
+        .withHeader("ConsistencyLevel", WireMock.equalTo("eventual"))
+}


### PR DESCRIPTION
Gjør kallet litt mer robust, siden ikke alle brukere har mail-feltet vi bytter ut. Se https://nav-it.slack.com/archives/C0190RZ6HB4/p1671536757273469 og https://github.com/navikt/kabal-innstillinger/blob/main/src/main/kotlin/no/nav/klage/oppgave/clients/azure/MicrosoftGraphClient.kt og https://learn.microsoft.com/en-us/answers/questions/577870/filtering-on-onpremisessamaccountname-is-not-worki