### PR TITLE
Legg til rekkefølge på utbetalingstidslinje

### DIFF
--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/avstemming/AvstemmingPublisherTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/avstemming/AvstemmingPublisherTest.kt
@@ -33,7 +33,7 @@ import no.nav.su.se.bakover.domain.sak.Sakstype
 import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.oversendtUtbetalingUtenKvittering
-import no.nav.su.se.bakover.test.utbetalingslinje
+import no.nav.su.se.bakover.test.utbetalingslinjeNy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 import java.math.BigDecimal
@@ -150,7 +150,7 @@ class AvstemmingPublisherTest {
                 saksnummer = saksnummer,
                 fnr = Fnr("12345678910"),
                 utbetalingslinjer = nonEmptyListOf(
-                    utbetalingslinje(
+                    utbetalingslinjeNy(
                         periode = januar(2021),
                         beløp = 5000,
                     ),

--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/avstemming/GrensesnittavstemmingDataBuilderTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/avstemming/GrensesnittavstemmingDataBuilderTest.kt
@@ -4,6 +4,7 @@ import arrow.core.NonEmptyList
 import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.Fnr
 import no.nav.su.se.bakover.common.NavIdentBruker
+import no.nav.su.se.bakover.common.Rekkefølge
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.idag
@@ -32,7 +33,7 @@ import no.nav.su.se.bakover.test.TikkendeKlokke
 import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.fixedClockAt
 import no.nav.su.se.bakover.test.fixedTidspunkt
-import no.nav.su.se.bakover.test.utbetalingslinje
+import no.nav.su.se.bakover.test.utbetalingslinjeNy
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.util.UUID
@@ -210,15 +211,16 @@ internal fun alleUtbetalinger(): List<Utbetaling.OversendtUtbetaling> {
             status = Kvittering.Utbetalingsstatus.OK,
             linjer = ForrigeUtbetalingslinjeKoblendeListe(
                 listOf(
-                    utbetalingslinje(
+                    utbetalingslinjeNy(
                         periode = mars(2020),
                         beløp = 100,
                         opprettet = clock.nextTidspunkt(),
                     ),
-                    utbetalingslinje(
+                    utbetalingslinjeNy(
                         periode = april(2020),
                         beløp = 200,
                         opprettet = clock.nextTidspunkt(),
+                        rekkefølge = Rekkefølge.skip(0),
                     ),
                 ),
             ).toNonEmptyList(),
@@ -229,17 +231,18 @@ internal fun alleUtbetalinger(): List<Utbetaling.OversendtUtbetaling> {
             status = Kvittering.Utbetalingsstatus.OK,
             linjer = ForrigeUtbetalingslinjeKoblendeListe(
                 listOf(
-                    utbetalingslinje(
+                    utbetalingslinjeNy(
                         periode = mars(2020),
                         beløp = 600,
                         uføregrad = 60,
                         opprettet = clock.nextTidspunkt(),
                     ),
-                    utbetalingslinje(
+                    utbetalingslinjeNy(
                         periode = april(2020),
                         beløp = 700,
                         uføregrad = 60,
                         opprettet = clock.nextTidspunkt(),
+                        rekkefølge = Rekkefølge.skip(0),
                     ),
                 ),
             ).toNonEmptyList(),
@@ -250,23 +253,25 @@ internal fun alleUtbetalinger(): List<Utbetaling.OversendtUtbetaling> {
             status = Kvittering.Utbetalingsstatus.OK_MED_VARSEL,
             linjer = ForrigeUtbetalingslinjeKoblendeListe(
                 listOf(
-                    utbetalingslinje(
+                    utbetalingslinjeNy(
                         periode = mars(2020),
                         beløp = 400,
                         uføregrad = 70,
                         opprettet = clock.nextTidspunkt(),
                     ),
-                    utbetalingslinje(
+                    utbetalingslinjeNy(
                         periode = april(2020),
                         beløp = 500,
                         uføregrad = 70,
                         opprettet = clock.nextTidspunkt(),
+                        rekkefølge = Rekkefølge.skip(0),
                     ),
-                    utbetalingslinje(
+                    utbetalingslinjeNy(
                         periode = mai(2020),
                         beløp = 500,
                         uføregrad = 75,
                         opprettet = clock.nextTidspunkt(),
+                        rekkefølge = Rekkefølge.skip(1),
                     ),
                 ),
             ).toNonEmptyList(),
@@ -277,29 +282,32 @@ internal fun alleUtbetalinger(): List<Utbetaling.OversendtUtbetaling> {
             status = Kvittering.Utbetalingsstatus.FEIL,
             linjer = ForrigeUtbetalingslinjeKoblendeListe(
                 listOf(
-                    utbetalingslinje(
+                    utbetalingslinjeNy(
                         periode = mars(2020),
                         beløp = 1000,
                         uføregrad = 10,
                         opprettet = clock.nextTidspunkt(),
                     ),
-                    utbetalingslinje(
+                    utbetalingslinjeNy(
                         periode = april(2020),
                         beløp = 2000,
                         uføregrad = 20,
                         opprettet = clock.nextTidspunkt(),
+                        rekkefølge = Rekkefølge.skip(0),
                     ),
-                    utbetalingslinje(
+                    utbetalingslinjeNy(
                         periode = mai(2020),
                         beløp = 3000,
                         uføregrad = 30,
                         opprettet = clock.nextTidspunkt(),
+                        rekkefølge = Rekkefølge.skip(1),
                     ),
-                    utbetalingslinje(
+                    utbetalingslinjeNy(
                         periode = juni(2020),
                         beløp = 4000,
                         uføregrad = 50,
                         opprettet = clock.nextTidspunkt(),
+                        rekkefølge = Rekkefølge.skip(2),
                     ),
                 ),
             ).toNonEmptyList(),
@@ -310,7 +318,7 @@ internal fun alleUtbetalinger(): List<Utbetaling.OversendtUtbetaling> {
             status = null,
             linjer = ForrigeUtbetalingslinjeKoblendeListe(
                 listOf(
-                    utbetalingslinje(
+                    utbetalingslinjeNy(
                         periode = år(2020),
                         beløp = 5000,
                         uføregrad = 15,

--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/avstemming/GrunnlagBuilderTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/avstemming/GrunnlagBuilderTest.kt
@@ -5,7 +5,7 @@ import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.mars
 import no.nav.su.se.bakover.common.periode.mars
 import no.nav.su.se.bakover.domain.oppdrag.Kvittering
-import no.nav.su.se.bakover.test.utbetalingslinje
+import no.nav.su.se.bakover.test.utbetalingslinjeNy
 import org.junit.jupiter.api.Test
 
 internal class GrunnlagBuilderTest {
@@ -43,7 +43,7 @@ internal class GrunnlagBuilderTest {
                     opprettet = 1.mars(2020),
                     status = Kvittering.Utbetalingsstatus.OK,
                     linjer = nonEmptyListOf(
-                        utbetalingslinje(periode = mars(2020), beløp = 1000),
+                        utbetalingslinjeNy(periode = mars(2020), beløp = 1000),
                     ),
                 ),
             ),
@@ -67,14 +67,14 @@ internal class GrunnlagBuilderTest {
                     opprettet = 1.mars(2020),
                     status = Kvittering.Utbetalingsstatus.OK,
                     linjer = nonEmptyListOf(
-                        utbetalingslinje(periode = mars(2020), beløp = 1000),
+                        utbetalingslinjeNy(periode = mars(2020), beløp = 1000),
                     ),
                 ),
                 lagUtbetaling(
                     opprettet = 1.mars(2020),
                     status = Kvittering.Utbetalingsstatus.FEIL,
                     linjer = nonEmptyListOf(
-                        utbetalingslinje(periode = mars(2020), beløp = -1000, uføregrad = 100),
+                        utbetalingslinjeNy(periode = mars(2020), beløp = -1000, uføregrad = 100),
                     ),
                 ),
             ),

--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/simulering/SimuleringRequestBuilderTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/simulering/SimuleringRequestBuilderTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.client.oppdrag.utbetaling.UtbetalingRequest
 import no.nav.su.se.bakover.client.oppdrag.utbetaling.UtbetalingRequestTest
 import no.nav.su.se.bakover.client.oppdrag.utbetaling.toUtbetalingRequest
+import no.nav.su.se.bakover.common.Rekkefølge
 import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.februar
 import no.nav.su.se.bakover.common.mai
@@ -49,9 +50,10 @@ internal class SimuleringRequestBuilderTest {
         val linjeSomSkalEndres = UtbetalingRequestTest.nyUtbetaling.sisteUtbetalingslinje()
 
         val linjeMedEndring = Utbetalingslinje.Endring.Opphør(
-            utbetalingslinje = linjeSomSkalEndres,
+            utbetalingslinjeSomSkalEndres = linjeSomSkalEndres,
             virkningsperiode = Periode.create(1.februar(2020), linjeSomSkalEndres.periode.tilOgMed),
             clock = Clock.systemUTC(),
+            rekkefølge = Rekkefølge.start(),
         )
         val utbetalingMedEndring = UtbetalingRequestTest.nyUtbetaling.copy(
             avstemmingsnøkkel = Avstemmingsnøkkel(18.september(2020).startOfDay()),
@@ -87,9 +89,10 @@ internal class SimuleringRequestBuilderTest {
         val linjeSomSkalEndres = UtbetalingRequestTest.nyUtbetaling.sisteUtbetalingslinje()
 
         val linjeMedEndring = Utbetalingslinje.Endring.Opphør(
-            utbetalingslinje = linjeSomSkalEndres,
+            utbetalingslinjeSomSkalEndres = linjeSomSkalEndres,
             virkningsperiode = Periode.create(1.oktober(2020), linjeSomSkalEndres.periode.tilOgMed),
             clock = Clock.systemUTC(),
+            rekkefølge = Rekkefølge.start(),
         )
         val utbetalingMedEndring = UtbetalingRequestTest.nyUtbetaling.copy(
             avstemmingsnøkkel = Avstemmingsnøkkel(18.september(2020).startOfDay()),

--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/simulering/SimuleringRequestBuilderValidationTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/simulering/SimuleringRequestBuilderValidationTest.kt
@@ -12,7 +12,7 @@ import no.nav.su.se.bakover.domain.oppdrag.avstemming.Avstemmingsnøkkel
 import no.nav.su.se.bakover.domain.oppdrag.simulering.SimulerUtbetalingForPeriode
 import no.nav.su.se.bakover.domain.sak.Sakstype
 import no.nav.su.se.bakover.test.fixedTidspunkt
-import no.nav.su.se.bakover.test.utbetalingslinje
+import no.nav.su.se.bakover.test.utbetalingslinjeNy
 import no.nav.system.os.tjenester.simulerfpservice.simulerfpserviceservicetypes.SimulerBeregningRequest
 import org.junit.jupiter.api.Test
 import org.xml.sax.helpers.DefaultHandler
@@ -43,7 +43,7 @@ internal class SimuleringRequestBuilderValidationTest {
                     saksnummer = saksnummer,
                     fnr = Fnr("12345678910"),
                     utbetalingslinjer = nonEmptyListOf(
-                        utbetalingslinje(
+                        utbetalingslinjeNy(
                             periode = januar(2020),
                             beløp = 10,
                             forrigeUtbetalingslinjeId = eksisterendeOppdragslinjeid,

--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/utbetaling/UtbetalingRequestTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/utbetaling/UtbetalingRequestTest.kt
@@ -6,6 +6,7 @@ import no.nav.su.se.bakover.client.oppdrag.avstemming.sakId
 import no.nav.su.se.bakover.client.oppdrag.avstemming.saksnummer
 import no.nav.su.se.bakover.common.Fnr
 import no.nav.su.se.bakover.common.NavIdentBruker
+import no.nav.su.se.bakover.common.Rekkefølge
 import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.periode.Periode
@@ -20,7 +21,7 @@ import no.nav.su.se.bakover.domain.oppdrag.avstemming.Avstemmingsnøkkel
 import no.nav.su.se.bakover.domain.sak.Sakstype
 import no.nav.su.se.bakover.test.TikkendeKlokke
 import no.nav.su.se.bakover.test.fixedTidspunkt
-import no.nav.su.se.bakover.test.utbetalingslinje
+import no.nav.su.se.bakover.test.utbetalingslinjeNy
 import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.LocalDate
@@ -43,19 +44,20 @@ internal class UtbetalingRequestTest {
             saksnummer = saksnummer,
             fnr = FNR,
             utbetalingslinjer = nonEmptyListOf(
-                utbetalingslinje(
+                utbetalingslinjeNy(
                     id = nyOppdragslinjeId1,
                     periode = januar(2020)..april(2020),
                     beløp = BELØP,
                     opprettet = clock.nextTidspunkt(),
                 ),
-                utbetalingslinje(
+                utbetalingslinjeNy(
                     id = nyOppdragslinjeId2,
                     periode = mai(2020)..desember(2020),
                     beløp = BELØP,
                     forrigeUtbetalingslinjeId = nyOppdragslinjeId1,
                     uføregrad = 70,
                     opprettet = clock.nextTidspunkt(),
+                    rekkefølge = Rekkefølge.skip(0),
                 ),
             ),
             behandler = NavIdentBruker.Attestant("A123456"),
@@ -157,19 +159,20 @@ internal class UtbetalingRequestTest {
             saksnummer = saksnummer,
             fnr = FNR,
             utbetalingslinjer = nonEmptyListOf(
-                utbetalingslinje(
+                utbetalingslinjeNy(
                     id = nyOppdragslinjeid1,
                     periode = januar(2020)..april(2020),
                     beløp = BELØP,
                     forrigeUtbetalingslinjeId = eksisterendeOppdragslinjeId,
                     opprettet = clock.nextTidspunkt(),
                 ),
-                utbetalingslinje(
+                utbetalingslinjeNy(
                     id = nyOppdragslinjeid2,
                     periode = mai(2020)..desember(2020),
                     beløp = BELØP,
                     forrigeUtbetalingslinjeId = nyOppdragslinjeid1,
                     opprettet = clock.nextTidspunkt(),
+                    rekkefølge = Rekkefølge.skip(0),
                 ),
             ),
             behandler = NavIdentBruker.Attestant("A123456"),
@@ -258,9 +261,10 @@ internal class UtbetalingRequestTest {
             avstemmingsnøkkel = Avstemmingsnøkkel(1.januar(2020).startOfDay()),
             utbetalingslinjer = nonEmptyListOf(
                 Utbetalingslinje.Endring.Opphør(
-                    utbetalingslinje = nyUtbetaling.sisteUtbetalingslinje(),
+                    utbetalingslinjeSomSkalEndres = nyUtbetaling.sisteUtbetalingslinje(),
                     virkningsperiode = Periode.create(1.januar(2020), nyUtbetaling.sisteUtbetalingslinje().periode.tilOgMed),
                     clock = Clock.systemUTC(),
+                    rekkefølge = Rekkefølge.start(),
                 ),
             ),
         )
@@ -269,9 +273,10 @@ internal class UtbetalingRequestTest {
             avstemmingsnøkkel = Avstemmingsnøkkel(1.januar(2020).startOfDay()),
             utbetalingslinjer = nonEmptyListOf(
                 Utbetalingslinje.Endring.Stans(
-                    utbetalingslinje = nyUtbetaling.sisteUtbetalingslinje(),
+                    utbetalingslinjeSomSkalEndres = nyUtbetaling.sisteUtbetalingslinje(),
                     virkningstidspunkt = 1.januar(2020),
                     clock = Clock.systemUTC(),
+                    rekkefølge = Rekkefølge.start(),
                 ),
             ),
         )
@@ -280,9 +285,10 @@ internal class UtbetalingRequestTest {
             avstemmingsnøkkel = Avstemmingsnøkkel(1.januar(2020).startOfDay()),
             utbetalingslinjer = nonEmptyListOf(
                 Utbetalingslinje.Endring.Reaktivering(
-                    utbetalingslinje = nyUtbetaling.sisteUtbetalingslinje(),
+                    utbetalingslinjeSomSkalEndres = nyUtbetaling.sisteUtbetalingslinje(),
                     virkningstidspunkt = 1.januar(2020),
                     clock = Clock.systemUTC(),
+                    rekkefølge = Rekkefølge.start(),
                 ),
             ),
         )

--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/utbetaling/UtbetalingXmlMappingTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/oppdrag/utbetaling/UtbetalingXmlMappingTest.kt
@@ -6,6 +6,7 @@ import no.nav.su.se.bakover.client.oppdrag.avstemming.sakId
 import no.nav.su.se.bakover.client.oppdrag.avstemming.saksnummer
 import no.nav.su.se.bakover.common.Fnr
 import no.nav.su.se.bakover.common.NavIdentBruker
+import no.nav.su.se.bakover.common.Rekkefølge
 import no.nav.su.se.bakover.common.februar
 import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.common.periode.Periode
@@ -18,7 +19,7 @@ import no.nav.su.se.bakover.domain.oppdrag.avstemming.Avstemmingsnøkkel
 import no.nav.su.se.bakover.domain.sak.Sakstype
 import no.nav.su.se.bakover.test.TikkendeKlokke
 import no.nav.su.se.bakover.test.fixedTidspunkt
-import no.nav.su.se.bakover.test.utbetalingslinje
+import no.nav.su.se.bakover.test.utbetalingslinjeNy
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
 import org.xmlunit.diff.DefaultNodeMatcher
@@ -39,23 +40,27 @@ class UtbetalingXmlMappingTest {
 
     private val clock = TikkendeKlokke()
 
-    private val førsteUtbetalingsLinje = utbetalingslinje(
+    private val rekkefølge = Rekkefølge.generator()
+    private val førsteUtbetalingsLinje = utbetalingslinjeNy(
         periode = januar(2020),
         beløp = 10,
         opprettet = clock.nextTidspunkt(),
+        rekkefølge = rekkefølge.neste(),
     )
-    private val andreUtbetalingslinje = utbetalingslinje(
+    private val andreUtbetalingslinje = utbetalingslinjeNy(
         periode = februar(2020),
         beløp = 20,
         forrigeUtbetalingslinjeId = førsteUtbetalingsLinje.id,
         uføregrad = 60,
         opprettet = clock.nextTidspunkt(),
+        rekkefølge = rekkefølge.neste(),
     )
 
     private val tredjeUtbetalingslinje = Utbetalingslinje.Endring.Opphør(
-        andreUtbetalingslinje,
+        utbetalingslinjeSomSkalEndres = andreUtbetalingslinje,
         virkningsperiode = Periode.create(1.februar(2020), andreUtbetalingslinje.periode.tilOgMed),
         opprettet = clock.nextTidspunkt(),
+        rekkefølge = rekkefølge.neste(),
     )
 
     private val fnr = Fnr("12345678910")

--- a/common/src/main/kotlin/no/nav/su/se/bakover/common/Rekkefølge.kt
+++ b/common/src/main/kotlin/no/nav/su/se/bakover/common/Rekkefølge.kt
@@ -1,0 +1,58 @@
+package no.nav.su.se.bakover.common
+
+/**
+ * 0-indeksert rekkefølge. Brukes for å sortere i stigende rekkefølge.
+ */
+@JvmInline
+value class Rekkefølge(
+    val value: Long,
+) : Comparable<Rekkefølge> {
+
+    init {
+        require(value >= 0) { "Rekkefølge må være større enn eller lik 0" }
+    }
+
+    override fun compareTo(other: Rekkefølge): Int {
+        return value.compareTo(other.value)
+    }
+
+    fun neste(): Rekkefølge {
+        return Rekkefølge(value + 1)
+    }
+
+    /**
+     * Hopper over de N neste.
+     * @param hoppOver 0 gir neste, 1 gir neste neste, osv.
+     */
+    fun skip(hoppOver: Long): Rekkefølge {
+        require(hoppOver >= 0) { "Kan ikke være negativt" }
+        return Rekkefølge(value + hoppOver + 1)
+    }
+
+    companion object {
+
+        fun start(): Rekkefølge {
+            return Rekkefølge(0)
+        }
+
+        /**
+         * Starter på start og over de N neste.
+         * @param hoppOver 0 gir neste, 1 gir neste neste, osv.
+         */
+        fun skip(hoppOver: Long): Rekkefølge {
+            require(hoppOver >= 0) { "Kan ikke være negativt" }
+            return start().skip(hoppOver)
+        }
+
+        fun generator(): RekkefølgeGenerator {
+            return RekkefølgeGenerator()
+        }
+    }
+}
+
+class RekkefølgeGenerator {
+    private var nextValue: Rekkefølge = Rekkefølge.start()
+    fun neste(): Rekkefølge {
+        return nextValue.also { nextValue = nextValue.neste() }
+    }
+}

--- a/common/src/test/kotlin/no/nav/su/se/bakover/common/RekkefølgeTest.kt
+++ b/common/src/test/kotlin/no/nav/su/se/bakover/common/RekkefølgeTest.kt
@@ -1,0 +1,57 @@
+package no.nav.su.se.bakover.common
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.Test
+
+internal class RekkefølgeTest {
+
+    @Test
+    fun `rekkefølge start`() {
+        Rekkefølge.start() shouldBe Rekkefølge(0)
+    }
+
+    @Test
+    fun `rekkefølge neste`() {
+        Rekkefølge.start().neste() shouldBe Rekkefølge(1)
+        Rekkefølge(1).neste() shouldBe Rekkefølge(2)
+        Rekkefølge(2).neste() shouldBe Rekkefølge(3)
+    }
+
+    @Test
+    fun `rekkefølge skip`() {
+        Rekkefølge.skip(0) shouldBe Rekkefølge(1)
+        Rekkefølge.skip(1) shouldBe Rekkefølge(2)
+        Rekkefølge.skip(2) shouldBe Rekkefølge(3)
+        Rekkefølge.skip(3) shouldBe Rekkefølge(4)
+
+        Rekkefølge.skip(0) shouldBe Rekkefølge(1)
+        Rekkefølge.skip(1) shouldBe Rekkefølge(2)
+        Rekkefølge.skip(2) shouldBe Rekkefølge(3)
+        Rekkefølge.skip(3) shouldBe Rekkefølge(4)
+    }
+
+    @Test
+    fun `rekkefølge generator`() {
+        val generator1 = Rekkefølge.generator()
+        val generator2 = Rekkefølge.generator()
+        generator1.neste() shouldBe Rekkefølge(0)
+        generator2.neste() shouldBe Rekkefølge(0)
+        generator1.neste() shouldBe Rekkefølge(1)
+        generator2.neste() shouldBe Rekkefølge(1)
+        generator1.neste() shouldBe Rekkefølge(2)
+        generator2.neste() shouldBe Rekkefølge(2)
+        generator1.neste() shouldBe Rekkefølge(3)
+        generator2.neste() shouldBe Rekkefølge(3)
+    }
+
+    @Test
+    fun `rekkefølge compareTo`() {
+        Rekkefølge(0) shouldBe Rekkefølge(0)
+        Rekkefølge(0) shouldNotBe Rekkefølge(1)
+        Rekkefølge(1) shouldBe Rekkefølge(1)
+        Rekkefølge(1) shouldNotBe Rekkefølge(2)
+        Rekkefølge(2) shouldBe Rekkefølge(2)
+        Rekkefølge(2) shouldNotBe Rekkefølge(3)
+    }
+}

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/utbetaling/UtbetalingRepoInternal.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/utbetaling/UtbetalingRepoInternal.kt
@@ -3,6 +3,7 @@ package no.nav.su.se.bakover.database.utbetaling
 import kotliquery.Row
 import no.nav.su.se.bakover.common.Fnr
 import no.nav.su.se.bakover.common.NavIdentBruker
+import no.nav.su.se.bakover.common.Rekkefølge
 import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.deserialize
 import no.nav.su.se.bakover.common.deserializeNullable
@@ -101,6 +102,7 @@ private fun Row.toUtbetalingslinje(): Utbetalingslinje {
         fraOgMed = localDate("fom"),
         tilOgMed = localDate("tom"),
         opprettet = tidspunkt("opprettet"),
+        rekkefølge = longOrNull("rekkefølge")?.let { Rekkefølge(it) },
         forrigeUtbetalingslinjeId = stringOrNull("forrigeUtbetalingslinjeId")?.let { uuid30("forrigeUtbetalingslinjeId") },
         beløp = int("beløp"),
         uføregrad = intOrNull("uføregrad")?.let { Uføregrad.parse(it) },
@@ -113,6 +115,7 @@ private fun Row.toUtbetalingslinje(): Utbetalingslinje {
                 Utbetalingslinje.Endring.Opphør(
                     id = linje.id,
                     opprettet = linje.opprettet,
+                    rekkefølge = linje.rekkefølge,
                     fraOgMed = linje.originalFraOgMed(),
                     tilOgMed = linje.originalTilOgMed(),
                     forrigeUtbetalingslinjeId = linje.forrigeUtbetalingslinjeId,
@@ -126,6 +129,7 @@ private fun Row.toUtbetalingslinje(): Utbetalingslinje {
                 Utbetalingslinje.Endring.Stans(
                     id = linje.id,
                     opprettet = linje.opprettet,
+                    rekkefølge = linje.rekkefølge,
                     fraOgMed = linje.originalFraOgMed(),
                     tilOgMed = linje.originalTilOgMed(),
                     forrigeUtbetalingslinjeId = linje.forrigeUtbetalingslinjeId,
@@ -139,6 +143,7 @@ private fun Row.toUtbetalingslinje(): Utbetalingslinje {
                 Utbetalingslinje.Endring.Reaktivering(
                     id = linje.id,
                     opprettet = linje.opprettet,
+                    rekkefølge = linje.rekkefølge,
                     fraOgMed = linje.originalFraOgMed(),
                     tilOgMed = linje.originalTilOgMed(),
                     forrigeUtbetalingslinjeId = linje.forrigeUtbetalingslinjeId,

--- a/database/src/main/resources/db/migration/V179__utbetalingslinje_legg_til_rekkefølge.sql
+++ b/database/src/main/resources/db/migration/V179__utbetalingslinje_legg_til_rekkefølge.sql
@@ -1,0 +1,7 @@
+ALTER TABLE
+    utbetalingslinje
+ADD COLUMN IF NOT EXISTS
+    rekkefølge bigint;
+
+CREATE INDEX utbetalingslinje_rekkefølge_index ON utbetalingslinje (rekkefølge ASC NULLS LAST);
+CREATE INDEX utbetalingslinje_opprettet_index ON utbetalingslinje (opprettet ASC NULLS LAST);

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/utbetaling/UtbetalingMapperTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/utbetaling/UtbetalingMapperTest.kt
@@ -17,7 +17,7 @@ import no.nav.su.se.bakover.domain.sak.Saksnummer
 import no.nav.su.se.bakover.domain.sak.Sakstype
 import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.fixedTidspunkt
-import no.nav.su.se.bakover.test.utbetalingslinje
+import no.nav.su.se.bakover.test.utbetalingslinjeNy
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
@@ -32,7 +32,7 @@ internal class UtbetalingMapperTest {
             saksnummer = Saksnummer(2021),
             fnr = Fnr(fnr = "12345678910"),
             utbetalingslinjer = nonEmptyListOf(
-                utbetalingslinje(
+                utbetalingslinjeNy(
                     periode = januar(2021),
                     beløp = 0,
                 ),
@@ -68,7 +68,7 @@ internal class UtbetalingMapperTest {
             saksnummer = Saksnummer(2021),
             fnr = Fnr(fnr = "12345678910"),
             utbetalingslinjer = nonEmptyListOf(
-                utbetalingslinje(
+                utbetalingslinjeNy(
                     periode = januar(2021),
                     beløp = 0,
                 ),

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/Utbetaling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppdrag/Utbetaling.kt
@@ -67,6 +67,7 @@ sealed interface Utbetaling : Comparable<Utbetaling> {
     fun kontrollerUtbetalingslinjer() {
         utbetalingslinjer.sjekkAlleNyeLinjerHarForskjelligForrigeReferanse()
         utbetalingslinjer.sjekkSortering()
+        utbetalingslinjer.sjekkRekkefølge()
     }
 
     data class UtbetalingForSimulering(

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/oppdrag/UtbetalingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/oppdrag/UtbetalingTest.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeTypeOf
 import no.nav.su.se.bakover.common.Fnr
 import no.nav.su.se.bakover.common.NavIdentBruker
+import no.nav.su.se.bakover.common.Rekkefølge
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.april
@@ -25,7 +26,7 @@ import no.nav.su.se.bakover.domain.sak.Sakstype
 import no.nav.su.se.bakover.test.fixedLocalDate
 import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.generer
-import no.nav.su.se.bakover.test.utbetalingslinje
+import no.nav.su.se.bakover.test.utbetalingslinjeNy
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.util.UUID
@@ -85,33 +86,39 @@ internal class UtbetalingTest {
         forrigeUtbetalingslinjeId: UUID30? = null,
         uføregrad: Uføregrad = Uføregrad.parse(50),
         opprettet: Tidspunkt = fixedTidspunkt,
-    ) = utbetalingslinje(
+        rekkefølge: Rekkefølge = Rekkefølge.start(),
+    ) = utbetalingslinjeNy(
         periode = Periode.create(fraOgMed, tilOgMed),
         beløp = beløp,
         forrigeUtbetalingslinjeId = forrigeUtbetalingslinjeId,
         uføregrad = uføregrad.value,
         opprettet = opprettet,
+        rekkefølge = rekkefølge,
     )
 
     private fun createUtbetalingslinjer(
         utbetalingOpprettet: Tidspunkt = fixedTidspunkt,
     ): NonEmptyList<Utbetalingslinje> {
+        val rekkefølge = Rekkefølge.generator()
         return ForrigeUtbetalingslinjeKoblendeListe(
             listOf(
                 createUtbetalingslinje(
                     fraOgMed = 1.januar(2019),
                     tilOgMed = 30.april(2020),
                     opprettet = utbetalingOpprettet.plusUnits(1),
+                    rekkefølge = rekkefølge.neste(),
                 ),
                 createUtbetalingslinje(
                     fraOgMed = 1.mai(2020),
                     tilOgMed = 31.august(2020),
                     opprettet = utbetalingOpprettet.plusUnits(2),
+                    rekkefølge = rekkefølge.neste(),
                 ),
                 createUtbetalingslinje(
                     fraOgMed = 1.september(2020),
                     tilOgMed = 31.januar(2021),
                     opprettet = utbetalingOpprettet.plusUnits(3),
+                    rekkefølge = rekkefølge.neste(),
                 ),
             ),
         ).toNonEmptyList()

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/oppdrag/UtbetalingslinjeTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/oppdrag/UtbetalingslinjeTest.kt
@@ -2,6 +2,7 @@ package no.nav.su.se.bakover.domain.oppdrag
 
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import no.nav.su.se.bakover.common.Rekkefølge
 import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.januar
 import no.nav.su.se.bakover.domain.grunnlag.Uføregrad
@@ -14,11 +15,13 @@ internal class UtbetalingslinjeTest {
 
     @Test
     fun `sortering i stigende rekkefølge - nyeste sist`() {
+        val rekkefølge = Rekkefølge.generator()
         assertThrows<IllegalStateException> {
             listOf(
                 Utbetalingslinje.Ny(
                     id = UUID30.randomUUID(),
                     opprettet = fixedTidspunkt,
+                    rekkefølge = rekkefølge.neste(),
                     fraOgMed = 1.januar(2020),
                     tilOgMed = 31.januar(2020),
                     forrigeUtbetalingslinjeId = null,
@@ -29,6 +32,7 @@ internal class UtbetalingslinjeTest {
                 Utbetalingslinje.Ny(
                     id = UUID30.randomUUID(),
                     opprettet = fixedTidspunkt.minus(1, ChronoUnit.DAYS),
+                    rekkefølge = rekkefølge.neste(),
                     fraOgMed = 1.januar(2020),
                     tilOgMed = 31.januar(2020),
                     forrigeUtbetalingslinjeId = null,
@@ -44,11 +48,13 @@ internal class UtbetalingslinjeTest {
 
     @Test
     fun `nye linjer har forskjellig forrige referanse`() {
+        val rekkefølge = Rekkefølge.generator()
         assertThrows<IllegalStateException> {
             listOf(
                 Utbetalingslinje.Ny(
                     id = UUID30.randomUUID(),
                     opprettet = fixedTidspunkt,
+                    rekkefølge = rekkefølge.neste(),
                     fraOgMed = 1.januar(2020),
                     tilOgMed = 31.januar(2020),
                     forrigeUtbetalingslinjeId = UUID30.fromString("268e62fb-3079-4e8d-ab32-ff9fb9"),
@@ -59,6 +65,7 @@ internal class UtbetalingslinjeTest {
                 Utbetalingslinje.Ny(
                     id = UUID30.randomUUID(),
                     opprettet = fixedTidspunkt,
+                    rekkefølge = rekkefølge.neste(),
                     fraOgMed = 1.januar(2020),
                     tilOgMed = 31.januar(2020),
                     forrigeUtbetalingslinjeId = UUID30.fromString("268e62fb-3079-4e8d-ab32-ff9fb9"),
@@ -74,11 +81,13 @@ internal class UtbetalingslinjeTest {
 
     @Test
     fun `nye linjer kan ikke overlappe`() {
+        val rekkefølge = Rekkefølge.generator()
         assertThrows<IllegalStateException> {
             listOf(
                 Utbetalingslinje.Ny(
                     id = UUID30.randomUUID(),
                     opprettet = fixedTidspunkt,
+                    rekkefølge = rekkefølge.neste(),
                     fraOgMed = 1.januar(2020),
                     tilOgMed = 31.januar(2020),
                     forrigeUtbetalingslinjeId = UUID30.fromString("268e62fb-3079-4e8d-ab32-ff9fb9"),
@@ -89,6 +98,7 @@ internal class UtbetalingslinjeTest {
                 Utbetalingslinje.Ny(
                     id = UUID30.randomUUID(),
                     opprettet = fixedTidspunkt,
+                    rekkefølge = rekkefølge.neste(),
                     fraOgMed = 1.januar(2020),
                     tilOgMed = 31.januar(2020),
                     forrigeUtbetalingslinjeId = UUID30.fromString("268e62fb-3079-4e8d-ab32-ff9fb9"),

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/oppdrag/avstemming/KonsistensavstemmingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/oppdrag/avstemming/KonsistensavstemmingTest.kt
@@ -5,6 +5,7 @@ import arrow.core.nonEmptyListOf
 import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.Fnr
 import no.nav.su.se.bakover.common.NavIdentBruker
+import no.nav.su.se.bakover.common.Rekkefølge
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.april
@@ -199,6 +200,7 @@ internal class KonsistensavstemmingTest {
                         fraOgMed = 1.september(2021),
                         tilOgMed = 31.desember(2021),
                         beløp = 20000,
+                        rekkefølge = Rekkefølge.skip(0),
                     ),
                 ),
             ).toNonEmptyList(),
@@ -223,6 +225,7 @@ internal class KonsistensavstemmingTest {
                         fraOgMed = 1.september(2021),
                         tilOgMed = 31.desember(2021),
                         beløp = 18000,
+                        rekkefølge = Rekkefølge.skip(0),
                     ),
                 ),
             ).toNonEmptyList(),
@@ -306,6 +309,7 @@ internal class KonsistensavstemmingTest {
                         fraOgMed = 1.september(2021),
                         tilOgMed = 31.desember(2021),
                         beløp = 20000,
+                        rekkefølge = Rekkefølge.skip(0),
                     ),
                 ),
             ).toNonEmptyList(),
@@ -330,6 +334,7 @@ internal class KonsistensavstemmingTest {
                         fraOgMed = 1.september(2021),
                         tilOgMed = 31.desember(2021),
                         beløp = 18000,
+                        rekkefølge = Rekkefølge.skip(0),
                     ),
                 ),
             ).toNonEmptyList(),
@@ -417,6 +422,7 @@ internal class KonsistensavstemmingTest {
 
     @Test
     fun `opphørte linjer framover i tid inkluderes - tar kun med nye linjer, selv om opphør har samme id`() {
+        val rekkefølge = Rekkefølge.generator()
         val første = createUtbetaling(
             fnr = fnr,
             saksnummer = saksnummer,
@@ -424,6 +430,7 @@ internal class KonsistensavstemmingTest {
             utbetalingsLinjer = nonEmptyListOf(
                 createUtbetalingslinje(
                     opprettet = Tidspunkt.now(førsteKlokke),
+                    rekkefølge = rekkefølge.neste(),
                     fraOgMed = 1.januar(2021),
                     tilOgMed = 31.desember(2021),
                     beløp = 15000,
@@ -437,9 +444,10 @@ internal class KonsistensavstemmingTest {
             opprettet = Tidspunkt.now(andreKlokke),
             utbetalingsLinjer = nonEmptyListOf(
                 Utbetalingslinje.Endring.Opphør(
-                    utbetalingslinje = første.utbetalingslinjer[0],
+                    utbetalingslinjeSomSkalEndres = første.utbetalingslinjer[0],
                     virkningsperiode = Periode.create(1.april(2021), første.utbetalingslinjer[0].periode.tilOgMed),
                     clock = andreKlokke,
+                    rekkefølge = Rekkefølge.start(),
                 ),
             ),
         )
@@ -491,9 +499,10 @@ internal class KonsistensavstemmingTest {
             opprettet = Tidspunkt.now(andreKlokke),
             utbetalingsLinjer = nonEmptyListOf(
                 Utbetalingslinje.Endring.Opphør(
-                    utbetalingslinje = første.utbetalingslinjer[0],
+                    utbetalingslinjeSomSkalEndres = første.utbetalingslinjer[0],
                     virkningsperiode = Periode.create(1.april(2021), første.utbetalingslinjer[0].periode.tilOgMed),
                     clock = andreKlokke,
+                    rekkefølge = Rekkefølge.start(),
                 ),
             ),
         )
@@ -508,6 +517,7 @@ internal class KonsistensavstemmingTest {
                     fraOgMed = 1.september(2021),
                     tilOgMed = 31.desember(2021),
                     beløp = 5000,
+                    rekkefølge = Rekkefølge.start(),
                 ),
             ),
         )
@@ -550,6 +560,7 @@ internal class KonsistensavstemmingTest {
                     fraOgMed = 1.januar(2021),
                     tilOgMed = 31.desember(2021),
                     beløp = 15000,
+                    rekkefølge = Rekkefølge.start(),
                 ),
             ),
         )
@@ -560,9 +571,10 @@ internal class KonsistensavstemmingTest {
             opprettet = Tidspunkt.now(andreKlokke),
             utbetalingsLinjer = nonEmptyListOf(
                 Utbetalingslinje.Endring.Opphør(
-                    utbetalingslinje = første.utbetalingslinjer[0],
+                    utbetalingslinjeSomSkalEndres = første.utbetalingslinjer[0],
                     virkningsperiode = Periode.create(1.april(2021), første.utbetalingslinjer[0].periode.tilOgMed),
                     clock = andreKlokke,
+                    rekkefølge = Rekkefølge.start(),
                 ),
             ),
         )
@@ -580,6 +592,7 @@ internal class KonsistensavstemmingTest {
 
     @Test
     fun `ny, stans og reaktivering - tar kun med seg nye linjer selv om stans og reaktivering har samme id`() {
+        val rekkefølge = Rekkefølge.generator()
         val første = createUtbetaling(
             fnr = fnr,
             saksnummer = saksnummer,
@@ -591,12 +604,14 @@ internal class KonsistensavstemmingTest {
                         fraOgMed = 1.januar(2021),
                         tilOgMed = 30.april(2021),
                         beløp = 10000,
+                        rekkefølge = rekkefølge.neste(),
                     ),
                     createUtbetalingslinje(
                         opprettet = Tidspunkt.now(førsteKlokke).plusUnits(1),
                         fraOgMed = 1.mai(2021),
                         tilOgMed = 31.desember(2021),
                         beløp = 15000,
+                        rekkefølge = rekkefølge.neste(),
                     ),
                 ),
             ).toNonEmptyList(),
@@ -604,9 +619,10 @@ internal class KonsistensavstemmingTest {
         )
 
         val stans1 = Utbetalingslinje.Endring.Stans(
-            utbetalingslinje = første.sisteUtbetalingslinje(),
+            utbetalingslinjeSomSkalEndres = første.sisteUtbetalingslinje(),
             virkningstidspunkt = 1.august(2021),
             clock = andreKlokke,
+            rekkefølge = Rekkefølge.start(),
         )
         val andre = createUtbetaling(
             fnr = fnr,
@@ -628,15 +644,17 @@ internal class KonsistensavstemmingTest {
                     fraOgMed = 1.august(2021),
                     tilOgMed = 31.desember(2021),
                     beløp = 5000,
+                    rekkefølge = Rekkefølge.start(),
                 ),
             ),
             behandler = defaultAttestant,
         )
 
         val stans2 = Utbetalingslinje.Endring.Stans(
-            utbetalingslinje = tredje.sisteUtbetalingslinje(),
+            utbetalingslinjeSomSkalEndres = tredje.sisteUtbetalingslinje(),
             virkningstidspunkt = 1.august(2021),
             clock = fjerdeKlokke,
+            rekkefølge = Rekkefølge.start(),
         )
 
         val fjerde = createUtbetaling(
@@ -650,9 +668,10 @@ internal class KonsistensavstemmingTest {
         )
 
         val gjen1 = Utbetalingslinje.Endring.Reaktivering(
-            utbetalingslinje = fjerde.sisteUtbetalingslinje(),
+            utbetalingslinjeSomSkalEndres = fjerde.sisteUtbetalingslinje(),
             virkningstidspunkt = 1.august(2021),
             clock = femteKlokke,
+            rekkefølge = Rekkefølge.start(),
         )
 
         val femte = createUtbetaling(
@@ -729,6 +748,7 @@ internal class KonsistensavstemmingTest {
 
     @Test
     fun `inkluderer alle attestanter for linjer som er endret`() {
+        val rekkefølge = Rekkefølge.generator()
         val første = createUtbetaling(
             fnr = fnr,
             saksnummer = saksnummer,
@@ -740,12 +760,14 @@ internal class KonsistensavstemmingTest {
                         fraOgMed = 1.januar(2021),
                         tilOgMed = 30.april(2021),
                         beløp = 10000,
+                        rekkefølge = rekkefølge.neste(),
                     ),
                     createUtbetalingslinje(
                         opprettet = Tidspunkt.now(førsteKlokke).plusUnits(1),
                         fraOgMed = 1.mai(2021),
                         tilOgMed = 31.desember(2021),
                         beløp = 15000,
+                        rekkefølge = rekkefølge.neste(),
                     ),
                 ),
             ).toNonEmptyList(),
@@ -753,9 +775,10 @@ internal class KonsistensavstemmingTest {
         )
 
         val stans1 = Utbetalingslinje.Endring.Stans(
-            utbetalingslinje = første.sisteUtbetalingslinje(),
+            utbetalingslinjeSomSkalEndres = første.sisteUtbetalingslinje(),
             virkningstidspunkt = 1.august(2021),
             clock = andreKlokke,
+            rekkefølge = Rekkefølge.start(),
         )
         val andre = createUtbetaling(
             fnr = fnr,
@@ -768,9 +791,10 @@ internal class KonsistensavstemmingTest {
         )
 
         val gjen1 = Utbetalingslinje.Endring.Reaktivering(
-            utbetalingslinje = andre.sisteUtbetalingslinje(),
+            utbetalingslinjeSomSkalEndres = stans1,
             virkningstidspunkt = 1.august(2021),
             clock = tredjeKlokke,
+            rekkefølge = Rekkefølge.start(),
         )
 
         val tredje = createUtbetaling(
@@ -828,6 +852,7 @@ internal class KonsistensavstemmingTest {
                         fraOgMed = 1.mai(2021),
                         tilOgMed = 31.desember(2021),
                         beløp = 17500,
+                        rekkefølge = Rekkefølge.skip(0),
                     ),
                 ),
             ).toNonEmptyList(),
@@ -988,12 +1013,14 @@ internal class KonsistensavstemmingTest {
 
     private fun createUtbetalingslinje(
         opprettet: Tidspunkt,
+        rekkefølge: Rekkefølge = Rekkefølge.start(),
         fraOgMed: LocalDate = 1.januar(2020),
         tilOgMed: LocalDate = 31.desember(2020),
         beløp: Int = 500,
         uføregrad: Uføregrad = Uføregrad.parse(50),
     ) = Utbetalingslinje.Ny(
         opprettet = opprettet,
+        rekkefølge = rekkefølge,
         fraOgMed = fraOgMed,
         tilOgMed = tilOgMed,
         beløp = beløp,

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/oppdrag/utbetaling/UtbetalingsstrategiGjenopptaTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/oppdrag/utbetaling/UtbetalingsstrategiGjenopptaTest.kt
@@ -4,6 +4,7 @@ import arrow.core.NonEmptyList
 import arrow.core.left
 import arrow.core.nonEmptyListOf
 import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.common.Rekkefølge
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.april
 import no.nav.su.se.bakover.common.desember
@@ -42,9 +43,10 @@ internal class UtbetalingsstrategiGjenopptaTest {
             opprettet = fixedTidspunkt,
             nonEmptyListOf(
                 Utbetalingslinje.Endring.Stans(
-                    utbetalingslinje = opprinnelig.sisteUtbetalingslinje(),
+                    utbetalingslinjeSomSkalEndres = opprinnelig.sisteUtbetalingslinje(),
                     virkningstidspunkt = 1.oktober(2020),
                     opprettet = fixedTidspunkt,
+                    rekkefølge = Rekkefølge.start(),
                 ),
             ),
         )
@@ -72,11 +74,15 @@ internal class UtbetalingsstrategiGjenopptaTest {
                 Utbetalingslinje.Endring.Reaktivering(
                     id = opprinnelig.utbetalingslinjer[0].id,
                     opprettet = actual.utbetalingslinjer[0].opprettet,
+                    rekkefølge = Rekkefølge.start(),
                     fraOgMed = opprinnelig.utbetalingslinjer[0].periode.fraOgMed,
                     tilOgMed = opprinnelig.utbetalingslinjer[0].periode.tilOgMed,
                     forrigeUtbetalingslinjeId = opprinnelig.utbetalingslinjer[0].forrigeUtbetalingslinjeId,
                     beløp = opprinnelig.utbetalingslinjer[0].beløp,
-                    virkningsperiode = Periode.create(1.oktober(2020), opprinnelig.utbetalingslinjer[0].periode.tilOgMed),
+                    virkningsperiode = Periode.create(
+                        1.oktober(2020),
+                        opprinnelig.utbetalingslinjer[0].periode.tilOgMed,
+                    ),
                     uføregrad = opprinnelig.utbetalingslinjer[0].uføregrad,
                     utbetalingsinstruksjonForEtterbetalinger = UtbetalingsinstruksjonForEtterbetalinger.SåFortSomMulig,
                 ),
@@ -108,9 +114,10 @@ internal class UtbetalingsstrategiGjenopptaTest {
             opprettet = fixedTidspunkt,
             nonEmptyListOf(
                 Utbetalingslinje.Endring.Stans(
-                    utbetalingslinje = første.sisteUtbetalingslinje(),
+                    utbetalingslinjeSomSkalEndres = første.sisteUtbetalingslinje(),
                     virkningstidspunkt = 1.oktober(2020),
-                    clock = fixedClock,
+                    opprettet = fixedTidspunkt,
+                    rekkefølge = Rekkefølge.start(),
                 ),
             ),
         )
@@ -119,9 +126,10 @@ internal class UtbetalingsstrategiGjenopptaTest {
             opprettet = fixedTidspunkt,
             nonEmptyListOf(
                 Utbetalingslinje.Endring.Reaktivering(
-                    utbetalingslinje = førsteStans.sisteUtbetalingslinje(),
+                    utbetalingslinjeSomSkalEndres = førsteStans.sisteUtbetalingslinje(),
                     virkningstidspunkt = 1.oktober(2020),
                     clock = fixedClock,
+                    rekkefølge = Rekkefølge.start(),
                 ),
             ),
         )
@@ -135,6 +143,7 @@ internal class UtbetalingsstrategiGjenopptaTest {
                     forrigeUtbetalingslinjeId = førsteGjenopptak.utbetalingslinjer[0].id,
                     beløp = 5100,
                     uføregrad = Uføregrad.parse(50),
+                    rekkefølge = Rekkefølge.start(),
                 ),
             ),
         )
@@ -142,9 +151,10 @@ internal class UtbetalingsstrategiGjenopptaTest {
         val andreStans = createOversendtUtbetaling(
             utbetalingslinjer = nonEmptyListOf(
                 Utbetalingslinje.Endring.Stans(
-                    utbetalingslinje = andre.sisteUtbetalingslinje(),
+                    utbetalingslinjeSomSkalEndres = andre.sisteUtbetalingslinje(),
                     virkningstidspunkt = 1.mai(2021),
                     clock = fixedClock,
+                    rekkefølge = Rekkefølge.start(),
                 ),
             ),
         )
@@ -169,6 +179,7 @@ internal class UtbetalingsstrategiGjenopptaTest {
             Utbetalingslinje.Endring.Reaktivering(
                 id = andre.utbetalingslinjer[0].id,
                 opprettet = actual.utbetalingslinjer[0].opprettet,
+                rekkefølge = Rekkefølge.start(),
                 fraOgMed = andre.utbetalingslinjer[0].periode.fraOgMed,
                 tilOgMed = andre.utbetalingslinjer[0].periode.tilOgMed,
                 forrigeUtbetalingslinjeId = andre.utbetalingslinjer[0].forrigeUtbetalingslinjeId,
@@ -201,9 +212,10 @@ internal class UtbetalingsstrategiGjenopptaTest {
             opprettet = fixedTidspunkt,
             nonEmptyListOf(
                 Utbetalingslinje.Endring.Stans(
-                    utbetalingslinje = første.sisteUtbetalingslinje(),
+                    utbetalingslinjeSomSkalEndres = første.sisteUtbetalingslinje(),
                     virkningstidspunkt = 1.januar(2020),
-                    clock = fixedClock,
+                    opprettet = fixedTidspunkt,
+                    rekkefølge = Rekkefølge.start(),
                 ),
             ),
         )
@@ -212,9 +224,10 @@ internal class UtbetalingsstrategiGjenopptaTest {
             opprettet = fixedTidspunkt,
             nonEmptyListOf(
                 Utbetalingslinje.Endring.Reaktivering(
-                    utbetalingslinje = andre.sisteUtbetalingslinje(),
+                    utbetalingslinjeSomSkalEndres = andre.sisteUtbetalingslinje(),
                     virkningstidspunkt = 1.januar(2020),
-                    clock = fixedClock,
+                    opprettet = fixedTidspunkt,
+                    rekkefølge = Rekkefølge.start(),
                 ),
             ),
         )
@@ -238,6 +251,7 @@ internal class UtbetalingsstrategiGjenopptaTest {
     fun `gjenopptar utbetalinger med flere utbetalingslinjer`() {
         val l1 = Utbetalingslinje.Ny(
             opprettet = fixedTidspunkt,
+            rekkefølge = Rekkefølge.start(),
             fraOgMed = 1.januar(2020),
             tilOgMed = 30.april(2020),
             forrigeUtbetalingslinjeId = null,
@@ -246,6 +260,7 @@ internal class UtbetalingsstrategiGjenopptaTest {
         )
         val l2 = Utbetalingslinje.Ny(
             opprettet = fixedTidspunkt.plusUnits(1),
+            rekkefølge = Rekkefølge.skip(0),
             fraOgMed = 1.mai(2020),
             tilOgMed = 31.desember(2020),
             forrigeUtbetalingslinjeId = l1.id,
@@ -262,9 +277,10 @@ internal class UtbetalingsstrategiGjenopptaTest {
         val stans = createOversendtUtbetaling(
             utbetalingslinjer = nonEmptyListOf(
                 Utbetalingslinje.Endring.Stans(
-                    utbetalingslinje = utbetaling.sisteUtbetalingslinje(),
+                    utbetalingslinjeSomSkalEndres = utbetaling.sisteUtbetalingslinje(),
                     virkningstidspunkt = 1.april(2020),
-                    clock = fixedClock,
+                    opprettet = fixedTidspunkt,
+                    rekkefølge = Rekkefølge.start(),
                 ),
             ),
         )
@@ -284,6 +300,7 @@ internal class UtbetalingsstrategiGjenopptaTest {
             Utbetalingslinje.Endring.Reaktivering(
                 id = utbetaling.sisteUtbetalingslinje().id,
                 opprettet = it.utbetalingslinjer[0].opprettet,
+                rekkefølge = Rekkefølge.start(),
                 fraOgMed = utbetaling.sisteUtbetalingslinje().periode.fraOgMed,
                 tilOgMed = utbetaling.sisteUtbetalingslinje().periode.tilOgMed,
                 forrigeUtbetalingslinjeId = utbetaling.sisteUtbetalingslinje().forrigeUtbetalingslinjeId,

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/oppdrag/utbetaling/UtbetalingsstrategiNyTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/oppdrag/utbetaling/UtbetalingsstrategiNyTest.kt
@@ -5,6 +5,7 @@ import arrow.core.nonEmptyListOf
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import no.nav.su.se.bakover.common.Rekkefølge
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.april
@@ -109,6 +110,7 @@ internal class UtbetalingsstrategiNyTest {
                     Utbetalingslinje.Ny(
                         id = it.utbetalingslinjer.single().id,
                         opprettet = fixedTidspunkt,
+                        rekkefølge = Rekkefølge.start(),
                         fraOgMed = 1.januar(2020),
                         tilOgMed = 30.april(2020),
                         forrigeUtbetalingslinjeId = null,
@@ -166,6 +168,7 @@ internal class UtbetalingsstrategiNyTest {
                         beløp = 20637,
                         forrigeUtbetalingslinjeId = eksisterendeUtbetalinger.single().utbetalingslinjer.single().id,
                         uføregrad = Uføregrad.parse(50),
+                        rekkefølge = Rekkefølge.start(),
                     ),
                     expectedUtbetalingslinje(
                         utbetalingslinjeId = it.utbetalingslinjer[1].id,
@@ -175,6 +178,7 @@ internal class UtbetalingsstrategiNyTest {
                         beløp = 20946,
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[0].id,
                         uføregrad = Uføregrad.parse(50),
+                        rekkefølge = Rekkefølge.skip(0),
                     ),
                     expectedUtbetalingslinje(
                         utbetalingslinjeId = it.utbetalingslinjer[2].id,
@@ -184,6 +188,7 @@ internal class UtbetalingsstrategiNyTest {
                         beløp = 20946,
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[1].id,
                         uføregrad = Uføregrad.parse(100),
+                        rekkefølge = Rekkefølge.skip(1),
                     ),
                 ),
             )
@@ -289,6 +294,7 @@ internal class UtbetalingsstrategiNyTest {
                     expectedUtbetalingslinje(
                         utbetalingslinjeId = it.utbetalingslinjer.single().id,
                         opprettet = it.utbetalingslinjer.single().opprettet,
+                        rekkefølge = Rekkefølge.start(),
                         fraOgMed = 1.januar(2020),
                         tilOgMed = 31.mars(2020),
                         beløp = 20637,
@@ -354,6 +360,7 @@ internal class UtbetalingsstrategiNyTest {
                     Utbetalingslinje.Ny(
                         id = it.utbetalingslinjer[0].id,
                         opprettet = it.utbetalingslinjer[0].opprettet,
+                        rekkefølge = Rekkefølge.start(),
                         fraOgMed = 1.januar(2020),
                         tilOgMed = 31.januar(2020),
                         forrigeUtbetalingslinjeId = null,
@@ -363,6 +370,7 @@ internal class UtbetalingsstrategiNyTest {
                     Utbetalingslinje.Ny(
                         id = it.utbetalingslinjer[1].id,
                         opprettet = it.utbetalingslinjer[1].opprettet,
+                        rekkefølge = Rekkefølge.skip(0),
                         fraOgMed = 1.februar(2020),
                         tilOgMed = 29.februar(2020),
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[0].id,
@@ -372,6 +380,7 @@ internal class UtbetalingsstrategiNyTest {
                     Utbetalingslinje.Ny(
                         id = it.utbetalingslinjer[2].id,
                         opprettet = it.utbetalingslinjer[2].opprettet,
+                        rekkefølge = Rekkefølge.skip(1),
                         fraOgMed = 1.mars(2020),
                         tilOgMed = 30.april(2020),
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[1].id,
@@ -493,6 +502,7 @@ internal class UtbetalingsstrategiNyTest {
                     Utbetalingslinje.Ny(
                         id = it.utbetalingslinjer[0].id,
                         opprettet = it.utbetalingslinjer[0].opprettet,
+                        rekkefølge = Rekkefølge.start(),
                         fraOgMed = 1.januar(2021),
                         tilOgMed = 31.januar(2021),
                         forrigeUtbetalingslinjeId = sak.utbetalinger.last().sisteUtbetalingslinje().id,
@@ -502,6 +512,7 @@ internal class UtbetalingsstrategiNyTest {
                     Utbetalingslinje.Ny(
                         id = it.utbetalingslinjer[1].id,
                         opprettet = it.utbetalingslinjer[1].opprettet,
+                        rekkefølge = Rekkefølge.skip(0),
                         fraOgMed = 1.februar(2021),
                         tilOgMed = 30.april(2021),
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[0].id,
@@ -511,6 +522,7 @@ internal class UtbetalingsstrategiNyTest {
                     Utbetalingslinje.Ny(
                         id = it.utbetalingslinjer[2].id,
                         opprettet = it.utbetalingslinjer[2].opprettet,
+                        rekkefølge = Rekkefølge.skip(1),
                         fraOgMed = 1.mai(2021),
                         tilOgMed = 31.desember(2021),
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[1].id,
@@ -560,6 +572,7 @@ internal class UtbetalingsstrategiNyTest {
                     Utbetalingslinje.Ny(
                         id = it.utbetalingslinjer[0].id,
                         opprettet = it.utbetalingslinjer[0].opprettet,
+                        rekkefølge = Rekkefølge.start(),
                         fraOgMed = 1.januar(2021),
                         tilOgMed = 31.januar(2021),
                         forrigeUtbetalingslinjeId = sak3.utbetalinger.last().sisteUtbetalingslinje().id,
@@ -569,6 +582,7 @@ internal class UtbetalingsstrategiNyTest {
                     Utbetalingslinje.Ny(
                         id = it.utbetalingslinjer[1].id,
                         opprettet = it.utbetalingslinjer[1].opprettet,
+                        rekkefølge = Rekkefølge.skip(0),
                         fraOgMed = 1.februar(2021),
                         tilOgMed = 31.desember(2021),
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[0].id,
@@ -578,6 +592,7 @@ internal class UtbetalingsstrategiNyTest {
                     Utbetalingslinje.Endring.Stans(
                         id = it.utbetalingslinjer[1].id,
                         opprettet = it.utbetalingslinjer[2].opprettet,
+                        rekkefølge = Rekkefølge.skip(1),
                         fraOgMed = 1.februar(2021),
                         tilOgMed = 31.desember(2021),
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[1].forrigeUtbetalingslinjeId,
@@ -634,6 +649,7 @@ internal class UtbetalingsstrategiNyTest {
                     Utbetalingslinje.Ny(
                         id = it.utbetalingslinjer[0].id,
                         opprettet = it.utbetalingslinjer[0].opprettet,
+                        rekkefølge = Rekkefølge.start(),
                         fraOgMed = 1.januar(2021),
                         tilOgMed = 31.januar(2021),
                         forrigeUtbetalingslinjeId = sak3.utbetalinger.last().sisteUtbetalingslinje().id,
@@ -643,6 +659,7 @@ internal class UtbetalingsstrategiNyTest {
                     Utbetalingslinje.Ny(
                         id = it.utbetalingslinjer[1].id,
                         opprettet = it.utbetalingslinjer[1].opprettet,
+                        rekkefølge = Rekkefølge.skip(0),
                         fraOgMed = 1.februar(2021),
                         tilOgMed = 31.desember(2021),
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[0].id,
@@ -652,6 +669,7 @@ internal class UtbetalingsstrategiNyTest {
                     Utbetalingslinje.Endring.Opphør(
                         id = it.utbetalingslinjer[1].id,
                         opprettet = it.utbetalingslinjer[2].opprettet,
+                        rekkefølge = Rekkefølge.skip(1),
                         fraOgMed = 1.februar(2021),
                         tilOgMed = 31.desember(2021),
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[1].forrigeUtbetalingslinjeId,
@@ -708,6 +726,7 @@ internal class UtbetalingsstrategiNyTest {
                     Utbetalingslinje.Ny(
                         id = it.utbetalingslinjer[0].id,
                         opprettet = it.utbetalingslinjer[0].opprettet,
+                        rekkefølge = Rekkefølge.start(),
                         fraOgMed = 1.januar(2021),
                         tilOgMed = 31.januar(2021),
                         forrigeUtbetalingslinjeId = sak4.utbetalinger.last().sisteUtbetalingslinje().id,
@@ -717,6 +736,7 @@ internal class UtbetalingsstrategiNyTest {
                     Utbetalingslinje.Ny(
                         id = it.utbetalingslinjer[1].id,
                         opprettet = it.utbetalingslinjer[1].opprettet,
+                        rekkefølge = Rekkefølge.skip(0),
                         fraOgMed = 1.februar(2021),
                         tilOgMed = 31.desember(2021),
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[0].id,
@@ -726,6 +746,7 @@ internal class UtbetalingsstrategiNyTest {
                     Utbetalingslinje.Endring.Stans(
                         id = it.utbetalingslinjer[1].id,
                         opprettet = it.utbetalingslinjer[2].opprettet,
+                        rekkefølge = Rekkefølge.skip(1),
                         fraOgMed = 1.februar(2021),
                         tilOgMed = 31.desember(2021),
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[1].forrigeUtbetalingslinjeId,
@@ -736,6 +757,7 @@ internal class UtbetalingsstrategiNyTest {
                     Utbetalingslinje.Endring.Reaktivering(
                         id = it.utbetalingslinjer[1].id,
                         opprettet = it.utbetalingslinjer[3].opprettet,
+                        rekkefølge = Rekkefølge.skip(2),
                         fraOgMed = 1.februar(2021),
                         tilOgMed = 31.desember(2021),
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[1].forrigeUtbetalingslinjeId,
@@ -751,6 +773,7 @@ internal class UtbetalingsstrategiNyTest {
     private fun expectedUtbetalingslinje(
         utbetalingslinjeId: UUID30,
         opprettet: Tidspunkt,
+        rekkefølge: Rekkefølge,
         fraOgMed: LocalDate,
         tilOgMed: LocalDate,
         beløp: Int,
@@ -760,6 +783,7 @@ internal class UtbetalingsstrategiNyTest {
         return Utbetalingslinje.Ny(
             id = utbetalingslinjeId,
             opprettet = opprettet,
+            rekkefølge = rekkefølge,
             fraOgMed = fraOgMed,
             tilOgMed = tilOgMed,
             forrigeUtbetalingslinjeId = forrigeUtbetalingslinjeId,

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/oppdrag/utbetaling/UtbetalingsstrategiOpphørTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/oppdrag/utbetaling/UtbetalingsstrategiOpphørTest.kt
@@ -3,6 +3,7 @@ package no.nav.su.se.bakover.domain.oppdrag.utbetaling
 import arrow.core.nonEmptyListOf
 import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.NavIdentBruker
+import no.nav.su.se.bakover.common.Rekkefølge
 import no.nav.su.se.bakover.common.april
 import no.nav.su.se.bakover.common.desember
 import no.nav.su.se.bakover.common.februar
@@ -120,6 +121,7 @@ internal class UtbetalingsstrategiOpphørTest {
                 Utbetalingslinje.Endring.Opphør(
                     id = it.utbetalingslinjer.single().id,
                     opprettet = it.utbetalingslinjer.single().opprettet,
+                    rekkefølge = Rekkefølge.start(),
                     fraOgMed = siste.utbetalingslinjer.single().periode.fraOgMed,
                     tilOgMed = siste.utbetalingslinjer.single().periode.tilOgMed,
                     beløp = siste.utbetalingslinjer.single().beløp,
@@ -155,6 +157,7 @@ internal class UtbetalingsstrategiOpphørTest {
                     Utbetalingslinje.Endring.Opphør(
                         id = sak.utbetalinger.last().sisteUtbetalingslinje().id,
                         opprettet = it.utbetalingslinjer[0].opprettet,
+                        rekkefølge = Rekkefølge.start(),
                         fraOgMed = 1.mai(2021),
                         tilOgMed = 31.desember(2021),
                         forrigeUtbetalingslinjeId = sak.utbetalinger.last().sisteUtbetalingslinje().forrigeUtbetalingslinjeId,
@@ -165,6 +168,7 @@ internal class UtbetalingsstrategiOpphørTest {
                     Utbetalingslinje.Ny(
                         id = it.utbetalingslinjer[1].id,
                         opprettet = it.utbetalingslinjer[1].opprettet,
+                        rekkefølge = Rekkefølge.skip(0),
                         fraOgMed = 1.april(2021),
                         tilOgMed = 30.april(2021),
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[0].id,
@@ -174,6 +178,7 @@ internal class UtbetalingsstrategiOpphørTest {
                     Utbetalingslinje.Ny(
                         id = it.utbetalingslinjer[2].id,
                         opprettet = it.utbetalingslinjer[2].opprettet,
+                        rekkefølge = Rekkefølge.skip(1),
                         fraOgMed = 1.mai(2021),
                         tilOgMed = 31.desember(2021),
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[1].id,
@@ -215,6 +220,7 @@ internal class UtbetalingsstrategiOpphørTest {
                     Utbetalingslinje.Endring.Opphør(
                         id = sak2.utbetalinger.last().sisteUtbetalingslinje().id,
                         opprettet = it.utbetalingslinjer[0].opprettet,
+                        rekkefølge = Rekkefølge.start(),
                         fraOgMed = 1.januar(2021),
                         tilOgMed = 31.desember(2021),
                         forrigeUtbetalingslinjeId = sak2.utbetalinger.last().sisteUtbetalingslinje().forrigeUtbetalingslinjeId,
@@ -225,6 +231,7 @@ internal class UtbetalingsstrategiOpphørTest {
                     Utbetalingslinje.Ny(
                         id = it.utbetalingslinjer[1].id,
                         opprettet = it.utbetalingslinjer[1].opprettet,
+                        rekkefølge = Rekkefølge.skip(0),
                         fraOgMed = 1.februar(2021),
                         tilOgMed = 31.desember(2021),
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[0].id,
@@ -234,6 +241,7 @@ internal class UtbetalingsstrategiOpphørTest {
                     Utbetalingslinje.Endring.Stans(
                         id = it.utbetalingslinjer[1].id,
                         opprettet = it.utbetalingslinjer[2].opprettet,
+                        rekkefølge = Rekkefølge.skip(1),
                         fraOgMed = 1.februar(2021),
                         tilOgMed = 31.desember(2021),
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[1].forrigeUtbetalingslinjeId,
@@ -281,6 +289,7 @@ internal class UtbetalingsstrategiOpphørTest {
                     Utbetalingslinje.Endring.Opphør(
                         id = sak2.utbetalinger.last().sisteUtbetalingslinje().id,
                         opprettet = it.utbetalingslinjer[0].opprettet,
+                        rekkefølge = Rekkefølge.start(),
                         fraOgMed = 1.januar(2021),
                         tilOgMed = 31.desember(2021),
                         forrigeUtbetalingslinjeId = sak2.utbetalinger.last().sisteUtbetalingslinje().forrigeUtbetalingslinjeId,
@@ -291,6 +300,7 @@ internal class UtbetalingsstrategiOpphørTest {
                     Utbetalingslinje.Ny(
                         id = it.utbetalingslinjer[1].id,
                         opprettet = it.utbetalingslinjer[1].opprettet,
+                        rekkefølge = Rekkefølge.skip(0),
                         fraOgMed = 1.februar(2021),
                         tilOgMed = 31.desember(2021),
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[0].id,
@@ -300,6 +310,7 @@ internal class UtbetalingsstrategiOpphørTest {
                     Utbetalingslinje.Endring.Opphør(
                         id = it.utbetalingslinjer[1].id,
                         opprettet = it.utbetalingslinjer[2].opprettet,
+                        rekkefølge = Rekkefølge.skip(1),
                         fraOgMed = 1.februar(2021),
                         tilOgMed = 31.desember(2021),
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[1].forrigeUtbetalingslinjeId,
@@ -348,6 +359,7 @@ internal class UtbetalingsstrategiOpphørTest {
                     Utbetalingslinje.Endring.Opphør(
                         id = sak2.utbetalinger.last().sisteUtbetalingslinje().id,
                         opprettet = it.utbetalingslinjer[0].opprettet,
+                        rekkefølge = Rekkefølge.start(),
                         fraOgMed = 1.januar(2021),
                         tilOgMed = 31.desember(2021),
                         forrigeUtbetalingslinjeId = sak2.utbetalinger.last().sisteUtbetalingslinje().forrigeUtbetalingslinjeId,
@@ -358,6 +370,7 @@ internal class UtbetalingsstrategiOpphørTest {
                     Utbetalingslinje.Ny(
                         id = it.utbetalingslinjer[1].id,
                         opprettet = it.utbetalingslinjer[1].opprettet,
+                        rekkefølge = Rekkefølge.skip(0),
                         fraOgMed = 1.februar(2021),
                         tilOgMed = 31.desember(2021),
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[0].id,
@@ -367,6 +380,7 @@ internal class UtbetalingsstrategiOpphørTest {
                     Utbetalingslinje.Endring.Stans(
                         id = it.utbetalingslinjer[1].id,
                         opprettet = it.utbetalingslinjer[2].opprettet,
+                        rekkefølge = Rekkefølge.skip(1),
                         fraOgMed = 1.februar(2021),
                         tilOgMed = 31.desember(2021),
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[1].forrigeUtbetalingslinjeId,
@@ -377,6 +391,7 @@ internal class UtbetalingsstrategiOpphørTest {
                     Utbetalingslinje.Endring.Reaktivering(
                         id = it.utbetalingslinjer[1].id,
                         opprettet = it.utbetalingslinjer[3].opprettet,
+                        rekkefølge = Rekkefølge.skip(2),
                         fraOgMed = 1.februar(2021),
                         tilOgMed = 31.desember(2021),
                         forrigeUtbetalingslinjeId = it.utbetalingslinjer[1].forrigeUtbetalingslinjeId,

--- a/test-common/src/main/kotlin/UtbetalingTestData.kt
+++ b/test-common/src/main/kotlin/UtbetalingTestData.kt
@@ -3,6 +3,7 @@ package no.nav.su.se.bakover.test
 import arrow.core.NonEmptyList
 import arrow.core.nonEmptyListOf
 import no.nav.su.se.bakover.common.Fnr
+import no.nav.su.se.bakover.common.Rekkefølge
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.periode.Periode
@@ -28,61 +29,122 @@ import java.util.UUID
 val avstemmingsnøkkel = Avstemmingsnøkkel(opprettet = fixedTidspunkt)
 val utbetalingsRequest = Utbetalingsrequest("<xml></xml>")
 
-fun utbetalingslinje(
+fun utbetalingslinjeNy(
     id: UUID30 = UUID30.randomUUID(),
     periode: Periode = år(2021),
     clock: Clock = fixedClock,
+    rekkefølge: Rekkefølge = Rekkefølge.start(),
     beløp: Int = 15000,
     forrigeUtbetalingslinjeId: UUID30? = null,
     uføregrad: Int = 50,
     kjøreplan: UtbetalingsinstruksjonForEtterbetalinger = UtbetalingsinstruksjonForEtterbetalinger.SåFortSomMulig,
-) = utbetalingslinje(
-    id = id,
-    periode = periode,
-    opprettet = Tidspunkt.now(clock),
-    beløp = beløp,
-    forrigeUtbetalingslinjeId = forrigeUtbetalingslinjeId,
-    uføregrad = uføregrad,
-    kjøreplan = kjøreplan,
-)
+): Utbetalingslinje.Ny {
+    return utbetalingslinjeNy(
+        id = id,
+        periode = periode,
+        rekkefølge = rekkefølge,
+        opprettet = Tidspunkt.now(clock),
+        beløp = beløp,
+        forrigeUtbetalingslinjeId = forrigeUtbetalingslinjeId,
+        uføregrad = uføregrad,
+        kjøreplan = kjøreplan,
+    )
+}
 
-fun utbetalingslinje(
+fun utbetalingslinjeNy(
     id: UUID30 = UUID30.randomUUID(),
     periode: Periode = år(2021),
     opprettet: Tidspunkt,
+    rekkefølge: Rekkefølge = Rekkefølge.start(),
     beløp: Int = 15000,
     forrigeUtbetalingslinjeId: UUID30? = null,
     uføregrad: Int = 50,
     kjøreplan: UtbetalingsinstruksjonForEtterbetalinger = UtbetalingsinstruksjonForEtterbetalinger.SåFortSomMulig,
-) = Utbetalingslinje.Ny(
-    id = id,
-    opprettet = opprettet,
-    fraOgMed = periode.fraOgMed,
-    tilOgMed = periode.tilOgMed,
-    forrigeUtbetalingslinjeId = forrigeUtbetalingslinjeId,
-    beløp = beløp,
-    uføregrad = Uføregrad.parse(uføregrad),
-    utbetalingsinstruksjonForEtterbetalinger = kjøreplan,
-)
-fun opphørtUtbetalingslinje(
+): Utbetalingslinje.Ny {
+    return Utbetalingslinje.Ny(
+        id = id,
+        opprettet = opprettet,
+        rekkefølge = rekkefølge,
+        fraOgMed = periode.fraOgMed,
+        tilOgMed = periode.tilOgMed,
+        forrigeUtbetalingslinjeId = forrigeUtbetalingslinjeId,
+        beløp = beløp,
+        uføregrad = Uføregrad.parse(uføregrad),
+        utbetalingsinstruksjonForEtterbetalinger = kjøreplan,
+    )
+}
+
+fun utbetalingslinjeOpphørt(
     id: UUID30 = UUID30.randomUUID(),
     periode: Periode = år(2021),
+    rekkefølge: Rekkefølge,
     clock: Clock = fixedClock,
     beløp: Int = 15000,
     forrigeUtbetalingslinjeId: UUID30? = null,
     uføregrad: Int = 50,
     kjøreplan: UtbetalingsinstruksjonForEtterbetalinger = UtbetalingsinstruksjonForEtterbetalinger.SåFortSomMulig,
-) = Utbetalingslinje.Endring.Opphør(
-    id = id,
-    opprettet = Tidspunkt.now(clock),
-    fraOgMed = periode.fraOgMed,
-    tilOgMed = periode.tilOgMed,
-    forrigeUtbetalingslinjeId = forrigeUtbetalingslinjeId,
-    beløp = beløp,
-    uføregrad = Uføregrad.parse(uføregrad),
-    virkningsperiode = periode,
-    utbetalingsinstruksjonForEtterbetalinger = kjøreplan,
-)
+): Utbetalingslinje.Endring.Opphør {
+    return Utbetalingslinje.Endring.Opphør(
+        id = id,
+        opprettet = Tidspunkt.now(clock),
+        rekkefølge = rekkefølge,
+        fraOgMed = periode.fraOgMed,
+        tilOgMed = periode.tilOgMed,
+        forrigeUtbetalingslinjeId = forrigeUtbetalingslinjeId,
+        beløp = beløp,
+        uføregrad = Uføregrad.parse(uføregrad),
+        virkningsperiode = periode,
+        utbetalingsinstruksjonForEtterbetalinger = kjøreplan,
+    )
+}
+
+fun utbetalingslinjeStans(
+    id: UUID30 = UUID30.randomUUID(),
+    periode: Periode = år(2021),
+    rekkefølge: Rekkefølge,
+    clock: Clock = fixedClock,
+    beløp: Int = 15000,
+    forrigeUtbetalingslinjeId: UUID30? = null,
+    uføregrad: Int = 50,
+    kjøreplan: UtbetalingsinstruksjonForEtterbetalinger = UtbetalingsinstruksjonForEtterbetalinger.SåFortSomMulig,
+): Utbetalingslinje.Endring.Stans {
+    return Utbetalingslinje.Endring.Stans(
+        id = id,
+        opprettet = Tidspunkt.now(clock),
+        rekkefølge = rekkefølge,
+        fraOgMed = periode.fraOgMed,
+        tilOgMed = periode.tilOgMed,
+        forrigeUtbetalingslinjeId = forrigeUtbetalingslinjeId,
+        beløp = beløp,
+        uføregrad = Uføregrad.parse(uføregrad),
+        virkningsperiode = periode,
+        utbetalingsinstruksjonForEtterbetalinger = kjøreplan,
+    )
+}
+
+fun utbetalingslinjeReaktivering(
+    id: UUID30 = UUID30.randomUUID(),
+    periode: Periode = år(2021),
+    rekkefølge: Rekkefølge,
+    clock: Clock = fixedClock,
+    beløp: Int = 15000,
+    forrigeUtbetalingslinjeId: UUID30? = null,
+    uføregrad: Int = 50,
+    kjøreplan: UtbetalingsinstruksjonForEtterbetalinger = UtbetalingsinstruksjonForEtterbetalinger.SåFortSomMulig,
+): Utbetalingslinje.Endring.Reaktivering {
+    return Utbetalingslinje.Endring.Reaktivering(
+        id = id,
+        opprettet = Tidspunkt.now(clock),
+        rekkefølge = rekkefølge,
+        fraOgMed = periode.fraOgMed,
+        tilOgMed = periode.tilOgMed,
+        forrigeUtbetalingslinjeId = forrigeUtbetalingslinjeId,
+        beløp = beløp,
+        uføregrad = Uføregrad.parse(uføregrad),
+        virkningsperiode = periode,
+        utbetalingsinstruksjonForEtterbetalinger = kjøreplan,
+    )
+}
 
 fun nyUtbetalingForSimulering(
     sakOgBehandling: Pair<Sak, Behandling>,
@@ -166,9 +228,10 @@ fun oversendtUtbetalingUtenKvittering(
     avstemmingsnøkkel: Avstemmingsnøkkel = no.nav.su.se.bakover.test.avstemmingsnøkkel,
     clock: Clock = fixedClock,
     utbetalingslinjer: NonEmptyList<Utbetalingslinje> = nonEmptyListOf(
-        utbetalingslinje(
+        utbetalingslinjeNy(
             clock = clock,
             periode = søknadsbehandling.periode,
+            rekkefølge = Rekkefølge.start(),
         ),
     ),
     eksisterendeUtbetalinger: List<Utbetaling.OversendtUtbetaling> = emptyList(),
@@ -192,9 +255,10 @@ fun oversendtUtbetalingUtenKvittering(
     avstemmingsnøkkel: Avstemmingsnøkkel = no.nav.su.se.bakover.test.avstemmingsnøkkel,
     clock: Clock = fixedClock,
     utbetalingslinjer: NonEmptyList<Utbetalingslinje> = nonEmptyListOf(
-        utbetalingslinje(
+        utbetalingslinjeNy(
             clock = clock,
             periode = periode,
+            rekkefølge = Rekkefølge.start(),
         ),
     ),
     eksisterendeUtbetalinger: List<Utbetaling.OversendtUtbetaling> = emptyList(),
@@ -217,7 +281,7 @@ fun oversendtUtbetalingUtenKvittering(
     saksnummer: Saksnummer = no.nav.su.se.bakover.test.saksnummer,
     clock: Clock = fixedClock,
     utbetalingslinjer: NonEmptyList<Utbetalingslinje> = nonEmptyListOf(
-        utbetalingslinje(
+        utbetalingslinjeNy(
             clock = clock,
             periode = periode,
         ),
@@ -258,7 +322,7 @@ fun simulertUtbetaling(
     saksnummer: Saksnummer = no.nav.su.se.bakover.test.saksnummer,
     clock: Clock = fixedClock,
     utbetalingslinjer: NonEmptyList<Utbetalingslinje> = nonEmptyListOf(
-        utbetalingslinje(
+        utbetalingslinjeNy(
             periode = periode,
             clock = clock,
         ),

--- a/test-common/src/main/kotlin/persistence/TestDataHelper.kt
+++ b/test-common/src/main/kotlin/persistence/TestDataHelper.kt
@@ -124,7 +124,7 @@ import no.nav.su.se.bakover.test.tikkendeFixedClock
 import no.nav.su.se.bakover.test.tilAttesteringSøknadsbehandling
 import no.nav.su.se.bakover.test.trekkSøknad
 import no.nav.su.se.bakover.test.underkjentSøknadsbehandling
-import no.nav.su.se.bakover.test.utbetalingslinje
+import no.nav.su.se.bakover.test.utbetalingslinjeNy
 import no.nav.su.se.bakover.test.vedtakIverksattStansAvYtelseFraIverksattSøknadsbehandlingsvedtak
 import no.nav.su.se.bakover.test.veileder
 import no.nav.su.se.bakover.test.vilkår.institusjonsoppholdvilkårAvslag
@@ -390,7 +390,7 @@ class TestDataHelper(
         stans: GjenopptaYtelseRevurdering.IverksattGjenopptakAvYtelse = persisterGjenopptakAvYtelseIverksatt(),
         periode: Periode = stønadsperiode2021.periode,
         avstemmingsnøkkel: Avstemmingsnøkkel = no.nav.su.se.bakover.test.avstemmingsnøkkel,
-        utbetalingslinjer: NonEmptyList<Utbetalingslinje> = nonEmptyListOf(utbetalingslinje(periode = periode)),
+        utbetalingslinjer: NonEmptyList<Utbetalingslinje> = nonEmptyListOf(utbetalingslinjeNy(periode = periode)),
         utbetalingId: UUID30 = UUID30.randomUUID(),
     ): VedtakGjenopptakAvYtelse {
         oversendtUtbetalingUtenKvittering(

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/sak/SakJsonTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/sak/SakJsonTest.kt
@@ -3,6 +3,7 @@ package no.nav.su.se.bakover.web.routes.sak
 import arrow.core.nonEmptyListOf
 import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.Fnr
+import no.nav.su.se.bakover.common.Rekkefølge
 import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.april
 import no.nav.su.se.bakover.common.desember
@@ -91,6 +92,7 @@ internal class SakJsonTest {
             val nyUtbetaling = Utbetalingslinje.Ny(
                 id = UUID30.randomUUID(),
                 opprettet = fixedTidspunkt,
+                rekkefølge = Rekkefølge.start(),
                 fraOgMed = 1.januar(2021),
                 tilOgMed = 31.desember(2021),
                 forrigeUtbetalingslinjeId = null,
@@ -98,19 +100,22 @@ internal class SakJsonTest {
                 uføregrad = Uføregrad.parse(50),
             )
             val midlertidigStans = Utbetalingslinje.Endring.Stans(
-                utbetalingslinje = nyUtbetaling,
+                utbetalingslinjeSomSkalEndres = nyUtbetaling,
                 virkningstidspunkt = 1.februar(2021),
                 clock = Clock.systemUTC(),
+                rekkefølge = Rekkefølge.start(),
             )
             val reaktivering = Utbetalingslinje.Endring.Reaktivering(
-                utbetalingslinje = midlertidigStans,
+                utbetalingslinjeSomSkalEndres = midlertidigStans,
                 virkningstidspunkt = 1.mars(2021),
                 clock = Clock.systemUTC(),
+                rekkefølge = Rekkefølge.start(),
             )
             val opphørslinje = Utbetalingslinje.Endring.Opphør(
-                utbetalingslinje = reaktivering,
+                utbetalingslinjeSomSkalEndres = reaktivering,
                 virkningsperiode = Periode.create(1.april(2021), reaktivering.periode.tilOgMed),
                 clock = Clock.systemUTC(),
+                rekkefølge = Rekkefølge.start(),
             )
 
             val utbetaling1 = mock<Utbetaling.OversendtUtbetaling.UtenKvittering> {

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/services/utbetaling/kvittering/LokalKvitteringJobTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/services/utbetaling/kvittering/LokalKvitteringJobTest.kt
@@ -5,6 +5,7 @@ import arrow.core.right
 import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.Fnr
 import no.nav.su.se.bakover.common.NavIdentBruker
+import no.nav.su.se.bakover.common.Rekkefølge
 import no.nav.su.se.bakover.common.Tidspunkt
 import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.januar
@@ -38,7 +39,7 @@ import java.util.UUID
 
 internal class LokalKvitteringJobTest {
 
-    val tidspunkt = fixedTidspunkt
+    private val tidspunkt = fixedTidspunkt
     val fnr = Fnr.generer()
 
     private val utbetaling = Utbetaling.UtbetalingForSimulering(
@@ -56,6 +57,7 @@ internal class LokalKvitteringJobTest {
                 forrigeUtbetalingslinjeId = null,
                 beløp = 0,
                 uføregrad = Uføregrad.parse(50),
+                rekkefølge = Rekkefølge.start(),
             ),
         ),
         behandler = NavIdentBruker.Attestant("attestant"),


### PR DESCRIPTION
Første steg i å fjerne opprettet fra utbetalingslinja (evt. la den være lik som opprettet på utbetaling). Trenger dette før vi gjør opprettet migreringen.