### PR TITLE
Legg til endepunkt for å resende søknadsbehandlingsvedtak

### DIFF
--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/sak/SakPostgresRepo.kt
@@ -140,6 +140,18 @@ internal class SakPostgresRepo(
             }
         }
     }
+    override fun hentSakForVedtak(vedtakId: UUID): Sak? {
+        return dbMetrics.timeQuery("hentSakForVedtak") {
+            sessionFactory.withSessionContext { sessionContext ->
+                sessionContext.withSession { session ->
+                    "select s.* from sak s join vedtak v on v.sakid = s.id where v.id =:vedtakId".hent(
+                        mapOf("vedtakId" to vedtakId),
+                        session,
+                    ) { it.toSak(sessionContext) }
+                }
+            }
+        }
+    }
 
     /***
      * @param personidenter Inneholder alle identer til brukeren, f.eks fnr og aktørid.

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPostgresRepo.kt
@@ -63,6 +63,7 @@ import no.nav.su.se.bakover.domain.vedtak.VedtakSomKanRevurderes
 import no.nav.su.se.bakover.domain.vedtak.VedtakStansAvYtelse
 import no.nav.su.se.bakover.domain.vedtak.Vedtaksammendrag
 import no.nav.su.se.bakover.domain.vedtak.Vedtakstype
+import java.time.LocalDate
 import java.util.UUID
 
 internal enum class VedtakType {
@@ -307,6 +308,27 @@ internal class VedtakPostgresRepo(
                         )
                     }
             }
+        }
+    }
+
+    override fun hentSøknadsbehandlingsvedtakFraOgMed(
+        fraOgMed: LocalDate,
+    ): List<UUID> {
+        return sessionFactory.withSession { session ->
+            """
+                select
+                  v.id
+                from
+                  vedtak v
+                where
+                  v.vedtaktype IN ('SØKNAD','AVSLAG')
+                  and v.opprettet >= :fraOgMed::date
+                order by
+                  v.opprettet
+            """.trimIndent()
+                .hentListe(mapOf("fraOgMed" to fraOgMed.toString()), session) {
+                    it.uuid("id")
+                }
         }
     }
 

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/Sak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/Sak.kt
@@ -188,7 +188,7 @@ data class Sak(
      *
      * ##NB
      * */
-    fun hentGjeldendeBeregningForEndringIYtelsePåDato(
+    fun hentGjeldendeBeregningForEndringIYtelseForMåned(
         måned: Måned,
         clock: Clock,
     ): Beregning? {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakRepo.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakRepo.kt
@@ -25,4 +25,5 @@ interface SakRepo {
 
     fun hentSakforSøknadsbehandling(søknadsbehandlingId: UUID): Sak
     fun hentSakForSøknad(søknadId: UUID): Sak?
+    fun hentSakForVedtak(vedtakId: UUID): Sak?
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/Avslagsvedtak.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/Avslagsvedtak.kt
@@ -13,7 +13,7 @@ import java.time.Clock
  * [GjeldendeVedtaksdata] tar ikke hensyn til avslagsvedtak per tidspunkt, siden de ikke påvirker selve ytelsen.
  * Så hvis vi på et tidspunkt skal kunne revurdere/omgjøre disse vedtakene, så kan man ikke blindt arve [VedtakSomKanRevurderes].
  */
-sealed interface Avslagsvedtak : Stønadsvedtak, Visitable<VedtakVisitor>, ErAvslag {
+sealed interface Avslagsvedtak : VedtakIverksattSøknadsbehandling, Visitable<VedtakVisitor>, ErAvslag {
     override val periode: Periode
     override val behandling: IverksattSøknadsbehandling.Avslag
 

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakInnvilgetSøknadsbehandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakInnvilgetSøknadsbehandling.kt
@@ -25,7 +25,7 @@ data class VedtakInnvilgetSøknadsbehandling private constructor(
     override val simulering: Simulering,
     override val utbetalingId: UUID30,
     override val dokumenttilstand: Dokumenttilstand,
-) : VedtakEndringIYtelse {
+) : VedtakEndringIYtelse, VedtakIverksattSøknadsbehandling {
 
     init {
         behandling.grunnlagsdataOgVilkårsvurderinger.krevAlleVilkårInnvilget()

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakIverksattSøknadsbehandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakIverksattSøknadsbehandling.kt
@@ -1,0 +1,10 @@
+package no.nav.su.se.bakover.domain.vedtak
+
+import no.nav.su.se.bakover.domain.søknadsbehandling.IverksattSøknadsbehandling
+
+/**
+ * Grupperer avslag og innvilgelser.
+ */
+sealed interface VedtakIverksattSøknadsbehandling : Stønadsvedtak {
+    override val behandling: IverksattSøknadsbehandling
+}

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakRepo.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakRepo.kt
@@ -5,6 +5,7 @@ import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.application.journal.JournalpostId
 import no.nav.su.se.bakover.common.periode.Måned
 import no.nav.su.se.bakover.common.persistence.TransactionContext
+import java.time.LocalDate
 import java.util.UUID
 
 interface VedtakRepo {
@@ -16,4 +17,7 @@ interface VedtakRepo {
     fun lagreITransaksjon(vedtak: Vedtak, tx: TransactionContext)
     fun hentForUtbetaling(utbetalingId: UUID30): VedtakSomKanRevurderes?
     fun hentJournalpostId(vedtakId: UUID): JournalpostId?
+    fun hentSøknadsbehandlingsvedtakFraOgMed(
+        fraOgMed: LocalDate,
+    ): List<UUID>
 }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/statistikk/ResendStatistikkhendelserService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/statistikk/ResendStatistikkhendelserService.kt
@@ -1,0 +1,8 @@
+package no.nav.su.se.bakover.service.statistikk
+
+import java.time.LocalDate
+
+interface ResendStatistikkhendelserService {
+
+    fun resendIverksattSøknadsbehandling(fraOgMedDato: LocalDate)
+}

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/statistikk/ResendStatistikkhendelserServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/statistikk/ResendStatistikkhendelserServiceImpl.kt
@@ -1,0 +1,64 @@
+package no.nav.su.se.bakover.service.statistikk
+
+import arrow.core.Either
+import arrow.core.getOrElse
+import no.nav.su.se.bakover.domain.sak.SakRepo
+import no.nav.su.se.bakover.domain.statistikk.StatistikkEvent
+import no.nav.su.se.bakover.domain.statistikk.StatistikkEventObserver
+import no.nav.su.se.bakover.domain.vedtak.Avslagsvedtak
+import no.nav.su.se.bakover.domain.vedtak.VedtakInnvilgetSøknadsbehandling
+import no.nav.su.se.bakover.domain.vedtak.VedtakIverksattSøknadsbehandling
+import no.nav.su.se.bakover.domain.vedtak.VedtakRepo
+import org.slf4j.LoggerFactory
+import java.time.LocalDate
+
+/**
+ * Har som ansvar og resende hendelser som ikke har blitt sendt til statistikk.
+ */
+class ResendStatistikkhendelserServiceImpl(
+    private val vedtakRepo: VedtakRepo,
+    private val sakRepo: SakRepo,
+    private val statistikkEventObserver: StatistikkEventObserver,
+) : ResendStatistikkhendelserService {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    override fun resendIverksattSøknadsbehandling(
+        fraOgMedDato: LocalDate,
+    ) {
+        log.info("Resend statistikk: Starter resend av statistikk for søknadsbehandlingvedtak fra og med $fraOgMedDato.")
+        vedtakRepo.hentSøknadsbehandlingsvedtakFraOgMed(fraOgMedDato).also {
+            log.info("Resend statistikk: Fant ${it.size} søknadsbehandlingvedtak fra og med $fraOgMedDato som skal resendes.")
+        }.forEachIndexed { index, vedtakId ->
+
+            log.info("Resend statistikk: for søknadsbehandlingvedtak $vedtakId")
+            sakRepo.hentSakForVedtak(vedtakId).let { sak ->
+                val vedtak = Either.catch {
+                    sak!!.vedtakListe.single { it.id == vedtakId } as VedtakIverksattSøknadsbehandling
+                }.getOrElse {
+                    log.error(
+                        "Resend statistikk: Fant ikke sak for vedtak ($vedtakId) eller var ikke av type VedtakIverksattSøknadsbehandling. FraOgMedDato: $fraOgMedDato",
+                        it,
+                    )
+                    if (index == 0) {
+                        log.error("Resend statistikk: Siden vi feilet på første element, avbryter vi. FraOgMedDato: $fraOgMedDato, vedtakId:$vedtakId")
+                        return
+                    }
+                    return@forEachIndexed
+                }
+                when (vedtak) {
+                    is VedtakInnvilgetSøknadsbehandling -> {
+                        statistikkEventObserver.handle(StatistikkEvent.Behandling.Søknad.Iverksatt.Innvilget(vedtak))
+                        statistikkEventObserver.handle(StatistikkEvent.Stønadsvedtak(vedtak) { sak!! })
+                        log.info("Resend statistikk: Sendte statistikk for VedtakInnvilgetSøknadsbehandling $vedtakId. FraOgMedDato: $fraOgMedDato.")
+                    }
+
+                    is Avslagsvedtak -> {
+                        statistikkEventObserver.handle(StatistikkEvent.Behandling.Søknad.Iverksatt.Avslag(vedtak))
+                        log.info("Resend statistikk: Sendte statistikk for Avslagsvedtak $vedtakId. FraOgMedDato: $fraOgMedDato")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/statistikk/src/main/kotlin/no/nav/su/se/bakover/statistikk/stønad/StønadsstatistikkMapper.kt
+++ b/statistikk/src/main/kotlin/no/nav/su/se/bakover/statistikk/stønad/StønadsstatistikkMapper.kt
@@ -186,7 +186,7 @@ private fun mapBeregning(
     val beregningForMåned = vedtak.periode.måneder()
         .toList()
         .flatMap {
-            val beregning = hentSak().hentGjeldendeBeregningForEndringIYtelsePåDato(it, clock)!!
+            val beregning = hentSak().hentGjeldendeBeregningForEndringIYtelseForMåned(it, clock)!!
             mapBeregning(vedtak, beregning)
         }
     val gjeldendeBeregningForMåned = beregningForMåned.associateBy { it.måned }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/Routes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/Routes.kt
@@ -80,7 +80,10 @@ internal fun Application.setupKtorRoutes(
                         applicationConfig,
                     )
                     avstemmingRoutes(accessProtectedServices.avstemming, clock)
-                    driftRoutes(accessProtectedServices.søknad)
+                    driftRoutes(
+                        søknadService = accessProtectedServices.søknad,
+                        resendStatistikkhendelserService = accessProtectedServices.resendStatistikkhendelserService,
+                    )
                     revurderingRoutes(
                         revurderingService = accessProtectedServices.revurdering,
                         sakService = accessProtectedServices.sak,

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/drift/DriftRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/drift/DriftRoutes.kt
@@ -9,6 +9,7 @@ import no.nav.su.se.bakover.common.Brukerrolle
 import no.nav.su.se.bakover.common.infrastructure.web.Resultat
 import no.nav.su.se.bakover.common.infrastructure.web.svar
 import no.nav.su.se.bakover.common.serialize
+import no.nav.su.se.bakover.service.statistikk.ResendStatistikkhendelserService
 import no.nav.su.se.bakover.service.søknad.SøknadService
 import no.nav.su.se.bakover.web.features.authorize
 import no.nav.su.se.bakover.web.routes.drift.FixSøknaderResponseJson.Companion.toJson
@@ -17,6 +18,7 @@ internal const val DRIFT_PATH = "/drift"
 
 internal fun Route.driftRoutes(
     søknadService: SøknadService,
+    resendStatistikkhendelserService: ResendStatistikkhendelserService,
 ) {
     patch("$DRIFT_PATH/søknader/fix") {
         authorize(Brukerrolle.Drift) {
@@ -31,4 +33,6 @@ internal fun Route.driftRoutes(
             call.svar(Resultat.json(HttpStatusCode.OK, """{ "Status" : "OK"}"""))
         }
     }
+
+    resendStatistikkRoute(resendStatistikkhendelserService)
 }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/drift/ResendStatistikkRoute.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/drift/ResendStatistikkRoute.kt
@@ -1,0 +1,36 @@
+package no.nav.su.se.bakover.web.routes.drift
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import no.nav.su.se.bakover.common.Brukerrolle
+import no.nav.su.se.bakover.common.infrastructure.web.Resultat
+import no.nav.su.se.bakover.common.infrastructure.web.svar
+import no.nav.su.se.bakover.common.infrastructure.web.withBody
+import no.nav.su.se.bakover.service.statistikk.ResendStatistikkhendelserService
+import no.nav.su.se.bakover.web.features.authorize
+import java.time.LocalDate
+
+internal fun Route.resendStatistikkRoute(
+    resendStatistikkhendelserService: ResendStatistikkhendelserService,
+) {
+    data class Body(
+        val fraOgMed: String,
+    )
+
+    post("/drift/resend-statistikk/vedtak/søknadsbehandling") {
+        authorize(Brukerrolle.Drift) {
+            call.withBody<Body> { body ->
+                CoroutineScope(Dispatchers.IO).launch {
+                    resendStatistikkhendelserService.resendIverksattSøknadsbehandling(LocalDate.parse(body.fraOgMed))
+                }
+
+                call.svar(Resultat.json(HttpStatusCode.Accepted, """{"status": "Accepted"}"""))
+            }
+        }
+    }
+}

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxy.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxy.kt
@@ -192,6 +192,7 @@ import no.nav.su.se.bakover.service.nøkkeltall.NøkkeltallService
 import no.nav.su.se.bakover.service.skatt.HentSamletSkattegrunnlagForBehandlingResponse
 import no.nav.su.se.bakover.service.skatt.KunneIkkeHenteSkattemelding
 import no.nav.su.se.bakover.service.skatt.SkatteService
+import no.nav.su.se.bakover.service.statistikk.ResendStatistikkhendelserService
 import no.nav.su.se.bakover.service.søknad.AvslåSøknadManglendeDokumentasjonService
 import no.nav.su.se.bakover.service.søknad.FantIkkeSøknad
 import no.nav.su.se.bakover.service.søknad.KunneIkkeLageSøknadPdf
@@ -1138,6 +1139,12 @@ open class AccessCheckProxy(
 
                 override val utløptFristForKontrollsamtaleService: UtløptFristForKontrollsamtaleService
                     get() = kastKanKunKallesFraAnnenService()
+            },
+            resendStatistikkhendelserService = object : ResendStatistikkhendelserService {
+                override fun resendIverksattSøknadsbehandling(fraOgMedDato: LocalDate) {
+                    // Driftsendepunkt, ingen direkteoppslag på person og ingen returdata
+                    services.resendStatistikkhendelserService.resendIverksattSøknadsbehandling(fraOgMedDato)
+                }
             },
         )
     }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/ServiceBuilder.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/ServiceBuilder.kt
@@ -27,6 +27,7 @@ import no.nav.su.se.bakover.service.revurdering.RevurderingServiceImpl
 import no.nav.su.se.bakover.service.revurdering.StansYtelseServiceImpl
 import no.nav.su.se.bakover.service.sak.SakServiceImpl
 import no.nav.su.se.bakover.service.skatt.SkatteServiceImpl
+import no.nav.su.se.bakover.service.statistikk.ResendStatistikkhendelserServiceImpl
 import no.nav.su.se.bakover.service.søknad.AvslåSøknadManglendeDokumentasjonServiceImpl
 import no.nav.su.se.bakover.service.søknad.SøknadServiceImpl
 import no.nav.su.se.bakover.service.søknad.lukk.LukkSøknadServiceImpl
@@ -298,6 +299,11 @@ object ServiceBuilder {
             stansYtelse = stansAvYtelseService,
             gjenopptaYtelse = gjenopptakAvYtelseService,
             kontrollsamtaleSetup = kontrollsamtaleSetup,
+            resendStatistikkhendelserService = ResendStatistikkhendelserServiceImpl(
+                vedtakRepo = databaseRepos.vedtakRepo,
+                sakRepo = databaseRepos.sak,
+                statistikkEventObserver = statistikkEventObserver,
+            ),
         )
     }
 }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/Services.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/Services.kt
@@ -16,6 +16,7 @@ import no.nav.su.se.bakover.service.klage.KlageService
 import no.nav.su.se.bakover.service.klage.KlageinstanshendelseService
 import no.nav.su.se.bakover.service.nøkkeltall.NøkkeltallService
 import no.nav.su.se.bakover.service.skatt.SkatteService
+import no.nav.su.se.bakover.service.statistikk.ResendStatistikkhendelserService
 import no.nav.su.se.bakover.service.søknad.AvslåSøknadManglendeDokumentasjonService
 import no.nav.su.se.bakover.service.søknad.SøknadService
 import no.nav.su.se.bakover.service.søknad.lukk.LukkSøknadService
@@ -50,4 +51,5 @@ data class Services(
     val sendPåminnelserOmNyStønadsperiodeService: SendPåminnelserOmNyStønadsperiodeService,
     val skatteService: SkatteService,
     val kontrollsamtaleSetup: KontrollsamtaleSetup,
+    val resendStatistikkhendelserService: ResendStatistikkhendelserService,
 )

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/TestServicesBuilder.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/TestServicesBuilder.kt
@@ -20,6 +20,7 @@ import no.nav.su.se.bakover.service.klage.KlageService
 import no.nav.su.se.bakover.service.klage.KlageinstanshendelseService
 import no.nav.su.se.bakover.service.nøkkeltall.NøkkeltallService
 import no.nav.su.se.bakover.service.skatt.SkatteService
+import no.nav.su.se.bakover.service.statistikk.ResendStatistikkhendelserService
 import no.nav.su.se.bakover.service.søknad.AvslåSøknadManglendeDokumentasjonService
 import no.nav.su.se.bakover.service.søknad.SøknadService
 import no.nav.su.se.bakover.service.søknad.lukk.LukkSøknadService
@@ -65,6 +66,7 @@ object TestServicesBuilder {
             override val opprettPlanlagtKontrollsamtaleService: OpprettKontrollsamtaleVedNyStønadsperiodeService = mock()
             override val utløptFristForKontrollsamtaleService: UtløptFristForKontrollsamtaleService = mock()
         },
+        resendStatistikkhendelserService: ResendStatistikkhendelserService = mock(),
     ): Services = Services(
         avstemming = avstemming,
         utbetaling = utbetaling,
@@ -90,5 +92,6 @@ object TestServicesBuilder {
         stansYtelse = stansAvYtelseService,
         gjenopptaYtelse = gjenopptakAvYtelseService,
         kontrollsamtaleSetup = kontrollsamtaleSetup,
+        resendStatistikkhendelserService = resendStatistikkhendelserService,
     )
 }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxyTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxyTest.kt
@@ -54,6 +54,7 @@ internal class AccessCheckProxyTest {
         sendPåminnelserOmNyStønadsperiodeService = mock(),
         skatteService = mock(),
         kontrollsamtaleSetup = mock(),
+        resendStatistikkhendelserService = mock(),
     )
 
     @Nested


### PR DESCRIPTION
IverksettSøknadsbehandlingServiceImpl som ble trukket ut fra SøknadsbehandlingServiceImpl i oktober har aldri sendt statistikk. Legger til en jobb som igangsettes fra driftssiden som kan rekjøre disse fra en dato.