### PR TITLE
Forenkl søknadsbehandling avkorting

### DIFF
--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/avkorting/AvkortingVedSøknadsbehandlingDbKtTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/avkorting/AvkortingVedSøknadsbehandlingDbKtTest.kt
@@ -1,126 +1,180 @@
 package no.nav.su.se.bakover.database.avkorting
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import io.kotest.assertions.throwables.shouldThrowWithMessage
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.beOfType
 import no.nav.su.se.bakover.common.objectMapper
-import no.nav.su.se.bakover.common.tid.Tidspunkt
-import no.nav.su.se.bakover.common.tid.periode.juni
 import no.nav.su.se.bakover.domain.avkorting.AvkortingVedSøknadsbehandling
-import no.nav.su.se.bakover.domain.avkorting.Avkortingsvarsel
-import no.nav.su.se.bakover.test.fixedClock
-import no.nav.su.se.bakover.test.simulering.simuleringFeilutbetaling
+import no.nav.su.se.bakover.test.avkorting.avkortingVedSøknadsbehandlingAvkortet
+import no.nav.su.se.bakover.test.avkorting.avkortingVedSøknadsbehandlingSkalAvkortes
+import no.nav.su.se.bakover.test.avkortingsvarselAvkortet
+import no.nav.su.se.bakover.test.avkortingsvarselSkalAvkortes
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.skyscreamer.jsonassert.Customization
 import org.skyscreamer.jsonassert.JSONAssert
-import java.util.UUID
+import org.skyscreamer.jsonassert.JSONCompareMode
+import org.skyscreamer.jsonassert.comparator.CustomComparator
 
 internal class AvkortingVedSøknadsbehandlingDbKtTest {
 
-    private val ingen1 = AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående
-    private val ingen2 = ingen1.håndter()
-    private val ingen3 = ingen2.iverksett(UUID.randomUUID())
-
-    private val kanIkke1 = ingen1.kanIkke()
-    private val kanIkke2 = ingen2.kanIkke()
-
-    private val varsel = Avkortingsvarsel.Utenlandsopphold.SkalAvkortes(
-        objekt = Avkortingsvarsel.Utenlandsopphold.Opprettet(
-            sakId = UUID.randomUUID(),
-            revurderingId = UUID.randomUUID(),
-            simulering = simuleringFeilutbetaling(juni(2021)),
-            opprettet = Tidspunkt.now(fixedClock),
-        ),
-    )
-
-    private val behandlingId = UUID.randomUUID()
-    private val varselAvkortet = varsel.avkortet(behandlingId)
-    private val utestående1 = AvkortingVedSøknadsbehandling.Uhåndtert.UteståendeAvkorting(avkortingsvarsel = varsel)
-    private val utestående2 = utestående1.håndter()
-    private val utestående3 = utestående2.iverksett(behandlingId)
-
     @Test
-    fun `ingen utestående`() {
-        val exp1 = """
-            {
-                "@type":"UHÅNDTERT_INGEN_UTESTÅENDE"
-            }
-        """.trimIndent()
-        JSONAssert.assertEquals(exp1, objectMapper.writeValueAsString(ingen1.toDb()), true)
-        objectMapper.readValue<AvkortingVedSøknadsbehandlingDb.Uhåndtert.IngenUtestående>(exp1)
-            .toDomain() shouldBe beOfType<AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående>()
-
-        val exp2 = """
-            {
-                "@type":"HÅNDTERT_INGEN_UTESTÅENDE"
-            }
-        """.trimIndent()
-        JSONAssert.assertEquals(exp2, objectMapper.writeValueAsString(ingen2.toDb()), true)
-        objectMapper.readValue<AvkortingVedSøknadsbehandlingDb.Håndtert.IngenUtestående>(exp2)
-            .toDomain() shouldBe beOfType<AvkortingVedSøknadsbehandling.Håndtert.IngenUtestående>()
-
-        val exp3 = """
-            {
-                "@type":"IVERKSATT_INGEN_UTESTÅENDE"
-            }
-        """.trimIndent()
-        JSONAssert.assertEquals(exp3, objectMapper.writeValueAsString(ingen3.toDb()), true)
-        objectMapper.readValue<AvkortingVedSøknadsbehandlingDb.Iverksatt.IngenUtestående>(exp3)
-            .toDomain() shouldBe beOfType<AvkortingVedSøknadsbehandling.Iverksatt.IngenUtestående>()
+    fun `ikke vurdert`() {
+        AvkortingVedSøknadsbehandling.IkkeVurdert.toDbJson() shouldBe null
+        // Denne deserialiseres ikke, men styres av domenetypen.
     }
 
     @Test
-    fun `kan ikke`() {
-        val exp4 = """
-            {
-                "@type":"UHÅNDTERT_KAN_IKKE",
-                "uhåndtert": {"@type":"UHÅNDTERT_INGEN_UTESTÅENDE"}
-            }
-        """.trimIndent()
-        JSONAssert.assertEquals(exp4, objectMapper.writeValueAsString(kanIkke1.toDb()), true)
-        objectMapper.readValue<AvkortingVedSøknadsbehandlingDb.Uhåndtert.KanIkkeHåndtere>(exp4)
-            .toDomain() shouldBe beOfType<AvkortingVedSøknadsbehandling.Uhåndtert.KanIkkeHåndtere>()
-
-        val exp5 = """
-            {
-                "@type":"HÅNDTERT_KAN_IKKE",
-                "håndtert": {"@type":"HÅNDTERT_INGEN_UTESTÅENDE"}
-            }
-        """.trimIndent()
-        JSONAssert.assertEquals(exp5, objectMapper.writeValueAsString(kanIkke2.toDb()), true)
-        objectMapper.readValue<AvkortingVedSøknadsbehandlingDb.Håndtert.KanIkkeHåndtere>(exp5)
-            .toDomain() shouldBe beOfType<AvkortingVedSøknadsbehandling.Håndtert.KanIkkeHåndtere>()
+    fun `ingen avkorting`() {
+        AvkortingVedSøknadsbehandling.IngenAvkorting.toDbJson() shouldBe null
+        // Denne deserialiseres ikke, men styres av domenetypen.
     }
 
     @Test
-    fun `utestående`() {
-        val exp6 = """
-            {
-                "@type":"UHÅNDTERT_UTESTÅENDE",
-                "avkortingsvarsel":${objectMapper.writeValueAsString(varsel.toDb())}
-            }
-        """.trimIndent()
-        JSONAssert.assertEquals(exp6, objectMapper.writeValueAsString(utestående1.toDb()), true)
-        objectMapper.readValue<AvkortingVedSøknadsbehandlingDb.Uhåndtert.UteståendeAvkorting>(exp6)
-            .toDomain() shouldBe beOfType<AvkortingVedSøknadsbehandling.Uhåndtert.UteståendeAvkorting>()
+    fun `skal avkortes`() {
+        val avkortingVedSøknadsbehandlingSkalAvkortes = avkortingVedSøknadsbehandlingSkalAvkortes()
+        avkortingVedSøknadsbehandlingSkalAvkortes.toDbJson()!!.let {
+            JSONAssert.assertEquals(
+                """{"@type": "SKAL_AVKORTES","avkortingsvarsel":"ignored"}""",
+                it,
+                CustomComparator(
+                    JSONCompareMode.STRICT,
+                    Customization(
+                        "avkortingsvarsel",
+                    ) { _, _ -> true },
+                ),
+            )
+            fromAvkortingDbJson(it) shouldBe avkortingVedSøknadsbehandlingSkalAvkortes
+        }
+    }
 
-        val exp7 = """
-            {
-                "@type":"HÅNDTERT_AVKORTET_UTESTÅENDE",
-                "avkortingsvarsel":${objectMapper.writeValueAsString(varsel.toDb())}
-            }
-        """.trimIndent()
-        JSONAssert.assertEquals(exp7, objectMapper.writeValueAsString(utestående2.toDb()), true)
-        objectMapper.readValue<AvkortingVedSøknadsbehandlingDb.Håndtert.AvkortUtestående>(exp7)
-            .toDomain() shouldBe beOfType<AvkortingVedSøknadsbehandling.Håndtert.AvkortUtestående>()
+    @Test
+    fun avkortet() {
+        val avkortingVedSøknadsbehandlingAvkortet = avkortingVedSøknadsbehandlingAvkortet()
+        avkortingVedSøknadsbehandlingAvkortet.toDbJson()!!.let {
+            JSONAssert.assertEquals(
+                """{"@type": "AVKORTET","avkortingsvarsel":"ignored"}""",
+                it,
+                CustomComparator(
+                    JSONCompareMode.STRICT,
+                    Customization(
+                        "avkortingsvarsel",
+                    ) { _, _ -> true },
+                ),
+            )
+            fromAvkortingDbJson(it) shouldBe avkortingVedSøknadsbehandlingAvkortet
+        }
+    }
 
-        val exp8 = """
-            {
-                "@type":"IVERKSATT_AVKORTET_UTESTÅENDE",
-                "avkortingsvarsel":${objectMapper.writeValueAsString(varselAvkortet.toDb())}
+    @Nested
+    inner class LegacyDeserialisering {
+
+        @Nested
+        inner class IngenUtestående {
+            @Test
+            fun UHÅNDTERT_INGEN_UTESTÅENDE() {
+                fromAvkortingDbJson(
+                    """{"@type":"UHÅNDTERT_INGEN_UTESTÅENDE"}""",
+                ) shouldBe AvkortingVedSøknadsbehandling.IkkeVurdert
             }
-        """.trimIndent()
-        JSONAssert.assertEquals(exp8, objectMapper.writeValueAsString(utestående3.toDb()), true)
-        objectMapper.readValue<AvkortingVedSøknadsbehandlingDb.Iverksatt.AvkortUtestående>(exp8)
-            .toDomain() shouldBe beOfType<AvkortingVedSøknadsbehandling.Iverksatt.AvkortUtestående>()
+
+            @Test
+            fun HÅNDTERT_INGEN_UTESTÅENDE() {
+                fromAvkortingDbJson(
+                    """{"@type":"HÅNDTERT_INGEN_UTESTÅENDE"}""",
+                ) shouldBe AvkortingVedSøknadsbehandling.IngenAvkorting
+            }
+
+            @Test
+            fun IVERKSATT_INGEN_UTESTÅENDE() {
+                fromAvkortingDbJson(
+                    """{"@type":"IVERKSATT_INGEN_UTESTÅENDE"}""",
+                ) shouldBe AvkortingVedSøknadsbehandling.IngenAvkorting
+            }
+        }
+
+        @Nested
+        inner class KanIkke {
+            @Test
+            fun UHÅNDTERT_KAN_IKKE() {
+                fromAvkortingDbJson(
+                    """
+                    {
+                        "@type":"UHÅNDTERT_KAN_IKKE",
+                        "uhåndtert": {"@type":"UHÅNDTERT_INGEN_UTESTÅENDE"}
+                    }
+                    """.trimIndent(),
+                ) shouldBe AvkortingVedSøknadsbehandling.IkkeVurdert
+            }
+
+            @Test
+            fun HÅNDTERT_KAN_IKKE() {
+                objectMapper.readValue<AvkortingVedSøknadsbehandlingDb.Håndtert.KanIkkeHåndtere>(
+                    """
+                        {
+                            "@type":"HÅNDTERT_KAN_IKKE",
+                            "håndtert": {"@type":"HÅNDTERT_INGEN_UTESTÅENDE"}
+                        }
+                    """.trimIndent(),
+                ).toDomain() shouldBe AvkortingVedSøknadsbehandling.IngenAvkorting
+            }
+
+            @Test
+            fun IVERKSATT_KAN_IKKE() {
+                shouldThrowWithMessage<IllegalStateException>("Avventer migrering av AvkortingVedSøknadsbehandlingDb.Iverksatt.KanIkkeHåndtere - skal ikke være i bruk.") {
+                    objectMapper.readValue<AvkortingVedSøknadsbehandlingDb.Iverksatt.KanIkkeHåndtere>(
+                        """
+                        {
+                            "@type":"IVERKSATT_KAN_IKKE",
+                            "håndtert": {"@type":"HÅNDTERT_INGEN_UTESTÅENDE"}
+                        }
+                        """.trimIndent(),
+                    ).toDomain()
+                }
+            }
+
+            @Nested
+            inner class Utestående {
+                @Test
+                fun UHÅNDTERT_UTESTÅENDE() {
+                    fromAvkortingDbJson(
+                        """
+                        {
+                            "@type":"UHÅNDTERT_UTESTÅENDE",
+                            "avkortingsvarsel":${objectMapper.writeValueAsString(avkortingsvarselSkalAvkortes().toDb())}
+                        }
+                        """.trimIndent(),
+                    ) shouldBe AvkortingVedSøknadsbehandling.IkkeVurdert
+                }
+
+                @Test
+                fun HÅNDTERT_AVKORTET_UTESTÅENDE() {
+                    val avkortingsvarselSkalAvkortes = avkortingsvarselSkalAvkortes()
+                    fromAvkortingDbJson(
+                        """
+                        {
+                            "@type":"HÅNDTERT_AVKORTET_UTESTÅENDE",
+                            "avkortingsvarsel":${objectMapper.writeValueAsString(avkortingsvarselSkalAvkortes.toDb())}
+                        }
+                        """.trimIndent(),
+                    ) shouldBe AvkortingVedSøknadsbehandling.SkalAvkortes(
+                        avkortingsvarselSkalAvkortes,
+                    )
+                }
+
+                @Test
+                fun IVERKSATT_AVKORTET_UTESTÅENDE() {
+                    val avkortingsvarselAvkortet = avkortingsvarselAvkortet()
+                    fromAvkortingDbJson(
+                        """
+                        {
+                            "@type":"IVERKSATT_AVKORTET_UTESTÅENDE",
+                            "avkortingsvarsel":${objectMapper.writeValueAsString(avkortingsvarselAvkortet.toDb())}
+                        }
+                        """.trimIndent(),
+                    ) shouldBe AvkortingVedSøknadsbehandling.Avkortet(avkortingsvarselAvkortet)
+                }
+            }
+        }
     }
 }

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/søknadsbehandling/SøknadsbehandlingPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/søknadsbehandling/SøknadsbehandlingPostgresRepoTest.kt
@@ -186,6 +186,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                     clock = fixedClock,
                     satsFactory = satsFactoryTestPåDato(),
                     nySaksbehandler = saksbehandler,
+                    uteståendeAvkortingPåSak = sak.uteståendeAvkortingSkalAvkortes,
                 ).getOrFail()
                 .also {
                     repo.lagre(it)
@@ -454,22 +455,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                 sakRepo = testDataHelper.sakRepo,
             )
 
-            iverksattAvslagUtenBeregning.avkorting.shouldBeInstanceOf<AvkortingVedSøknadsbehandling.Iverksatt.KanIkkeHåndtere>()
-                .also {
-                    it.håndtert.shouldBeInstanceOf<AvkortingVedSøknadsbehandling.Håndtert.AvkortUtestående>().also {
-                        it shouldBe AvkortingVedSøknadsbehandling.Håndtert.AvkortUtestående(
-                            Avkortingsvarsel.Utenlandsopphold.SkalAvkortes(
-                                objekt = Avkortingsvarsel.Utenlandsopphold.Opprettet(
-                                    id = it.avkortingsvarsel.id,
-                                    sakId = sakOppdatertMedSøknad.id,
-                                    revurderingId = revurderingSomFørteTilAvkorting.id,
-                                    opprettet = it.avkortingsvarsel.opprettet,
-                                    simulering = it.avkortingsvarsel.simulering,
-                                ),
-                            ),
-                        )
-                    }
-                }
+            iverksattAvslagUtenBeregning.avkorting shouldBe AvkortingVedSøknadsbehandling.IngenAvkorting
         }
     }
 
@@ -498,6 +484,7 @@ internal class SøknadsbehandlingPostgresRepoTest {
                 revurderingId = revurderingSomFørteTilAvkorting.id,
                 sakRepo = testDataHelper.sakRepo,
             )
+            val uteståendeAvkorting = sak.uteståendeAvkorting as Avkortingsvarsel.Utenlandsopphold.SkalAvkortes
 
             val (sakOppdatertMedSøknad, iverksattSøknadsbehandlingVedtak, _) = testDataHelper.persisterSøknadsbehandlingIverksattInnvilgetMedKvittertUtbetaling(
                 sakOgSøknad = Pair(sak, testDataHelper.persisterJournalførtSøknadMedOppgave(sakId = sak.id).second),
@@ -513,21 +500,20 @@ internal class SøknadsbehandlingPostgresRepoTest {
             testDataHelper.sakRepo.hentSak(sak.id) shouldBe sakOppdatertMedSøknad
             sakOppdatertMedSøknad.uteståendeAvkorting.shouldBeInstanceOf<Avkortingsvarsel.Ingen>()
 
-            iverksattSøknadsbehandlingVedtak.behandling.avkorting.shouldBeInstanceOf<AvkortingVedSøknadsbehandling.Iverksatt.AvkortUtestående>()
-                .also {
-                    it.avkortingsvarsel shouldBe Avkortingsvarsel.Utenlandsopphold.Avkortet(
-                        Avkortingsvarsel.Utenlandsopphold.SkalAvkortes(
-                            objekt = Avkortingsvarsel.Utenlandsopphold.Opprettet(
-                                id = it.avkortingsvarsel.id,
-                                sakId = sakOppdatertMedSøknad.id,
-                                revurderingId = revurderingSomFørteTilAvkorting.id,
-                                opprettet = it.avkortingsvarsel.opprettet,
-                                simulering = it.avkortingsvarsel.simulering,
-                            ),
+            iverksattSøknadsbehandlingVedtak.behandling.avkorting shouldBe AvkortingVedSøknadsbehandling.Avkortet(
+                Avkortingsvarsel.Utenlandsopphold.Avkortet(
+                    Avkortingsvarsel.Utenlandsopphold.SkalAvkortes(
+                        objekt = Avkortingsvarsel.Utenlandsopphold.Opprettet(
+                            id = uteståendeAvkorting.id,
+                            sakId = sakOppdatertMedSøknad.id,
+                            revurderingId = revurderingSomFørteTilAvkorting.id,
+                            opprettet = uteståendeAvkorting.opprettet,
+                            simulering = uteståendeAvkorting.simulering,
                         ),
-                        behandlingId = iverksattSøknadsbehandlingVedtak.behandling.id,
-                    )
-                }
+                    ),
+                    behandlingId = iverksattSøknadsbehandlingVedtak.behandling.id,
+                ),
+            )
         }
     }
 

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/avkorting/UteståendeAvkorting.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/avkorting/UteståendeAvkorting.kt
@@ -103,15 +103,15 @@ sealed interface KanIkkeRevurderePgaAvkorting {
 fun Sak.unngåRevurderingAvPeriodeDetErPågåendeAvkortingFor(
     revurderingsperiode: Periode,
 ): Either<KanIkkeRevurderePgaAvkorting.PågåendeAvkortingForPeriode, Unit> {
-    val pågåendeAvkorting: List<Pair<VedtakInnvilgetSøknadsbehandling, AvkortingVedSøknadsbehandling.Iverksatt.AvkortUtestående>> =
+    val pågåendeAvkorting: List<Pair<VedtakInnvilgetSøknadsbehandling, AvkortingVedSøknadsbehandling.Avkortet>> =
         vedtakstidslinje()
-            .let { it ?: throw IllegalStateException("Kunne ikke konstruere vedtakstidslinje for saksnummer $saksnummer. feilet med $it") }
+            .let { it ?: throw IllegalStateException("Kunne ikke konstruere vedtakstidslinje for saksnummer $saksnummer siden vi ikke har vedtak.") }
             .asSequence()
             .map { it.originaltVedtak }
             .filterIsInstance<VedtakInnvilgetSøknadsbehandling>()
             .map { it to it.behandling.avkorting }
-            .filter { (_, avkorting) -> avkorting is AvkortingVedSøknadsbehandling.Iverksatt.AvkortUtestående }
-            .filterIsInstance<Pair<VedtakInnvilgetSøknadsbehandling, AvkortingVedSøknadsbehandling.Iverksatt.AvkortUtestående>>()
+            .filter { (_, avkorting) -> avkorting is AvkortingVedSøknadsbehandling.Avkortet }
+            .filterIsInstance<Pair<VedtakInnvilgetSøknadsbehandling, AvkortingVedSøknadsbehandling.Avkortet>>()
             .toList()
 
     return if (pågåendeAvkorting.isEmpty()) {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/BeregnetSøknadsbehandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/BeregnetSøknadsbehandling.kt
@@ -11,6 +11,7 @@ import no.nav.su.se.bakover.common.person.Fnr
 import no.nav.su.se.bakover.common.tid.Tidspunkt
 import no.nav.su.se.bakover.common.tid.periode.Periode
 import no.nav.su.se.bakover.domain.avkorting.AvkortingVedSøknadsbehandling
+import no.nav.su.se.bakover.domain.avkorting.AvkortingVedSøknadsbehandling.IngenAvkorting
 import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.AvslagGrunnetBeregning
 import no.nav.su.se.bakover.domain.behandling.VurderAvslagGrunnetBeregning
@@ -41,7 +42,7 @@ sealed class BeregnetSøknadsbehandling : Søknadsbehandling(), Søknadsbehandli
     abstract override val beregning: Beregning
     abstract override val stønadsperiode: Stønadsperiode
     abstract override val aldersvurdering: Aldersvurdering
-    abstract override val avkorting: AvkortingVedSøknadsbehandling.Håndtert
+    abstract override val avkorting: AvkortingVedSøknadsbehandling.KlarTilIverksetting
     abstract override val saksbehandler: NavIdentBruker.Saksbehandler
 
     override fun simuler(
@@ -121,7 +122,7 @@ sealed class BeregnetSøknadsbehandling : Søknadsbehandling(), Søknadsbehandli
         override val eksterneGrunnlag: EksterneGrunnlag,
         override val attesteringer: Attesteringshistorikk,
         override val søknadsbehandlingsHistorikk: Søknadsbehandlingshistorikk,
-        override val avkorting: AvkortingVedSøknadsbehandling.Håndtert,
+        override val avkorting: AvkortingVedSøknadsbehandling.KlarTilIverksetting,
         override val sakstype: Sakstype,
         override val saksbehandler: NavIdentBruker.Saksbehandler,
     ) : BeregnetSøknadsbehandling() {
@@ -146,7 +147,6 @@ sealed class BeregnetSøknadsbehandling : Søknadsbehandling(), Søknadsbehandli
         override fun copyInternal(
             stønadsperiode: Stønadsperiode,
             grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger.Søknadsbehandling,
-            avkorting: AvkortingVedSøknadsbehandling,
             søknadsbehandlingshistorikk: Søknadsbehandlingshistorikk,
             aldersvurdering: Aldersvurdering,
         ): Innvilget {
@@ -176,13 +176,19 @@ sealed class BeregnetSøknadsbehandling : Søknadsbehandling(), Søknadsbehandli
         override val eksterneGrunnlag: EksterneGrunnlag,
         override val attesteringer: Attesteringshistorikk,
         override val søknadsbehandlingsHistorikk: Søknadsbehandlingshistorikk,
-        override val avkorting: AvkortingVedSøknadsbehandling.Håndtert.KanIkkeHåndtere,
         override val sakstype: Sakstype,
         override val saksbehandler: NavIdentBruker.Saksbehandler,
     ) : BeregnetSøknadsbehandling(), ErAvslag {
+
         override val periode: Periode = aldersvurdering.stønadsperiode.periode
+
         override val simulering: Simulering? = null
+
         override val stønadsperiode: Stønadsperiode = aldersvurdering.stønadsperiode
+
+        /** Ingenting og avkorte ved avslag. */
+        override val avkorting = IngenAvkorting
+
         private val avslagsgrunnForBeregning: List<Avslagsgrunn> =
             when (val vurdering = VurderAvslagGrunnetBeregning.vurderAvslagGrunnetBeregning(beregning)) {
                 is AvslagGrunnetBeregning.Ja -> listOf(vurdering.grunn.toAvslagsgrunn())
@@ -201,7 +207,6 @@ sealed class BeregnetSøknadsbehandling : Søknadsbehandling(), Søknadsbehandli
         override fun copyInternal(
             stønadsperiode: Stønadsperiode,
             grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger.Søknadsbehandling,
-            avkorting: AvkortingVedSøknadsbehandling,
             søknadsbehandlingshistorikk: Søknadsbehandlingshistorikk,
             aldersvurdering: Aldersvurdering,
         ): Avslag {
@@ -249,7 +254,6 @@ sealed class BeregnetSøknadsbehandling : Søknadsbehandling(), Søknadsbehandli
                         handling = SøknadsbehandlingsHandling.SendtTilAttestering,
                     ),
                 ),
-                avkorting = avkorting.kanIkke(),
                 sakstype = sakstype,
             ).right()
         }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/IverksattSøknadsbehandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/IverksattSøknadsbehandling.kt
@@ -42,12 +42,11 @@ sealed class IverksattSøknadsbehandling : Søknadsbehandling() {
     abstract override val saksbehandler: NavIdentBruker.Saksbehandler
     abstract override val attesteringer: Attesteringshistorikk
     abstract override val aldersvurdering: Aldersvurdering
-    abstract override val avkorting: AvkortingVedSøknadsbehandling.Iverksatt
+    abstract override val avkorting: AvkortingVedSøknadsbehandling.Vurdert
 
     override fun copyInternal(
         stønadsperiode: Stønadsperiode,
         grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger.Søknadsbehandling,
-        avkorting: AvkortingVedSøknadsbehandling,
         søknadsbehandlingshistorikk: Søknadsbehandlingshistorikk,
         aldersvurdering: Aldersvurdering,
     ) = throw UnsupportedOperationException("Kan ikke kalle copyInternal på en iverksatt søknadsbehandling.")
@@ -73,7 +72,7 @@ sealed class IverksattSøknadsbehandling : Søknadsbehandling() {
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling,
         override val eksterneGrunnlag: EksterneGrunnlag,
-        override val avkorting: AvkortingVedSøknadsbehandling.Iverksatt,
+        override val avkorting: AvkortingVedSøknadsbehandling.Ferdig,
         override val sakstype: Sakstype,
     ) : IverksattSøknadsbehandling() {
         override val stønadsperiode: Stønadsperiode = aldersvurdering.stønadsperiode
@@ -95,6 +94,10 @@ sealed class IverksattSøknadsbehandling : Søknadsbehandling() {
     }
 
     sealed class Avslag : IverksattSøknadsbehandling(), ErAvslag {
+
+        /** Ingenting og avkorte ved avslag. */
+        override val avkorting = AvkortingVedSøknadsbehandling.IngenAvkorting
+
         data class MedBeregning(
             override val id: UUID,
             override val opprettet: Tidspunkt,
@@ -112,7 +115,6 @@ sealed class IverksattSøknadsbehandling : Søknadsbehandling() {
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling,
             override val eksterneGrunnlag: EksterneGrunnlag,
-            override val avkorting: AvkortingVedSøknadsbehandling.Iverksatt.KanIkkeHåndtere,
             override val sakstype: Sakstype,
         ) : Avslag() {
             override val periode: Periode = aldersvurdering.stønadsperiode.periode
@@ -163,7 +165,6 @@ sealed class IverksattSøknadsbehandling : Søknadsbehandling() {
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling,
             override val eksterneGrunnlag: EksterneGrunnlag,
-            override val avkorting: AvkortingVedSøknadsbehandling.Iverksatt.KanIkkeHåndtere,
             override val sakstype: Sakstype,
         ) : Avslag() {
             override val periode: Periode = aldersvurdering.stønadsperiode.periode

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/SimulertSøknadsbehandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/SimulertSøknadsbehandling.kt
@@ -48,7 +48,7 @@ data class SimulertSøknadsbehandling(
     override val eksterneGrunnlag: EksterneGrunnlag,
     override val attesteringer: Attesteringshistorikk,
     override val søknadsbehandlingsHistorikk: Søknadsbehandlingshistorikk,
-    override val avkorting: AvkortingVedSøknadsbehandling.Håndtert,
+    override val avkorting: AvkortingVedSøknadsbehandling.KlarTilIverksetting,
     override val sakstype: Sakstype,
     override val saksbehandler: NavIdentBruker.Saksbehandler,
 ) : Søknadsbehandling(), Søknadsbehandling.KanOppdaterePeriodeGrunnlagVilkår {
@@ -71,7 +71,6 @@ data class SimulertSøknadsbehandling(
     override fun copyInternal(
         stønadsperiode: Stønadsperiode,
         grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger.Søknadsbehandling,
-        avkorting: AvkortingVedSøknadsbehandling,
         søknadsbehandlingshistorikk: Søknadsbehandlingshistorikk,
         aldersvurdering: Aldersvurdering,
     ): SimulertSøknadsbehandling {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/SøknadsbehandlingTilAttestering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/SøknadsbehandlingTilAttestering.kt
@@ -36,7 +36,7 @@ sealed class SøknadsbehandlingTilAttestering : Søknadsbehandling() {
     abstract fun tilUnderkjent(attestering: Attestering): UnderkjentSøknadsbehandling
     abstract override val aldersvurdering: Aldersvurdering
     abstract override val attesteringer: Attesteringshistorikk
-    abstract override val avkorting: AvkortingVedSøknadsbehandling.Håndtert
+    abstract override val avkorting: AvkortingVedSøknadsbehandling.Vurdert
 
     override fun leggTilSkatt(skatt: EksterneGrunnlagSkatt): Either<KunneIkkeLeggeTilSkattegrunnlag, Søknadsbehandling> =
         KunneIkkeLeggeTilSkattegrunnlag.UgyldigTilstand.left()
@@ -59,14 +59,14 @@ sealed class SøknadsbehandlingTilAttestering : Søknadsbehandling() {
         override val eksterneGrunnlag: EksterneGrunnlag,
         override val attesteringer: Attesteringshistorikk,
         override val søknadsbehandlingsHistorikk: Søknadsbehandlingshistorikk,
-        override val avkorting: AvkortingVedSøknadsbehandling.Håndtert,
         override val sakstype: Sakstype,
+        override val avkorting: AvkortingVedSøknadsbehandling.KlarTilIverksetting,
     ) : SøknadsbehandlingTilAttestering() {
         override val stønadsperiode: Stønadsperiode = aldersvurdering.stønadsperiode
+
         override fun copyInternal(
             stønadsperiode: Stønadsperiode,
             grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger.Søknadsbehandling,
-            avkorting: AvkortingVedSøknadsbehandling,
             søknadsbehandlingshistorikk: Søknadsbehandlingshistorikk,
             aldersvurdering: Aldersvurdering,
         ): SøknadsbehandlingTilAttestering {
@@ -141,14 +141,21 @@ sealed class SøknadsbehandlingTilAttestering : Søknadsbehandling() {
                 grunnlagsdata = grunnlagsdata,
                 vilkårsvurderinger = vilkårsvurderinger,
                 eksterneGrunnlag = eksterneGrunnlag,
-                avkorting = avkorting.iverksett(id),
+                avkorting = when (avkorting) {
+                    is AvkortingVedSøknadsbehandling.IngenAvkorting -> avkorting
+                    is AvkortingVedSøknadsbehandling.SkalAvkortes -> avkorting.avkort(id)
+                },
                 sakstype = sakstype,
             )
         }
     }
 
     sealed class Avslag : SøknadsbehandlingTilAttestering(), ErAvslag {
+
         abstract override val aldersvurdering: Aldersvurdering
+
+        /** Ingenting og avkorte ved avslag. */
+        override val avkorting = AvkortingVedSøknadsbehandling.IngenAvkorting
 
         fun iverksett(attestering: Attestering.Iverksatt): IverksattSøknadsbehandling.Avslag {
             return when (this) {
@@ -173,7 +180,6 @@ sealed class SøknadsbehandlingTilAttestering : Søknadsbehandling() {
             override val eksterneGrunnlag: EksterneGrunnlag,
             override val attesteringer: Attesteringshistorikk,
             override val søknadsbehandlingsHistorikk: Søknadsbehandlingshistorikk,
-            override val avkorting: AvkortingVedSøknadsbehandling.Håndtert.KanIkkeHåndtere,
             override val sakstype: Sakstype,
         ) : Avslag() {
             override val stønadsperiode: Stønadsperiode = aldersvurdering.stønadsperiode
@@ -223,7 +229,6 @@ sealed class SøknadsbehandlingTilAttestering : Søknadsbehandling() {
                     grunnlagsdata = grunnlagsdata,
                     vilkårsvurderinger = vilkårsvurderinger,
                     eksterneGrunnlag = eksterneGrunnlag,
-                    avkorting = avkorting,
                     sakstype = sakstype,
                 )
             }
@@ -231,7 +236,6 @@ sealed class SøknadsbehandlingTilAttestering : Søknadsbehandling() {
             override fun copyInternal(
                 stønadsperiode: Stønadsperiode,
                 grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger.Søknadsbehandling,
-                avkorting: AvkortingVedSøknadsbehandling,
                 søknadsbehandlingshistorikk: Søknadsbehandlingshistorikk,
                 aldersvurdering: Aldersvurdering,
             ): UtenBeregning {
@@ -263,7 +267,6 @@ sealed class SøknadsbehandlingTilAttestering : Søknadsbehandling() {
                     grunnlagsdata = grunnlagsdata,
                     vilkårsvurderinger = vilkårsvurderinger,
                     eksterneGrunnlag = eksterneGrunnlag,
-                    avkorting = avkorting.iverksett(id),
                     sakstype = sakstype,
                 )
             }
@@ -286,7 +289,6 @@ sealed class SøknadsbehandlingTilAttestering : Søknadsbehandling() {
             override val eksterneGrunnlag: EksterneGrunnlag,
             override val attesteringer: Attesteringshistorikk,
             override val søknadsbehandlingsHistorikk: Søknadsbehandlingshistorikk,
-            override val avkorting: AvkortingVedSøknadsbehandling.Håndtert.KanIkkeHåndtere,
             override val sakstype: Sakstype,
         ) : Avslag() {
             override val stønadsperiode: Stønadsperiode = aldersvurdering.stønadsperiode
@@ -341,7 +343,6 @@ sealed class SøknadsbehandlingTilAttestering : Søknadsbehandling() {
                     grunnlagsdata = grunnlagsdata,
                     vilkårsvurderinger = vilkårsvurderinger,
                     eksterneGrunnlag = eksterneGrunnlag,
-                    avkorting = avkorting,
                     sakstype = sakstype,
                 )
             }
@@ -349,7 +350,6 @@ sealed class SøknadsbehandlingTilAttestering : Søknadsbehandling() {
             override fun copyInternal(
                 stønadsperiode: Stønadsperiode,
                 grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger.Søknadsbehandling,
-                avkorting: AvkortingVedSøknadsbehandling,
                 søknadsbehandlingshistorikk: Søknadsbehandlingshistorikk,
                 aldersvurdering: Aldersvurdering,
             ): MedBeregning {
@@ -382,7 +382,6 @@ sealed class SøknadsbehandlingTilAttestering : Søknadsbehandling() {
                     grunnlagsdata = grunnlagsdata,
                     vilkårsvurderinger = vilkårsvurderinger,
                     eksterneGrunnlag = eksterneGrunnlag,
-                    avkorting = avkorting.iverksett(id),
                     sakstype = sakstype,
                 )
             }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/UnderkjentSøknadsbehandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/UnderkjentSøknadsbehandling.kt
@@ -48,7 +48,7 @@ sealed class UnderkjentSøknadsbehandling : Søknadsbehandling(), Søknadsbehand
     abstract override val saksbehandler: NavIdentBruker.Saksbehandler
     abstract override val attesteringer: Attesteringshistorikk
     abstract override val aldersvurdering: Aldersvurdering
-    abstract override val avkorting: AvkortingVedSøknadsbehandling.Håndtert
+    abstract override val avkorting: AvkortingVedSøknadsbehandling.Vurdert
 
     abstract fun nyOppgaveId(nyOppgaveId: OppgaveId): UnderkjentSøknadsbehandling
 
@@ -81,7 +81,7 @@ sealed class UnderkjentSøknadsbehandling : Søknadsbehandling(), Søknadsbehand
         override val grunnlagsdata: Grunnlagsdata,
         override val vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling,
         override val eksterneGrunnlag: EksterneGrunnlag,
-        override val avkorting: AvkortingVedSøknadsbehandling.Håndtert,
+        override val avkorting: AvkortingVedSøknadsbehandling.KlarTilIverksetting,
         override val sakstype: Sakstype,
     ) : UnderkjentSøknadsbehandling() {
         override val stønadsperiode: Stønadsperiode = aldersvurdering.stønadsperiode
@@ -99,7 +99,6 @@ sealed class UnderkjentSøknadsbehandling : Søknadsbehandling(), Søknadsbehand
         override fun copyInternal(
             stønadsperiode: Stønadsperiode,
             grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger.Søknadsbehandling,
-            avkorting: AvkortingVedSøknadsbehandling,
             søknadsbehandlingshistorikk: Søknadsbehandlingshistorikk,
             aldersvurdering: Aldersvurdering,
         ): Innvilget {
@@ -214,6 +213,9 @@ sealed class UnderkjentSøknadsbehandling : Søknadsbehandling(), Søknadsbehand
     }
 
     sealed class Avslag : UnderkjentSøknadsbehandling(), ErAvslag {
+
+        override val avkorting = AvkortingVedSøknadsbehandling.IngenAvkorting
+
         data class MedBeregning(
             override val id: UUID,
             override val opprettet: Tidspunkt,
@@ -231,7 +233,6 @@ sealed class UnderkjentSøknadsbehandling : Søknadsbehandling(), Søknadsbehand
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling,
             override val eksterneGrunnlag: EksterneGrunnlag,
-            override val avkorting: AvkortingVedSøknadsbehandling.Håndtert.KanIkkeHåndtere,
             override val sakstype: Sakstype,
         ) : Avslag() {
             override val periode: Periode = aldersvurdering.stønadsperiode.periode
@@ -255,7 +256,6 @@ sealed class UnderkjentSøknadsbehandling : Søknadsbehandling(), Søknadsbehand
             override fun copyInternal(
                 stønadsperiode: Stønadsperiode,
                 grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger.Søknadsbehandling,
-                avkorting: AvkortingVedSøknadsbehandling,
                 søknadsbehandlingshistorikk: Søknadsbehandlingshistorikk,
                 aldersvurdering: Aldersvurdering,
             ): MedBeregning {
@@ -306,7 +306,6 @@ sealed class UnderkjentSøknadsbehandling : Søknadsbehandling(), Søknadsbehand
                             handling = SøknadsbehandlingsHandling.SendtTilAttestering,
                         ),
                     ),
-                    avkorting = avkorting,
                     sakstype = sakstype,
                 ).right()
             }
@@ -335,7 +334,6 @@ sealed class UnderkjentSøknadsbehandling : Søknadsbehandling(), Søknadsbehand
             override val grunnlagsdata: Grunnlagsdata,
             override val vilkårsvurderinger: Vilkårsvurderinger.Søknadsbehandling,
             override val eksterneGrunnlag: EksterneGrunnlag,
-            override val avkorting: AvkortingVedSøknadsbehandling.Håndtert.KanIkkeHåndtere,
             override val sakstype: Sakstype,
         ) : Avslag() {
             override val stønadsperiode: Stønadsperiode = aldersvurdering.stønadsperiode
@@ -345,7 +343,6 @@ sealed class UnderkjentSøknadsbehandling : Søknadsbehandling(), Søknadsbehand
             override fun copyInternal(
                 stønadsperiode: Stønadsperiode,
                 grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger.Søknadsbehandling,
-                avkorting: AvkortingVedSøknadsbehandling,
                 søknadsbehandlingshistorikk: Søknadsbehandlingshistorikk,
                 aldersvurdering: Aldersvurdering,
             ): UtenBeregning {
@@ -405,7 +402,6 @@ sealed class UnderkjentSøknadsbehandling : Søknadsbehandling(), Søknadsbehand
                             handling = SøknadsbehandlingsHandling.SendtTilAttestering,
                         ),
                     ),
-                    avkorting = avkorting,
                     sakstype = sakstype,
                 ).right()
             }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/VilkårsvurdertSøknadsbehandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/VilkårsvurdertSøknadsbehandling.kt
@@ -38,8 +38,6 @@ sealed class VilkårsvurdertSøknadsbehandling :
     Søknadsbehandling(),
     Søknadsbehandling.KanOppdaterePeriodeGrunnlagVilkår {
 
-    abstract override val avkorting: AvkortingVedSøknadsbehandling.Uhåndtert
-
     override fun leggTilSkatt(skatt: EksterneGrunnlagSkatt): Either<KunneIkkeLeggeTilSkattegrunnlag, Søknadsbehandling> {
         return copyInternal(
             grunnlagsdataOgVilkårsvurderinger = grunnlagsdataOgVilkårsvurderinger.leggTilSkatt(skatt).let {
@@ -62,7 +60,6 @@ sealed class VilkårsvurdertSøknadsbehandling :
             grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger.Søknadsbehandling,
             attesteringer: Attesteringshistorikk,
             saksbehandlingsHistorikk: Søknadsbehandlingshistorikk,
-            avkorting: AvkortingVedSøknadsbehandling.Uhåndtert,
             sakstype: Sakstype,
             saksbehandler: NavIdentBruker.Saksbehandler,
         ): VilkårsvurdertSøknadsbehandling {
@@ -113,7 +110,6 @@ sealed class VilkårsvurdertSøknadsbehandling :
                         eksterneGrunnlag = eksterneGrunnlag,
                         attesteringer = attesteringer,
                         søknadsbehandlingsHistorikk = saksbehandlingsHistorikk,
-                        avkorting = avkorting.kanIkke(),
                         sakstype = sakstype,
                         saksbehandler = saksbehandler,
                     )
@@ -135,7 +131,6 @@ sealed class VilkårsvurdertSøknadsbehandling :
                         eksterneGrunnlag = eksterneGrunnlag,
                         attesteringer = attesteringer,
                         søknadsbehandlingsHistorikk = saksbehandlingsHistorikk,
-                        avkorting = avkorting.uhåndtert(),
                         sakstype = sakstype,
                         saksbehandler = saksbehandler,
                     )
@@ -157,7 +152,6 @@ sealed class VilkårsvurdertSøknadsbehandling :
                         eksterneGrunnlag = eksterneGrunnlag,
                         attesteringer = attesteringer,
                         søknadsbehandlingsHistorikk = saksbehandlingsHistorikk,
-                        avkorting = avkorting.kanIkke(),
                         sakstype = sakstype,
                         saksbehandler = saksbehandler,
                     )
@@ -181,7 +175,6 @@ sealed class VilkårsvurdertSøknadsbehandling :
         override val eksterneGrunnlag: EksterneGrunnlag,
         override val attesteringer: Attesteringshistorikk,
         override val søknadsbehandlingsHistorikk: Søknadsbehandlingshistorikk,
-        override val avkorting: AvkortingVedSøknadsbehandling.Uhåndtert,
         override val sakstype: Sakstype,
         override val saksbehandler: NavIdentBruker.Saksbehandler,
     ) : VilkårsvurdertSøknadsbehandling(), KanBeregnes {
@@ -191,6 +184,8 @@ sealed class VilkårsvurdertSøknadsbehandling :
         override val beregning = null
         override val simulering: Simulering? = null
 
+        /** Avkorting vurderes ikke før vi må; beregningsteget. */
+        override val avkorting = AvkortingVedSøknadsbehandling.IkkeVurdert
         init {
             kastHvisGrunnlagsdataOgVilkårsvurderingerPeriodenOgBehandlingensPerioderErUlike()
             // TODO jah: Enable denne når det ikke finnes proddata med ufullstendig i denne tilstanden:
@@ -208,7 +203,6 @@ sealed class VilkårsvurdertSøknadsbehandling :
         override fun copyInternal(
             stønadsperiode: Stønadsperiode,
             grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger.Søknadsbehandling,
-            avkorting: AvkortingVedSøknadsbehandling,
             søknadsbehandlingshistorikk: Søknadsbehandlingshistorikk,
             aldersvurdering: Aldersvurdering,
         ): VilkårsvurdertSøknadsbehandling {
@@ -237,13 +231,15 @@ sealed class VilkårsvurdertSøknadsbehandling :
         override val eksterneGrunnlag: EksterneGrunnlag,
         override val attesteringer: Attesteringshistorikk,
         override val søknadsbehandlingsHistorikk: Søknadsbehandlingshistorikk,
-        override val avkorting: AvkortingVedSøknadsbehandling.Uhåndtert.KanIkkeHåndtere,
         override val sakstype: Sakstype,
         override val saksbehandler: NavIdentBruker.Saksbehandler,
     ) : VilkårsvurdertSøknadsbehandling(), ErAvslag {
         override val stønadsperiode: Stønadsperiode = aldersvurdering.stønadsperiode
         override val beregning = null
         override val simulering: Simulering? = null
+
+        /** Tar ikke */
+        override val avkorting = AvkortingVedSøknadsbehandling.IngenAvkorting
 
         override fun skalSendeVedtaksbrev(): Boolean {
             return true
@@ -252,7 +248,6 @@ sealed class VilkårsvurdertSøknadsbehandling :
         override fun copyInternal(
             stønadsperiode: Stønadsperiode,
             grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger.Søknadsbehandling,
-            avkorting: AvkortingVedSøknadsbehandling,
             søknadsbehandlingshistorikk: Søknadsbehandlingshistorikk,
             aldersvurdering: Aldersvurdering,
         ): Avslag {
@@ -301,7 +296,6 @@ sealed class VilkårsvurdertSøknadsbehandling :
                 eksterneGrunnlag = eksterneGrunnlag,
                 attesteringer = attesteringer,
                 søknadsbehandlingsHistorikk = this.søknadsbehandlingsHistorikk,
-                avkorting = avkorting.håndter().kanIkke(),
                 sakstype = sakstype,
             ).right()
         }
@@ -336,7 +330,6 @@ sealed class VilkårsvurdertSøknadsbehandling :
                         handling = SøknadsbehandlingsHandling.SendtTilAttestering,
                     ),
                 ),
-                avkorting = avkorting.håndter().kanIkke(),
                 sakstype = sakstype,
             ).right()
         }
@@ -364,13 +357,14 @@ sealed class VilkårsvurdertSøknadsbehandling :
         override val eksterneGrunnlag: EksterneGrunnlag,
         override val attesteringer: Attesteringshistorikk,
         override val søknadsbehandlingsHistorikk: Søknadsbehandlingshistorikk,
-        override val avkorting: AvkortingVedSøknadsbehandling.Uhåndtert.KanIkkeHåndtere,
+
         override val sakstype: Sakstype,
         override val saksbehandler: NavIdentBruker.Saksbehandler,
     ) : VilkårsvurdertSøknadsbehandling() {
         override val stønadsperiode: Stønadsperiode? = aldersvurdering?.stønadsperiode
         override val beregning = null
         override val simulering: Simulering? = null
+        override val avkorting = AvkortingVedSøknadsbehandling.IkkeVurdert
 
         override fun skalSendeVedtaksbrev(): Boolean {
             return true
@@ -379,7 +373,6 @@ sealed class VilkårsvurdertSøknadsbehandling :
         override fun copyInternal(
             stønadsperiode: Stønadsperiode,
             grunnlagsdataOgVilkårsvurderinger: GrunnlagsdataOgVilkårsvurderinger.Søknadsbehandling,
-            avkorting: AvkortingVedSøknadsbehandling,
             søknadsbehandlingshistorikk: Søknadsbehandlingshistorikk,
             aldersvurdering: Aldersvurdering,
         ): Uavklart {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/iverksett/avslå/manglendedokumentasjon/AvslåPgaManglendeDokumentasjon.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/iverksett/avslå/manglendedokumentasjon/AvslåPgaManglendeDokumentasjon.kt
@@ -11,7 +11,6 @@ import no.nav.su.se.bakover.common.ident.NavIdentBruker
 import no.nav.su.se.bakover.common.tid.Tidspunkt
 import no.nav.su.se.bakover.common.tid.periode.Periode
 import no.nav.su.se.bakover.domain.Sak
-import no.nav.su.se.bakover.domain.avkorting.AvkortingVedSøknadsbehandling
 import no.nav.su.se.bakover.domain.behandling.Attestering
 import no.nav.su.se.bakover.domain.dokument.Dokument
 import no.nav.su.se.bakover.domain.dokument.KunneIkkeLageDokument
@@ -106,7 +105,6 @@ private fun avslå(
         .leggTilStønadsperiodeOgAldersvurderingHvisNull(
             clock = clock,
             satsFactory = satsFactory,
-            avkorting = sak.hentUteståendeAvkortingForSøknadsbehandling().fold({ it }, { it }).kanIkke(),
         )
         .avslåPgaManglendeDokumentasjon(request.saksbehandler, clock)
         .tilAttestering(fritekstTilBrev = request.fritekstTilBrev).let { søknadsbehandlingTilAttestering ->
@@ -131,7 +129,6 @@ private fun avslå(
 private fun Søknadsbehandling.leggTilStønadsperiodeOgAldersvurderingHvisNull(
     clock: Clock,
     satsFactory: SatsFactory,
-    avkorting: AvkortingVedSøknadsbehandling,
 ): Søknadsbehandling {
     if (stønadsperiode != null) return this
 
@@ -146,7 +143,6 @@ private fun Søknadsbehandling.leggTilStønadsperiodeOgAldersvurderingHvisNull(
         ),
         formuegrenserFactory = satsFactory.formuegrenserFactory,
         clock = clock,
-        avkorting = avkorting,
     )
 }
 

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/opprett/NySøknadsbehandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/opprett/NySøknadsbehandling.kt
@@ -3,7 +3,6 @@ package no.nav.su.se.bakover.domain.søknadsbehandling.opprett
 import no.nav.su.se.bakover.common.ident.NavIdentBruker
 import no.nav.su.se.bakover.common.person.Fnr
 import no.nav.su.se.bakover.common.tid.Tidspunkt
-import no.nav.su.se.bakover.domain.avkorting.AvkortingVedSøknadsbehandling
 import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.grunnlag.StøtterHentingAvEksternGrunnlag
@@ -25,7 +24,6 @@ data class NySøknadsbehandling(
     val søknad: Søknad.Journalført.MedOppgave,
     val oppgaveId: OppgaveId,
     val fnr: Fnr,
-    val avkorting: AvkortingVedSøknadsbehandling.Uhåndtert.KanIkkeHåndtere,
     val sakstype: Sakstype,
     val saksbehandler: NavIdentBruker.Saksbehandler,
 ) {
@@ -65,7 +63,6 @@ data class NySøknadsbehandling(
             eksterneGrunnlag = StøtterHentingAvEksternGrunnlag.ikkeHentet(),
             attesteringer = Attesteringshistorikk.empty(),
             søknadsbehandlingsHistorikk = søknadsbehandlingsHistorikk,
-            avkorting = avkorting,
             sakstype = sakstype,
             saksbehandler = saksbehandler,
         )

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/opprett/OpprettNySøknadsbehandling.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/opprett/OpprettNySøknadsbehandling.kt
@@ -54,7 +54,6 @@ fun Sak.opprettNySøknadsbehandling(
         søknad = søknad,
         oppgaveId = søknad.oppgaveId,
         fnr = søknad.fnr,
-        avkorting = this.hentUteståendeAvkortingForSøknadsbehandling().fold({ it }, { it }).kanIkke(),
         sakstype = søknad.type,
         saksbehandler = saksbehandler,
     ).let { nySøknadsbehandling ->

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/stønadsperiode/OppdaterStønadsperiode.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/stønadsperiode/OppdaterStønadsperiode.kt
@@ -79,7 +79,6 @@ private fun Sak.internalOppdater(
         formuegrenserFactory = formuegrenserFactory,
         clock = clock,
         saksbehandler = saksbehandler,
-        avkorting = this.hentUteståendeAvkortingForSøknadsbehandling().fold({ it }, { it }).kanIkke(),
     ).getOrElse {
         return when (it) {
             is no.nav.su.se.bakover.domain.søknadsbehandling.KunneIkkeOppdatereStønadsperiode.KunneIkkeOppdatereGrunnlagsdata -> {

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/avkorting/AvkortingVedSøknadsbehandlingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/avkorting/AvkortingVedSøknadsbehandlingTest.kt
@@ -1,139 +1,28 @@
 package no.nav.su.se.bakover.domain.avkorting
 
 import io.kotest.matchers.shouldBe
-import no.nav.su.se.bakover.common.tid.Tidspunkt
-import no.nav.su.se.bakover.common.tid.periode.juni
-import no.nav.su.se.bakover.test.fixedClock
-import no.nav.su.se.bakover.test.simulering.simuleringFeilutbetaling
+import no.nav.su.se.bakover.test.avkorting.avkortingVedSøknadsbehandlingAvkortet
+import no.nav.su.se.bakover.test.avkorting.avkortingVedSøknadsbehandlingSkalAvkortes
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
 internal class AvkortingVedSøknadsbehandlingTest {
 
-    private val id = UUID.randomUUID()
-    private val avkortingsvarsel = Avkortingsvarsel.Utenlandsopphold.SkalAvkortes(
-        objekt = Avkortingsvarsel.Utenlandsopphold.Opprettet(
-            sakId = UUID.randomUUID(),
-            revurderingId = UUID.randomUUID(),
-            simulering = simuleringFeilutbetaling(juni(2021)),
-            opprettet = Tidspunkt.now(fixedClock),
-        ),
-    )
-
     @Test
-    fun `normalflyt uhåndtert ingen utestående`() {
-        val original = AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående
-        original.uhåndtert() shouldBe original
-        original.håndter() shouldBe AvkortingVedSøknadsbehandling.Håndtert.IngenUtestående
-        original.kanIkke() shouldBe AvkortingVedSøknadsbehandling.Uhåndtert.KanIkkeHåndtere(original)
-    }
-
-    @Test
-    fun `flyt kan ikke håndtere uhåndtert ingen utestående`() {
-        val original = AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående.kanIkke()
-        original.uhåndtert() shouldBe AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående
-        original.kanIkke() shouldBe original
-        original.håndter() shouldBe AvkortingVedSøknadsbehandling.Håndtert.KanIkkeHåndtere(
-            AvkortingVedSøknadsbehandling.Håndtert.IngenUtestående,
+    fun `overgang SkalAvkortes til Avkortet`() {
+        val søknadsbehandlingId = UUID.randomUUID()
+        val id = UUID.randomUUID()
+        val sakId = UUID.randomUUID()
+        val revurderingId = UUID.randomUUID()
+        avkortingVedSøknadsbehandlingSkalAvkortes(
+            id = id,
+            sakId = sakId,
+            revurderingId = revurderingId,
+        ).avkort(søknadsbehandlingId) shouldBe avkortingVedSøknadsbehandlingAvkortet(
+            id = id,
+            sakId = sakId,
+            søknadsbehandlingId = søknadsbehandlingId,
+            revurderingId = revurderingId,
         )
-    }
-
-    @Test
-    fun `normalflyt håndtert ingen utestående`() {
-        val original = AvkortingVedSøknadsbehandling.Håndtert.IngenUtestående
-        original.uhåndtert() shouldBe AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående
-        original.iverksett(UUID.randomUUID()) shouldBe AvkortingVedSøknadsbehandling.Iverksatt.IngenUtestående
-        original.kanIkke() shouldBe AvkortingVedSøknadsbehandling.Håndtert.KanIkkeHåndtere(original)
-    }
-
-    @Test
-    fun `flyt kan ikke håndtere håndtert ingen utestående`() {
-        val original = AvkortingVedSøknadsbehandling.Håndtert.IngenUtestående.kanIkke()
-        original.uhåndtert() shouldBe AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående
-        original.kanIkke() shouldBe original
-        original.iverksett(UUID.randomUUID()) shouldBe AvkortingVedSøknadsbehandling.Iverksatt.KanIkkeHåndtere(
-            AvkortingVedSøknadsbehandling.Håndtert.IngenUtestående,
-        )
-    }
-
-    @Test
-    fun `normalflyt uhåndtert utesteående`() {
-        val original = AvkortingVedSøknadsbehandling.Uhåndtert.UteståendeAvkorting(
-            avkortingsvarsel,
-        )
-        original.uhåndtert() shouldBe original
-        original.håndter() shouldBe AvkortingVedSøknadsbehandling.Håndtert.AvkortUtestående(
-            avkortingsvarsel,
-        )
-        original.kanIkke() shouldBe AvkortingVedSøknadsbehandling.Uhåndtert.KanIkkeHåndtere(
-            original,
-        )
-    }
-
-    @Test
-    fun `flyt kan ikke håndtere uhåndtert utestående`() {
-        val original = AvkortingVedSøknadsbehandling.Uhåndtert.UteståendeAvkorting(
-            avkortingsvarsel,
-        ).kanIkke()
-        original.uhåndtert() shouldBe AvkortingVedSøknadsbehandling.Uhåndtert.UteståendeAvkorting(
-            avkortingsvarsel,
-        )
-        original.håndter() shouldBe AvkortingVedSøknadsbehandling.Håndtert.KanIkkeHåndtere(
-            AvkortingVedSøknadsbehandling.Håndtert.AvkortUtestående(
-                avkortingsvarsel,
-            ),
-        )
-        original.kanIkke() shouldBe original
-    }
-
-    @Test
-    fun `normalflyt håndtert utesteående`() {
-        val original = AvkortingVedSøknadsbehandling.Håndtert.AvkortUtestående(
-            avkortingsvarsel,
-        )
-        original.uhåndtert() shouldBe AvkortingVedSøknadsbehandling.Uhåndtert.UteståendeAvkorting(
-            avkortingsvarsel,
-        )
-        original.iverksett(id) shouldBe AvkortingVedSøknadsbehandling.Iverksatt.AvkortUtestående(
-            avkortingsvarsel.avkortet(id),
-        )
-        original.kanIkke() shouldBe AvkortingVedSøknadsbehandling.Håndtert.KanIkkeHåndtere(
-            original,
-        )
-    }
-
-    @Test
-    fun `flyt kan ikke håndtere håndtert utestående`() {
-        val original = AvkortingVedSøknadsbehandling.Håndtert.AvkortUtestående(
-            avkortingsvarsel,
-        ).kanIkke()
-        original.uhåndtert() shouldBe AvkortingVedSøknadsbehandling.Uhåndtert.UteståendeAvkorting(
-            avkortingsvarsel,
-        )
-        original.iverksett(UUID.randomUUID()) shouldBe AvkortingVedSøknadsbehandling.Iverksatt.KanIkkeHåndtere(
-            AvkortingVedSøknadsbehandling.Håndtert.AvkortUtestående(
-                avkortingsvarsel,
-            ),
-        )
-        original.kanIkke() shouldBe original
-    }
-
-    @Test
-    fun `potpurri`() {
-        val start = AvkortingVedSøknadsbehandling.Uhåndtert.UteståendeAvkorting(
-            avkortingsvarsel,
-        )
-
-        start.kanIkke().håndter().uhåndtert() shouldBe start
-        start.håndter().kanIkke().uhåndtert() shouldBe start
-        start.kanIkke().håndter().iverksett(id) shouldBe AvkortingVedSøknadsbehandling.Iverksatt.KanIkkeHåndtere(
-            AvkortingVedSøknadsbehandling.Håndtert.AvkortUtestående(
-                avkortingsvarsel,
-            ),
-        )
-        start.håndter().iverksett(id) shouldBe AvkortingVedSøknadsbehandling.Iverksatt.AvkortUtestående(
-            avkortingsvarsel.avkortet(id),
-        )
-        start.kanIkke().håndter().uhåndtert().uhåndtert() shouldBe start
     }
 }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/beregning/EnsligBeregningTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/beregning/EnsligBeregningTest.kt
@@ -109,12 +109,13 @@ internal class EnsligBeregningTest {
                     tilhører = FradragTilhører.BRUKER,
                 ),
             ),
-        ).also { (_, søknadsbehandling) ->
+        ).also { (sak, søknadsbehandling) ->
             søknadsbehandling.beregn(
                 begrunnelse = "blabla",
                 clock = fixedClock,
                 satsFactory = satsFactoryTestPåDato(LocalDate.now(1.juni(2021).fixedClock())),
                 nySaksbehandler = saksbehandler,
+                uteståendeAvkortingPåSak = sak.uteståendeAvkortingSkalAvkortes,
             ).getOrFail().also {
                 it.beregning.getSumYtelse() shouldBe 138992
                 it.beregning.getSumFradrag() shouldBe 60000

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/beregning/EnsligBorMedVoksneBeregningTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/beregning/EnsligBorMedVoksneBeregningTest.kt
@@ -131,12 +131,13 @@ internal class EnsligBorMedVoksneBeregningTest {
                     periode = stønadsperiode2021.periode,
                 ),
             ),
-        ).also { (_, vilkårsvurdert) ->
+        ).also { (sak, vilkårsvurdert) ->
             vilkårsvurdert.beregn(
                 begrunnelse = null,
                 clock = fixedClock,
                 satsFactory = satsFactoryTestPåDato(LocalDate.now(1.juni(2021).fixedClock())),
                 nySaksbehandler = saksbehandler,
+                uteståendeAvkortingPåSak = sak.uteståendeAvkortingSkalAvkortes,
             ).getOrFail().also {
                 it.beregning.getSumYtelse() shouldBe 124072
                 it.beregning.getSumFradrag() shouldBe 60000

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/beregning/EpsOver67BeregningTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/beregning/EpsOver67BeregningTest.kt
@@ -145,12 +145,13 @@ internal class EpsOver67BeregningTest {
                     tilhører = FradragTilhører.EPS,
                 ),
             ),
-        ).also { (_, vilkårsvurdert) ->
+        ).also { (sak, vilkårsvurdert) ->
             vilkårsvurdert.beregn(
                 begrunnelse = null,
                 clock = fixedClock,
                 satsFactory = satsFactoryTestPåDato(LocalDate.now(1.juni(2021).fixedClock())),
                 nySaksbehandler = saksbehandler,
+                uteståendeAvkortingPåSak = sak.uteståendeAvkortingSkalAvkortes,
             ).getOrFail().also { beregnet ->
                 beregnet.beregning.getSumYtelse() shouldBe 116144
                 beregnet.beregning.getSumFradrag() shouldBe 67927.95999999999

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/beregning/EpsUnder67BeregningTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/beregning/EpsUnder67BeregningTest.kt
@@ -129,12 +129,13 @@ internal class EpsUnder67BeregningTest {
                     tilhører = FradragTilhører.EPS,
                 ),
             ),
-        ).also { (_, vilkårsvurdert) ->
+        ).also { (sak, vilkårsvurdert) ->
             vilkårsvurdert.beregn(
                 begrunnelse = null,
                 clock = fixedClock,
                 satsFactory = satsFactoryTestPåDato(LocalDate.now(1.juni(2021).fixedClock())),
                 nySaksbehandler = saksbehandler,
+                uteståendeAvkortingPåSak = sak.uteståendeAvkortingSkalAvkortes,
             ).getOrFail().also { beregnet ->
                 beregnet.beregning.getSumYtelse() shouldBe 90984
                 beregnet.beregning.getSumFradrag() shouldBe 108003.96

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/beregning/EpsUnder67OgUførFlyktningBeregningTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/beregning/EpsUnder67OgUførFlyktningBeregningTest.kt
@@ -153,12 +153,13 @@ internal class EpsUnder67OgUførFlyktningBeregningTest {
                     tilhører = FradragTilhører.EPS,
                 ),
             ),
-        ).also { (_, vilkårsvurdert) ->
+        ).also { (sak, vilkårsvurdert) ->
             vilkårsvurdert.beregn(
                 begrunnelse = null,
                 clock = fixedClock,
                 satsFactory = satsFactoryTestPåDato(LocalDate.now(1.juni(2021).fixedClock())),
                 nySaksbehandler = saksbehandler,
+                uteståendeAvkortingPåSak = sak.uteståendeAvkortingSkalAvkortes,
             ).getOrFail().also { beregnet ->
                 beregnet.beregning.getSumYtelse() shouldBe 74828
                 beregnet.beregning.getSumFradrag() shouldBe 109250.72000000004

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/OpprettRevurderingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/OpprettRevurderingTest.kt
@@ -128,7 +128,7 @@ internal class OpprettRevurderingTest {
             clock = clock,
         ).let { it.first to it.third }
             .shouldBeType<Pair<Sak, VedtakInnvilgetSøknadsbehandling>>().also {
-                it.second.behandling.avkorting.shouldBeType<AvkortingVedSøknadsbehandling.Iverksatt.AvkortUtestående>()
+                it.second.behandling.avkorting.shouldBeType<AvkortingVedSøknadsbehandling.Avkortet>()
                     .also {
                         it.avkortingsvarsel.periode() shouldBe mai(2021)..september(2021)
                     }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/avkorting/UteståendeAvkortingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/avkorting/UteståendeAvkortingTest.kt
@@ -6,38 +6,38 @@ import no.nav.su.se.bakover.common.tid.periode.desember
 import no.nav.su.se.bakover.common.tid.periode.februar
 import no.nav.su.se.bakover.common.tid.periode.januar
 import no.nav.su.se.bakover.common.tid.periode.mars
-import no.nav.su.se.bakover.test.uhåndtertUteståendeAvkorting
+import no.nav.su.se.bakover.test.avkortingVedRevurderingUhåndtertUtestående
 import org.junit.jupiter.api.Test
 
 class UteståendeAvkortingTest {
 
     @Test
     fun `Revurderingsperiode jan, utestående periode jan-feb forventer left`() {
-        val avkorting = uhåndtertUteståendeAvkorting(januar(2021), februar(2021))
+        val avkorting = avkortingVedRevurderingUhåndtertUtestående(januar(2021), februar(2021))
         kontrollerAtUteståendeAvkortingRevurderes(januar(2021), avkorting).shouldBeLeft()
     }
 
     @Test
     fun `Revurderingsperiode feb, utestående periode jan-feb forventer left`() {
-        val avkorting = uhåndtertUteståendeAvkorting(januar(2021), februar(2021))
+        val avkorting = avkortingVedRevurderingUhåndtertUtestående(januar(2021), februar(2021))
         kontrollerAtUteståendeAvkortingRevurderes(februar(2021), avkorting).shouldBeLeft()
     }
 
     @Test
     fun `Revurderingsperiode jan-feb, utestående periode jan-feb forventer right`() {
-        val avkorting = uhåndtertUteståendeAvkorting(januar(2021), februar(2021))
+        val avkorting = avkortingVedRevurderingUhåndtertUtestående(januar(2021), februar(2021))
         kontrollerAtUteståendeAvkortingRevurderes(januar(2021)..mars(2021), avkorting).shouldBeRight()
     }
 
     @Test
     fun `Revurderingsperiode des-mars, utestående periode jan-feb forventer right`() {
-        val avkorting = uhåndtertUteståendeAvkorting(januar(2021), februar(2021))
+        val avkorting = avkortingVedRevurderingUhåndtertUtestående(januar(2021), februar(2021))
         kontrollerAtUteståendeAvkortingRevurderes(desember(2020)..mars(2021), avkorting).shouldBeRight()
     }
 
     @Test
     fun `Revurderingsperiode mars, utestående periode jan-feb forventer right`() {
-        val avkorting = uhåndtertUteståendeAvkorting(januar(2021), februar(2021))
+        val avkorting = avkortingVedRevurderingUhåndtertUtestående(januar(2021), februar(2021))
         kontrollerAtUteståendeAvkortingRevurderes(mars(2021), avkorting).shouldBeRight()
     }
 }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/StatusovergangTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/StatusovergangTest.kt
@@ -89,6 +89,7 @@ internal class StatusovergangTest {
             clock = fixedClock,
             satsFactory = satsFactoryTestPåDato(),
             nySaksbehandler = saksbehandler,
+            uteståendeAvkortingPåSak = null,
         ).getOrFail() as BeregnetSøknadsbehandling.Innvilget
 
     private val beregnetAvslag: BeregnetSøknadsbehandling.Avslag =
@@ -101,6 +102,7 @@ internal class StatusovergangTest {
             clock = fixedClock,
             satsFactory = satsFactoryTestPåDato(),
             nySaksbehandler = saksbehandler,
+            uteståendeAvkortingPåSak = null,
         ).getOrFail() as BeregnetSøknadsbehandling.Avslag
 
     private val simulert: SimulertSøknadsbehandling =
@@ -600,6 +602,7 @@ internal class StatusovergangTest {
                 clock = fixedClock,
                 satsFactory = satsFactoryTestPåDato(),
                 nySaksbehandler = saksbehandler,
+                uteståendeAvkortingPåSak = null,
             ).getOrFail() shouldBe beregnetInnvilget
         }
 
@@ -610,6 +613,7 @@ internal class StatusovergangTest {
                 clock = fixedClock,
                 satsFactory = satsFactoryTestPåDato(),
                 nySaksbehandler = saksbehandler,
+                uteståendeAvkortingPåSak = null,
             ).getOrFail() shouldBe beregnetInnvilget.copy(
                 søknadsbehandlingsHistorikk = beregnetInnvilget.søknadsbehandlingsHistorikk.leggTilNyeHendelser(
                     nonEmptyListOf(
@@ -626,6 +630,7 @@ internal class StatusovergangTest {
                 clock = fixedClock,
                 satsFactory = satsFactoryTestPåDato(),
                 nySaksbehandler = saksbehandler,
+                uteståendeAvkortingPåSak = null,
             ).getOrFail() shouldBe beregnetAvslag.copy(
                 søknadsbehandlingsHistorikk = beregnetAvslag.søknadsbehandlingsHistorikk.leggTilNyeHendelser(
                     nonEmptyListOf(
@@ -642,6 +647,7 @@ internal class StatusovergangTest {
                 clock = fixedClock,
                 satsFactory = satsFactoryTestPåDato(),
                 nySaksbehandler = saksbehandler,
+                uteståendeAvkortingPåSak = null,
             ).getOrFail() shouldBe beregnetInnvilget.copy(
                 søknadsbehandlingsHistorikk = simulert.søknadsbehandlingsHistorikk.leggTilNyeHendelser(
                     nonEmptyListOf(
@@ -658,6 +664,7 @@ internal class StatusovergangTest {
                 clock = fixedClock,
                 satsFactory = satsFactoryTestPåDato(),
                 nySaksbehandler = saksbehandler,
+                uteståendeAvkortingPåSak = null,
             ).getOrFail() shouldBe beregnetAvslag
                 .medFritekstTilBrev(underkjentAvslagBeregning.fritekstTilBrev)
                 .copy(
@@ -677,6 +684,7 @@ internal class StatusovergangTest {
                 clock = fixedClock,
                 satsFactory = satsFactoryTestPåDato(),
                 nySaksbehandler = saksbehandler,
+                uteståendeAvkortingPåSak = null,
             ).getOrFail() shouldBe beregnetInnvilget
                 .medFritekstTilBrev(underkjentInnvilget.fritekstTilBrev)
                 .copy(
@@ -710,6 +718,7 @@ internal class StatusovergangTest {
                     clock = fixedClock,
                     satsFactory = satsFactoryTestPåDato(),
                     nySaksbehandler = saksbehandler,
+                    uteståendeAvkortingPåSak = null,
                 ) shouldBe KunneIkkeBeregne.UgyldigTilstand(it::class).left()
             }
         }
@@ -1007,7 +1016,6 @@ internal class StatusovergangTest {
                     formuegrenserFactory = formuegrenserFactoryTestPåDato(),
                     clock = fixedClock,
                     saksbehandler = saksbehandler,
-                    avkorting = it.avkorting,
                 ).isRight() shouldBe true
             }
         }
@@ -1028,7 +1036,6 @@ internal class StatusovergangTest {
                     formuegrenserFactory = formuegrenserFactoryTestPåDato(),
                     clock = fixedClock,
                     saksbehandler = saksbehandler,
-                    avkorting = it.avkorting,
                 ).isLeft() shouldBe true
             }
         }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/SøknadsbehandlingSkattTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/SøknadsbehandlingSkattTest.kt
@@ -71,7 +71,7 @@ internal class SøknadsbehandlingSkattTest {
             søknadsbehandlingVilkårsvurdertInnvilget().second
                 .leggTilSkatt(EksterneGrunnlagSkatt.Hentet(nySkattegrunnlag(), null))
                 .getOrFail()
-                .beregn(saksbehandler, "", fixedClock, satsFactoryTestPåDato())
+                .beregn(saksbehandler, "", fixedClock, satsFactoryTestPåDato(), null)
                 .getOrFail()
                 .leggTilSkatt(EksterneGrunnlagSkatt.Hentet(nySkattegrunnlag(), null))
                 .shouldBeRight()
@@ -88,7 +88,7 @@ internal class SøknadsbehandlingSkattTest {
             søknadsbehandlingVilkårsvurdertInnvilget().second
                 .leggTilSkatt(EksterneGrunnlagSkatt.Hentet(nySkattegrunnlag(), null))
                 .getOrFail()
-                .beregn(saksbehandler, "", fixedClock, satsFactoryTestPåDato())
+                .beregn(saksbehandler, "", fixedClock, satsFactoryTestPåDato(), null)
                 .getOrFail()
                 .simuler(
                     saksbehandler,
@@ -110,7 +110,7 @@ internal class SøknadsbehandlingSkattTest {
             søknadsbehandlingVilkårsvurdertInnvilget().second
                 .leggTilSkatt(EksterneGrunnlagSkatt.Hentet(nySkattegrunnlag(), null))
                 .getOrFail()
-                .beregn(saksbehandler, "", fixedClock, satsFactoryTestPåDato())
+                .beregn(saksbehandler, "", fixedClock, satsFactoryTestPåDato(), null)
                 .getOrFail()
                 .simuler(saksbehandler, fixedClock) { _, _ -> simuleringNy().right() }
                 .getOrFail()

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/AvslåSøknadManglendeDokumentasjonServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/AvslåSøknadManglendeDokumentasjonServiceImplTest.kt
@@ -10,7 +10,6 @@ import no.nav.su.se.bakover.common.ident.NavIdentBruker
 import no.nav.su.se.bakover.common.tid.Tidspunkt
 import no.nav.su.se.bakover.common.tid.periode.Periode
 import no.nav.su.se.bakover.domain.Sak
-import no.nav.su.se.bakover.domain.avkorting.AvkortingVedSøknadsbehandling
 import no.nav.su.se.bakover.domain.behandling.Attestering
 import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.behandling.avslag.Avslagsgrunn
@@ -149,9 +148,6 @@ internal class AvslåSøknadManglendeDokumentasjonServiceImplTest {
                     ).getOrFail(),
                 ),
                 eksterneGrunnlag = uavklart.eksterneGrunnlag,
-                avkorting = AvkortingVedSøknadsbehandling.Iverksatt.KanIkkeHåndtere(
-                    håndtert = AvkortingVedSøknadsbehandling.Håndtert.IngenUtestående,
-                ),
                 sakstype = sak.type,
                 søknadsbehandlingsHistorikk = Søknadsbehandlingshistorikk.createFromExisting(
                     listOf(
@@ -295,9 +291,6 @@ internal class AvslåSøknadManglendeDokumentasjonServiceImplTest {
                     ).getOrFail(),
                 ),
                 eksterneGrunnlag = vilkårsvurdertInnvilget.eksterneGrunnlag,
-                avkorting = AvkortingVedSøknadsbehandling.Iverksatt.KanIkkeHåndtere(
-                    håndtert = AvkortingVedSøknadsbehandling.Håndtert.IngenUtestående,
-                ),
                 sakstype = sak.type,
                 søknadsbehandlingsHistorikk = vilkårsvurdertInnvilget.søknadsbehandlingsHistorikk.leggTilNyeHendelser(
                     nonEmptyListOf(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceIverksettTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceIverksettTest.kt
@@ -16,7 +16,6 @@ import no.nav.su.se.bakover.common.persistence.SessionFactory
 import no.nav.su.se.bakover.common.person.Fnr
 import no.nav.su.se.bakover.common.tid.periode.Periode
 import no.nav.su.se.bakover.domain.Sak
-import no.nav.su.se.bakover.domain.avkorting.AvkortingVedSøknadsbehandling
 import no.nav.su.se.bakover.domain.behandling.Attestering
 import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.brev.BrevService
@@ -257,9 +256,6 @@ internal class SøknadsbehandlingServiceIverksettTest {
                 grunnlagsdata = avslagTilAttestering.grunnlagsdata,
                 vilkårsvurderinger = avslagTilAttestering.vilkårsvurderinger,
                 eksterneGrunnlag = avslagTilAttestering.eksterneGrunnlag,
-                avkorting = AvkortingVedSøknadsbehandling.Iverksatt.KanIkkeHåndtere(
-                    håndtert = AvkortingVedSøknadsbehandling.Håndtert.IngenUtestående,
-                ),
                 sakstype = avslagTilAttestering.sakstype,
                 søknadsbehandlingsHistorikk = nySøknadsbehandlingshistorikkSendtTilAttesteringAvslåttBeregning(
                     saksbehandler = avslagTilAttestering.saksbehandler,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceLeggTilFradragsgrunnlagTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceLeggTilFradragsgrunnlagTest.kt
@@ -78,7 +78,6 @@ class SøknadsbehandlingServiceLeggTilFradragsgrunnlagTest {
             vilkårsvurderinger = behandling.vilkårsvurderinger,
             eksterneGrunnlag = behandling.eksterneGrunnlag,
             attesteringer = behandling.attesteringer,
-            avkorting = behandling.avkorting,
             sakstype = behandling.sakstype,
             saksbehandler = behandling.saksbehandler,
             søknadsbehandlingsHistorikk = behandling.søknadsbehandlingsHistorikk.leggTilNyHendelse(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceOpprettetTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceOpprettetTest.kt
@@ -7,7 +7,6 @@ import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import no.nav.su.se.bakover.domain.Sak
-import no.nav.su.se.bakover.domain.avkorting.AvkortingVedSøknadsbehandling
 import no.nav.su.se.bakover.domain.behandling.Attesteringshistorikk
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.grunnlag.StøtterHentingAvEksternGrunnlag
@@ -202,7 +201,6 @@ internal class SøknadsbehandlingServiceOpprettetTest {
                 vilkårsvurderinger = vilkårsvurderingSøknadsbehandlingIkkeVurdert(),
                 eksterneGrunnlag = StøtterHentingAvEksternGrunnlag.ikkeHentet(),
                 attesteringer = Attesteringshistorikk.empty(),
-                avkorting = AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående.kanIkke(),
                 sakstype = sak.type,
                 saksbehandler = saksbehandler,
                 søknadsbehandlingsHistorikk = Søknadsbehandlingshistorikk.nyHistorikk(
@@ -226,7 +224,6 @@ internal class SøknadsbehandlingServiceOpprettetTest {
                     søknad = søknad,
                     oppgaveId = søknad.oppgaveId,
                     fnr = søknad.fnr,
-                    avkorting = AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående.kanIkke(),
                     sakstype = sak.type,
                     saksbehandler = saksbehandler,
                 )
@@ -249,7 +246,6 @@ internal class SøknadsbehandlingServiceOpprettetTest {
                         vilkårsvurderinger = vilkårsvurderingSøknadsbehandlingIkkeVurdert(),
                         eksterneGrunnlag = StøtterHentingAvEksternGrunnlag.ikkeHentet(),
                         attesteringer = Attesteringshistorikk.empty(),
-                        avkorting = AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående.kanIkke(),
                         sakstype = sak.type,
                         saksbehandler = saksbehandler,
                         søknadsbehandlingsHistorikk = Søknadsbehandlingshistorikk.nyHistorikk(

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceUnderkjennTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceUnderkjennTest.kt
@@ -330,7 +330,7 @@ class SøknadsbehandlingServiceUnderkjennTest {
             grunnlagsdata = innvilgetBehandlingTilAttestering.grunnlagsdata,
             vilkårsvurderinger = innvilgetBehandlingTilAttestering.vilkårsvurderinger,
             eksterneGrunnlag = innvilgetBehandlingTilAttestering.eksterneGrunnlag,
-            avkorting = AvkortingVedSøknadsbehandling.Håndtert.IngenUtestående,
+            avkorting = AvkortingVedSøknadsbehandling.IngenAvkorting,
             sakstype = innvilgetBehandlingTilAttestering.sakstype,
             søknadsbehandlingsHistorikk = innvilgetBehandlingTilAttestering.søknadsbehandlingsHistorikk,
         )
@@ -424,7 +424,7 @@ class SøknadsbehandlingServiceUnderkjennTest {
             grunnlagsdata = innvilgetBehandlingTilAttestering.grunnlagsdata,
             vilkårsvurderinger = innvilgetBehandlingTilAttestering.vilkårsvurderinger,
             eksterneGrunnlag = innvilgetBehandlingTilAttestering.eksterneGrunnlag,
-            avkorting = AvkortingVedSøknadsbehandling.Håndtert.IngenUtestående,
+            avkorting = AvkortingVedSøknadsbehandling.IngenAvkorting,
             sakstype = innvilgetBehandlingTilAttestering.sakstype,
             søknadsbehandlingsHistorikk = innvilgetBehandlingTilAttestering.søknadsbehandlingsHistorikk,
         )

--- a/test-common/src/main/kotlin/AvkortingTestData.kt
+++ b/test-common/src/main/kotlin/AvkortingTestData.kt
@@ -2,10 +2,7 @@ package no.nav.su.se.bakover.test
 
 import no.nav.su.se.bakover.common.tid.Tidspunkt
 import no.nav.su.se.bakover.common.tid.periode.Periode
-import no.nav.su.se.bakover.common.tid.periode.desember
 import no.nav.su.se.bakover.common.tid.periode.juni
-import no.nav.su.se.bakover.common.tid.periode.november
-import no.nav.su.se.bakover.common.tid.periode.oktober
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.avkorting.AvkortingVedRevurdering
 import no.nav.su.se.bakover.domain.avkorting.Avkortingsvarsel
@@ -22,7 +19,7 @@ import java.time.Clock
 import java.time.LocalDate
 import java.util.UUID
 
-fun uhåndtertUteståendeAvkorting(
+fun avkortingVedRevurderingUhåndtertUtestående(
     vararg perioder: Periode = listOf(juni(2021)).toTypedArray(),
     id: UUID = UUID.randomUUID(),
     opprettet: Tidspunkt = fixedTidspunkt,
@@ -33,27 +30,65 @@ fun uhåndtertUteståendeAvkorting(
     ),
 ): AvkortingVedRevurdering.Uhåndtert.UteståendeAvkorting {
     return AvkortingVedRevurdering.Uhåndtert.UteståendeAvkorting(
-        Avkortingsvarsel.Utenlandsopphold.SkalAvkortes(
-            Avkortingsvarsel.Utenlandsopphold.Opprettet(
-                id = id,
-                sakId = sakId,
-                revurderingId = revurderingId,
-                opprettet = opprettet,
-                simulering = simulering,
-            ),
+        avkortingsvarselSkalAvkortes(
+            perioder = perioder,
+            id = id,
+            sakId = sakId,
+            revurderingId = revurderingId,
+            opprettet = opprettet,
+            simulering = simulering,
         ),
     )
 }
 
-fun avkortingsvarselUtenlandsopphold(
+fun avkortingsvarselSkalAvkortes(
+    vararg perioder: Periode = listOf(juni(2021)).toTypedArray(),
     id: UUID = UUID.randomUUID(),
     opprettet: Tidspunkt = fixedTidspunkt,
     sakId: UUID = UUID.randomUUID(),
     revurderingId: UUID = UUID.randomUUID(),
     simulering: Simulering = simuleringFeilutbetaling(
-        oktober(2020),
-        november(2020),
-        desember(2020),
+        perioder = perioder,
+    ),
+) = Avkortingsvarsel.Utenlandsopphold.SkalAvkortes(
+    avkortingsvarselUtenlandsoppholdOpprettet(
+        id = id,
+        sakId = sakId,
+        revurderingId = revurderingId,
+        opprettet = opprettet,
+        simulering = simulering,
+    ),
+)
+
+fun avkortingsvarselAvkortet(
+    vararg perioder: Periode = listOf(juni(2021)).toTypedArray(),
+    id: UUID = UUID.randomUUID(),
+    opprettet: Tidspunkt = fixedTidspunkt,
+    sakId: UUID = UUID.randomUUID(),
+    revurderingId: UUID = UUID.randomUUID(),
+    simulering: Simulering = simuleringFeilutbetaling(
+        perioder = perioder,
+    ),
+    søknadsbehandlingId: UUID = UUID.randomUUID(),
+) = Avkortingsvarsel.Utenlandsopphold.Avkortet(
+    avkortingsvarselSkalAvkortes(
+        id = id,
+        sakId = sakId,
+        revurderingId = revurderingId,
+        opprettet = opprettet,
+        simulering = simulering,
+    ),
+    behandlingId = søknadsbehandlingId,
+)
+
+fun avkortingsvarselUtenlandsoppholdOpprettet(
+    vararg perioder: Periode = listOf(juni(2021)).toTypedArray(),
+    id: UUID = UUID.randomUUID(),
+    opprettet: Tidspunkt = fixedTidspunkt,
+    sakId: UUID = UUID.randomUUID(),
+    revurderingId: UUID = UUID.randomUUID(),
+    simulering: Simulering = simuleringFeilutbetaling(
+        perioder = perioder,
     ),
 ) = Avkortingsvarsel.Utenlandsopphold.Opprettet(
     id = id,

--- a/test-common/src/main/kotlin/SøknadsbehandlingTestData.kt
+++ b/test-common/src/main/kotlin/SøknadsbehandlingTestData.kt
@@ -208,6 +208,7 @@ fun søknadsbehandlingBeregnetInnvilget(
             clock = clock,
             satsFactory = satsFactoryTestPåDato(),
             nySaksbehandler = saksbehandler,
+            uteståendeAvkortingPåSak = sak.uteståendeAvkortingSkalAvkortes,
         ).getOrFail() as BeregnetSøknadsbehandling.Innvilget
         Pair(
             sak.copy(
@@ -259,6 +260,7 @@ fun søknadsbehandlingBeregnetAvslag(
             clock = clock,
             satsFactory = satsFactoryTestPåDato(),
             nySaksbehandler = saksbehandler,
+            uteståendeAvkortingPåSak = sak.uteståendeAvkortingSkalAvkortes,
         ).getOrFail() as BeregnetSøknadsbehandling.Avslag
         Pair(
             sak.copy(
@@ -1168,6 +1170,7 @@ fun beregnetSøknadsbehandling(
             clock = clock,
             satsFactory = satsFactoryTestPåDato(vilkårsvurdert.opprettet.toLocalDate(zoneIdOslo)),
             nySaksbehandler = saksbehandler,
+            uteståendeAvkortingPåSak = sak.uteståendeAvkortingSkalAvkortes,
         ).getOrFail().let { beregnet ->
             sak.copy(søknadsbehandlinger = sak.søknadsbehandlinger.filterNot { it.id == vilkårsvurdert.id } + beregnet) to beregnet
         }

--- a/test-common/src/main/kotlin/avkorting/AvkortingVedSøknadsbehandlingTestData.kt
+++ b/test-common/src/main/kotlin/avkorting/AvkortingVedSøknadsbehandlingTestData.kt
@@ -1,0 +1,61 @@
+package no.nav.su.se.bakover.test.avkorting
+
+import no.nav.su.se.bakover.common.tid.Tidspunkt
+import no.nav.su.se.bakover.common.tid.periode.Periode
+import no.nav.su.se.bakover.common.tid.periode.juni
+import no.nav.su.se.bakover.domain.avkorting.AvkortingVedSøknadsbehandling
+import no.nav.su.se.bakover.domain.avkorting.AvkortingVedSøknadsbehandling.IkkeVurdert
+import no.nav.su.se.bakover.domain.avkorting.AvkortingVedSøknadsbehandling.IngenAvkorting
+import no.nav.su.se.bakover.domain.avkorting.AvkortingVedSøknadsbehandling.SkalAvkortes
+import no.nav.su.se.bakover.domain.oppdrag.simulering.Simulering
+import no.nav.su.se.bakover.test.avkortingsvarselAvkortet
+import no.nav.su.se.bakover.test.avkortingsvarselSkalAvkortes
+import no.nav.su.se.bakover.test.fixedTidspunkt
+import no.nav.su.se.bakover.test.simulering.simuleringFeilutbetaling
+import java.util.UUID
+
+fun avkortingVedSøknadsbehandlingIngenAvkorting() = IngenAvkorting
+
+fun avkortingVedSøknadsbehandlingIkkeVurdert() = IkkeVurdert
+
+fun avkortingVedSøknadsbehandlingSkalAvkortes(
+    vararg perioder: Periode = listOf(juni(2021)).toTypedArray(),
+    id: UUID = UUID.randomUUID(),
+    opprettet: Tidspunkt = fixedTidspunkt,
+    sakId: UUID = UUID.randomUUID(),
+    revurderingId: UUID = UUID.randomUUID(),
+    simulering: Simulering = simuleringFeilutbetaling(
+        perioder = perioder,
+    ),
+) = SkalAvkortes(
+    avkortingsvarsel = avkortingsvarselSkalAvkortes(
+        perioder = perioder,
+        id = id,
+        sakId = sakId,
+        revurderingId = revurderingId,
+        opprettet = opprettet,
+        simulering = simulering,
+    ),
+)
+
+fun avkortingVedSøknadsbehandlingAvkortet(
+    vararg perioder: Periode = listOf(juni(2021)).toTypedArray(),
+    id: UUID = UUID.randomUUID(),
+    opprettet: Tidspunkt = fixedTidspunkt,
+    sakId: UUID = UUID.randomUUID(),
+    revurderingId: UUID = UUID.randomUUID(),
+    simulering: Simulering = simuleringFeilutbetaling(
+        perioder = perioder,
+    ),
+    søknadsbehandlingId: UUID = UUID.randomUUID(),
+) = AvkortingVedSøknadsbehandling.Avkortet(
+    avkortingsvarsel = avkortingsvarselAvkortet(
+        perioder = perioder,
+        id = id,
+        sakId = sakId,
+        revurderingId = revurderingId,
+        opprettet = opprettet,
+        simulering = simulering,
+        søknadsbehandlingId = søknadsbehandlingId,
+    ),
+)

--- a/test-common/src/main/kotlin/persistence/TestDataHelper.kt
+++ b/test-common/src/main/kotlin/persistence/TestDataHelper.kt
@@ -22,7 +22,6 @@ import no.nav.su.se.bakover.common.tid.periode.Periode
 import no.nav.su.se.bakover.database.DatabaseBuilder
 import no.nav.su.se.bakover.database.DomainToQueryParameterMapper
 import no.nav.su.se.bakover.domain.Sak
-import no.nav.su.se.bakover.domain.avkorting.AvkortingVedSøknadsbehandling
 import no.nav.su.se.bakover.domain.behandling.Attestering
 import no.nav.su.se.bakover.domain.grunnlag.EksterneGrunnlag
 import no.nav.su.se.bakover.domain.grunnlag.EksterneGrunnlagSkatt
@@ -1232,7 +1231,6 @@ class TestDataHelper(
             søknad = søknad,
             oppgaveId = søknad.oppgaveId,
             fnr = sak.fnr,
-            avkorting = AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående.kanIkke(),
             sakstype = sak.type,
             saksbehandler = saksbehandler,
         ).let { nySøknadsbehandling ->

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/AvkortingVedSøknadsbehandlingJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknadsbehandling/AvkortingVedSøknadsbehandlingJson.kt
@@ -5,32 +5,9 @@ import no.nav.su.se.bakover.web.routes.toJson
 
 internal fun AvkortingVedSøknadsbehandling.toJson(): SimuleringJson? {
     return when (this) {
-        is AvkortingVedSøknadsbehandling.Håndtert.AvkortUtestående -> {
-            avkortingsvarsel.toJson()
-        }
-        is AvkortingVedSøknadsbehandling.Håndtert.IngenUtestående -> {
-            null
-        }
-        is AvkortingVedSøknadsbehandling.Iverksatt.AvkortUtestående -> {
-            avkortingsvarsel.toJson()
-        }
-        is AvkortingVedSøknadsbehandling.Iverksatt.IngenUtestående -> {
-            null
-        }
-        is AvkortingVedSøknadsbehandling.Uhåndtert.IngenUtestående -> {
-            null
-        }
-        is AvkortingVedSøknadsbehandling.Uhåndtert.UteståendeAvkorting -> {
-            avkortingsvarsel.toJson()
-        }
-        is AvkortingVedSøknadsbehandling.Håndtert.KanIkkeHåndtere -> {
-            null
-        }
-        is AvkortingVedSøknadsbehandling.Iverksatt.KanIkkeHåndtere -> {
-            null
-        }
-        is AvkortingVedSøknadsbehandling.Uhåndtert.KanIkkeHåndtere -> {
-            null
-        }
+        AvkortingVedSøknadsbehandling.IkkeVurdert -> null
+        AvkortingVedSøknadsbehandling.IngenAvkorting -> null
+        is AvkortingVedSøknadsbehandling.Avkortet -> this.avkortingsvarsel.toJson()
+        is AvkortingVedSøknadsbehandling.SkalAvkortes -> this.avkortingsvarsel.toJson()
     }
 }


### PR DESCRIPTION
Prøver og rette opp i en bug i produksjon dersom det har kommet et avkortingsvarsel etter en søknadsbehandling har blitt opprettet. Forenkler avkortingsflyten i søknadsbehandling samtidig. Nå holder det å beregne på nytt neste gang dette oppstår. Videre arbeid kan være å gi saksbehandler/attestant en advarsel hvis vi oppdager mismatch. Og en sjekk før vi sender til attestering.

Dette er gjort uten databaseendringer/migrering. Som også kan gjøres på et senere tidspunkt hvis de gamle typene er forvirrende i databaselaget/databasen.