### PR TITLE
Attestantnavn oversendelse

### DIFF
--- a/common/infrastructure/src/main/kotlin/no/nav/su/se/bakover/common/infrastructure/web/Feilresponser.kt
+++ b/common/infrastructure/src/main/kotlin/no/nav/su/se/bakover/common/infrastructure/web/Feilresponser.kt
@@ -210,6 +210,10 @@ object Feilresponser {
         "Feil ved henting av saksbehandler navn",
         "feil_ved_henting_av_saksbehandler_navn",
     )
+    val feilVedHentingAvAttestantNavn = InternalServerError.errorJson(
+        "Feil ved henting av attestant navn",
+        "feil_ved_henting_av_attestant_navn",
+    )
 
     val feilVedHentingAvVedtakDato = InternalServerError.errorJson(
         "Feil ved henting av vedtak dato",

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Attestering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/behandling/Attestering.kt
@@ -21,6 +21,8 @@ data class Attesteringshistorikk private constructor(
             return create(emptyList())
         }
 
+        fun create(attestering: Attestering): Attesteringshistorikk = create(listOf(attestering))
+
         /**
          * For å gjenopprette en persistert [Attesteringshistorikk]
          */

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/LagBrevRequest.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/LagBrevRequest.kt
@@ -432,6 +432,7 @@ interface LagBrevRequest {
             override val person: Person,
             override val dagensDato: LocalDate,
             val saksbehandlerNavn: String,
+            val attestantNavn: String?,
             val fritekst: String,
             val klageDato: LocalDate,
             val vedtaksbrevDato: LocalDate,
@@ -440,6 +441,7 @@ interface LagBrevRequest {
             override val pdfInnhold: PdfInnhold = PdfInnhold.Klage.Oppretthold(
                 personalia = lagPersonalia(),
                 saksbehandlerNavn = saksbehandlerNavn,
+                attestantNavn = attestantNavn,
                 fritekst = fritekst,
                 klageDato = klageDato.ddMMyyyy(),
                 vedtakDato = vedtaksbrevDato.ddMMyyyy(),

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/PdfInnhold.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/PdfInnhold.kt
@@ -210,6 +210,7 @@ abstract class PdfInnhold {
         data class Oppretthold(
             val personalia: Personalia,
             val saksbehandlerNavn: String,
+            val attestantNavn: String?,
             val fritekst: String,
             val klageDato: String,
             val vedtakDato: String,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/AvvistKlage.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/AvvistKlage.kt
@@ -102,7 +102,7 @@ data class AvvistKlage(
     }
 
     override fun lagBrevRequest(
-        hentNavnForNavIdent: (saksbehandler: NavIdentBruker.Saksbehandler) -> Either<KunneIkkeHenteNavnForNavIdent, String>,
+        hentNavnForNavIdent: (saksbehandler: NavIdentBruker) -> Either<KunneIkkeHenteNavnForNavIdent, String>,
         hentVedtaksbrevDato: (klageId: UUID) -> LocalDate?,
         hentPerson: (fnr: Fnr) -> Either<KunneIkkeHentePerson, Person>,
         clock: Clock,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/IverksattAvvistKlage.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/IverksattAvvistKlage.kt
@@ -36,7 +36,7 @@ data class IverksattAvvistKlage(
     }
 
     override fun lagBrevRequest(
-        hentNavnForNavIdent: (saksbehandler: NavIdentBruker.Saksbehandler) -> Either<KunneIkkeHenteNavnForNavIdent, String>,
+        hentNavnForNavIdent: (saksbehandler: NavIdentBruker) -> Either<KunneIkkeHenteNavnForNavIdent, String>,
         hentVedtaksbrevDato: (klageId: UUID) -> LocalDate?,
         hentPerson: (fnr: Fnr) -> Either<KunneIkkeHentePerson, Person>,
         clock: Clock,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/Klage.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/Klage.kt
@@ -69,7 +69,7 @@ sealed interface Klage : Klagefelter {
     }
 
     fun lagBrevRequest(
-        hentNavnForNavIdent: (saksbehandler: NavIdentBruker.Saksbehandler) -> Either<KunneIkkeHenteNavnForNavIdent, String>,
+        hentNavnForNavIdent: (saksbehandler: NavIdentBruker) -> Either<KunneIkkeHenteNavnForNavIdent, String>,
         hentVedtaksbrevDato: (klageId: UUID) -> LocalDate?,
         hentPerson: (fnr: Fnr) -> Either<KunneIkkeHentePerson, Person>,
         clock: Clock,
@@ -192,6 +192,7 @@ sealed interface KunneIkkeLageBrevRequestForKlage {
     data class UgyldigTilstand(val fra: KClass<out Klage>) : KunneIkkeLageBrevRequestForKlage
     data class FeilVedHentingAvPerson(val personFeil: KunneIkkeHentePerson) : KunneIkkeLageBrevRequestForKlage
     data class FeilVedHentingAvSaksbehandlernavn(val feil: KunneIkkeHenteNavnForNavIdent) : KunneIkkeLageBrevRequestForKlage
+    class FeilVedHentingAvAttestantnavn(val feil: KunneIkkeHenteNavnForNavIdent) : KunneIkkeLageBrevRequestForKlage
 }
 
 sealed interface KunneIkkeHenteFritekstTilBrev {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/Klage.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/Klage.kt
@@ -192,7 +192,7 @@ sealed interface KunneIkkeLageBrevRequestForKlage {
     data class UgyldigTilstand(val fra: KClass<out Klage>) : KunneIkkeLageBrevRequestForKlage
     data class FeilVedHentingAvPerson(val personFeil: KunneIkkeHentePerson) : KunneIkkeLageBrevRequestForKlage
     data class FeilVedHentingAvSaksbehandlernavn(val feil: KunneIkkeHenteNavnForNavIdent) : KunneIkkeLageBrevRequestForKlage
-    class FeilVedHentingAvAttestantnavn(val feil: KunneIkkeHenteNavnForNavIdent) : KunneIkkeLageBrevRequestForKlage
+    data class FeilVedHentingAvAttestantnavn(val feil: KunneIkkeHenteNavnForNavIdent) : KunneIkkeLageBrevRequestForKlage
 }
 
 sealed interface KunneIkkeHenteFritekstTilBrev {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/KlageTilAttestering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/KlageTilAttestering.kt
@@ -37,7 +37,7 @@ sealed interface KlageTilAttestering : Klage, KlageTilAttesteringFelter {
         }
 
         override fun lagBrevRequest(
-            hentNavnForNavIdent: (saksbehandler: NavIdentBruker.Saksbehandler) -> Either<KunneIkkeHenteNavnForNavIdent, String>,
+            hentNavnForNavIdent: (saksbehandler: NavIdentBruker) -> Either<KunneIkkeHenteNavnForNavIdent, String>,
             hentVedtaksbrevDato: (klageId: UUID) -> LocalDate?,
             hentPerson: (fnr: Fnr) -> Either<KunneIkkeHentePerson, Person>,
             clock: Clock,
@@ -103,7 +103,7 @@ sealed interface KlageTilAttestering : Klage, KlageTilAttesteringFelter {
         override fun getFritekstTilBrev() = vurderinger.fritekstTilOversendelsesbrev.right()
 
         override fun lagBrevRequest(
-            hentNavnForNavIdent: (saksbehandler: NavIdentBruker.Saksbehandler) -> Either<KunneIkkeHenteNavnForNavIdent, String>,
+            hentNavnForNavIdent: (saksbehandler: NavIdentBruker) -> Either<KunneIkkeHenteNavnForNavIdent, String>,
             hentVedtaksbrevDato: (klageId: UUID) -> LocalDate?,
             hentPerson: (fnr: Fnr) -> Either<KunneIkkeHentePerson, Person>,
             clock: Clock,
@@ -116,6 +116,8 @@ sealed interface KlageTilAttestering : Klage, KlageTilAttesteringFelter {
                 saksbehandlerNavn = hentNavnForNavIdent(this.saksbehandler).getOrElse {
                     return KunneIkkeLageBrevRequestForKlage.FeilVedHentingAvSaksbehandlernavn(it).left()
                 },
+                attestantNavn = this.attesteringer.prøvHentSisteAttestering()?.attestant?.let { hentNavnForNavIdent(it) }
+                    ?.getOrElse { return KunneIkkeLageBrevRequestForKlage.FeilVedHentingAvAttestantnavn(it).left() },
                 fritekst = this.vurderinger.fritekstTilOversendelsesbrev,
                 saksnummer = this.saksnummer,
                 klageDato = this.datoKlageMottatt,

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/klage/KlageServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/klage/KlageServiceImpl.kt
@@ -304,15 +304,12 @@ class KlageServiceImpl(
                 .left()
         }
 
-        val oversendtKlage = klage.oversend(
-            Attestering.Iverksatt(
-                attestant = attestant,
-                opprettet = Tidspunkt.now(clock),
-            ),
-        ).getOrElse { return it.left() }
+        val oversendtKlage =
+            klage.oversend(Attestering.Iverksatt(attestant = attestant, opprettet = Tidspunkt.now(clock)))
+                .getOrElse { return it.left() }
 
-        val dokument = klage.lagBrevRequest(
-            hentNavnForNavIdent = { identClient.hentNavnForNavIdent(klage.saksbehandler) },
+        val dokument = oversendtKlage.lagBrevRequest(
+            hentNavnForNavIdent = identClient::hentNavnForNavIdent,
             hentVedtaksbrevDato = { klageRepo.hentVedtaksbrevDatoSomDetKlagesPå(klage.id) },
             hentPerson = { personService.hentPerson(klage.fnr) },
             clock = clock,

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/OversendKlageTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/OversendKlageTest.kt
@@ -44,9 +44,11 @@ import no.nav.su.se.bakover.test.utfyltVilkårsvurdertKlageTilVurdering
 import no.nav.su.se.bakover.test.utfyltVurdertKlage
 import no.nav.su.se.bakover.test.vurdertKlageTilAttestering
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -139,7 +141,7 @@ internal class OversendKlageTest {
                 on { hentVedtaksbrevDatoSomDetKlagesPå(any()) } doReturn 1.januar(2021)
             },
             identClient = mock {
-                on { hentNavnForNavIdent(any()) } doReturn "Some name".right()
+                on { hentNavnForNavIdent(any()) }.thenReturn("Some name".right(), "attestant".right())
             },
             personServiceMock = mock {
                 on { hentPerson(any()) } doReturn person.right()
@@ -156,7 +158,11 @@ internal class OversendKlageTest {
 
         verify(mocks.klageRepoMock).hentVedtaksbrevDatoSomDetKlagesPå(argThat { it shouldBe klage.id })
         verify(mocks.klageRepoMock).hentKlage(argThat { it shouldBe klage.id })
-        verify(mocks.identClient).hentNavnForNavIdent(argThat { it shouldBe klage.saksbehandler })
+        val captor = argumentCaptor<NavIdentBruker>()
+        verify(mocks.identClient, times(2)).hentNavnForNavIdent(captor.capture())
+        captor.firstValue shouldBe klage.saksbehandler
+        captor.lastValue shouldBe attestant
+
         verify(mocks.personServiceMock).hentPerson(argThat { it shouldBe sak.fnr })
         verify(mocks.brevServiceMock).lagBrev(
             argThat {
@@ -164,6 +170,7 @@ internal class OversendKlageTest {
                     person = person,
                     dagensDato = fixedLocalDate,
                     saksbehandlerNavn = "Some name",
+                    attestantNavn = "attestant",
                     fritekst = klage.vurderinger.fritekstTilOversendelsesbrev,
                     klageDato = 15.januar(2021),
                     vedtaksbrevDato = 1.januar(2021),
@@ -184,7 +191,7 @@ internal class OversendKlageTest {
                 on { hentVedtaksbrevDatoSomDetKlagesPå(any()) } doReturn 1.januar(2021)
             },
             identClient = mock {
-                on { hentNavnForNavIdent(any()) } doReturn "Some name".right()
+                on { hentNavnForNavIdent(any()) }.thenReturn("Some name".right(), "attestant".right())
             },
             personServiceMock = mock {
                 on { hentPerson(any()) } doReturn person.right()
@@ -204,7 +211,10 @@ internal class OversendKlageTest {
 
         verify(mocks.klageRepoMock).hentVedtaksbrevDatoSomDetKlagesPå(argThat { it shouldBe klage.id })
         verify(mocks.klageRepoMock).hentKlage(argThat { it shouldBe klage.id })
-        verify(mocks.identClient).hentNavnForNavIdent(argThat { it shouldBe klage.saksbehandler })
+        val captor = argumentCaptor<NavIdentBruker>()
+        verify(mocks.identClient, times(2)).hentNavnForNavIdent(captor.capture())
+        captor.firstValue shouldBe klage.saksbehandler
+        captor.lastValue shouldBe attestant
         verify(mocks.personServiceMock).hentPerson(argThat { it shouldBe sak.fnr })
         verify(mocks.brevServiceMock).lagBrev(
             argThat {
@@ -212,6 +222,7 @@ internal class OversendKlageTest {
                     person = person,
                     dagensDato = fixedLocalDate,
                     saksbehandlerNavn = "Some name",
+                    attestantNavn = "attestant",
                     fritekst = klage.vurderinger.fritekstTilOversendelsesbrev,
                     klageDato = 15.januar(2021),
                     vedtaksbrevDato = 1.januar(2021),
@@ -224,7 +235,7 @@ internal class OversendKlageTest {
     }
 
     @Test
-    fun `Kunne ikke oversende til klageinstans`() {
+    fun `Kunne ikke oversende til klageinstans (client feil)`() {
         val (sak, klage) = vurdertKlageTilAttestering()
         val person = person(fnr = sak.fnr)
         val journalpostIdKnyttetTilVedtakDetKlagePå = JournalpostId("journalpostIdKnyttetTilVedtakDetKlagePå")
@@ -235,7 +246,7 @@ internal class OversendKlageTest {
                 on { hentVedtaksbrevDatoSomDetKlagesPå(any()) } doReturn 1.januar(2021)
             },
             identClient = mock {
-                on { hentNavnForNavIdent(any()) } doReturn "Some name".right()
+                on { hentNavnForNavIdent(any()) }.thenReturn("Some name".right(), "attestant".right())
             },
             personServiceMock = mock {
                 on { hentPerson(any()) } doReturn person.right()
@@ -258,7 +269,10 @@ internal class OversendKlageTest {
 
         verify(mocks.klageRepoMock).hentVedtaksbrevDatoSomDetKlagesPå(argThat { it shouldBe klage.id })
         verify(mocks.klageRepoMock).hentKlage(argThat { it shouldBe klage.id })
-        verify(mocks.identClient).hentNavnForNavIdent(argThat { it shouldBe klage.saksbehandler })
+        val captor = argumentCaptor<NavIdentBruker>()
+        verify(mocks.identClient, times(2)).hentNavnForNavIdent(captor.capture())
+        captor.firstValue shouldBe klage.saksbehandler
+        captor.lastValue shouldBe attestant
         verify(mocks.personServiceMock).hentPerson(argThat { it shouldBe sak.fnr })
         verify(mocks.brevServiceMock).lagBrev(
             argThat {
@@ -266,6 +280,7 @@ internal class OversendKlageTest {
                     person = person,
                     dagensDato = fixedLocalDate,
                     saksbehandlerNavn = "Some name",
+                    attestantNavn = "attestant",
                     fritekst = klage.vurderinger.fritekstTilOversendelsesbrev,
                     klageDato = 15.januar(2021),
                     vedtaksbrevDato = 1.januar(2021),
@@ -277,12 +292,7 @@ internal class OversendKlageTest {
         val expectedKlage = OversendtKlage(
             forrigeSteg = klage,
             attesteringer = Attesteringshistorikk.create(
-                listOf(
-                    Attestering.Iverksatt(
-                        attestant = attestant,
-                        opprettet = fixedTidspunkt,
-                    ),
-                ),
+                Attestering.Iverksatt(attestant = attestant, opprettet = fixedTidspunkt),
             ),
             klageinstanshendelser = Klageinstanshendelser.empty(),
         )
@@ -299,7 +309,7 @@ internal class OversendKlageTest {
                         opprettet = it.opprettet,
                         tittel = "Oversendelsesbrev til klager",
                         generertDokument = pdfAsBytes,
-                        generertDokumentJson = "{\"personalia\":{\"dato\":\"01.01.2021\",\"fødselsnummer\":\"${sak.fnr}\",\"fornavn\":\"Tore\",\"etternavn\":\"Strømøy\",\"saksnummer\":12345676},\"saksbehandlerNavn\":\"Some name\",\"fritekst\":\"fritekstTilBrev\",\"klageDato\":\"15.01.2021\",\"vedtakDato\":\"01.01.2021\",\"saksnummer\":12345676,\"erAldersbrev\":false}",
+                        generertDokumentJson = "{\"personalia\":{\"dato\":\"01.01.2021\",\"fødselsnummer\":\"${sak.fnr}\",\"fornavn\":\"Tore\",\"etternavn\":\"Strømøy\",\"saksnummer\":12345676},\"saksbehandlerNavn\":\"Some name\",\"attestantNavn\":\"attestant\",\"fritekst\":\"fritekstTilBrev\",\"klageDato\":\"15.01.2021\",\"vedtakDato\":\"01.01.2021\",\"saksnummer\":12345676,\"erAldersbrev\":false}",
                     ),
                     metadata = Dokument.Metadata(
                         sakId = sak.id,
@@ -466,7 +476,7 @@ internal class OversendKlageTest {
                 on { hentJournalpostId(any()) } doReturn journalpostIdForVedtak
             },
             identClient = mock {
-                on { hentNavnForNavIdent(any()) } doReturn "Some name".right()
+                on { hentNavnForNavIdent(any()) }.thenReturn("Some name".right(), "attestant".right())
             },
             personServiceMock = mock {
                 on { hentPerson(any()) } doReturn person.right()
@@ -482,7 +492,7 @@ internal class OversendKlageTest {
             },
             observer = observerMock,
         )
-        val attestant = NavIdentBruker.Attestant("s2")
+        val attestant = NavIdentBruker.Attestant("attestant")
 
         var expectedKlage: OversendtKlage?
         mocks.service.oversend(
@@ -492,12 +502,7 @@ internal class OversendKlageTest {
             expectedKlage = OversendtKlage(
                 forrigeSteg = klage,
                 attesteringer = Attesteringshistorikk.create(
-                    listOf(
-                        Attestering.Iverksatt(
-                            attestant = attestant,
-                            opprettet = fixedTidspunkt,
-                        ),
-                    ),
+                    Attestering.Iverksatt(attestant = attestant, opprettet = fixedTidspunkt),
                 ),
                 klageinstanshendelser = Klageinstanshendelser.empty(),
             )
@@ -507,7 +512,11 @@ internal class OversendKlageTest {
 
         verify(mocks.klageRepoMock).hentVedtaksbrevDatoSomDetKlagesPå(argThat { it shouldBe klage.id })
         verify(mocks.klageRepoMock).hentKlage(argThat { it shouldBe klage.id })
-        verify(mocks.identClient).hentNavnForNavIdent(argThat { it shouldBe klage.saksbehandler })
+        val captor = argumentCaptor<NavIdentBruker>()
+        verify(mocks.identClient, times(2)).hentNavnForNavIdent(captor.capture())
+        captor.firstValue shouldBe expectedKlage!!.saksbehandler
+        captor.lastValue shouldBe expectedKlage!!.attesteringer.hentSisteAttestering().attestant
+
         verify(mocks.personServiceMock).hentPerson(argThat { it shouldBe sak.fnr })
         verify(mocks.brevServiceMock).lagBrev(
             argThat {
@@ -515,6 +524,7 @@ internal class OversendKlageTest {
                     person = person,
                     dagensDato = fixedLocalDate,
                     saksbehandlerNavn = "Some name",
+                    attestantNavn = "attestant",
                     fritekst = klage.vurderinger.fritekstTilOversendelsesbrev,
                     klageDato = 15.januar(2021),
                     vedtaksbrevDato = 1.januar(2021),
@@ -535,7 +545,7 @@ internal class OversendKlageTest {
                         opprettet = it.opprettet,
                         tittel = "Oversendelsesbrev til klager",
                         generertDokument = pdfAsBytes,
-                        generertDokumentJson = "{\"personalia\":{\"dato\":\"01.01.2021\",\"fødselsnummer\":\"${sak.fnr}\",\"fornavn\":\"Tore\",\"etternavn\":\"Strømøy\",\"saksnummer\":12345676},\"saksbehandlerNavn\":\"Some name\",\"fritekst\":\"fritekstTilBrev\",\"klageDato\":\"15.01.2021\",\"vedtakDato\":\"01.01.2021\",\"saksnummer\":12345676,\"erAldersbrev\":false}",
+                        generertDokumentJson = "{\"personalia\":{\"dato\":\"01.01.2021\",\"fødselsnummer\":\"${sak.fnr}\",\"fornavn\":\"Tore\",\"etternavn\":\"Strømøy\",\"saksnummer\":12345676},\"saksbehandlerNavn\":\"Some name\",\"attestantNavn\":\"attestant\",\"fritekst\":\"fritekstTilBrev\",\"klageDato\":\"15.01.2021\",\"vedtakDato\":\"01.01.2021\",\"saksnummer\":12345676,\"erAldersbrev\":false}",
                     ),
                     metadata = Dokument.Metadata(
                         sakId = sak.id,
@@ -546,7 +556,6 @@ internal class OversendKlageTest {
                         journalpostId = null,
                         brevbestillingId = null,
                     ),
-
                 )
             },
             argThat { it shouldBe TestSessionFactory.transactionContext },

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/klage/KlageRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/klage/KlageRoutes.kt
@@ -24,6 +24,7 @@ import no.nav.su.se.bakover.common.infrastructure.web.Feilresponser.fantIkkePers
 import no.nav.su.se.bakover.common.infrastructure.web.Feilresponser.fantIkkeSak
 import no.nav.su.se.bakover.common.infrastructure.web.Feilresponser.fantIkkeSaksbehandlerEllerAttestant
 import no.nav.su.se.bakover.common.infrastructure.web.Feilresponser.fantIkkeVedtak
+import no.nav.su.se.bakover.common.infrastructure.web.Feilresponser.feilVedHentingAvAttestantNavn
 import no.nav.su.se.bakover.common.infrastructure.web.Feilresponser.feilVedHentingAvSaksbehandlerNavn
 import no.nav.su.se.bakover.common.infrastructure.web.Feilresponser.feilVedHentingAvVedtakDato
 import no.nav.su.se.bakover.common.infrastructure.web.Feilresponser.kunneIkkeOppretteOppgave
@@ -515,6 +516,8 @@ private fun KunneIkkeLageBrevRequestForKlage.toErrorJson(): Resultat {
             "Kan ikke gå fra tilstanden ${fra.simpleName}",
             "ugyldig_tilstand",
         )
+
+        is KunneIkkeLageBrevRequestForKlage.FeilVedHentingAvAttestantnavn -> feilVedHentingAvAttestantNavn
     }
 }
 


### PR DESCRIPTION
Send attestant-navnet til oversendelses brevet (fikset at saksbehandler også vises i PDF-gen)