### PR TITLE
fikser deserialisering av Skattegrunnlagsobjekt dersom den er null

### DIFF
--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/skatteetaten/SpesifisertSummertSkattegrunnlagResponseJson.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/skatteetaten/SpesifisertSummertSkattegrunnlagResponseJson.kt
@@ -18,7 +18,7 @@ import no.nav.su.se.bakover.client.skatteetaten.SpesifisertSummertSkattegrunnlag
 private val log = LoggerFactory.getLogger(SpesifisertSummertSkattegrunnlagResponseJson::class.java)
 
 internal data class SpesifisertSummertSkattegrunnlagResponseJson(
-    val grunnlag: List<SpesifisertSummertSkattegrunnlagsobjekt> = emptyList(),
+    val grunnlag: List<SpesifisertSummertSkattegrunnlagsobjekt>? = emptyList(),
     val skatteoppgjoersdato: String?,
     val svalbardGrunnlag: List<SpesifisertSummertSkattegrunnlagsobjekt>? = null,
 ) {
@@ -155,8 +155,9 @@ private fun SpesifisertSummertSkattegrunnlagResponseJson.toDomain(
         return it.left()
     }
 
-    val mappet: List<Skattegrunnlag.Grunnlag> = (this.grunnlag + (this.svalbardGrunnlag ?: emptyList()))
-        .map { it.toDomain(år, stadie) }
+    val mappet: List<Skattegrunnlag.Grunnlag> =
+        ((this.grunnlag ?: emptyList()) + (this.svalbardGrunnlag ?: emptyList()))
+            .map { it.toDomain(år, stadie) }
 
     return Skattegrunnlag.SkattegrunnlagForÅr(
         oppgjørsdato = oppgjørsdato,

--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/skatteetaten/SkatteClientTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/skatteetaten/SkatteClientTest.kt
@@ -29,7 +29,7 @@ import org.slf4j.MDC
 import java.time.LocalDate
 import java.time.Year
 
-internal class SamletSkattegrunnlagTest {
+internal class SkatteClientTest {
     private val azureAdMock = mock<AzureAd> {
         on { onBehalfOfToken(any(), any()) } doReturn "etOnBehalfOfToken"
     }
@@ -304,6 +304,50 @@ internal class SamletSkattegrunnlagTest {
             oppgjør = SamletSkattegrunnlagForÅrOgStadie.Oppgjør(
                 oppslag = nySkattegrunnlagForÅr(
                     oppgjørsdato = LocalDate.parse("2021-04-01"),
+                    verdsettingsrabattSomGirGjeldsreduksjon = emptyList(),
+                    oppjusteringAvEierinntekt = emptyList(),
+                    manglerKategori = emptyList(),
+                    annet = emptyList(),
+                ).right(),
+                inntektsår = år,
+            ),
+            år = år,
+        )
+    }
+
+    @Test
+    fun `kan deserialisere alle feltene i responsen er null`() {
+        wireMockServer.stubFor(
+            WireMock.get("/api/v1/spesifisertsummertskattegrunnlag")
+                .willReturn(
+                    WireMock.ok("""{"grunnlag":null,"svalbardGrunnlag":null,"skatteoppgjoersdato":null}""".trimIndent())
+                        .withHeader("Content-Type", "application/json"),
+                ),
+        )
+
+        val år = Year.of(2021)
+        client.hentSamletSkattegrunnlag(fnr, år) shouldBe SamletSkattegrunnlagForÅr(
+            utkast = SamletSkattegrunnlagForÅrOgStadie.Utkast(
+                oppslag = nySkattegrunnlagForÅr(
+                    oppgjørsdato = null,
+                    inntekt = emptyList(),
+                    formue = emptyList(),
+                    formuesFradrag = emptyList(),
+                    inntektsfradrag = emptyList(),
+                    verdsettingsrabattSomGirGjeldsreduksjon = emptyList(),
+                    oppjusteringAvEierinntekt = emptyList(),
+                    manglerKategori = emptyList(),
+                    annet = emptyList(),
+                ).right(),
+                inntektsår = år,
+            ),
+            oppgjør = SamletSkattegrunnlagForÅrOgStadie.Oppgjør(
+                oppslag = nySkattegrunnlagForÅr(
+                    oppgjørsdato = null,
+                    inntekt = emptyList(),
+                    formue = emptyList(),
+                    formuesFradrag = emptyList(),
+                    inntektsfradrag = emptyList(),
                     verdsettingsrabattSomGirGjeldsreduksjon = emptyList(),
                     oppjusteringAvEierinntekt = emptyList(),
                     manglerKategori = emptyList(),


### PR DESCRIPTION
jeg var veldig usikker hvordan vi egentlig har lyst til å håndtere at grunnlag er null. Nå skal det i det minste funke