### PR TITLE
Behandling servicer bruker oppdater oppgave istedenfor lukk + opprett

### DIFF
--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/oppgave/OppgaveHttpClient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/oppgave/OppgaveHttpClient.kt
@@ -92,11 +92,11 @@ internal class OppgaveHttpClient(
 
     override fun oppdaterOppgave(
         oppgaveId: OppgaveId,
-        beskrivelse: String,
+        oppdatertOppgaveInfo: OppdaterOppgaveInfo,
     ): Either<KunneIkkeOppdatereOppgave, OppgaveHttpKallResponse> {
         return onBehalfOfToken()
             .mapLeft { KunneIkkeOppdatereOppgave.FeilVedHentingAvToken }
-            .flatMap { oppdaterOppgaveHttpClient.oppdaterBeskrivelse(oppgaveId, it, beskrivelse) }
+            .flatMap { oppdaterOppgaveHttpClient.oppdaterOppgave(oppgaveId, it, oppdatertOppgaveInfo) }
     }
 
     override fun oppdaterOppgaveMedSystembruker(

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/oppgave/OppgaveClientStub.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/oppgave/OppgaveClientStub.kt
@@ -58,14 +58,14 @@ data object OppgaveClientStub : OppgaveClient {
 
     override fun oppdaterOppgave(
         oppgaveId: OppgaveId,
-        beskrivelse: String,
+        oppdatertOppgaveInfo: OppdaterOppgaveInfo,
     ): Either<KunneIkkeOppdatereOppgave, OppgaveHttpKallResponse> = OppgaveHttpKallResponse(
         oppgaveId = OppgaveId("stubbedOppgaveId"),
         request = "stubbedRequest",
         response = "stubbedResponse",
         beskrivelse = "stubbedBeskrivelse",
         oppgavetype = Oppgavetype.BEHANDLE_SAK,
-    ).right().also { log.info("OppgaveClientStub oppdaterer oppgave $oppgaveId med beskrivelse: $beskrivelse") }
+    ).right().also { log.info("OppgaveClientStub oppdaterer oppgave $oppgaveId med beskrivelse: ${oppdatertOppgaveInfo.beskrivelse}") }
 
     override fun oppdaterOppgaveMedSystembruker(
         oppgaveId: OppgaveId,

--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/oppgave/OppdaterHttpClientTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/oppgave/OppdaterHttpClientTest.kt
@@ -13,6 +13,7 @@ import no.nav.su.se.bakover.common.domain.auth.AccessToken
 import no.nav.su.se.bakover.common.domain.auth.TokenOppslag
 import no.nav.su.se.bakover.common.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.common.infrastructure.config.ApplicationConfig
+import no.nav.su.se.bakover.domain.oppgave.OppdaterOppgaveInfo
 import no.nav.su.se.bakover.oppgave.domain.Oppgavetype
 import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.getOrFail
@@ -206,9 +207,15 @@ internal class OppdaterHttpClientTest {
                 clock = fixedClock,
             )
 
-            val actual =
-                client.oppdaterOppgave(oppgaveId = OppgaveId(oppgaveId.toString()), beskrivelse = "en beskrivelse")
-                    .getOrFail()
+            val actual = client.oppdaterOppgave(
+                oppgaveId = OppgaveId(oppgaveId.toString()),
+                oppdatertOppgaveInfo = OppdaterOppgaveInfo(
+                    beskrivelse = "en beskrivelse",
+                    oppgavetype = Oppgavetype.BEHANDLE_SAK,
+                    status = null,
+                    tilordnetRessurs = null,
+                ),
+            ).getOrFail()
 
             val expectedBody = createJsonPatchRequestedBody(
                 """--- 01.01.2021 02:02 - en beskrivelse ---\n\nDette er den orginale beskrivelsen""",

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/klage/KlagePostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/klage/KlagePostgresRepo.kt
@@ -435,13 +435,11 @@ internal class KlagePostgresRepo(
 
         fun avvistKlageTilAttestering() = KlageTilAttestering.Avvist(
             forrigeSteg = avvistKlage(),
-            oppgaveId = oppgaveId,
             saksbehandler = saksbehandler,
         )
 
         fun vurdertKlageTilAttestering() = KlageTilAttestering.Vurdert(
             forrigeSteg = bekreftetVurdertKlage(),
-            oppgaveId = oppgaveId,
             saksbehandler = saksbehandler,
         )
 

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/dokument/DokumentPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/dokument/DokumentPostgresRepoTest.kt
@@ -10,7 +10,6 @@ import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
 import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.journal.JournalpostId
 import no.nav.su.se.bakover.test.fixedTidspunkt
-import no.nav.su.se.bakover.test.oppgaveIdKlage
 import no.nav.su.se.bakover.test.pdfATom
 import no.nav.su.se.bakover.test.persistence.TestDataHelper
 import no.nav.su.se.bakover.test.persistence.withMigratedDb
@@ -30,7 +29,6 @@ internal class DokumentPostgresRepoTest {
             val revurdering = testDataHelper.persisterRevurderingIverksattInnvilget().second
             val klage = testDataHelper.persisterKlageOversendt(
                 vedtak = testDataHelper.persisterSøknadsbehandlingIverksattInnvilgetMedKvittertUtbetaling().second,
-                oppgaveId = oppgaveIdKlage,
             )
 
             // Dette er en snarvei for å teste alle referansene til et dokument og ikke noe som vil oppstå naturlig.

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/revurdering/RevurderingPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/revurdering/RevurderingPostgresRepoTest.kt
@@ -51,12 +51,11 @@ internal class RevurderingPostgresRepoTest {
 
                         tdh.revurderingRepo.lagre(
                             simulert.tilAttestering(
-                                attesteringsoppgaveId = OppgaveId("attesteringsoppgave id"),
                                 saksbehandler = Saksbehandler("DenAndreSaksbehandleren"),
                             ).getOrFail(),
                         )
                         tdh.revurderingRepo.hent(simulert.id)!!.shouldBeType<RevurderingTilAttestering.Innvilget>().also {
-                            it.oppgaveId shouldBe OppgaveId("attesteringsoppgave id")
+                            it.oppgaveId shouldBe OppgaveId("oppgaveIdRevurdering")
                             it.saksbehandler shouldBe Saksbehandler("DenAndreSaksbehandleren")
                         }
                     }

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/tilbakekreving/TilbakekrevingUnderRevurderingPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/tilbakekreving/TilbakekrevingUnderRevurderingPostgresRepoTest.kt
@@ -14,7 +14,6 @@ import no.nav.su.se.bakover.test.fixedClockAt
 import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.genererKravgrunnlagFraSimulering
 import no.nav.su.se.bakover.test.getOrFail
-import no.nav.su.se.bakover.test.oppgaveIdRevurdering
 import no.nav.su.se.bakover.test.persistence.TestDataHelper
 import no.nav.su.se.bakover.test.persistence.withMigratedDb
 import no.nav.su.se.bakover.test.saksbehandler
@@ -120,7 +119,6 @@ internal class TilbakekrevingUnderRevurderingPostgresRepoTest {
             tilbakekrevingRepo.hentMottattKravgrunnlag() shouldBe emptyList()
 
             val iverksatt = revurdering.tilAttestering(
-                attesteringsoppgaveId = oppgaveIdRevurdering,
                 saksbehandler = saksbehandler,
             ).getOrFail().tilIverksatt(
                 attestant = attestant,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/AvvistKlage.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/AvvistKlage.kt
@@ -123,15 +123,11 @@ data class AvvistKlage(
 
     override fun sendTilAttestering(
         saksbehandler: NavIdentBruker.Saksbehandler,
-        opprettOppgave: () -> Either<KunneIkkeSendeKlageTilAttestering.KunneIkkeOppretteOppgave, OppgaveId>,
     ): Either<KunneIkkeSendeKlageTilAttestering, KlageTilAttestering.Avvist> {
-        return opprettOppgave().map { oppgaveId ->
-            KlageTilAttestering.Avvist(
-                forrigeSteg = this,
-                oppgaveId = oppgaveId,
-                saksbehandler = saksbehandler,
-            )
-        }
+        return KlageTilAttestering.Avvist(
+            forrigeSteg = this,
+            saksbehandler = saksbehandler,
+        ).right()
     }
 
     override fun kanAvsluttes() = true

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/Klage.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/Klage.kt
@@ -83,7 +83,6 @@ sealed interface Klage : Klagefelter {
     /** @return [KlageTilAttestering] */
     fun sendTilAttestering(
         saksbehandler: NavIdentBruker.Saksbehandler,
-        opprettOppgave: () -> Either<KunneIkkeSendeKlageTilAttestering.KunneIkkeOppretteOppgave, OppgaveId>,
     ): Either<KunneIkkeSendeKlageTilAttestering, KlageTilAttestering> {
         return KunneIkkeSendeKlageTilAttestering.UgyldigTilstand(this::class).left()
     }
@@ -91,7 +90,6 @@ sealed interface Klage : Klagefelter {
     /** @return [VurdertKlage.Bekreftet] eller [AvvistKlage] */
     fun underkjenn(
         underkjentAttestering: Attestering.Underkjent,
-        opprettOppgave: () -> Either<KunneIkkeUnderkjenneKlage.KunneIkkeOppretteOppgave, OppgaveId>,
     ): Either<KunneIkkeUnderkjenneKlage, Klage> {
         // TODO jah: Man kan også underkjenne til Avvist, så til vil variere basert på nåværende tilstand.
         return KunneIkkeUnderkjenneKlage.UgyldigTilstand(this::class, VurdertKlage.Bekreftet::class).left()

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/VurdertKlage.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/klage/VurdertKlage.kt
@@ -252,15 +252,11 @@ sealed interface VurdertKlage : Klage, VurdertKlageFelter, KanGenerereBrevutkast
 
         override fun sendTilAttestering(
             saksbehandler: NavIdentBruker.Saksbehandler,
-            opprettOppgave: () -> Either<KunneIkkeSendeKlageTilAttestering.KunneIkkeOppretteOppgave, OppgaveId>,
         ): Either<KunneIkkeSendeKlageTilAttestering, KlageTilAttestering> {
-            return opprettOppgave().map { oppgaveId ->
-                KlageTilAttestering.Vurdert(
-                    forrigeSteg = this,
-                    oppgaveId = oppgaveId,
-                    saksbehandler = saksbehandler,
-                )
-            }
+            return KlageTilAttestering.Vurdert(
+                forrigeSteg = this,
+                saksbehandler = saksbehandler,
+            ).right()
         }
 
         override fun kanAvsluttes() = klageinstanshendelser.isEmpty()

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppgave/OppgaveClient.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppgave/OppgaveClient.kt
@@ -15,6 +15,7 @@ data class OppdaterOppgaveInfo(
     val beskrivelse: String,
     val oppgavetype: Oppgavetype? = null,
     val status: String? = null,
+    val tilordnetRessurs: String? = null,
 )
 
 interface OppgaveClient {
@@ -24,7 +25,7 @@ interface OppgaveClient {
     fun lukkOppgaveMedSystembruker(oppgaveId: OppgaveId): Either<KunneIkkeLukkeOppgave, OppgaveHttpKallResponse>
     fun oppdaterOppgave(
         oppgaveId: OppgaveId,
-        beskrivelse: String,
+        oppdatertOppgaveInfo: OppdaterOppgaveInfo,
     ): Either<KunneIkkeOppdatereOppgave, OppgaveHttpKallResponse>
 
     fun oppdaterOppgaveMedSystembruker(

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppgave/OppgaveService.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppgave/OppgaveService.kt
@@ -21,7 +21,7 @@ interface OppgaveService {
 
     fun oppdaterOppgave(
         oppgaveId: OppgaveId,
-        beskrivelse: String,
+        oppdaterOppgaveInfo: OppdaterOppgaveInfo,
     ): Either<KunneIkkeOppdatereOppgave, OppgaveHttpKallResponse>
 
     /** Skal kun brukes ved asynkrone kall, der man ikke har tilgang til bruker's JTW */

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/RevurderingTilAttestering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/RevurderingTilAttestering.kt
@@ -188,7 +188,6 @@ sealed class RevurderingTilAttestering : Revurdering() {
 
     fun underkjenn(
         attestering: Attestering.Underkjent,
-        oppgaveId: OppgaveId,
     ): UnderkjentRevurdering {
         return when (this) {
             is Innvilget -> UnderkjentRevurdering.Innvilget(

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/SimulertRevurdering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/SimulertRevurdering.kt
@@ -190,7 +190,6 @@ sealed class SimulertRevurdering : RevurderingKanBeregnes(), LeggTilVedtaksbrevv
         override fun skalTilbakekreve() = tilbakekrevingsbehandling.skalTilbakekreve().isRight()
 
         fun tilAttestering(
-            attesteringsoppgaveId: OppgaveId,
             saksbehandler: NavIdentBruker.Saksbehandler,
         ): Either<KunneIkkeSendeInnvilgetRevurderingTilAttestering, RevurderingTilAttestering.Innvilget> {
             val gyldigTilbakekrevingsbehandling = when (tilbakekrevingsbehandling) {
@@ -220,7 +219,7 @@ sealed class SimulertRevurdering : RevurderingKanBeregnes(), LeggTilVedtaksbrevv
                 saksbehandler = saksbehandler,
                 beregning = beregning,
                 simulering = simulering,
-                oppgaveId = attesteringsoppgaveId,
+                oppgaveId = oppgaveId,
                 revurderingsårsak = revurderingsårsak,
                 grunnlagsdataOgVilkårsvurderinger = grunnlagsdataOgVilkårsvurderinger,
                 informasjonSomRevurderes = informasjonSomRevurderes,
@@ -293,7 +292,6 @@ sealed class SimulertRevurdering : RevurderingKanBeregnes(), LeggTilVedtaksbrevv
         }
 
         fun tilAttestering(
-            attesteringsoppgaveId: OppgaveId,
             saksbehandler: NavIdentBruker.Saksbehandler,
         ): Either<KanIkkeSendeOpphørtRevurderingTilAttestering, RevurderingTilAttestering.Opphørt> {
             if (revurderingsårsak.årsak == Revurderingsårsak.Årsak.REGULER_GRUNNBELØP) {
@@ -327,7 +325,7 @@ sealed class SimulertRevurdering : RevurderingKanBeregnes(), LeggTilVedtaksbrevv
                 saksbehandler = saksbehandler,
                 beregning = beregning,
                 simulering = simulering,
-                oppgaveId = attesteringsoppgaveId,
+                oppgaveId = oppgaveId,
                 revurderingsårsak = revurderingsårsak,
                 grunnlagsdataOgVilkårsvurderinger = grunnlagsdataOgVilkårsvurderinger,
                 informasjonSomRevurderes = informasjonSomRevurderes,

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/UnderkjentRevurdering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/UnderkjentRevurdering.kt
@@ -162,7 +162,6 @@ sealed class UnderkjentRevurdering : RevurderingKanBeregnes(), LeggTilVedtaksbre
         }
 
         fun tilAttestering(
-            oppgaveId: OppgaveId,
             saksbehandler: NavIdentBruker.Saksbehandler,
         ) = RevurderingTilAttestering.Innvilget(
             id = id,
@@ -293,7 +292,6 @@ sealed class UnderkjentRevurdering : RevurderingKanBeregnes(), LeggTilVedtaksbre
         data object KanIkkeSendeEnOpphørtGReguleringTilAttestering
 
         fun tilAttestering(
-            oppgaveId: OppgaveId,
             saksbehandler: NavIdentBruker.Saksbehandler,
         ): Either<KanIkkeSendeEnOpphørtGReguleringTilAttestering, RevurderingTilAttestering.Opphørt> {
             if (revurderingsårsak.årsak == Revurderingsårsak.Årsak.REGULER_GRUNNBELØP) {

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/brev/BrevForTilbakekrevingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/brev/BrevForTilbakekrevingTest.kt
@@ -3,7 +3,6 @@ package no.nav.su.se.bakover.domain.brev
 import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.Beløp
 import no.nav.su.se.bakover.common.MånedBeløp
-import no.nav.su.se.bakover.common.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.common.extensions.august
 import no.nav.su.se.bakover.common.extensions.fixedClock
 import no.nav.su.se.bakover.common.extensions.juli
@@ -151,10 +150,7 @@ class BrevForTilbakekrevingTest {
             val utførtAv = NavIdentBruker.Saksbehandler("utførtAv")
             val fritekst = "underkjentBrevMedTilbakekrevingFritekst"
             innvilgetTilbakekrevingTilAttestering(clock = clock).let { (sak, revurdering) ->
-                sak to revurdering.underkjenn(
-                    attestering = attesteringUnderkjent(clock),
-                    oppgaveId = OppgaveId("underkjentAttesteringOppgave"),
-                )
+                sak to revurdering.underkjenn(attestering = attesteringUnderkjent(clock))
             }.let { (_, revurdering) ->
                 revurdering.lagForhåndsvarsel(
                     utførtAv = utførtAv,
@@ -218,7 +214,6 @@ class BrevForTilbakekrevingTest {
                 clock = clock,
             ).let { (sak, revurdering) ->
                 sak to revurdering.tilAttestering(
-                    attesteringsoppgaveId = OppgaveId("attesteringsoppgaveId"),
                     saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "saksbehandlerSomSendteTilAttestering"),
                 ).getOrFail()
             }.let { (sak, revurdering) ->
@@ -275,7 +270,6 @@ class BrevForTilbakekrevingTest {
                 clock = clock,
             ).let { (sak, revurdering) ->
                 sak to revurdering.tilAttestering(
-                    attesteringsoppgaveId = OppgaveId("attesteringsoppgaveId"),
                     saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "saksbehandlerSomSendteTilAttestering"),
                 ).getOrFail()
             }.let { (sak, revurdering) ->
@@ -296,12 +290,8 @@ class BrevForTilbakekrevingTest {
             val clock = TikkendeKlokke(1.august(2021).fixedClock())
             simulertOpphørTilbakekreving(clock = clock).let { (sak, revurdering) ->
                 sak to revurdering.tilAttestering(
-                    attesteringsoppgaveId = OppgaveId("attesteringsoppgaveId"),
                     saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "saksbehandlerSomSendteTilAttestering"),
-                ).getOrFail().underkjenn(
-                    attestering = attesteringUnderkjent(clock),
-                    oppgaveId = OppgaveId("underkjentAttesteringOppgave"),
-                )
+                ).getOrFail().underkjenn(attestering = attesteringUnderkjent(clock))
             }.let { (sak, revurdering) ->
                 requireType<Pair<Sak, UnderkjentRevurdering.Opphørt>>(sak to revurdering)
                 val expectedTilbakekreving = expectedTilbakekrevingForOpphør()
@@ -334,7 +324,6 @@ class BrevForTilbakekrevingTest {
             val attestantSomIverksatte = NavIdentBruker.Attestant(navIdent = "attestantSomIverksatte")
             simulertOpphørTilbakekreving(clock = clock).let { (sak, revurdering) ->
                 sak to revurdering.tilAttestering(
-                    attesteringsoppgaveId = OppgaveId("attesteringsoppgaveId"),
                     saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "saksbehandlerSomSendteTilAttestering"),
                 ).getOrFail().tilIverksatt(
                     attestant = attestantSomIverksatte,

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/opprett/OpprettNySøknadsbehandlingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/søknadsbehandling/opprett/OpprettNySøknadsbehandlingTest.kt
@@ -1,6 +1,7 @@
 package no.nav.su.se.bakover.domain.søknadsbehandling.opprett
 
 import arrow.core.left
+import arrow.core.right
 import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.tid.periode.mai
@@ -11,6 +12,7 @@ import no.nav.su.se.bakover.test.innvilgetSøknadsbehandlingMedÅpenRegulering
 import no.nav.su.se.bakover.test.iverksattSøknadsbehandling
 import no.nav.su.se.bakover.test.nySakUføre
 import no.nav.su.se.bakover.test.nySøknadsbehandlingMedStønadsperiode
+import no.nav.su.se.bakover.test.oppgave.nyOppgaveHttpKallResponse
 import no.nav.su.se.bakover.test.opprettetRevurdering
 import no.nav.su.se.bakover.test.saksbehandler
 import no.nav.su.se.bakover.test.søknad.nySøknadPåEksisterendeSak
@@ -21,7 +23,11 @@ internal class OpprettNySøknadsbehandlingTest {
     @Test
     fun `oppretter søknadsbehandling dersom det ikke finnes eksisterende åpne behandlinger`() {
         val (sak, søknad) = nySakUføre()
-        sak.opprettNySøknadsbehandling(søknad.id, fixedClock, saksbehandler).shouldBeRight()
+        sak.opprettNySøknadsbehandling(
+            søknad.id,
+            fixedClock,
+            saksbehandler,
+        ) { _, _ -> nyOppgaveHttpKallResponse().right() }.shouldBeRight()
     }
 
     @Test
@@ -31,7 +37,7 @@ internal class OpprettNySøknadsbehandlingTest {
             søknadsbehandling.søknad.id,
             fixedClock,
             saksbehandler,
-        ) shouldBe Sak.KunneIkkeOppretteSøknadsbehandling.FinnesAlleredeSøknadsehandlingForSøknad.left()
+        ) { _, _ -> nyOppgaveHttpKallResponse().right() } shouldBe Sak.KunneIkkeOppretteSøknadsbehandling.FinnesAlleredeSøknadsehandlingForSøknad.left()
     }
 
     @Test
@@ -43,7 +49,7 @@ internal class OpprettNySøknadsbehandlingTest {
             søknad.id,
             fixedClock,
             saksbehandler,
-        ) shouldBe Sak.KunneIkkeOppretteSøknadsbehandling.HarÅpenSøknadsbehandling.left()
+        ) { _, _ -> nyOppgaveHttpKallResponse().right() } shouldBe Sak.KunneIkkeOppretteSøknadsbehandling.HarÅpenSøknadsbehandling.left()
     }
 
     @Test
@@ -57,7 +63,7 @@ internal class OpprettNySøknadsbehandlingTest {
             søknadId = søknad.id,
             clock = clock,
             saksbehandler = saksbehandler,
-        ).shouldBeRight()
+        ) { _, _ -> nyOppgaveHttpKallResponse().right() }.shouldBeRight()
     }
 
     @Test
@@ -74,6 +80,6 @@ internal class OpprettNySøknadsbehandlingTest {
             søknadId = søknad.id,
             clock = clock,
             saksbehandler = saksbehandler,
-        ).shouldBeRight()
+        ) { _, _ -> nyOppgaveHttpKallResponse().right() }.shouldBeRight()
     }
 }

--- a/oppgave/domain/src/main/kotlin/no/nav/su/se/bakover/oppgave/domain/OppgaveHttpKallResponse.kt
+++ b/oppgave/domain/src/main/kotlin/no/nav/su/se/bakover/oppgave/domain/OppgaveHttpKallResponse.kt
@@ -7,7 +7,7 @@ import no.nav.su.se.bakover.common.domain.oppgave.OppgaveId
  *
  * TODO - Denne er sauset på alle steder der oppgave service, og client brukes. Mulig vi må skille bedre på dette
  *
- * Mulig vi vi kan heller ersatte denne med at client og service returnere oppgaveHendelse
+ * Mulig vi kan heller ersatte denne med at client og service returnere oppgaveHendelse
  */
 data class OppgaveHttpKallResponse(
     val oppgaveId: OppgaveId,

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/oppgave/OppgaveServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/oppgave/OppgaveServiceImpl.kt
@@ -41,9 +41,9 @@ class OppgaveServiceImpl(
 
     override fun oppdaterOppgave(
         oppgaveId: OppgaveId,
-        beskrivelse: String,
+        oppdaterOppgaveInfo: OppdaterOppgaveInfo,
     ): Either<KunneIkkeOppdatereOppgave, OppgaveHttpKallResponse> {
-        return oppgaveClient.oppdaterOppgave(oppgaveId, beskrivelse)
+        return oppgaveClient.oppdaterOppgave(oppgaveId, oppdaterOppgaveInfo)
     }
 
     override fun oppdaterOppgaveMedSystembruker(

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -22,7 +22,6 @@ import no.nav.su.se.bakover.common.tid.periode.Periode
 import no.nav.su.se.bakover.domain.grunnlag.fradrag.LeggTilFradragsgrunnlagRequest
 import no.nav.su.se.bakover.domain.oppdrag.simulering.simulerUtbetaling
 import no.nav.su.se.bakover.domain.oppgave.OppdaterOppgaveInfo
-import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
 import no.nav.su.se.bakover.domain.oppgave.OppgaveService
 import no.nav.su.se.bakover.domain.revurdering.AbstraktRevurdering
 import no.nav.su.se.bakover.domain.revurdering.AvsluttetRevurdering
@@ -97,6 +96,7 @@ import no.nav.su.se.bakover.domain.vilkår.pensjon.LeggTilPensjonsVilkårRequest
 import no.nav.su.se.bakover.domain.vilkår.uføre.LeggTilUførevurderingerRequest
 import no.nav.su.se.bakover.domain.vilkår.utenlandsopphold.LeggTilFlereUtenlandsoppholdRequest
 import no.nav.su.se.bakover.oppgave.domain.KunneIkkeOppdatereOppgave
+import no.nav.su.se.bakover.oppgave.domain.Oppgavetype
 import no.nav.su.se.bakover.service.tilbakekreving.TilbakekrevingUnderRevurderingService
 import no.nav.su.se.bakover.service.utbetaling.UtbetalingService
 import no.nav.su.se.bakover.vedtak.application.VedtakService
@@ -720,63 +720,26 @@ class RevurderingServiceImpl(
             return it.left()
         }
 
-        val aktørId = personService.hentAktørId(revurdering.fnr).getOrElse {
-            log.error("Fant ikke aktør-id")
-            return KunneIkkeSendeRevurderingTilAttestering.FantIkkeAktørId.left()
-        }
-
-        val tilordnetRessurs = revurdering.attesteringer.lastOrNull()?.attestant
-
-        val oppgaveResponse = oppgaveService.opprettOppgave(
-            OppgaveConfig.AttesterRevurdering(
-                saksnummer = revurdering.saksnummer,
-                aktørId = aktørId,
-                // Første gang den sendes til attestering er attestant null, de påfølgende gangene vil den være attestanten som har underkjent.
-                tilordnetRessurs = tilordnetRessurs,
-                clock = clock,
-            ),
-        ).getOrElse {
-            log.error("Kunne ikke opprette Attesteringsoppgave. Avbryter handlingen.")
-            return KunneIkkeSendeRevurderingTilAttestering.KunneIkkeOppretteOppgave.left()
-        }
-
-        oppgaveService.lukkOppgave(revurdering.oppgaveId).mapLeft {
-            log.error("Kunne ikke lukke oppgaven med id ${revurdering.oppgaveId}, knyttet til revurderingen. Oppgaven må lukkes manuelt.")
-        }
-
-        // TODO endre rekkefølge slik at vi ikke lager/lukker oppgaver før vi har vært innom domenemodellen
         val (tilAttestering, statistikkhendelse) = when (revurdering) {
-            is SimulertRevurdering.Innvilget -> revurdering.tilAttestering(
-                oppgaveResponse.oppgaveId,
-                saksbehandler,
-            ).getOrElse {
+            is SimulertRevurdering.Innvilget -> revurdering.tilAttestering(saksbehandler).getOrElse {
                 return KunneIkkeSendeRevurderingTilAttestering.FeilInnvilget(it).left()
             }.let {
                 Pair(it, StatistikkEvent.Behandling.Revurdering.TilAttestering.Innvilget(it))
             }
 
-            is SimulertRevurdering.Opphørt -> revurdering.tilAttestering(
-                oppgaveResponse.oppgaveId,
-                saksbehandler,
-            ).getOrElse {
+            is SimulertRevurdering.Opphørt -> revurdering.tilAttestering(saksbehandler).getOrElse {
                 return KunneIkkeSendeRevurderingTilAttestering.FeilOpphørt(it).left()
             }.let {
                 Pair(it, StatistikkEvent.Behandling.Revurdering.TilAttestering.Opphør(it))
             }
 
-            is UnderkjentRevurdering.Opphørt -> revurdering.tilAttestering(
-                oppgaveResponse.oppgaveId,
-                saksbehandler,
-            ).getOrElse {
+            is UnderkjentRevurdering.Opphørt -> revurdering.tilAttestering(saksbehandler).getOrElse {
                 return KunneIkkeSendeRevurderingTilAttestering.KanIkkeRegulereGrunnbeløpTilOpphør.left()
             }.let {
                 Pair(it, StatistikkEvent.Behandling.Revurdering.TilAttestering.Opphør(it))
             }
 
-            is UnderkjentRevurdering.Innvilget -> revurdering.tilAttestering(
-                oppgaveResponse.oppgaveId,
-                saksbehandler,
-            ).let {
+            is UnderkjentRevurdering.Innvilget -> revurdering.tilAttestering(saksbehandler).let {
                 Pair(it, StatistikkEvent.Behandling.Revurdering.TilAttestering.Innvilget(it))
             }
 
@@ -784,6 +747,18 @@ class RevurderingServiceImpl(
                 revurdering::class,
                 RevurderingTilAttestering::class,
             ).left()
+        }
+
+        // best effort for å oppdatere oppgave
+        oppgaveService.oppdaterOppgave(
+            oppgaveId = tilAttestering.oppgaveId,
+            oppdaterOppgaveInfo = OppdaterOppgaveInfo(
+                beskrivelse = "Sendt revurdering til attestering",
+                oppgavetype = Oppgavetype.ATTESTERING,
+                tilordnetRessurs = revurdering.attesteringer.lastOrNull()?.attestant?.navIdent,
+            ),
+        ).mapLeft {
+            log.error("Kunne ikke oppdatere oppgave ${tilAttestering.oppgaveId} for revurdering ${tilAttestering.id} med informasjon om at den er sendt til attestering. Feilen var $it")
         }
 
         revurderingRepo.lagre(tilAttestering)
@@ -915,33 +890,19 @@ class RevurderingServiceImpl(
             return KunneIkkeUnderkjenneRevurdering.SaksbehandlerOgAttestantKanIkkeVæreSammePerson.left()
         }
 
-        val aktørId = personService.hentAktørId(revurdering.fnr).getOrElse {
-            log.error("Fant ikke aktør-id for revurdering: ${revurdering.id}")
-            return KunneIkkeUnderkjenneRevurdering.FantIkkeAktørId.left()
-        }
-
-        val oppgaveResponse = oppgaveService.opprettOppgave(
-            OppgaveConfig.Revurderingsbehandling(
-                saksnummer = revurdering.saksnummer,
-                aktørId = aktørId,
-                tilordnetRessurs = revurdering.saksbehandler,
-                clock = clock,
-            ),
-        ).getOrElse {
-            log.error("revurdering ${revurdering.id} ble ikke underkjent. Klarte ikke opprette behandlingsoppgave")
-            return@underkjenn KunneIkkeUnderkjenneRevurdering.KunneIkkeOppretteOppgave.left()
-        }
-
-        val underkjent = revurdering.underkjenn(attestering, oppgaveResponse.oppgaveId)
-
+        val underkjent = revurdering.underkjenn(attestering)
         revurderingRepo.lagre(underkjent)
 
-        val eksisterendeOppgaveId = revurdering.oppgaveId
-
-        oppgaveService.lukkOppgave(eksisterendeOppgaveId).mapLeft {
-            log.error("Kunne ikke lukke attesteringsoppgave $eksisterendeOppgaveId ved underkjenning av revurdering $revurderingId. Dette må gjøres manuelt.")
-        }.map {
-            log.info("Lukket attesteringsoppgave $eksisterendeOppgaveId ved underkjenning av revurdering $revurderingId")
+        // best effort for å oppdatere oppgave
+        oppgaveService.oppdaterOppgave(
+            underkjent.oppgaveId,
+            oppdaterOppgaveInfo = OppdaterOppgaveInfo(
+                beskrivelse = "Revurderingen er blitt underkjent",
+                oppgavetype = Oppgavetype.BEHANDLE_SAK,
+                tilordnetRessurs = revurdering.saksbehandler.navIdent,
+            ),
+        ).mapLeft {
+            log.error("Kunne ikke oppdatere oppgave ${underkjent.oppgaveId} for revurdering ${underkjent.id} med informasjon om at den er underkjent. Feilen var $it")
         }
 
         when (underkjent) {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/revurdering/RevurderingServiceImpl.kt
@@ -21,6 +21,7 @@ import no.nav.su.se.bakover.common.tid.Tidspunkt
 import no.nav.su.se.bakover.common.tid.periode.Periode
 import no.nav.su.se.bakover.domain.grunnlag.fradrag.LeggTilFradragsgrunnlagRequest
 import no.nav.su.se.bakover.domain.oppdrag.simulering.simulerUtbetaling
+import no.nav.su.se.bakover.domain.oppgave.OppdaterOppgaveInfo
 import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
 import no.nav.su.se.bakover.domain.oppgave.OppgaveService
 import no.nav.su.se.bakover.domain.revurdering.AbstraktRevurdering
@@ -661,7 +662,7 @@ class RevurderingServiceImpl(
     ): Either<KunneIkkeOppdatereOppgave, Unit> {
         return oppgaveService.oppdaterOppgave(
             oppgaveId = oppgaveId,
-            beskrivelse = "Forhåndsvarsel er sendt.",
+            oppdaterOppgaveInfo = OppdaterOppgaveInfo(beskrivelse = "Forhåndsvarsel er sendt."),
         ).onLeft {
             log.error("Kunne ikke oppdatere oppgave $oppgaveId for revurdering $revurderingId med informasjon om at forhåndsvarsel er sendt")
         }.onRight {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/AvslåSøknadManglendeDokumentasjonServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/AvslåSøknadManglendeDokumentasjonServiceImpl.kt
@@ -6,6 +6,7 @@ import dokument.domain.brev.BrevService
 import no.nav.su.se.bakover.common.domain.PdfA
 import no.nav.su.se.bakover.common.person.Fnr
 import no.nav.su.se.bakover.domain.Sak
+import no.nav.su.se.bakover.domain.oppgave.OppgaveService
 import no.nav.su.se.bakover.domain.sak.SakService
 import no.nav.su.se.bakover.domain.søknadsbehandling.iverksett.IverksettSøknadsbehandlingService
 import no.nav.su.se.bakover.domain.søknadsbehandling.iverksett.avslå.IverksattAvslåttSøknadsbehandlingResponse
@@ -13,6 +14,8 @@ import no.nav.su.se.bakover.domain.søknadsbehandling.iverksett.avslå.manglende
 import no.nav.su.se.bakover.domain.søknadsbehandling.iverksett.avslå.manglendedokumentasjon.KunneIkkeAvslåSøknad
 import no.nav.su.se.bakover.domain.søknadsbehandling.iverksett.avslå.manglendedokumentasjon.avslåSøknadPgaManglendeDokumentasjon
 import no.nav.su.se.bakover.service.utbetaling.UtbetalingService
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import satser.domain.SatsFactory
 import vilkår.formue.domain.FormuegrenserFactory
 import java.time.Clock
@@ -25,7 +28,10 @@ class AvslåSøknadManglendeDokumentasjonServiceImpl(
     private val iverksettSøknadsbehandlingService: IverksettSøknadsbehandlingService,
     private val utbetalingService: UtbetalingService,
     private val brevService: BrevService,
+    private val oppgaveService: OppgaveService,
 ) : AvslåSøknadManglendeDokumentasjonService {
+
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
 
     override fun avslå(
         command: AvslåManglendeDokumentasjonCommand,
@@ -43,13 +49,21 @@ class AvslåSøknadManglendeDokumentasjonServiceImpl(
     private fun lagAvslag(command: AvslåManglendeDokumentasjonCommand): Either<KunneIkkeAvslåSøknad, IverksattAvslåttSøknadsbehandlingResponse> {
         return sakService.hentSakForSøknad(command.søknadId)
             .getOrElse { throw IllegalArgumentException("Fant ikke søknad ${command.søknadId}. Kan ikke avslå søknad pga. manglende dokumentasjon.") }
-            .avslåSøknadPgaManglendeDokumentasjon(
-                command = command,
-                clock = clock,
-                satsFactory = satsFactory,
-                formuegrenserFactory = formuegrenserFactory,
-                genererPdf = brevService::lagDokument,
-                simulerUtbetaling = utbetalingService::simulerUtbetaling,
-            )
+            .let { sak ->
+                sak.avslåSøknadPgaManglendeDokumentasjon(
+                    command = command,
+                    clock = clock,
+                    satsFactory = satsFactory,
+                    formuegrenserFactory = formuegrenserFactory,
+                    genererPdf = brevService::lagDokument,
+                    simulerUtbetaling = utbetalingService::simulerUtbetaling,
+                    lukkOppgave = {
+                        oppgaveService.lukkOppgave(it).mapLeft {
+                            log.error("Kunne ikke lukke oppgave ved avslå pga manglende dokumentasjon for søknad ${command.søknadId}, for sak ${sak.id}. Feil var $it")
+                            it
+                        }
+                    },
+                )
+            }
     }
 }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/AvvistKlageTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/klage/AvvistKlageTest.kt
@@ -3,7 +3,6 @@ package no.nav.su.se.bakover.service.klage
 import arrow.core.left
 import arrow.core.right
 import io.kotest.matchers.shouldBe
-import no.nav.su.se.bakover.common.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.common.ident.NavIdentBruker
 import no.nav.su.se.bakover.domain.klage.AvvistKlage
 import no.nav.su.se.bakover.domain.klage.Klage
@@ -272,13 +271,10 @@ internal class AvvistKlageTest {
 
         val actual = klage.sendTilAttestering(
             saksbehandler = NavIdentBruker.Saksbehandler("saksbehandler"),
-        ) {
-            OppgaveId("klageOppgaveId").right()
-        }.getOrFail()
+        ).getOrFail()
 
         actual shouldBe KlageTilAttestering.Avvist(
             forrigeSteg = klage,
-            oppgaveId = klage.oppgaveId,
             saksbehandler = klage.saksbehandler,
         )
     }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RegulerGrunnbeløpServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/revurdering/RegulerGrunnbeløpServiceImplTest.kt
@@ -2,7 +2,6 @@ package no.nav.su.se.bakover.service.revurdering
 
 import arrow.core.left
 import arrow.core.nonEmptyListOf
-import arrow.core.right
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import no.nav.su.se.bakover.common.extensions.august
@@ -20,11 +19,9 @@ import no.nav.su.se.bakover.domain.vilkår.uføre.LeggTilUførevilkårRequest
 import no.nav.su.se.bakover.domain.vilkår.uføre.LeggTilUførevurderingerRequest
 import no.nav.su.se.bakover.domain.vilkår.uføre.UførevilkårStatus
 import no.nav.su.se.bakover.test.TikkendeKlokke
-import no.nav.su.se.bakover.test.aktørId
 import no.nav.su.se.bakover.test.argThat
 import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.getOrFail
-import no.nav.su.se.bakover.test.oppgave.nyOppgaveHttpKallResponse
 import no.nav.su.se.bakover.test.opprettetRevurdering
 import no.nav.su.se.bakover.test.revurderingId
 import no.nav.su.se.bakover.test.revurderingUnderkjent
@@ -189,13 +186,6 @@ internal class RegulerGrunnbeløpServiceImplTest {
             revurderingRepo = mock {
                 on { hent(any()) } doReturn simulertRevurdering
             },
-            personService = mock {
-                on { hentAktørId(any()) } doReturn aktørId.right()
-            },
-            oppgaveService = mock {
-                on { opprettOppgave(any()) } doReturn nyOppgaveHttpKallResponse().right()
-                on { lukkOppgave(any()) } doReturn nyOppgaveHttpKallResponse().right()
-            },
             sakService = mock {
                 on { hentSakForRevurdering(any()) } doReturn sak
             },
@@ -213,9 +203,6 @@ internal class RegulerGrunnbeløpServiceImplTest {
 
             inOrder(it.revurderingRepo, it.personService, it.oppgaveService) {
                 verify(it.revurderingRepo).hent(simulertRevurdering.id)
-                verify(it.personService).hentAktørId(argThat { it shouldBe sak.fnr })
-                verify(it.oppgaveService).opprettOppgave(any())
-                verify(it.oppgaveService).lukkOppgave(any())
             }
             verifyNoMoreInteractions(it.revurderingRepo, it.personService, it.oppgaveService)
         }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/AvslåSøknadManglendeDokumentasjonServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknad/AvslåSøknadManglendeDokumentasjonServiceImplTest.kt
@@ -21,6 +21,7 @@ import no.nav.su.se.bakover.domain.behandling.avslag.Avslagsgrunn
 import no.nav.su.se.bakover.domain.grunnlag.GrunnlagsdataOgVilkårsvurderinger
 import no.nav.su.se.bakover.domain.grunnlag.OpplysningspliktBeskrivelse
 import no.nav.su.se.bakover.domain.grunnlag.Opplysningspliktgrunnlag
+import no.nav.su.se.bakover.domain.oppgave.OppgaveService
 import no.nav.su.se.bakover.domain.sak.SakService
 import no.nav.su.se.bakover.domain.sak.oppdaterSøknadsbehandling
 import no.nav.su.se.bakover.domain.statistikk.StatistikkEvent
@@ -36,6 +37,7 @@ import no.nav.su.se.bakover.domain.søknadsbehandling.stønadsperiode.Aldersvurd
 import no.nav.su.se.bakover.domain.vedtak.VedtakAvslagVilkår
 import no.nav.su.se.bakover.domain.vilkår.OpplysningspliktVilkår
 import no.nav.su.se.bakover.domain.vilkår.VurderingsperiodeOpplysningsplikt
+import no.nav.su.se.bakover.oppgave.domain.KunneIkkeLukkeOppgave
 import no.nav.su.se.bakover.service.utbetaling.UtbetalingService
 import no.nav.su.se.bakover.test.argThat
 import no.nav.su.se.bakover.test.fixedClock
@@ -44,6 +46,8 @@ import no.nav.su.se.bakover.test.formuegrenserFactoryTestPåDato
 import no.nav.su.se.bakover.test.getOrFail
 import no.nav.su.se.bakover.test.nySøknadsbehandlingUtenStønadsperiode
 import no.nav.su.se.bakover.test.nySøknadsbehandlingshendelse
+import no.nav.su.se.bakover.test.oppgave.nyOppgaveHttpKallResponse
+import no.nav.su.se.bakover.test.oppgave.oppgaveId
 import no.nav.su.se.bakover.test.saksbehandler
 import no.nav.su.se.bakover.test.satsFactoryTestPåDato
 import no.nav.su.se.bakover.test.simulering.simulerUtbetaling
@@ -97,6 +101,9 @@ internal class AvslåSøknadManglendeDokumentasjonServiceImplTest {
             },
             brevService = mock {
                 on { lagDokument(any(), anyOrNull()) } doReturn mockedDokument.right()
+            },
+            oppgaveService = mock {
+                on { lukkOppgave(any()) } doReturn nyOppgaveHttpKallResponse().right()
             },
         ).let { serviceAndMocks ->
             val actualSak = serviceAndMocks.service.avslå(
@@ -244,6 +251,9 @@ internal class AvslåSøknadManglendeDokumentasjonServiceImplTest {
             },
             brevService = mock {
                 on { lagDokument(any(), anyOrNull()) } doReturn mockedDokument.right()
+            },
+            oppgaveService = mock {
+                on { lukkOppgave(any()) } doReturn KunneIkkeLukkeOppgave.FeilVedHentingAvOppgave(oppgaveId).left()
             },
         ).let { serviceAndMocks ->
 
@@ -412,6 +422,7 @@ internal class AvslåSøknadManglendeDokumentasjonServiceImplTest {
         val formuegrenserFactory: FormuegrenserFactory = formuegrenserFactoryTestPåDato(),
         val utbetalingService: UtbetalingService = mock(),
         val brevService: BrevService = mock(),
+        val oppgaveService: OppgaveService = mock(),
     ) {
         val service = AvslåSøknadManglendeDokumentasjonServiceImpl(
             clock = clock,
@@ -421,6 +432,7 @@ internal class AvslåSøknadManglendeDokumentasjonServiceImplTest {
             iverksettSøknadsbehandlingService = iverksettSøknadsbehandlingService,
             utbetalingService = utbetalingService,
             brevService = brevService,
+            oppgaveService = oppgaveService,
         )
 
         fun verifyNoMoreInteractions() {

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceAttesteringTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceAttesteringTest.kt
@@ -1,111 +1,40 @@
 package no.nav.su.se.bakover.service.søknadsbehandling
 
 import arrow.core.left
-import arrow.core.right
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.domain.Stønadsperiode
-import no.nav.su.se.bakover.common.domain.oppgave.OppgaveId
-import no.nav.su.se.bakover.common.person.AktørId
 import no.nav.su.se.bakover.common.tid.periode.år
-import no.nav.su.se.bakover.domain.oppgave.KunneIkkeOppretteOppgave
-import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
+import no.nav.su.se.bakover.domain.oppgave.OppdaterOppgaveInfo
 import no.nav.su.se.bakover.domain.oppgave.OppgaveService
 import no.nav.su.se.bakover.domain.statistikk.StatistikkEvent
 import no.nav.su.se.bakover.domain.statistikk.StatistikkEventObserver
 import no.nav.su.se.bakover.domain.søknadsbehandling.SøknadsbehandlingRepo
 import no.nav.su.se.bakover.domain.søknadsbehandling.SøknadsbehandlingService
 import no.nav.su.se.bakover.domain.søknadsbehandling.SøknadsbehandlingTilAttestering
-import no.nav.su.se.bakover.domain.søknadsbehandling.tilAttestering.KunneIkkeSendeSøknadsbehandlingTilAttestering
-import no.nav.su.se.bakover.oppgave.domain.KunneIkkeLukkeOppgave
+import no.nav.su.se.bakover.oppgave.domain.KunneIkkeOppdatereOppgave
+import no.nav.su.se.bakover.oppgave.domain.Oppgavetype
 import no.nav.su.se.bakover.test.argThat
-import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.getOrFail
-import no.nav.su.se.bakover.test.oppgave.nyOppgaveHttpKallResponse
 import no.nav.su.se.bakover.test.saksbehandler
 import no.nav.su.se.bakover.test.shouldBeType
 import no.nav.su.se.bakover.test.simulertSøknadsbehandlingUføre
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
-import person.domain.KunneIkkeHentePerson
 import person.domain.PersonService
 
 class SøknadsbehandlingServiceAttesteringTest {
 
-    private val nyOppgaveId = OppgaveId("123")
-    private val aktørId = AktørId("12345")
     private val simulertBehandling = simulertSøknadsbehandlingUføre(
         stønadsperiode = Stønadsperiode.create(år(2021)),
     ).second
-
-    @Test
-    fun `sjekk at vi sender inn riktig oppgaveId ved lukking av oppgave ved attestering`() {
-        val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
-            on { hent(any()) } doReturn simulertBehandling
-        }
-
-        val personServiceMock: PersonService = mock {
-            on { hentAktørId(any()) } doReturn aktørId.right()
-        }
-
-        val oppgaveServiceMock = mock<OppgaveService> {
-            on { opprettOppgave(any()) } doReturn nyOppgaveHttpKallResponse().right()
-            on { lukkOppgave(any()) } doReturn nyOppgaveHttpKallResponse().right()
-        }
-
-        val eventObserver: StatistikkEventObserver = mock()
-
-        val gammelOppgaveId = simulertBehandling.oppgaveId
-
-        val actual = createSøknadsbehandlingService(
-            søknadsbehandlingRepo = søknadsbehandlingRepoMock,
-            oppgaveService = oppgaveServiceMock,
-            personService = personServiceMock,
-            observer = eventObserver,
-        ).sendTilAttestering(
-            SøknadsbehandlingService.SendTilAttesteringRequest(
-                simulertBehandling.id,
-                saksbehandler,
-                "",
-            ),
-        ).getOrFail()
-
-        actual.shouldBeType<SøknadsbehandlingTilAttestering.Innvilget>().also {
-            it.oppgaveId shouldBe nyOppgaveId
-            it.saksbehandler shouldBe saksbehandler
-            it.fritekstTilBrev shouldBe ""
-        }
-
-        inOrder(søknadsbehandlingRepoMock, personServiceMock, oppgaveServiceMock, eventObserver) {
-            verify(søknadsbehandlingRepoMock).hent(simulertBehandling.id)
-            verify(personServiceMock).hentAktørId(simulertBehandling.fnr)
-            verify(oppgaveServiceMock).opprettOppgave(
-                config = OppgaveConfig.AttesterSøknadsbehandling(
-                    søknadId = simulertBehandling.søknad.id,
-                    aktørId = aktørId,
-                    tilordnetRessurs = null,
-                    clock = fixedClock,
-                ),
-            )
-            verify(søknadsbehandlingRepoMock).defaultTransactionContext()
-            verify(søknadsbehandlingRepoMock).lagre(eq(actual), anyOrNull())
-            verify(oppgaveServiceMock).lukkOppgave(gammelOppgaveId)
-            verify(eventObserver).handle(
-                argThat {
-                    it shouldBe StatistikkEvent.Behandling.Søknad.TilAttestering.Innvilget(actual as SøknadsbehandlingTilAttestering.Innvilget)
-                },
-            )
-        }
-        verifyNoMoreInteractions(søknadsbehandlingRepoMock, personServiceMock, oppgaveServiceMock, eventObserver)
-    }
 
     @Test
     fun `svarer med feil dersom man ikke finner behandling`() {
@@ -138,108 +67,18 @@ class SøknadsbehandlingServiceAttesteringTest {
     }
 
     @Test
-    fun `svarer med feil dersom man ikke finner aktørid for person`() {
+    fun `sender til attestering selv om oppdatering av oppgave feiler`() {
         val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
             on { hent(any()) } doReturn simulertBehandling
         }
-
-        val personServiceMock: PersonService = mock {
-            on { hentAktørId(any()) } doReturn KunneIkkeHentePerson.FantIkkePerson.left()
-        }
-
-        val oppgaveServiceMock = mock<OppgaveService>()
-
-        val eventObserver: StatistikkEventObserver = mock()
-
-        val actual = createSøknadsbehandlingService(
-            søknadsbehandlingRepo = søknadsbehandlingRepoMock,
-            oppgaveService = oppgaveServiceMock,
-            personService = personServiceMock,
-            observer = eventObserver,
-        ).sendTilAttestering(
-            SøknadsbehandlingService.SendTilAttesteringRequest(
-                simulertBehandling.id,
-                saksbehandler,
-                "",
-            ),
-        )
-
-        actual shouldBe KunneIkkeSendeSøknadsbehandlingTilAttestering.KunneIkkeFinneAktørId.left()
-
-        verify(søknadsbehandlingRepoMock).hent(simulertBehandling.id)
-        verify(personServiceMock).hentAktørId(simulertBehandling.fnr)
-
-        verifyNoMoreInteractions(søknadsbehandlingRepoMock, personServiceMock, oppgaveServiceMock, eventObserver)
-    }
-
-    @Test
-    fun `svarer med feil dersom man ikke får til å opprette oppgave til attestant`() {
-        val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
-            on { hent(any()) } doReturn simulertBehandling
-        }
-
-        val personServiceMock: PersonService = mock {
-            on { hentAktørId(any()) } doReturn aktørId.right()
-        }
-        val oppgaveServiceMock: OppgaveService = mock {
-            on { opprettOppgave(any()) } doReturn KunneIkkeOppretteOppgave.left()
-        }
-        val eventObserver: StatistikkEventObserver = mock()
-
-        val actual = createSøknadsbehandlingService(
-            søknadsbehandlingRepo = søknadsbehandlingRepoMock,
-            oppgaveService = oppgaveServiceMock,
-            personService = personServiceMock,
-            observer = eventObserver,
-        ).sendTilAttestering(
-            SøknadsbehandlingService.SendTilAttesteringRequest(
-                simulertBehandling.id,
-                saksbehandler,
-                "",
-            ),
-        )
-
-        actual shouldBe KunneIkkeSendeSøknadsbehandlingTilAttestering.KunneIkkeOppretteOppgave.left()
-
-        verify(søknadsbehandlingRepoMock).hent(simulertBehandling.id)
-        verify(personServiceMock).hentAktørId(simulertBehandling.fnr)
-        verify(oppgaveServiceMock).opprettOppgave(
-            argThat {
-                it shouldBe OppgaveConfig.AttesterSøknadsbehandling(
-                    søknadId = simulertBehandling.søknad.id,
-                    aktørId = aktørId,
-                    tilordnetRessurs = null,
-                    clock = fixedClock,
-                )
-            },
-        )
-
-        verifyNoMoreInteractions(søknadsbehandlingRepoMock, personServiceMock, oppgaveServiceMock, eventObserver)
-    }
-
-    @Test
-    fun `sender til attestering selv om lukking av eksisterende oppgave feiler`() {
-        val søknadsbehandlingRepoMock = mock<SøknadsbehandlingRepo> {
-            on { hent(any()) } doReturn simulertBehandling
-        }
-
-        val personServiceMock: PersonService = mock {
-            on { hentAktørId(any()) } doReturn aktørId.right()
-        }
-
         val oppgaveServiceMock = mock<OppgaveService> {
-            on { opprettOppgave(any()) } doReturn nyOppgaveHttpKallResponse().right()
-            on { lukkOppgave(any()) } doAnswer { KunneIkkeLukkeOppgave.FeilVedHentingAvOppgave(it.getArgument(0)).left() }
+            on { oppdaterOppgave(any(), any()) } doReturn KunneIkkeOppdatereOppgave.FeilVedHentingAvOppgave.left()
         }
-
         val eventObserver: StatistikkEventObserver = mock()
-
-        val gammelOppgaveId = simulertBehandling.oppgaveId
 
         val actual = createSøknadsbehandlingService(
             søknadsbehandlingRepo = søknadsbehandlingRepoMock,
             oppgaveService = oppgaveServiceMock,
-            personService = personServiceMock,
             observer = eventObserver,
         ).sendTilAttestering(
             SøknadsbehandlingService.SendTilAttesteringRequest(
@@ -251,29 +90,28 @@ class SøknadsbehandlingServiceAttesteringTest {
 
         actual.shouldBeType<SøknadsbehandlingTilAttestering.Innvilget>().also {
             it.saksbehandler shouldBe saksbehandler
-            it.oppgaveId shouldBe nyOppgaveId
         }
 
-        inOrder(søknadsbehandlingRepoMock, personServiceMock, oppgaveServiceMock, eventObserver) {
+        inOrder(søknadsbehandlingRepoMock, oppgaveServiceMock, eventObserver) {
             verify(søknadsbehandlingRepoMock).hent(simulertBehandling.id)
-            verify(personServiceMock).hentAktørId(simulertBehandling.fnr)
-            verify(oppgaveServiceMock).opprettOppgave(
-                config = OppgaveConfig.AttesterSøknadsbehandling(
-                    søknadId = simulertBehandling.søknad.id,
-                    aktørId = aktørId,
-                    tilordnetRessurs = null,
-                    clock = fixedClock,
-                ),
+            verify(oppgaveServiceMock).oppdaterOppgave(
+                argThat { it shouldBe actual.oppgaveId },
+                argThat {
+                    it shouldBe OppdaterOppgaveInfo(
+                        beskrivelse = "Sendt til attestering",
+                        oppgavetype = Oppgavetype.ATTESTERING,
+                        tilordnetRessurs = actual.attesteringer.prøvHentSisteAttestering()?.attestant?.navIdent,
+                    )
+                },
             )
             verify(søknadsbehandlingRepoMock).defaultTransactionContext()
             verify(søknadsbehandlingRepoMock).lagre(eq(actual), anyOrNull())
-            verify(oppgaveServiceMock).lukkOppgave(gammelOppgaveId)
             verify(eventObserver).handle(
                 argThat {
                     it shouldBe StatistikkEvent.Behandling.Søknad.TilAttestering.Innvilget(actual as SøknadsbehandlingTilAttestering.Innvilget)
                 },
             )
         }
-        verifyNoMoreInteractions(søknadsbehandlingRepoMock, personServiceMock, oppgaveServiceMock, eventObserver)
+        verifyNoMoreInteractions(søknadsbehandlingRepoMock, oppgaveServiceMock, eventObserver)
     }
 }

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceOpprettetTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/søknadsbehandling/SøknadsbehandlingServiceOpprettetTest.kt
@@ -11,6 +11,7 @@ import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.grunnlag.Grunnlagsdata
 import no.nav.su.se.bakover.domain.grunnlag.GrunnlagsdataOgVilkårsvurderinger
 import no.nav.su.se.bakover.domain.grunnlag.StøtterHentingAvEksternGrunnlag
+import no.nav.su.se.bakover.domain.oppgave.OppdaterOppgaveInfo
 import no.nav.su.se.bakover.domain.statistikk.StatistikkEvent
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.Personopplysninger
 import no.nav.su.se.bakover.domain.søknadsbehandling.SøknadsbehandlingRepo
@@ -25,6 +26,8 @@ import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.getOrFail
 import no.nav.su.se.bakover.test.nySakUføre
+import no.nav.su.se.bakover.test.oppgave.nyOppgaveHttpKallResponse
+import no.nav.su.se.bakover.test.oppgave.oppgaveId
 import no.nav.su.se.bakover.test.sakId
 import no.nav.su.se.bakover.test.saksbehandler
 import no.nav.su.se.bakover.test.saksnummer
@@ -32,6 +35,7 @@ import no.nav.su.se.bakover.test.søknad.nySakMedLukketSøknad
 import no.nav.su.se.bakover.test.søknad.nySakMedNySøknad
 import no.nav.su.se.bakover.test.søknad.nySakMedjournalførtSøknadOgOppgave
 import no.nav.su.se.bakover.test.søknad.nySøknadJournalførtMedOppgave
+import no.nav.su.se.bakover.test.søknad.oppgaveIdSøknad
 import no.nav.su.se.bakover.test.søknad.søknadinnholdUføre
 import no.nav.su.se.bakover.test.søknadsbehandlingIverksattAvslagMedBeregning
 import no.nav.su.se.bakover.test.søknadsbehandlingIverksattAvslagUtenBeregning
@@ -179,6 +183,9 @@ internal class SøknadsbehandlingServiceOpprettetTest {
             sakService = mock {
                 on { hentSak(any<UUID>()) } doReturn sak.right()
             },
+            oppgaveService = mock {
+                on { oppdaterOppgave(any(), any()) } doReturn nyOppgaveHttpKallResponse().right()
+            },
         )
 
         serviceAndMocks.søknadsbehandlingService.opprett(
@@ -218,6 +225,15 @@ internal class SøknadsbehandlingServiceOpprettetTest {
             VilkårsvurdertSøknadsbehandling.Uavklart::periode,
         )
         verify(serviceAndMocks.sakService).hentSak(argThat<UUID> { it shouldBe sak.id })
+        verify(serviceAndMocks.oppgaveService).oppdaterOppgave(
+            argThat { it shouldBe oppgaveIdSøknad },
+            argThat {
+                it shouldBe OppdaterOppgaveInfo(
+                    beskrivelse = "Tilordnet oppgave til saksbehandler",
+                    tilordnetRessurs = saksbehandler.navIdent,
+                )
+            },
+        )
         verify(søknadsbehandlingRepoMock).lagreNySøknadsbehandling(
             argThat {
                 it shouldBe NySøknadsbehandling(

--- a/test-common/src/main/kotlin/KlageTestData.kt
+++ b/test-common/src/main/kotlin/KlageTestData.kt
@@ -2,7 +2,6 @@
 
 package no.nav.su.se.bakover.test
 
-import arrow.core.right
 import no.nav.su.se.bakover.common.domain.Saksnummer
 import no.nav.su.se.bakover.common.domain.attestering.Attestering
 import no.nav.su.se.bakover.common.domain.attestering.Attesteringshistorikk
@@ -44,7 +43,7 @@ fun opprettetKlage(
     opprettet: Tidspunkt = fixedTidspunkt.plus(31, ChronoUnit.DAYS),
     sakId: UUID = no.nav.su.se.bakover.test.sakId,
     journalpostId: JournalpostId = JournalpostId("klageJournalpostId"),
-    oppgaveId: OppgaveId = OppgaveId("klageOppgaveId"),
+    oppgaveId: OppgaveId = oppgaveIdKlage,
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
     datoKlageMottatt: LocalDate = 15.januar(2021),
     sakMedVedtak: Sak = vedtakSøknadsbehandlingIverksattInnvilget(sakId = sakId).first,
@@ -81,7 +80,7 @@ fun påbegyntVilkårsvurdertKlage(
     opprettet: Tidspunkt = fixedTidspunkt.plus(31, ChronoUnit.DAYS),
     sakId: UUID = no.nav.su.se.bakover.test.sakId,
     journalpostId: JournalpostId = JournalpostId("klageJournalpostId"),
-    oppgaveId: OppgaveId = OppgaveId("klageOppgaveId"),
+    oppgaveId: OppgaveId = oppgaveIdKlage,
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
     datoKlageMottatt: LocalDate = 15.januar(2021),
     vedtakId: UUID? = null,
@@ -126,7 +125,7 @@ fun utfyltVilkårsvurdertKlageTilVurdering(
     opprettet: Tidspunkt = fixedTidspunkt.plus(31, ChronoUnit.DAYS),
     sakId: UUID = no.nav.su.se.bakover.test.sakId,
     journalpostId: JournalpostId = JournalpostId("klageJournalpostId"),
-    oppgaveId: OppgaveId = OppgaveId("klageOppgaveId"),
+    oppgaveId: OppgaveId = oppgaveIdKlage,
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
     datoKlageMottatt: LocalDate = 15.januar(2021),
     vedtakId: UUID = UUID.randomUUID(),
@@ -174,7 +173,7 @@ fun utfyltAvvistVilkårsvurdertKlage(
     opprettet: Tidspunkt = fixedTidspunkt.plus(31, ChronoUnit.DAYS),
     sakId: UUID = no.nav.su.se.bakover.test.sakId,
     journalpostId: JournalpostId = JournalpostId("klageJournalpostId"),
-    oppgaveId: OppgaveId = OppgaveId("klageOppgaveId"),
+    oppgaveId: OppgaveId = oppgaveIdKlage,
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
     datoKlageMottatt: LocalDate = 15.januar(2021),
     vedtakId: UUID = UUID.randomUUID(),
@@ -219,7 +218,7 @@ fun bekreftetVilkårsvurdertKlageTilVurdering(
     opprettet: Tidspunkt = fixedTidspunkt.plus(31, ChronoUnit.DAYS),
     sakId: UUID = no.nav.su.se.bakover.test.sakId,
     journalpostId: JournalpostId = JournalpostId("klageJournalpostId"),
-    oppgaveId: OppgaveId = OppgaveId("klageOppgaveId"),
+    oppgaveId: OppgaveId = oppgaveIdKlage,
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
     datoKlageMottatt: LocalDate = 15.januar(2021),
     vedtakId: UUID = UUID.randomUUID(),
@@ -265,7 +264,7 @@ fun bekreftetAvvistVilkårsvurdertKlage(
     opprettet: Tidspunkt = fixedTidspunkt.plus(31, ChronoUnit.DAYS),
     sakId: UUID = no.nav.su.se.bakover.test.sakId,
     journalpostId: JournalpostId = JournalpostId("klageJournalpostId"),
-    oppgaveId: OppgaveId = OppgaveId("klageOppgaveId"),
+    oppgaveId: OppgaveId = oppgaveIdKlage,
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
     datoKlageMottatt: LocalDate = 15.januar(2021),
     vedtakId: UUID = UUID.randomUUID(),
@@ -308,7 +307,7 @@ fun påbegyntVurdertKlage(
     opprettet: Tidspunkt = fixedTidspunkt.plus(31, ChronoUnit.DAYS),
     sakId: UUID = no.nav.su.se.bakover.test.sakId,
     journalpostId: JournalpostId = JournalpostId("klageJournalpostId"),
-    oppgaveId: OppgaveId = OppgaveId("klageOppgaveId"),
+    oppgaveId: OppgaveId = oppgaveIdKlage,
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
     datoKlageMottatt: LocalDate = 15.januar(2021),
     vedtakId: UUID = UUID.randomUUID(),
@@ -356,7 +355,7 @@ fun utfyltVurdertKlage(
     sakId: UUID = no.nav.su.se.bakover.test.sakId,
     fnr: Fnr = Fnr.generer(),
     journalpostId: JournalpostId = JournalpostId("klageJournalpostId"),
-    oppgaveId: OppgaveId = OppgaveId("klageOppgaveId"),
+    oppgaveId: OppgaveId = oppgaveIdKlage,
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
     datoKlageMottatt: LocalDate = 15.januar(2021),
     vedtakId: UUID = UUID.randomUUID(),
@@ -407,7 +406,7 @@ fun bekreftetVurdertKlage(
     opprettet: Tidspunkt = fixedTidspunkt.plus(31, ChronoUnit.DAYS),
     sakId: UUID = no.nav.su.se.bakover.test.sakId,
     journalpostId: JournalpostId = JournalpostId("klageJournalpostId"),
-    oppgaveId: OppgaveId = OppgaveId("klageOppgaveId"),
+    oppgaveId: OppgaveId = oppgaveIdKlage,
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
     datoKlageMottatt: LocalDate = 15.januar(2021),
     vedtakId: UUID = UUID.randomUUID(),
@@ -456,7 +455,7 @@ fun avvistKlage(
     opprettet: Tidspunkt = fixedTidspunkt.plus(31, ChronoUnit.DAYS),
     sakId: UUID = no.nav.su.se.bakover.test.sakId,
     journalpostId: JournalpostId = JournalpostId("klageJournalpostId"),
-    oppgaveId: OppgaveId = OppgaveId("klageOppgaveId"),
+    oppgaveId: OppgaveId = oppgaveIdKlage,
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
     datoKlageMottatt: LocalDate = 15.januar(2021),
     vedtakId: UUID = UUID.randomUUID(),
@@ -520,7 +519,6 @@ fun vurdertKlageTilAttestering(
     opprettet: Tidspunkt = fixedTidspunkt.plus(31, ChronoUnit.DAYS),
     sakId: UUID = no.nav.su.se.bakover.test.sakId,
     journalpostId: JournalpostId = JournalpostId("klageJournalpostId"),
-    oppgaveIdTilAttestering: OppgaveId = OppgaveId("klageTilAttesteringOppgaveId"),
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
     datoKlageMottatt: LocalDate = 15.januar(2021),
     vedtakId: UUID = UUID.randomUUID(),
@@ -539,7 +537,7 @@ fun vurdertKlageTilAttestering(
         opprettet = opprettet,
         sakId = sakId,
         journalpostId = journalpostId,
-        oppgaveId = OppgaveId("klageOppgaveId"),
+        oppgaveId = oppgaveIdKlage,
         saksbehandler = saksbehandler,
         datoKlageMottatt = datoKlageMottatt,
         vedtakId = vedtakId,
@@ -552,7 +550,6 @@ fun vurdertKlageTilAttestering(
         sakMedVedtak = sakMedVedtak,
     ).let {
         val klage = it.second.sendTilAttestering(
-            opprettOppgave = { oppgaveIdTilAttestering.right() },
             saksbehandler = saksbehandler,
         ).getOrFail()
 
@@ -569,7 +566,6 @@ fun avvistKlageTilAttestering(
     opprettet: Tidspunkt = fixedTidspunkt.plus(31, ChronoUnit.DAYS),
     sakId: UUID = no.nav.su.se.bakover.test.sakId,
     journalpostId: JournalpostId = JournalpostId("klageJournalpostId"),
-    oppgaveIdTilAttestering: OppgaveId = OppgaveId("klageTilAttesteringOppgaveId"),
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
     datoKlageMottatt: LocalDate = 15.januar(2021),
     vedtakId: UUID = UUID.randomUUID(),
@@ -600,7 +596,7 @@ fun avvistKlageTilAttestering(
     ).let {
         val klage = it.second.sendTilAttestering(
             saksbehandler,
-        ) { oppgaveIdTilAttestering.right() }.getOrFail()
+        ).getOrFail()
 
         Pair(
             it.first.oppdaterKlage(klage),
@@ -614,7 +610,6 @@ fun underkjentKlageTilVurdering(
     opprettet: Tidspunkt = fixedTidspunkt.plus(31, ChronoUnit.DAYS),
     sakId: UUID = no.nav.su.se.bakover.test.sakId,
     journalpostId: JournalpostId = JournalpostId("klageJournalpostId"),
-    underkjentKlageOppgaveId: OppgaveId = OppgaveId("underkjentKlageOppgaveId"),
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
     datoKlageMottatt: LocalDate = 15.januar(2021),
     vedtakId: UUID = UUID.randomUUID(),
@@ -636,7 +631,6 @@ fun underkjentKlageTilVurdering(
         opprettet = opprettet,
         sakId = sakId,
         journalpostId = journalpostId,
-        oppgaveIdTilAttestering = OppgaveId("klageTilAttesteringOppgaveId"),
         saksbehandler = saksbehandler,
         datoKlageMottatt = datoKlageMottatt,
         vedtakId = vedtakId,
@@ -655,7 +649,7 @@ fun underkjentKlageTilVurdering(
                 grunn = attesteringsgrunn,
                 kommentar = attesteringskommentar,
             ),
-        ) { underkjentKlageOppgaveId.right() }.getOrFail()
+        ).getOrFail()
         Pair(
             it.first.oppdaterKlage(klage),
             klage,
@@ -668,7 +662,6 @@ fun underkjentAvvistKlage(
     opprettet: Tidspunkt = fixedTidspunkt.plus(31, ChronoUnit.DAYS),
     sakId: UUID = no.nav.su.se.bakover.test.sakId,
     journalpostId: JournalpostId = JournalpostId("klageJournalpostId"),
-    underkjentKlageOppgaveId: OppgaveId = OppgaveId("underkjentKlageOppgaveId"),
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
     datoKlageMottatt: LocalDate = 15.januar(2021),
     vedtakId: UUID = UUID.randomUUID(),
@@ -705,7 +698,7 @@ fun underkjentAvvistKlage(
                 grunn = attesteringsgrunn,
                 kommentar = attesteringskommentar,
             ),
-        ) { underkjentKlageOppgaveId.right() }.getOrFail()
+        ).getOrFail()
 
         Pair(
             it.first.oppdaterKlage(klage),
@@ -719,7 +712,6 @@ fun underkjentTilVurderingKlageTilAttestering(
     opprettet: Tidspunkt = fixedTidspunkt.plus(31, ChronoUnit.DAYS),
     sakId: UUID = no.nav.su.se.bakover.test.sakId,
     journalpostId: JournalpostId = JournalpostId("klageJournalpostId"),
-    oppgaveIdTilAttestering: OppgaveId = OppgaveId("underkjentKlageTilAttesteringOppgaveId"),
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
     datoKlageMottatt: LocalDate = 15.januar(2021),
     vedtakId: UUID = UUID.randomUUID(),
@@ -738,7 +730,6 @@ fun underkjentTilVurderingKlageTilAttestering(
         opprettet = opprettet,
         sakId = sakId,
         journalpostId = journalpostId,
-        underkjentKlageOppgaveId = OppgaveId("underkjentKlageOppgaveId"),
         saksbehandler = saksbehandler,
         datoKlageMottatt = datoKlageMottatt,
         vedtakId = vedtakId,
@@ -752,7 +743,6 @@ fun underkjentTilVurderingKlageTilAttestering(
     ).let {
         val klage = it.second.sendTilAttestering(
             saksbehandler = saksbehandler,
-            opprettOppgave = { oppgaveIdTilAttestering.right() },
         ).getOrFail()
         Pair(
             it.first.oppdaterKlage(klage),
@@ -767,7 +757,6 @@ fun oversendtKlage(
     opprettet: Tidspunkt = Tidspunkt.now(clock).plus(31, ChronoUnit.DAYS),
     sakId: UUID = UUID.randomUUID(),
     journalpostId: JournalpostId = JournalpostId("klageJournalpostId"),
-    oppgaveIdTilAttestering: OppgaveId = OppgaveId("klageTilAttesteringOppgaveId"),
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
     datoKlageMottatt: LocalDate = 15.januar(2021),
     vedtakId: UUID = UUID.randomUUID(),
@@ -797,7 +786,6 @@ fun oversendtKlage(
         opprettet = opprettet,
         sakId = sakId,
         journalpostId = journalpostId,
-        oppgaveIdTilAttestering = oppgaveIdTilAttestering,
         saksbehandler = saksbehandler,
         datoKlageMottatt = datoKlageMottatt,
         vedtakId = vedtakId,
@@ -827,7 +815,6 @@ fun iverksattAvvistKlage(
     opprettet: Tidspunkt = fixedTidspunkt.plus(31, ChronoUnit.DAYS),
     sakId: UUID = no.nav.su.se.bakover.test.sakId,
     journalpostId: JournalpostId = JournalpostId("klageJournalpostId"),
-    oppgaveIdTilAttestering: OppgaveId = OppgaveId("klageTilAttesteringOppgaveId"),
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
     datoKlageMottatt: LocalDate = 15.januar(2021),
     vedtakId: UUID = UUID.randomUUID(),
@@ -845,7 +832,6 @@ fun iverksattAvvistKlage(
         opprettet = opprettet,
         sakId = sakId,
         journalpostId = journalpostId,
-        oppgaveIdTilAttestering = oppgaveIdTilAttestering,
         saksbehandler = saksbehandler,
         datoKlageMottatt = datoKlageMottatt,
         vedtakId = vedtakId,

--- a/test-common/src/main/kotlin/RevurderingTestData.kt
+++ b/test-common/src/main/kotlin/RevurderingTestData.kt
@@ -347,7 +347,6 @@ fun revurderingTilAttestering(
     vilkårOverrides: List<Vilkår> = emptyList(),
     grunnlagsdataOverrides: List<Grunnlag> = emptyList(),
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
-    attesteringsoppgaveId: OppgaveId = OppgaveId("oppgaveid"),
     utbetalingerKjørtTilOgMed: (clock: Clock) -> LocalDate = { LocalDate.now(it) },
     brevvalg: BrevvalgRevurdering.Valgt = sendBrev(),
     skalUtsetteTilbakekreving: Boolean = false,
@@ -370,17 +369,11 @@ fun revurderingTilAttestering(
     ).let { (sak, simulert) ->
         val tilAttestering = when (simulert) {
             is SimulertRevurdering.Innvilget -> {
-                simulert.tilAttestering(
-                    attesteringsoppgaveId = attesteringsoppgaveId,
-                    saksbehandler = saksbehandler,
-                ).getOrFail()
+                simulert.tilAttestering(saksbehandler = saksbehandler).getOrFail()
             }
 
             is SimulertRevurdering.Opphørt -> {
-                simulert.tilAttestering(
-                    attesteringsoppgaveId = attesteringsoppgaveId,
-                    saksbehandler = saksbehandler,
-                ).getOrFail()
+                simulert.tilAttestering(saksbehandler = saksbehandler).getOrFail()
             }
         }
         sak.oppdaterRevurdering(tilAttestering) to tilAttestering
@@ -416,10 +409,7 @@ fun revurderingUnderkjent(
         grunnlagsdataOverrides = grunnlagsdataOverrides,
         utbetalingerKjørtTilOgMed = utbetalingerKjørtTilOgMed,
     ).let { (sak, tilAttestering) ->
-        val underkjent = tilAttestering.underkjenn(
-            attestering = attestering,
-            oppgaveId = OppgaveId("underkjentOppgaveId"),
-        )
+        val underkjent = tilAttestering.underkjenn(attestering = attestering)
         sak.oppdaterRevurdering(underkjent) to underkjent
     }
 }
@@ -484,7 +474,6 @@ fun iverksattRevurdering(
     grunnlagsdataOverrides: List<Grunnlag> = emptyList(),
     attestant: NavIdentBruker.Attestant = no.nav.su.se.bakover.test.attestant,
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
-    attesteringsoppgaveId: OppgaveId = OppgaveId("oppgaveid"),
     utbetalingerKjørtTilOgMed: (clock: Clock) -> LocalDate = { LocalDate.now(it) },
     brevvalg: BrevvalgRevurdering.Valgt = sendBrev(),
     skalUtsetteTilbakekreving: Boolean = false,
@@ -503,7 +492,6 @@ fun iverksattRevurdering(
         vilkårOverrides = vilkårOverrides,
         grunnlagsdataOverrides = grunnlagsdataOverrides,
         saksbehandler = saksbehandler,
-        attesteringsoppgaveId = attesteringsoppgaveId,
         utbetalingerKjørtTilOgMed = utbetalingerKjørtTilOgMed,
         brevvalg = brevvalg,
         skalUtsetteTilbakekreving = skalUtsetteTilbakekreving,

--- a/test-common/src/main/kotlin/SøknadsbehandlingTestData.kt
+++ b/test-common/src/main/kotlin/SøknadsbehandlingTestData.kt
@@ -555,6 +555,7 @@ fun nySøknadsbehandlingUtenStønadsperiode(
         søknadId = søknad.id,
         clock = clock,
         saksbehandler = saksbehandler,
+        oppdaterOppgave = null,
     ).getOrFail().let { (sak, _, behandling) ->
         Pair(sak, behandling)
     }

--- a/test-common/src/main/kotlin/VedtakTestData.kt
+++ b/test-common/src/main/kotlin/VedtakTestData.kt
@@ -7,7 +7,6 @@ import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.domain.Saksnummer
 import no.nav.su.se.bakover.common.domain.Stønadsperiode
 import no.nav.su.se.bakover.common.domain.attestering.Attestering
-import no.nav.su.se.bakover.common.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.common.domain.sak.SakInfo
 import no.nav.su.se.bakover.common.domain.sak.Sakstype
 import no.nav.su.se.bakover.common.extensions.startOfMonth
@@ -194,7 +193,6 @@ fun vedtakRevurderingIverksattInnvilget(
     grunnlagsdataOverrides: List<Grunnlag> = emptyList(),
     attestant: NavIdentBruker.Attestant = no.nav.su.se.bakover.test.attestant,
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
-    attesteringsoppgaveId: OppgaveId = OppgaveId("oppgaveid"),
     utbetalingerKjørtTilOgMed: (clock: Clock) -> LocalDate = { LocalDate.now(it) },
     brevvalg: BrevvalgRevurdering.Valgt = sendBrev(),
     skalTilbakekreve: Boolean = true,
@@ -211,7 +209,6 @@ fun vedtakRevurderingIverksattInnvilget(
         grunnlagsdataOverrides = grunnlagsdataOverrides,
         attestant = attestant,
         saksbehandler = saksbehandler,
-        attesteringsoppgaveId = attesteringsoppgaveId,
         utbetalingerKjørtTilOgMed = utbetalingerKjørtTilOgMed,
         brevvalg = brevvalg,
         skalTilbakekreve = skalTilbakekreve,

--- a/test-common/src/main/kotlin/persistence/TestDataHelper.kt
+++ b/test-common/src/main/kotlin/persistence/TestDataHelper.kt
@@ -1568,11 +1568,9 @@ class TestDataHelper(
 
     fun persisterKlageTilAttesteringVurdert(
         vedtak: VedtakInnvilgetSøknadsbehandling = persisterSøknadsbehandlingIverksattInnvilgetMedKvittertUtbetaling().second,
-        oppgaveId: OppgaveId = OppgaveId("klageTilAttesteringOppgaveId"),
     ): KlageTilAttestering.Vurdert {
         return persisterKlageVurdertBekreftet(vedtak = vedtak).sendTilAttestering(
             saksbehandler = NavIdentBruker.Saksbehandler(navIdent = "saksbehandlerKlageTilAttestering"),
-            opprettOppgave = { oppgaveId.right() },
         ).getOrFail().let {
             if (it !is KlageTilAttestering.Vurdert) throw IllegalStateException("Forventet en KlageTilAttestering(TilVurdering). fikk ${it::class} ved opprettelse av test-data")
             it
@@ -1583,13 +1581,11 @@ class TestDataHelper(
 
     fun persisterKlageTilAttesteringAvvist(
         vedtak: VedtakInnvilgetSøknadsbehandling = persisterSøknadsbehandlingIverksattInnvilgetMedKvittertUtbetaling().second,
-        oppgaveId: OppgaveId = OppgaveId("klageTilAttesteringOppgaveId"),
         saksbehandler: NavIdentBruker.Saksbehandler = NavIdentBruker.Saksbehandler("saksbehandlerAvvistKlageTilAttestering"),
         fritekstTilBrev: String = "en god, og lang fritekst",
     ): KlageTilAttestering.Avvist {
         return persisterKlageAvvist(vedtak, saksbehandler, fritekstTilBrev).sendTilAttestering(
             saksbehandler = saksbehandler,
-            opprettOppgave = { oppgaveId.right() },
         ).getOrFail().also {
             databaseRepos.klageRepo.lagre(it)
         }
@@ -1597,41 +1593,38 @@ class TestDataHelper(
 
     fun persisterKlageUnderkjentVurdert(
         vedtak: VedtakInnvilgetSøknadsbehandling = persisterSøknadsbehandlingIverksattInnvilgetMedKvittertUtbetaling().second,
-        oppgaveId: OppgaveId = OppgaveId("underkjentKlageOppgaveId"),
     ): VurdertKlage.Bekreftet {
-        return persisterKlageTilAttesteringVurdert(vedtak = vedtak, oppgaveId = oppgaveId).underkjenn(
+        return persisterKlageTilAttesteringVurdert(vedtak = vedtak).underkjenn(
             underkjentAttestering = Attestering.Underkjent(
                 attestant = NavIdentBruker.Attestant(navIdent = "saksbehandlerUnderkjentKlage"),
                 opprettet = Tidspunkt.now(clock),
                 grunn = UnderkjennAttesteringsgrunnBehandling.ANDRE_FORHOLD,
                 kommentar = "underkjennelseskommentar",
             ),
-        ) { oppgaveId.right() }.getOrFail().also {
+        ).getOrFail().also {
             databaseRepos.klageRepo.lagre(it)
         }
     }
 
     fun persisterKlageUnderkjentAvvist(
         vedtak: VedtakInnvilgetSøknadsbehandling = persisterSøknadsbehandlingIverksattInnvilgetMedKvittertUtbetaling().second,
-        oppgaveId: OppgaveId = OppgaveId("underkjentKlageOppgaveId"),
     ): AvvistKlage {
-        return persisterKlageTilAttesteringAvvist(vedtak, oppgaveId).underkjenn(
+        return persisterKlageTilAttesteringAvvist(vedtak).underkjenn(
             underkjentAttestering = Attestering.Underkjent(
                 attestant = NavIdentBruker.Attestant(navIdent = "saksbehandlerUnderkjentKlage"),
                 opprettet = Tidspunkt.now(clock),
                 grunn = UnderkjennAttesteringsgrunnBehandling.ANDRE_FORHOLD,
                 kommentar = "underkjennelseskommentar",
             ),
-        ) { oppgaveId.right() }.getOrFail().also {
+        ).getOrFail().also {
             databaseRepos.klageRepo.lagre(it)
         }
     }
 
     fun persisterKlageOversendt(
         vedtak: VedtakInnvilgetSøknadsbehandling = persisterSøknadsbehandlingIverksattInnvilgetMedKvittertUtbetaling().second,
-        oppgaveId: OppgaveId = OppgaveId("klageTilAttesteringOppgaveId"),
     ): OversendtKlage {
-        return persisterKlageTilAttesteringVurdert(vedtak = vedtak, oppgaveId = oppgaveId).oversend(
+        return persisterKlageTilAttesteringVurdert(vedtak = vedtak).oversend(
             iverksattAttestering = Attestering.Iverksatt(
                 attestant = NavIdentBruker.Attestant(navIdent = "saksbehandlerOversendtKlage"),
                 opprettet = Tidspunkt.now(clock),
@@ -1643,9 +1636,8 @@ class TestDataHelper(
 
     fun persisterKlageIverksattAvvist(
         vedtak: VedtakInnvilgetSøknadsbehandling = persisterSøknadsbehandlingIverksattInnvilgetMedKvittertUtbetaling().second,
-        oppgaveId: OppgaveId = OppgaveId("klageTilAttesteringOppgaveId"),
     ): IverksattAvvistKlage {
-        return persisterKlageTilAttesteringAvvist(vedtak, oppgaveId).iverksett(
+        return persisterKlageTilAttesteringAvvist(vedtak).iverksett(
             iverksattAttestering = Attestering.Iverksatt(
                 attestant = NavIdentBruker.Attestant(navIdent = "saksbehandlerIverksattAvvistKlage"),
                 opprettet = Tidspunkt.now(clock),

--- a/test-common/src/test/kotlin/xml/AssertXmlEqualsKtTest.kt
+++ b/test-common/src/test/kotlin/xml/AssertXmlEqualsKtTest.kt
@@ -1,0 +1,73 @@
+package xml
+
+import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.test.xml.shouldBeSimilarXmlTo
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+
+class AssertXmlEqualsKtTest {
+
+    @Test
+    fun `gir ut en forståelig feilmelding, dersom daten i XML'en ikke er lik`() {
+        val xml1 = """
+            <person>
+                <navn>Per</navn>
+                <alder>30</alder>
+            </person>
+        """.trimIndent()
+        val xml2 = """
+            <person>
+                <navn>Per</navn>
+                <alder>31</alder>
+            </person>
+        """.trimIndent()
+
+        assertThrows(AssertionError::class.java) {
+            xml2 shouldBeSimilarXmlTo xml1
+        }.message shouldBe """
+            Expected XMLs to be similar, but found differences:
+            Expected text value '31' but was '30' - comparing <alder ...>31</alder> at /person[1]/alder[1]/text()[1] to <alder ...>30</alder> at /person[1]/alder[1]/text()[1] (DIFFERENT)
+        """.trimIndent()
+    }
+
+    @Test
+    fun `gir ut en forståelig feilmelding, dersom strukturen i XML'en ikke er lik`() {
+        val xml1 = """
+            <person>
+                <navn>Per</navn>
+                <alder>30</alder>
+            </person>
+        """.trimIndent()
+        val xml2 = """
+            <person>
+                <alder>30</alder>
+                <navn>Per</navn>
+            </person>
+        """.trimIndent()
+
+        assertThrows(AssertionError::class.java) {
+            xml2 shouldBeSimilarXmlTo xml1
+        }.message shouldBe """
+            Expected XMLs to be similar, but found differences:
+            Expected element tag name 'alder' but was 'navn' - comparing <alder...> at /person[1]/alder[1] to <navn...> at /person[1]/navn[1] (DIFFERENT)
+        """.trimIndent()
+    }
+
+    @Test
+    fun `Gir ikke ut noen melding dersom XML dataen & strukturen er riktig`() {
+        val xml1 = """
+            <person>
+                <navn>Per</navn>
+                <alder>30</alder>
+            </person>
+        """.trimIndent()
+        val xml2 = """
+            <person>
+                <navn>Per</navn>
+                <alder>30</alder>
+            </person>
+        """.trimIndent()
+        assertDoesNotThrow { xml2 shouldBeSimilarXmlTo xml1 }
+    }
+}

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/komponenttest/TilbakekrevingUnderRevurderingKomponentTest.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/komponenttest/TilbakekrevingUnderRevurderingKomponentTest.kt
@@ -173,7 +173,7 @@ class TilbakekrevingUnderRevurderingKomponentTest {
 		<kodeHjemmel>SUL_13</kodeHjemmel>
 		<renterBeregnes>N</renterBeregnes>
 		<enhetAnsvarlig>8020</enhetAnsvarlig>
-		<kontrollfelt>2021-02-01-01.02.20.000000</kontrollfelt>
+		<kontrollfelt>2021-02-01-01.02.19.000000</kontrollfelt>
 		<saksbehId>K231B433</saksbehId>
 		<tilbakekrevingsperiode>
 			<periode>
@@ -285,7 +285,7 @@ class TilbakekrevingUnderRevurderingKomponentTest {
 		<kodeHjemmel>SUL_13</kodeHjemmel>
 		<renterBeregnes>N</renterBeregnes>
 		<enhetAnsvarlig>8020</enhetAnsvarlig>
-		<kontrollfelt>2021-02-01-01.02.20.000000</kontrollfelt>
+		<kontrollfelt>2021-02-01-01.02.19.000000</kontrollfelt>
 		<saksbehId>K231B433</saksbehId>
 		<tilbakekrevingsperiode>
 			<periode>
@@ -392,7 +392,7 @@ class TilbakekrevingUnderRevurderingKomponentTest {
 		<kodeHjemmel>SUL_13</kodeHjemmel>
 		<renterBeregnes>N</renterBeregnes>
 		<enhetAnsvarlig>8020</enhetAnsvarlig>
-		<kontrollfelt>2021-02-01-01.02.20.000000</kontrollfelt>
+		<kontrollfelt>2021-02-01-01.02.19.000000</kontrollfelt>
 		<saksbehId>K231B433</saksbehId>
 		<tilbakekrevingsperiode>
 			<periode>

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/komponenttest/TilbakekrevingUnderRevurderingKomponentTest.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/komponenttest/TilbakekrevingUnderRevurderingKomponentTest.kt
@@ -173,7 +173,7 @@ class TilbakekrevingUnderRevurderingKomponentTest {
 		<kodeHjemmel>SUL_13</kodeHjemmel>
 		<renterBeregnes>N</renterBeregnes>
 		<enhetAnsvarlig>8020</enhetAnsvarlig>
-		<kontrollfelt>2021-02-01-01.02.19.000000</kontrollfelt>
+		<kontrollfelt>2021-02-01-01.02.18.000000</kontrollfelt>
 		<saksbehId>K231B433</saksbehId>
 		<tilbakekrevingsperiode>
 			<periode>
@@ -285,7 +285,7 @@ class TilbakekrevingUnderRevurderingKomponentTest {
 		<kodeHjemmel>SUL_13</kodeHjemmel>
 		<renterBeregnes>N</renterBeregnes>
 		<enhetAnsvarlig>8020</enhetAnsvarlig>
-		<kontrollfelt>2021-02-01-01.02.19.000000</kontrollfelt>
+		<kontrollfelt>2021-02-01-01.02.18.000000</kontrollfelt>
 		<saksbehId>K231B433</saksbehId>
 		<tilbakekrevingsperiode>
 			<periode>
@@ -392,7 +392,7 @@ class TilbakekrevingUnderRevurderingKomponentTest {
 		<kodeHjemmel>SUL_13</kodeHjemmel>
 		<renterBeregnes>N</renterBeregnes>
 		<enhetAnsvarlig>8020</enhetAnsvarlig>
-		<kontrollfelt>2021-02-01-01.02.19.000000</kontrollfelt>
+		<kontrollfelt>2021-02-01-01.02.18.000000</kontrollfelt>
 		<saksbehId>K231B433</saksbehId>
 		<tilbakekrevingsperiode>
 			<periode>

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/AvbrytTilbakekrevingsbehandling.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/AvbrytTilbakekrevingsbehandling.kt
@@ -140,7 +140,7 @@ fun verifiserAvbrytTilbakekrevingRespons(
   "versjon": $expectedVersjon,
   "attesteringer": [],
   "erKravgrunnlagUtdatert": false,
-  "avsluttetTidspunkt": "2021-02-01T01:04:49.456789Z",
+  "avsluttetTidspunkt": "2021-02-01T01:04:48.456789Z",
   "notat": null,
 }"""
     actual.shouldBeSimilarJsonTo(expected, "kravgrunnlag.hendelseId", "opprettet", "kravgrunnlag.kontrollfelt")

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/AvbrytTilbakekrevingsbehandling.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/AvbrytTilbakekrevingsbehandling.kt
@@ -140,7 +140,7 @@ fun verifiserAvbrytTilbakekrevingRespons(
   "versjon": $expectedVersjon,
   "attesteringer": [],
   "erKravgrunnlagUtdatert": false,
-  "avsluttetTidspunkt": "2021-02-01T01:04:48.456789Z",
+  "avsluttetTidspunkt": "2021-02-01T01:04:46.456789Z",
   "notat": null,
 }"""
     actual.shouldBeSimilarJsonTo(expected, "kravgrunnlag.hendelseId", "opprettet", "kravgrunnlag.kontrollfelt")

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/ForhåndsvarsleTilbakekrevingsbehandling.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/ForhåndsvarsleTilbakekrevingsbehandling.kt
@@ -117,7 +117,7 @@ fun verifiserForhåndsvarsletTilbakekrevingsbehandlingRespons(
   "kravgrunnlag":{
     "eksternKravgrunnlagsId":"123456",
     "eksternVedtakId":"654321",
-    "kontrollfelt":"2021-02-01-02.03.28.456789",
+    "kontrollfelt":"2021-02-01-02.03.27.456789",
     "status":"NY",
     "grunnlagsperiode":[
       {

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/ForhåndsvarsleTilbakekrevingsbehandling.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/ForhåndsvarsleTilbakekrevingsbehandling.kt
@@ -117,7 +117,7 @@ fun verifiserForhåndsvarsletTilbakekrevingsbehandlingRespons(
   "kravgrunnlag":{
     "eksternKravgrunnlagsId":"123456",
     "eksternVedtakId":"654321",
-    "kontrollfelt":"2021-02-01-02.03.27.456789",
+    "kontrollfelt":"2021-02-01-02.03.26.456789",
     "status":"NY",
     "grunnlagsperiode":[
       {

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/IverksettTilbakekrevingsbehandling.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/IverksettTilbakekrevingsbehandling.kt
@@ -230,7 +230,7 @@ fun verifiserIverksattTilbakekrevingsbehandlingRespons(
   "kravgrunnlag":{
     "eksternKravgrunnlagsId":"123456",
     "eksternVedtakId":"654321",
-    "kontrollfelt":"2021-02-01-02.03.28.456789",
+    "kontrollfelt":"2021-02-01-02.03.27.456789",
     "status":"NY",
     "grunnlagsperiode":[
       {

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/IverksettTilbakekrevingsbehandling.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/IverksettTilbakekrevingsbehandling.kt
@@ -230,7 +230,7 @@ fun verifiserIverksattTilbakekrevingsbehandlingRespons(
   "kravgrunnlag":{
     "eksternKravgrunnlagsId":"123456",
     "eksternVedtakId":"654321",
-    "kontrollfelt":"2021-02-01-02.03.27.456789",
+    "kontrollfelt":"2021-02-01-02.03.26.456789",
     "status":"NY",
     "grunnlagsperiode":[
       {

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/LeggTilNotatTilbakekrevingsbehandling.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/LeggTilNotatTilbakekrevingsbehandling.kt
@@ -89,7 +89,7 @@ fun verifiserLeggTilNotatTilbakekrevingRespons(
   "kravgrunnlag":{
     "eksternKravgrunnlagsId":"123456",
     "eksternVedtakId":"654321",
-    "kontrollfelt":"2021-02-01-02.03.27.456789",
+    "kontrollfelt":"2021-02-01-02.03.26.456789",
     "status":"NY",
     "grunnlagsperiode":[
       {

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/LeggTilNotatTilbakekrevingsbehandling.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/LeggTilNotatTilbakekrevingsbehandling.kt
@@ -89,7 +89,7 @@ fun verifiserLeggTilNotatTilbakekrevingRespons(
   "kravgrunnlag":{
     "eksternKravgrunnlagsId":"123456",
     "eksternVedtakId":"654321",
-    "kontrollfelt":"2021-02-01-02.03.28.456789",
+    "kontrollfelt":"2021-02-01-02.03.27.456789",
     "status":"NY",
     "grunnlagsperiode":[
       {

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/OppdaterKravgrunnlagTilbakekrevingsbehandling.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/OppdaterKravgrunnlagTilbakekrevingsbehandling.kt
@@ -88,7 +88,7 @@ fun verifiserOppdatertKravgrunnlagRespons(
   "kravgrunnlag":{
     "eksternKravgrunnlagsId":"123456",
     "eksternVedtakId":"654321",
-    "kontrollfelt":"2021-02-01-02.04.40.456789",
+    "kontrollfelt":"2021-02-01-02.04.38.456789",
     "status":"NY",
     "grunnlagsperiode":[
       {

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/OppdaterKravgrunnlagTilbakekrevingsbehandling.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/OppdaterKravgrunnlagTilbakekrevingsbehandling.kt
@@ -88,7 +88,7 @@ fun verifiserOppdatertKravgrunnlagRespons(
   "kravgrunnlag":{
     "eksternKravgrunnlagsId":"123456",
     "eksternVedtakId":"654321",
-    "kontrollfelt":"2021-02-01-02.04.41.456789",
+    "kontrollfelt":"2021-02-01-02.04.40.456789",
     "status":"NY",
     "grunnlagsperiode":[
       {

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/OppdaterVedtaksbrevTilbakekrevingsbehandling.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/OppdaterVedtaksbrevTilbakekrevingsbehandling.kt
@@ -96,7 +96,7 @@ fun verifiserOppdatertVedtaksbrevTilbakekrevingsbehandlingRespons(
   "kravgrunnlag":{
     "eksternKravgrunnlagsId":"123456",
     "eksternVedtakId":"654321",
-    "kontrollfelt":"2021-02-01-02.03.28.456789",
+    "kontrollfelt":"2021-02-01-02.03.27.456789",
     "status":"NY",
     "grunnlagsperiode":[
       {

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/OppdaterVedtaksbrevTilbakekrevingsbehandling.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/OppdaterVedtaksbrevTilbakekrevingsbehandling.kt
@@ -96,7 +96,7 @@ fun verifiserOppdatertVedtaksbrevTilbakekrevingsbehandlingRespons(
   "kravgrunnlag":{
     "eksternKravgrunnlagsId":"123456",
     "eksternVedtakId":"654321",
-    "kontrollfelt":"2021-02-01-02.03.27.456789",
+    "kontrollfelt":"2021-02-01-02.03.26.456789",
     "status":"NY",
     "grunnlagsperiode":[
       {

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/OpprettTilbakekrevingsbehandling.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/OpprettTilbakekrevingsbehandling.kt
@@ -26,7 +26,7 @@ internal fun AppComponents.opprettTilbakekrevingsbehandling(
     verifiserRespons: Boolean = true,
     utførSideeffekter: Boolean = true,
     saksversjon: Long,
-    expectedKontrollfelt: String = "2021-02-01-02.03.27.456789",
+    expectedKontrollfelt: String = "2021-02-01-02.03.26.456789",
 ): OpprettetTilbakekrevingsbehandlingRespons {
     val appComponents = this
     val sakFørKallJson = hentSak(sakId, client)
@@ -103,7 +103,7 @@ fun verifiserOpprettetTilbakekrevingsbehandlingRespons(
     actual: String,
     sakId: String,
     expectedVersjon: Long,
-    expectedKontrollfelt: String = "2021-02-01-02.03.27.456789",
+    expectedKontrollfelt: String = "2021-02-01-02.03.26.456789",
 ) {
     val expected = """
 {

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/OpprettTilbakekrevingsbehandling.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/OpprettTilbakekrevingsbehandling.kt
@@ -26,7 +26,7 @@ internal fun AppComponents.opprettTilbakekrevingsbehandling(
     verifiserRespons: Boolean = true,
     utførSideeffekter: Boolean = true,
     saksversjon: Long,
-    expectedKontrollfelt: String = "2021-02-01-02.03.28.456789",
+    expectedKontrollfelt: String = "2021-02-01-02.03.27.456789",
 ): OpprettetTilbakekrevingsbehandlingRespons {
     val appComponents = this
     val sakFørKallJson = hentSak(sakId, client)
@@ -103,7 +103,7 @@ fun verifiserOpprettetTilbakekrevingsbehandlingRespons(
     actual: String,
     sakId: String,
     expectedVersjon: Long,
-    expectedKontrollfelt: String = "2021-02-01-02.03.28.456789",
+    expectedKontrollfelt: String = "2021-02-01-02.03.27.456789",
 ) {
     val expected = """
 {

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/SendTilbakekrevingsbehandlingTilAttestering.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/SendTilbakekrevingsbehandlingTilAttestering.kt
@@ -117,7 +117,7 @@ fun verifiserTilbakekrevingsbehandlingTilAttesteringRespons(
   "kravgrunnlag":{
     "eksternKravgrunnlagsId":"123456",
     "eksternVedtakId":"654321",
-    "kontrollfelt":"2021-02-01-02.03.28.456789",
+    "kontrollfelt":"2021-02-01-02.03.27.456789",
     "status":"NY",
     "grunnlagsperiode":[
       {

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/SendTilbakekrevingsbehandlingTilAttestering.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/SendTilbakekrevingsbehandlingTilAttestering.kt
@@ -117,7 +117,7 @@ fun verifiserTilbakekrevingsbehandlingTilAttesteringRespons(
   "kravgrunnlag":{
     "eksternKravgrunnlagsId":"123456",
     "eksternVedtakId":"654321",
-    "kontrollfelt":"2021-02-01-02.03.27.456789",
+    "kontrollfelt":"2021-02-01-02.03.26.456789",
     "status":"NY",
     "grunnlagsperiode":[
       {

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/TilbakekrevingsbehandlingIT.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/TilbakekrevingsbehandlingIT.kt
@@ -164,7 +164,7 @@ internal class TilbakekrevingsbehandlingIT {
                 ],
                 "eksternKravgrunnlagId":"123456",
                 "eksternVedtakId":"654321",
-                "eksternKontrollfelt":"2021-02-01-02.03.28.456789",
+                "eksternKontrollfelt":"2021-02-01-02.03.27.456789",
                 "bruttoSkalTilbakekreveSummert":0,
                 "nettoSkalTilbakekreveSummert":0,
                 "bruttoSkalIkkeTilbakekreveSummert":12383,

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/TilbakekrevingsbehandlingIT.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/TilbakekrevingsbehandlingIT.kt
@@ -164,7 +164,7 @@ internal class TilbakekrevingsbehandlingIT {
                 ],
                 "eksternKravgrunnlagId":"123456",
                 "eksternVedtakId":"654321",
-                "eksternKontrollfelt":"2021-02-01-02.03.27.456789",
+                "eksternKontrollfelt":"2021-02-01-02.03.26.456789",
                 "bruttoSkalTilbakekreveSummert":0,
                 "nettoSkalTilbakekreveSummert":0,
                 "bruttoSkalIkkeTilbakekreveSummert":12383,

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/TilbakekrevingsbehandlingStatusendringIT.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/TilbakekrevingsbehandlingStatusendringIT.kt
@@ -59,7 +59,7 @@ internal class TilbakekrevingsbehandlingStatusendringIT {
                 // Må økes etter hvert som vi får flere hendelser.
                 saksversjon = 2,
                 client = this.client,
-                expectedKontrollfelt = "2021-02-01-02.03.29.456789",
+                expectedKontrollfelt = "2021-02-01-02.03.28.456789",
             ).let {
                 JSONObject(it.responseJson).getJSONObject("kravgrunnlag").getString("eksternVedtakId")
             }

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/TilbakekrevingsbehandlingStatusendringIT.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/TilbakekrevingsbehandlingStatusendringIT.kt
@@ -59,7 +59,7 @@ internal class TilbakekrevingsbehandlingStatusendringIT {
                 // Må økes etter hvert som vi får flere hendelser.
                 saksversjon = 2,
                 client = this.client,
-                expectedKontrollfelt = "2021-02-01-02.03.28.456789",
+                expectedKontrollfelt = "2021-02-01-02.03.27.456789",
             ).let {
                 JSONObject(it.responseJson).getJSONObject("kravgrunnlag").getString("eksternVedtakId")
             }

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/UnderkjennTilbakekrevingsbehandling.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/UnderkjennTilbakekrevingsbehandling.kt
@@ -135,7 +135,7 @@ fun verifiserUnderkjentTilbakekrevingsbehandlingRespons(
   "kravgrunnlag":{
     "eksternKravgrunnlagsId":"123456",
     "eksternVedtakId":"654321",
-    "kontrollfelt":"2021-02-01-02.03.28.456789",
+    "kontrollfelt":"2021-02-01-02.03.27.456789",
     "status":"NY",
     "grunnlagsperiode":[
       {

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/UnderkjennTilbakekrevingsbehandling.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/UnderkjennTilbakekrevingsbehandling.kt
@@ -135,7 +135,7 @@ fun verifiserUnderkjentTilbakekrevingsbehandlingRespons(
   "kravgrunnlag":{
     "eksternKravgrunnlagsId":"123456",
     "eksternVedtakId":"654321",
-    "kontrollfelt":"2021-02-01-02.03.27.456789",
+    "kontrollfelt":"2021-02-01-02.03.26.456789",
     "status":"NY",
     "grunnlagsperiode":[
       {

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/VurderTilbakekrevingsbehandling.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/VurderTilbakekrevingsbehandling.kt
@@ -53,7 +53,7 @@ internal fun vurderTilbakekrevingsbehandling(
         ],
         "eksternKravgrunnlagId":"123456",
         "eksternVedtakId":"654321",
-        "eksternKontrollfelt":"2021-02-01-02.03.28.456789",
+        "eksternKontrollfelt":"2021-02-01-02.03.27.456789",
         "bruttoSkalTilbakekreveSummert":12383,
         "nettoSkalTilbakekreveSummert":6191,
         "bruttoSkalIkkeTilbakekreveSummert":0,
@@ -148,7 +148,7 @@ fun verifiserVurdertTilbakekrevingsbehandlingRespons(
   "kravgrunnlag":{
     "eksternKravgrunnlagsId":"123456",
     "eksternVedtakId":"654321",
-    "kontrollfelt":"2021-02-01-02.03.28.456789",
+    "kontrollfelt":"2021-02-01-02.03.27.456789",
     "status":"NY",
     "grunnlagsperiode":[
       {

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/VurderTilbakekrevingsbehandling.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/tilbakekreving/VurderTilbakekrevingsbehandling.kt
@@ -53,7 +53,7 @@ internal fun vurderTilbakekrevingsbehandling(
         ],
         "eksternKravgrunnlagId":"123456",
         "eksternVedtakId":"654321",
-        "eksternKontrollfelt":"2021-02-01-02.03.27.456789",
+        "eksternKontrollfelt":"2021-02-01-02.03.26.456789",
         "bruttoSkalTilbakekreveSummert":12383,
         "nettoSkalTilbakekreveSummert":6191,
         "bruttoSkalIkkeTilbakekreveSummert":0,
@@ -148,7 +148,7 @@ fun verifiserVurdertTilbakekrevingsbehandlingRespons(
   "kravgrunnlag":{
     "eksternKravgrunnlagsId":"123456",
     "eksternVedtakId":"654321",
-    "kontrollfelt":"2021-02-01-02.03.27.456789",
+    "kontrollfelt":"2021-02-01-02.03.26.456789",
     "status":"NY",
     "grunnlagsperiode":[
       {

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxy.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxy.kt
@@ -508,7 +508,7 @@ open class AccessCheckProxy(
                 override fun lukkOppgaveMedSystembruker(oppgaveId: OppgaveId) = kastKanKunKallesFraAnnenService()
                 override fun oppdaterOppgave(
                     oppgaveId: OppgaveId,
-                    beskrivelse: String,
+                    oppdaterOppgaveInfo: OppdaterOppgaveInfo,
                 ): Either<KunneIkkeOppdatereOppgave, OppgaveHttpKallResponse> = kastKanKunKallesFraAnnenService()
 
                 override fun oppdaterOppgaveMedSystembruker(

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/ServiceBuilder.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/ServiceBuilder.kt
@@ -295,6 +295,7 @@ data object ServiceBuilder {
                 iverksettSøknadsbehandlingService = iverksettSøknadsbehandlingService,
                 utbetalingService = utbetalingService,
                 brevService = brevService,
+                oppgaveService = oppgaveService,
             ),
             klageService = klageService,
             klageinstanshendelseService = klageinstanshendelseService,

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/klage/OversendKlageTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/routes/klage/OversendKlageTest.kt
@@ -12,7 +12,6 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.server.testing.testApplication
 import no.nav.su.se.bakover.common.brukerrolle.Brukerrolle
-import no.nav.su.se.bakover.domain.brev.jsonRequest.FeilVedHentingAvInformasjon
 import no.nav.su.se.bakover.domain.klage.KunneIkkeLageBrevKommandoForKlage
 import no.nav.su.se.bakover.domain.klage.KunneIkkeOversendeKlage
 import no.nav.su.se.bakover.domain.klage.OpprettetKlage


### PR DESCRIPTION
Tilordnet ressurs blir også lagt på når saksbehandler trykker på opprett behandling for en søknadsbehandling

edit: la merke til at Klage også lukker/oppretter - skal oppdatere PR til å fikse dette