### PR TITLE
Grupper personhendelseoppgaver på sakId

### DIFF
--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/oppgave/OppgaveHttpClient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/oppgave/OppgaveHttpClient.kt
@@ -165,9 +165,7 @@ internal class OppgaveHttpClient(
                 "--- ${
                     Tidspunkt.now(clock).toOppgaveFormat()
                 } - Opprettet av Supplerende Stønad ---\nSaksnummer : ${config.saksreferanse}\nPersonhendelse: ${
-                    OppgavebeskrivelseMapper.map(
-                        config.personhendelsestype,
-                    )
+                    OppgavebeskrivelseMapper.map(config.personhendelse)
                 }"
 
             is OppgaveConfig.Kontrollsamtale ->

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/oppgave/OppgavebeskrivelseMapper.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/oppgave/OppgavebeskrivelseMapper.kt
@@ -1,5 +1,6 @@
 package no.nav.su.se.bakover.client.oppgave
 
+import arrow.core.NonEmptyCollection
 import no.nav.su.se.bakover.client.oppgave.OppgaveHttpClient.Companion.toOppgaveFormat
 import no.nav.su.se.bakover.domain.klage.KlageinstansUtfall
 import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
@@ -14,7 +15,11 @@ data object OppgavebeskrivelseMapper {
             "\n\n${config.utfall.lukkBeskrivelse()}"
     }
 
-    fun map(hendelse: Personhendelse.Hendelse) = when (hendelse) {
+    fun map(hendelser: NonEmptyCollection<Personhendelse.Hendelse>): String = hendelser.map {
+        map(it)
+    }.joinToString { "\n\n" }
+
+    fun map(hendelse: Personhendelse.Hendelse): String = when (hendelse) {
         is Personhendelse.Hendelse.Dødsfall -> {
             "Dødsfall\n" +
                 "\tDødsdato: ${hendelse.dødsdato ?: "Ikke oppgitt"}"

--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/oppgave/OppgavebeskrivelseMapperTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/oppgave/OppgavebeskrivelseMapperTest.kt
@@ -4,53 +4,94 @@ import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.domain.personhendelse.Personhendelse
 import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.fixedLocalDate
+import no.nav.su.se.bakover.test.nyPersonhendelseKnyttetTilSak
 import org.junit.jupiter.api.Test
 import person.domain.SivilstandTyper
 import java.time.LocalDate
 
+/**
+ * hvis du endrer på noen av expected, må du sjekke at indenten faktisk er tabs, or ikke spaces. Selv om du taster
+ * inn tab, så kan det være at intellij setter inn 4 spaces. bruk piltastene for å verifisere
+ */
 internal class OppgavebeskrivelseMapperTest {
     @Test
     fun `mapper dødsfallshendelser riktig`() {
-        val personhendelse = Personhendelse.Hendelse.Dødsfall(fixedLocalDate)
-
-        OppgavebeskrivelseMapper.map(personhendelse) shouldBe "Dødsfall\n" +
-            "\tDødsdato: 2021-01-01"
+        val nyHendelse = nyPersonhendelseKnyttetTilSak(
+            hendelse = Personhendelse.Hendelse.Dødsfall(fixedLocalDate),
+        )
+        OppgavebeskrivelseMapper.mapOne(nyHendelse) shouldBe """
+            Dødsfall
+            	Dødsdato: 2021-01-01
+            	Mottatt hendelsestidspunkt: 01.01.2021 02:02
+            	Endringstype: OPPRETTET
+            	HendelseId: ${nyHendelse.id}
+            	Tidligere hendelseid: Ingen tidligere
+        """.trimIndent()
     }
 
     @Test
     fun `mapper endringer i sivilstand riktig`() {
-        val personhendelse = Personhendelse.Hendelse.Sivilstand(
-            type = SivilstandTyper.GIFT,
-            gyldigFraOgMed = LocalDate.now(fixedClock),
-            relatertVedSivilstand = null,
-            bekreftelsesdato = null,
+        val nyHendelse = nyPersonhendelseKnyttetTilSak(
+            hendelse = Personhendelse.Hendelse.Sivilstand(
+                type = SivilstandTyper.GIFT,
+                gyldigFraOgMed = LocalDate.now(fixedClock),
+                relatertVedSivilstand = null,
+                bekreftelsesdato = null,
+            ),
         )
 
-        OppgavebeskrivelseMapper.map(personhendelse) shouldBe "Endring i sivilstand\n" +
-            "\ttype: Gift\n" +
-            "\tGyldig fra og med: 2021-01-01\n" +
-            "\tBekreftelsesdato: Ikke oppgitt"
+        OppgavebeskrivelseMapper.mapOne(nyHendelse) shouldBe """
+            Endring i sivilstand
+            	Type: Gift
+            	Gyldig fra og med: 2021-01-01
+            	Bekreftelsesdato: Ikke oppgitt
+            	Mottatt hendelsestidspunkt: 01.01.2021 02:02
+            	Endringstype: OPPRETTET
+            	HendelseId: ${nyHendelse.id}
+            	Tidligere hendelseid: Ingen tidligere
+        """.trimIndent()
     }
 
     @Test
     fun `mapper utflytting fra norge riktig`() {
-        val personhendelse = Personhendelse.Hendelse.UtflyttingFraNorge(LocalDate.now(fixedClock))
-
-        OppgavebeskrivelseMapper.map(personhendelse) shouldBe "Utflytting fra Norge\n" +
-            "\tUtflyttingsdato: 2021-01-01"
+        val nyHendelse = nyPersonhendelseKnyttetTilSak(
+            hendelse = Personhendelse.Hendelse.UtflyttingFraNorge(LocalDate.now(fixedClock)),
+        )
+        OppgavebeskrivelseMapper.mapOne(nyHendelse).trimIndent() shouldBe """
+            Utflytting fra Norge
+            	Utflyttingsdato: 2021-01-01
+            	Mottatt hendelsestidspunkt: 01.01.2021 02:02
+            	Endringstype: OPPRETTET
+            	HendelseId: ${nyHendelse.id}
+            	Tidligere hendelseid: Ingen tidligere
+        """.trimIndent()
     }
 
     @Test
     fun `mapper bostedsadresse riktig`() {
-        val personhendelse = Personhendelse.Hendelse.Bostedsadresse
-
-        OppgavebeskrivelseMapper.map(personhendelse) shouldBe "Endring i bostedsadresse"
+        val nyHendelse = nyPersonhendelseKnyttetTilSak(
+            hendelse = Personhendelse.Hendelse.Bostedsadresse,
+        )
+        OppgavebeskrivelseMapper.mapOne(nyHendelse) shouldBe """
+            Endring i bostedsadresse
+            	Mottatt hendelsestidspunkt: 01.01.2021 02:02
+            	Endringstype: OPPRETTET
+            	HendelseId: ${nyHendelse.id}
+            	Tidligere hendelseid: Ingen tidligere
+        """.trimIndent()
     }
 
     @Test
     fun `mapper kontaktadresse riktig`() {
-        val personhendelse = Personhendelse.Hendelse.Kontaktadresse
-
-        OppgavebeskrivelseMapper.map(personhendelse) shouldBe "Endring i kontaktadresse"
+        val nyHendelse = nyPersonhendelseKnyttetTilSak(
+            hendelse = Personhendelse.Hendelse.Kontaktadresse,
+        )
+        OppgavebeskrivelseMapper.mapOne(nyHendelse) shouldBe """
+            Endring i kontaktadresse
+            	Mottatt hendelsestidspunkt: 01.01.2021 02:02
+            	Endringstype: OPPRETTET
+            	HendelseId: ${nyHendelse.id}
+            	Tidligere hendelseid: Ingen tidligere
+        """.trimIndent()
     }
 }

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/personhendelse/PersonhendelsePostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/personhendelse/PersonhendelsePostgresRepo.kt
@@ -10,6 +10,7 @@ import no.nav.su.se.bakover.common.infrastructure.persistence.PostgresSessionFac
 import no.nav.su.se.bakover.common.infrastructure.persistence.hent
 import no.nav.su.se.bakover.common.infrastructure.persistence.hentListe
 import no.nav.su.se.bakover.common.infrastructure.persistence.insert
+import no.nav.su.se.bakover.common.infrastructure.persistence.tidspunkt
 import no.nav.su.se.bakover.common.person.Fnr
 import no.nav.su.se.bakover.common.serialize
 import no.nav.su.se.bakover.common.tid.Tidspunkt
@@ -50,7 +51,7 @@ internal class PersonhendelsePostgresRepo(
                     mapOf(
                         "id" to personhendelse.id,
                         "sakId" to personhendelse.sakId,
-                        "opprettet" to tidspunkt,
+                        "opprettet" to personhendelse.opprettet,
                         "endret" to tidspunkt,
                         "endringstype" to personhendelse.endringstype.toDatabasetype(),
                         "hendelse" to serialize(personhendelse.hendelse.toJson()),
@@ -65,7 +66,6 @@ internal class PersonhendelsePostgresRepo(
     }
 
     override fun lagre(personhendelse: List<Personhendelse.TilknyttetSak.SendtTilOppgave>) {
-        // val endret = Tidspunkt.now(clock)
         val multiLineQuery: String = personhendelse.joinToString("\n") {
             "update personhendelse set oppgaveId = '${it.oppgaveId}', endret = :endret where id = '${it.id}';"
         }
@@ -132,6 +132,7 @@ internal class PersonhendelsePostgresRepo(
         saksnummer = Saksnummer(long("saksnummer")),
         metadata = deserialize<MetadataJson>(string("metadata")).toDomain(),
         antallFeiledeForsøk = int("antallFeiledeForsøk"),
+        opprettet = tidspunkt("opprettet"),
     )
 
     private fun Row.toSendtTilOppgave(oppgaveId: OppgaveId) = Personhendelse.TilknyttetSak.SendtTilOppgave(
@@ -143,6 +144,7 @@ internal class PersonhendelsePostgresRepo(
         metadata = deserialize<MetadataJson>(string("metadata")).toDomain(),
         oppgaveId = oppgaveId,
         antallFeiledeForsøk = int("antallFeiledeForsøk"),
+        opprettet = tidspunkt("opprettet"),
     )
 
     private fun Row.toPersonhendelse(): Personhendelse.TilknyttetSak =

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/personhendelse/PersonhendelsePostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/personhendelse/PersonhendelsePostgresRepoTest.kt
@@ -10,6 +10,7 @@ import no.nav.su.se.bakover.common.person.Fnr
 import no.nav.su.se.bakover.domain.personhendelse.Personhendelse
 import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.fixedLocalDate
+import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.generer
 import no.nav.su.se.bakover.test.nyPersonhendelseKnyttetTilSak
 import no.nav.su.se.bakover.test.persistence.TestDataHelper
@@ -47,11 +48,12 @@ internal class PersonhendelsePostgresRepoTest {
             )
             val sak = testDataHelper.persisterJournalførtSøknadMedOppgave().first
             val id = UUID.randomUUID()
-            repo.lagre(hendelse.tilknyttSak(id, SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type)))
+            repo.lagre(hendelse.tilknyttSak(id, SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type), fixedTidspunkt))
 
             repo.hent(id) shouldBe hendelse.tilknyttSak(
                 id = id,
                 SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type),
+                fixedTidspunkt,
             )
             hentMetadata(id, dataSource) shouldBe PersonhendelsePostgresRepo.MetadataJson(
                 hendelseId = hendelseId,
@@ -86,11 +88,12 @@ internal class PersonhendelsePostgresRepoTest {
             val sak = testDataHelper.persisterJournalførtSøknadMedOppgave().first
             val id = UUID.randomUUID()
 
-            repo.lagre(hendelse.tilknyttSak(id, SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type)))
+            repo.lagre(hendelse.tilknyttSak(id, SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type), fixedTidspunkt))
 
             repo.hent(id) shouldBe hendelse.tilknyttSak(
                 id = id,
                 SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type),
+                fixedTidspunkt,
             )
             hentMetadata(id, dataSource) shouldBe PersonhendelsePostgresRepo.MetadataJson(
                 hendelseId = hendelseId,
@@ -130,10 +133,11 @@ internal class PersonhendelsePostgresRepoTest {
             val sak = testDataHelper.persisterJournalførtSøknadMedOppgave().first
             val id = UUID.randomUUID()
 
-            repo.lagre(hendelse.tilknyttSak(id, SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type)))
+            repo.lagre(hendelse.tilknyttSak(id, SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type), fixedTidspunkt))
             repo.hent(id) shouldBe hendelse.tilknyttSak(
                 id = id,
                 SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type),
+                fixedTidspunkt,
             )
             hentMetadata(id, dataSource) shouldBe PersonhendelsePostgresRepo.MetadataJson(
                 hendelseId = hendelseId,
@@ -168,10 +172,11 @@ internal class PersonhendelsePostgresRepoTest {
             val sak = testDataHelper.persisterJournalførtSøknadMedOppgave().first
             val id = UUID.randomUUID()
 
-            repo.lagre(hendelse.tilknyttSak(id, SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type)))
+            repo.lagre(hendelse.tilknyttSak(id, SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type), fixedTidspunkt))
             repo.hent(id) shouldBe hendelse.tilknyttSak(
                 id = id,
                 SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type),
+                fixedTidspunkt,
             )
             hentMetadata(id, dataSource) shouldBe PersonhendelsePostgresRepo.MetadataJson(
                 hendelseId = hendelseId,
@@ -206,10 +211,11 @@ internal class PersonhendelsePostgresRepoTest {
             val sak = testDataHelper.persisterJournalførtSøknadMedOppgave().first
             val id = UUID.randomUUID()
 
-            repo.lagre(hendelse.tilknyttSak(id, SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type)))
+            repo.lagre(hendelse.tilknyttSak(id, SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type), fixedTidspunkt))
             repo.hent(id) shouldBe hendelse.tilknyttSak(
                 id = id,
                 SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type),
+                fixedTidspunkt,
             )
             hentMetadata(id, dataSource) shouldBe PersonhendelsePostgresRepo.MetadataJson(
                 hendelseId = hendelseId,
@@ -276,12 +282,25 @@ internal class PersonhendelsePostgresRepoTest {
             val sak2 = testDataHelper.persisterJournalførtSøknadMedOppgave().first
             val id2 = UUID.randomUUID()
 
-            repo.lagre(hendelse.tilknyttSak(id1, SakInfo(sak1.id, sak1.saksnummer, sak1.fnr, sak1.type)))
-            repo.lagre(hendelse.tilknyttSak(id2, SakInfo(sak2.id, sak2.saksnummer, sak2.fnr, sak2.type)))
+            repo.lagre(
+                hendelse.tilknyttSak(
+                    id1,
+                    SakInfo(sak1.id, sak1.saksnummer, sak1.fnr, sak1.type),
+                    fixedTidspunkt,
+                ),
+            )
+            repo.lagre(
+                hendelse.tilknyttSak(
+                    id2,
+                    SakInfo(sak2.id, sak2.saksnummer, sak2.fnr, sak2.type),
+                    fixedTidspunkt,
+                ),
+            )
 
             repo.hent(id1) shouldBe hendelse.tilknyttSak(
                 id = id1,
                 SakInfo(sak1.id, sak1.saksnummer, sak1.fnr, sak1.type),
+                fixedTidspunkt,
             )
             hentMetadata(id1, dataSource) shouldBe PersonhendelsePostgresRepo.MetadataJson(
                 hendelseId = hendelseId,
@@ -316,12 +335,17 @@ internal class PersonhendelsePostgresRepoTest {
             val id = UUID.randomUUID()
             val sak = testDataHelper.persisterJournalførtSøknadMedOppgave().first
 
-            val hendelseKnyttetTilSak = hendelse.tilknyttSak(id, SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type))
+            val hendelseKnyttetTilSak =
+                hendelse.tilknyttSak(id, SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type), fixedTidspunkt)
             repo.lagre(hendelseKnyttetTilSak)
             repo.lagre(nonEmptyListOf(hendelseKnyttetTilSak.tilSendtTilOppgave(OppgaveId("oppgaveId"))))
 
             val oppdatertHendelse = repo.hent(id)
-            oppdatertHendelse shouldBe hendelse.tilknyttSak(id, SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type))
+            oppdatertHendelse shouldBe hendelse.tilknyttSak(
+                id,
+                SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type),
+                fixedTidspunkt,
+            )
                 .tilSendtTilOppgave(OppgaveId("oppgaveId"))
         }
     }
@@ -361,9 +385,10 @@ internal class PersonhendelsePostgresRepoTest {
             )
             val sak = testDataHelper.persisterJournalførtSøknadMedOppgave().first
 
-            val hendelse1KnyttetTilSak = hendelse1.tilknyttSak(id1, SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type))
+            val hendelse1KnyttetTilSak =
+                hendelse1.tilknyttSak(id1, SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type), fixedTidspunkt)
             repo.lagre(hendelse1KnyttetTilSak)
-            repo.lagre(hendelse2.tilknyttSak(id2, SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type)))
+            repo.lagre(hendelse2.tilknyttSak(id2, SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type), fixedTidspunkt))
 
             repo.lagre(nonEmptyListOf(hendelse1KnyttetTilSak.tilSendtTilOppgave(OppgaveId("oppgaveId"))))
 
@@ -371,6 +396,7 @@ internal class PersonhendelsePostgresRepoTest {
                 hendelse2.tilknyttSak(
                     id2,
                     SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type),
+                    fixedTidspunkt,
                 ),
             )
         }
@@ -413,9 +439,9 @@ internal class PersonhendelsePostgresRepoTest {
             )
 
             val hendelse1TilknyttetSak =
-                hendelse1.tilknyttSak(hendelseId1, SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type))
+                hendelse1.tilknyttSak(hendelseId1, SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type), fixedTidspunkt)
             val hendelse2TilknyttetSak =
-                hendelse2.tilknyttSak(hendelseId2, SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type))
+                hendelse2.tilknyttSak(hendelseId2, SakInfo(sak.id, sak.saksnummer, sak.fnr, sak.type), fixedTidspunkt)
             repo.lagre(hendelse1TilknyttetSak)
             repo.lagre(hendelse2TilknyttetSak)
 

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppgave/OppgaveConfig.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppgave/OppgaveConfig.kt
@@ -11,6 +11,7 @@ import no.nav.su.se.bakover.common.person.AktørId
 import no.nav.su.se.bakover.common.tid.Tidspunkt
 import no.nav.su.se.bakover.common.tid.periode.DatoIntervall
 import no.nav.su.se.bakover.domain.klage.KlageinstansUtfall
+import no.nav.su.se.bakover.domain.personhendelse.Personhendelse.TilknyttetSak.IkkeSendtTilOppgave
 import no.nav.su.se.bakover.oppgave.domain.Oppgavetype
 import java.time.Clock
 import java.time.LocalDate
@@ -112,7 +113,7 @@ sealed interface OppgaveConfig {
 
     data class Personhendelse(
         val saksnummer: Saksnummer,
-        val personhendelsestype: NonEmptySet<no.nav.su.se.bakover.domain.personhendelse.Personhendelse.Hendelse>,
+        val personhendelse: NonEmptySet<IkkeSendtTilOppgave>,
         override val aktørId: AktørId,
         override val clock: Clock,
     ) : OppgaveConfig {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppgave/OppgaveConfig.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppgave/OppgaveConfig.kt
@@ -1,5 +1,6 @@
 package no.nav.su.se.bakover.domain.oppgave
 
+import arrow.core.NonEmptySet
 import no.nav.su.se.bakover.common.domain.Saksnummer
 import no.nav.su.se.bakover.common.domain.kodeverk.Behandlingstema
 import no.nav.su.se.bakover.common.domain.kodeverk.Behandlingstype
@@ -111,7 +112,7 @@ sealed interface OppgaveConfig {
 
     data class Personhendelse(
         val saksnummer: Saksnummer,
-        val personhendelsestype: no.nav.su.se.bakover.domain.personhendelse.Personhendelse.Hendelse,
+        val personhendelsestype: NonEmptySet<no.nav.su.se.bakover.domain.personhendelse.Personhendelse.Hendelse>,
         override val aktørId: AktørId,
         override val clock: Clock,
     ) : OppgaveConfig {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/personhendelse/Personhendelse.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/personhendelse/Personhendelse.kt
@@ -5,6 +5,7 @@ import no.nav.su.se.bakover.common.domain.Saksnummer
 import no.nav.su.se.bakover.common.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.common.domain.sak.SakInfo
 import no.nav.su.se.bakover.common.person.Fnr
+import no.nav.su.se.bakover.common.tid.Tidspunkt
 import person.domain.SivilstandTyper
 import java.time.LocalDate
 import java.util.UUID
@@ -17,31 +18,34 @@ sealed interface Personhendelse {
         OPPHØRT,
     }
 
-    abstract val endringstype: Endringstype
-    abstract val hendelse: Hendelse
-    abstract val metadata: Metadata
+    val endringstype: Endringstype
+    val hendelse: Hendelse
+    val metadata: Metadata
 
     data class IkkeTilknyttetSak(
         override val endringstype: Endringstype,
         override val hendelse: Hendelse,
         override val metadata: Metadata,
     ) : Personhendelse {
-        fun tilknyttSak(id: UUID, sakIdSaksnummerFnr: SakInfo) = TilknyttetSak.IkkeSendtTilOppgave(
-            endringstype = endringstype,
-            hendelse = hendelse,
-            id = id,
-            sakId = sakIdSaksnummerFnr.sakId,
-            saksnummer = sakIdSaksnummerFnr.saksnummer,
-            metadata = metadata,
-            antallFeiledeForsøk = 0,
-        )
+        fun tilknyttSak(id: UUID, sakIdSaksnummerFnr: SakInfo, opprettet: Tidspunkt) =
+            TilknyttetSak.IkkeSendtTilOppgave(
+                endringstype = endringstype,
+                hendelse = hendelse,
+                id = id,
+                sakId = sakIdSaksnummerFnr.sakId,
+                saksnummer = sakIdSaksnummerFnr.saksnummer,
+                metadata = metadata,
+                antallFeiledeForsøk = 0,
+                opprettet = opprettet,
+            )
     }
 
     sealed interface TilknyttetSak : Personhendelse {
-        abstract val id: UUID
-        abstract val sakId: UUID
-        abstract val saksnummer: Saksnummer
-        abstract val antallFeiledeForsøk: Int
+        val id: UUID
+        val sakId: UUID
+        val saksnummer: Saksnummer
+        val antallFeiledeForsøk: Int
+        val opprettet: Tidspunkt
 
         data class IkkeSendtTilOppgave(
             override val endringstype: Endringstype,
@@ -51,6 +55,7 @@ sealed interface Personhendelse {
             override val saksnummer: Saksnummer,
             override val metadata: Metadata,
             override val antallFeiledeForsøk: Int,
+            override val opprettet: Tidspunkt,
         ) : TilknyttetSak {
             fun tilSendtTilOppgave(oppgaveId: OppgaveId) =
                 SendtTilOppgave(
@@ -62,6 +67,7 @@ sealed interface Personhendelse {
                     oppgaveId = oppgaveId,
                     metadata = metadata,
                     antallFeiledeForsøk = antallFeiledeForsøk,
+                    opprettet = opprettet,
                 )
         }
 
@@ -74,6 +80,7 @@ sealed interface Personhendelse {
             override val metadata: Metadata,
             val oppgaveId: OppgaveId,
             override val antallFeiledeForsøk: Int,
+            override val opprettet: Tidspunkt,
         ) : TilknyttetSak
     }
 

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/personhendelse/PersonhendelseRepo.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/personhendelse/PersonhendelseRepo.kt
@@ -1,8 +1,8 @@
 package no.nav.su.se.bakover.domain.personhendelse
 
 interface PersonhendelseRepo {
-    fun lagre(personhendelse: Personhendelse.TilknyttetSak.SendtTilOppgave)
+    fun lagre(personhendelse: List<Personhendelse.TilknyttetSak.SendtTilOppgave>)
     fun lagre(personhendelse: Personhendelse.TilknyttetSak.IkkeSendtTilOppgave)
     fun hentPersonhendelserUtenOppgave(): List<Personhendelse.TilknyttetSak.IkkeSendtTilOppgave>
-    fun inkrementerAntallFeiledeForsøk(personhendelse: Personhendelse.TilknyttetSak)
+    fun inkrementerAntallFeiledeForsøk(personhendelse: List<Personhendelse.TilknyttetSak>)
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/Vedtaksammendrag.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/Vedtaksammendrag.kt
@@ -55,7 +55,7 @@ fun List<Vedtaksammendrag>.tilInnvilgetForMånedEllerSenere(
     fraOgMedEllerSenere: Måned,
 ): InnvilgetForMånedEllerSenere {
     return this
-        .filter { it.periode.inneholder(fraOgMedEllerSenere) }
+        .filter { it.periode.inneholder(fraOgMedEllerSenere) || fraOgMedEllerSenere.fraOgMed < it.periode.fraOgMed }
         .groupBy { it.fødselsnummer }
         .mapNotNull {
             require(it.value.map { it.opprettet }.distinct().size == it.value.size) {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/personhendelser/PersonhendelseService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/personhendelser/PersonhendelseService.kt
@@ -4,6 +4,7 @@ import arrow.core.NonEmptyList
 import no.nav.su.se.bakover.common.extensions.toNonEmptyList
 import no.nav.su.se.bakover.common.person.Fnr
 import no.nav.su.se.bakover.common.sikkerLogg
+import no.nav.su.se.bakover.common.tid.Tidspunkt
 import no.nav.su.se.bakover.common.tid.periode.Måned
 import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
@@ -43,14 +44,10 @@ class PersonhendelseService(
         }.single()
         sikkerLogg.debug("Personhendelse for sak: $personhendelse")
         personhendelseRepo.lagre(
-            personhendelse = personhendelse.tilknyttSak(UUID.randomUUID(), eksisterendeSakIdOgNummer),
+            personhendelse = personhendelse.tilknyttSak(UUID.randomUUID(), eksisterendeSakIdOgNummer, Tidspunkt.now(clock)),
         )
     }
 
-    /*
-    TODO ai 02.09: Kan vurdere på sikt å lage kun en oppgave for flere personhendelser for samme bruker,
-        f.eks hvis endringstypen er ANNULERT eller KORRIGERT.
-     */
     fun opprettOppgaverForPersonhendelser() {
         val personhendelser = personhendelseRepo.hentPersonhendelserUtenOppgave()
         personhendelser.groupBy { it.sakId }
@@ -76,7 +73,7 @@ class PersonhendelseService(
                 oppgaveServiceImpl.opprettOppgaveMedSystembruker(
                     OppgaveConfig.Personhendelse(
                         saksnummer = sak.saksnummer,
-                        personhendelsestype = personhendelser.map { it.hendelse }.toNonEmptySet(),
+                        personhendelse = personhendelser.toNonEmptySet(),
                         aktørId = aktørId,
                         clock = clock,
                     ),

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/personhendelser/PersonhendelseServiceTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/personhendelser/PersonhendelseServiceTest.kt
@@ -83,6 +83,7 @@ internal class PersonhendelseServiceTest {
                         fnr,
                         Sakstype.UFØRE,
                     ),
+                    opprettet = fixedTidspunkt,
                 )
             },
         )
@@ -164,7 +165,7 @@ internal class PersonhendelseServiceTest {
             argThat {
                 it shouldBe OppgaveConfig.Personhendelse(
                     saksnummer = personhendelse.saksnummer,
-                    personhendelsestype = nonEmptySetOf(personhendelse.hendelse),
+                    personhendelse = nonEmptySetOf(personhendelse),
                     aktørId = AktørId("aktørId"),
                     clock = fixedClock,
                 )
@@ -224,7 +225,7 @@ internal class PersonhendelseServiceTest {
             argThat {
                 it shouldBe OppgaveConfig.Personhendelse(
                     saksnummer = personhendelse.saksnummer,
-                    personhendelsestype = nonEmptySetOf(personhendelse.hendelse),
+                    personhendelse = nonEmptySetOf(personhendelse),
                     aktørId = AktørId("aktørId"),
                     clock = fixedClock,
                 )
@@ -274,5 +275,6 @@ internal class PersonhendelseServiceTest {
                 personidenter = listOf(UUID.randomUUID().toString()).toNonEmptyList(),
             ),
             antallFeiledeForsøk = 0,
+            opprettet = fixedTidspunkt,
         )
 }

--- a/test-common/src/main/kotlin/PersonhendelseTestData.kt
+++ b/test-common/src/main/kotlin/PersonhendelseTestData.kt
@@ -7,6 +7,7 @@ import no.nav.su.se.bakover.common.domain.sak.SakInfo
 import no.nav.su.se.bakover.common.domain.sak.Sakstype
 import no.nav.su.se.bakover.common.person.AktørId
 import no.nav.su.se.bakover.common.person.Fnr
+import no.nav.su.se.bakover.common.tid.Tidspunkt
 import no.nav.su.se.bakover.domain.personhendelse.Personhendelse
 import java.util.UUID
 
@@ -40,6 +41,7 @@ fun nyPersonhendelseKnyttetTilSak(
     saksnummer: Saksnummer = no.nav.su.se.bakover.test.saksnummer,
     fnr: Fnr = no.nav.su.se.bakover.test.fnr,
     sakstype: Sakstype = Sakstype.UFØRE,
+    opprettet: Tidspunkt = fixedTidspunkt,
 ): Personhendelse.TilknyttetSak.IkkeSendtTilOppgave {
     return nyPersonhendelseIkkeKnyttetTilSak(
         endringstype = endringstype,
@@ -55,6 +57,7 @@ fun nyPersonhendelseKnyttetTilSak(
             fnr = fnr,
             type = sakstype,
         ),
+        opprettet = opprettet,
     )
 }
 
@@ -67,6 +70,7 @@ fun nyPersonhendelseSendtTilOppgave(
     fnr: Fnr = no.nav.su.se.bakover.test.fnr,
     sakstype: Sakstype = Sakstype.UFØRE,
     oppgaveId: OppgaveId = no.nav.su.se.bakover.test.oppgave.oppgaveId,
+    opprettet: Tidspunkt = fixedTidspunkt,
 ): Personhendelse.TilknyttetSak.SendtTilOppgave {
     return nyPersonhendelseKnyttetTilSak(
         endringstype = endringstype,
@@ -76,5 +80,6 @@ fun nyPersonhendelseSendtTilOppgave(
         saksnummer = saksnummer,
         fnr = fnr,
         sakstype = sakstype,
+        opprettet = opprettet,
     ).tilSendtTilOppgave(oppgaveId = oppgaveId)
 }

--- a/test-common/src/main/kotlin/PersonhendelseTestData.kt
+++ b/test-common/src/main/kotlin/PersonhendelseTestData.kt
@@ -1,0 +1,80 @@
+package no.nav.su.se.bakover.test
+
+import arrow.core.nonEmptyListOf
+import no.nav.su.se.bakover.common.domain.Saksnummer
+import no.nav.su.se.bakover.common.domain.oppgave.OppgaveId
+import no.nav.su.se.bakover.common.domain.sak.SakInfo
+import no.nav.su.se.bakover.common.domain.sak.Sakstype
+import no.nav.su.se.bakover.common.person.AktørId
+import no.nav.su.se.bakover.common.person.Fnr
+import no.nav.su.se.bakover.domain.personhendelse.Personhendelse
+import java.util.UUID
+
+fun nyPersonhendelseIkkeKnyttetTilSak(
+    endringstype: Personhendelse.Endringstype = Personhendelse.Endringstype.OPPRETTET,
+    hendelse: Personhendelse.Hendelse = Personhendelse.Hendelse.Dødsfall(fixedLocalDate),
+    aktørId: AktørId = no.nav.su.se.bakover.test.aktørId,
+    fnr: Fnr = no.nav.su.se.bakover.test.fnr,
+    hendelseId: String = "hendelseId",
+): Personhendelse.IkkeTilknyttetSak {
+    return Personhendelse.IkkeTilknyttetSak(
+        endringstype = endringstype,
+        hendelse = hendelse,
+        metadata = Personhendelse.Metadata(
+            hendelseId = hendelseId,
+            personidenter = nonEmptyListOf(aktørId.toString(), fnr.toString()),
+            tidligereHendelseId = null,
+            offset = 0,
+            partisjon = 0,
+            master = "FREG",
+            key = "someKey",
+        ),
+    )
+}
+
+fun nyPersonhendelseKnyttetTilSak(
+    endringstype: Personhendelse.Endringstype = Personhendelse.Endringstype.OPPRETTET,
+    hendelse: Personhendelse.Hendelse = Personhendelse.Hendelse.Dødsfall(fixedLocalDate),
+    id: UUID = UUID.randomUUID(),
+    sakId: UUID = no.nav.su.se.bakover.test.sakId,
+    saksnummer: Saksnummer = no.nav.su.se.bakover.test.saksnummer,
+    fnr: Fnr = no.nav.su.se.bakover.test.fnr,
+    sakstype: Sakstype = Sakstype.UFØRE,
+): Personhendelse.TilknyttetSak.IkkeSendtTilOppgave {
+    return nyPersonhendelseIkkeKnyttetTilSak(
+        endringstype = endringstype,
+        hendelse = hendelse,
+        fnr = fnr,
+        aktørId = aktørId,
+        hendelseId = id.toString(),
+    ).tilknyttSak(
+        id = id,
+        sakIdSaksnummerFnr = SakInfo(
+            sakId = sakId,
+            saksnummer = saksnummer,
+            fnr = fnr,
+            type = sakstype,
+        ),
+    )
+}
+
+fun nyPersonhendelseSendtTilOppgave(
+    endringstype: Personhendelse.Endringstype = Personhendelse.Endringstype.OPPRETTET,
+    hendelse: Personhendelse.Hendelse = Personhendelse.Hendelse.Dødsfall(fixedLocalDate),
+    id: UUID = UUID.randomUUID(),
+    sakId: UUID = no.nav.su.se.bakover.test.sakId,
+    saksnummer: Saksnummer = no.nav.su.se.bakover.test.saksnummer,
+    fnr: Fnr = no.nav.su.se.bakover.test.fnr,
+    sakstype: Sakstype = Sakstype.UFØRE,
+    oppgaveId: OppgaveId = no.nav.su.se.bakover.test.oppgave.oppgaveId,
+): Personhendelse.TilknyttetSak.SendtTilOppgave {
+    return nyPersonhendelseKnyttetTilSak(
+        endringstype = endringstype,
+        hendelse = hendelse,
+        id = id,
+        sakId = sakId,
+        saksnummer = saksnummer,
+        fnr = fnr,
+        sakstype = sakstype,
+    ).tilSendtTilOppgave(oppgaveId = oppgaveId)
+}


### PR DESCRIPTION
Tidligere laget vi en oppgave per personhendelse, men nå grupperer vi hendelsene per sak og legger de i samme oppgaven. Neste steg blir å hente tidligere åpne oppgaver og legge de der istedet.