### PR TITLE
fjern comparable for datointervall

### DIFF
--- a/common/domain/src/main/kotlin/no/nav/su/se/bakover/common/domain/Stønadsperiode.kt
+++ b/common/domain/src/main/kotlin/no/nav/su/se/bakover/common/domain/Stønadsperiode.kt
@@ -11,7 +11,7 @@ import java.time.Year
 
 data class Stønadsperiode private constructor(
     val periode: Periode,
-) : Comparable<Stønadsperiode> {
+) {
 
     infix fun inneholder(periode: Periode) = this.periode.inneholder(periode)
     infix fun inneholder(stønadsperiode: Stønadsperiode) = this.periode.inneholder(stønadsperiode.periode)
@@ -40,7 +40,6 @@ data class Stønadsperiode private constructor(
         data object FraOgMedDatoKanIkkeVæreFør2021 : UgyldigStønadsperiode
     }
 
-    override fun compareTo(other: Stønadsperiode) = periode.compareTo(other.periode)
     fun måneder() = periode.måneder()
     fun toYearRange(): YearRange = YearRange(Year.of(this.periode.fraOgMed.year), Year.of(this.periode.tilOgMed.year))
 }

--- a/common/domain/src/main/kotlin/no/nav/su/se/bakover/common/domain/tid/periode/Måned.kt
+++ b/common/domain/src/main/kotlin/no/nav/su/se/bakover/common/domain/tid/periode/Måned.kt
@@ -24,6 +24,8 @@ data class Måned private constructor(
             require(this.før(that))
         }
     }
+    // TODO - her vil vi ha en egen compareTo og comaprable på måned
+    // override fun compareTo(other: Måned): Int = this.årOgMåned.compareTo(other.årOgMåned)
 
     /**
      * Returns a range from this value up to but excluding the specified to value.

--- a/common/domain/src/test/kotlin/no/nav/su/se/bakover/common/domain/periode/DatoIntervallTest.kt
+++ b/common/domain/src/test/kotlin/no/nav/su/se/bakover/common/domain/periode/DatoIntervallTest.kt
@@ -1,7 +1,5 @@
 package no.nav.su.se.bakover.common.domain.periode
 
-import io.kotest.matchers.ints.shouldBeGreaterThan
-import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import no.nav.su.se.bakover.common.extensions.april
 import no.nav.su.se.bakover.common.extensions.august
@@ -26,13 +24,6 @@ import no.nav.su.se.bakover.common.tid.periode.år
 import org.junit.jupiter.api.Test
 
 internal class DatoIntervallTest {
-
-    @Test
-    fun compareTo() {
-        DatoIntervall(1.januar(2021), 31.januar(2021)).compareTo(DatoIntervall(1.januar(2021), 31.januar(2021))) shouldBe 0
-        DatoIntervall(1.januar(2021), 31.januar(2021)).compareTo(DatoIntervall(1.januar(2021), 31.desember(2021))).shouldBeLessThan(0)
-        DatoIntervall(1.januar(2021), 31.januar(2021)).compareTo(DatoIntervall(1.januar(2021), 1.januar(2021))).shouldBeGreaterThan(0)
-    }
 
     @Test
     fun inneholder() {

--- a/common/domain/src/test/kotlin/no/nav/su/se/bakover/common/domain/periode/DatoIntervall_dagerTest.kt
+++ b/common/domain/src/test/kotlin/no/nav/su/se/bakover/common/domain/periode/DatoIntervall_dagerTest.kt
@@ -1,0 +1,84 @@
+package no.nav.su.se.bakover.common.domain.periode
+
+import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.common.extensions.april
+import no.nav.su.se.bakover.common.extensions.august
+import no.nav.su.se.bakover.common.extensions.desember
+import no.nav.su.se.bakover.common.extensions.februar
+import no.nav.su.se.bakover.common.extensions.januar
+import no.nav.su.se.bakover.common.extensions.juli
+import no.nav.su.se.bakover.common.extensions.juni
+import no.nav.su.se.bakover.common.extensions.mai
+import no.nav.su.se.bakover.common.extensions.mars
+import no.nav.su.se.bakover.common.extensions.november
+import no.nav.su.se.bakover.common.extensions.oktober
+import no.nav.su.se.bakover.common.extensions.september
+import no.nav.su.se.bakover.common.tid.periode.DatoIntervall
+import no.nav.su.se.bakover.common.tid.periode.dager
+import no.nav.su.se.bakover.common.tid.periode.januar
+import no.nav.su.se.bakover.common.tid.periode.år
+import org.junit.jupiter.api.Test
+
+internal class DatoIntervall_dagerTest {
+
+    @Test
+    fun `ingen dager`() {
+        listOf<DatoIntervall>().dager() shouldBe emptyList()
+    }
+
+    @Test
+    fun `1 dag`() {
+        DatoIntervall(1.januar(2022), 1.januar(2022)).dager() shouldBe listOf(1.januar(2022))
+
+        listOf(
+            DatoIntervall(1.januar(2022), 1.januar(2022)),
+            DatoIntervall(1.januar(2022), 1.januar(2022)),
+        ).dager() shouldBe listOf(1.januar(2022))
+    }
+
+    @Test
+    fun `2 dager`() {
+        DatoIntervall(1.januar(2022), 2.januar(2022)).dager() shouldBe
+            listOf(1.januar(2022), 2.januar(2022))
+
+        listOf(
+            DatoIntervall(1.januar(2022), 1.januar(2022)),
+            DatoIntervall(1.januar(2022), 2.januar(2022)),
+            DatoIntervall(2.januar(2022), 2.januar(2022)),
+        ).dager() shouldBe listOf(1.januar(2022), 2.januar(2022))
+
+        listOf(
+            DatoIntervall(1.januar(2022), 1.januar(2022)),
+            DatoIntervall(2.januar(2022), 2.januar(2022)),
+        ).dager() shouldBe listOf(1.januar(2022), 2.januar(2022))
+    }
+
+    @Test
+    fun `1 måned`() {
+        januar(2022).dager() shouldBe
+            (1..31).map { it.januar(2022) }
+    }
+
+    @Test
+    fun `1 år`() {
+        val expected = (1..31).map { it.januar(2022) } +
+            (1..28).map { it.februar(2022) } +
+            (1..31).map { it.mars(2022) } +
+            (1..30).map { it.april(2022) } +
+            (1..31).map { it.mai(2022) } +
+            (1..30).map { it.juni(2022) } +
+            (1..31).map { it.juli(2022) } +
+            (1..31).map { it.august(2022) } +
+            (1..30).map { it.september(2022) } +
+            (1..31).map { it.oktober(2022) } +
+            (1..30).map { it.november(2022) } +
+            (1..31).map { it.desember(2022) }
+        år(2022).dager() shouldBe expected
+        listOf(
+            år(2022),
+            januar(2022),
+            DatoIntervall(3.juli(2022), 3.juli(2022)),
+            DatoIntervall(7.februar(2022), 18.august(2022)),
+        ).dager() shouldBe expected
+    }
+}

--- a/common/domain/src/test/kotlin/no/nav/su/se/bakover/common/domain/periode/DatoIntervall_slåSammenTest.kt
+++ b/common/domain/src/test/kotlin/no/nav/su/se/bakover/common/domain/periode/DatoIntervall_slåSammenTest.kt
@@ -1,0 +1,107 @@
+package no.nav.su.se.bakover.common.domain.periode
+
+import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.common.extensions.desember
+import no.nav.su.se.bakover.common.extensions.februar
+import no.nav.su.se.bakover.common.extensions.januar
+import no.nav.su.se.bakover.common.extensions.mars
+import no.nav.su.se.bakover.common.tid.periode.DatoIntervall
+import no.nav.su.se.bakover.test.getOrFail
+import org.junit.jupiter.api.Test
+
+internal class DatoIntervall_slåSammenTest {
+
+    @Test
+    fun `1 day - DatoIntervall`() {
+        val interval = DatoIntervall(1.januar(2022))
+
+        val result = (interval slåSammen interval).getOrFail()
+
+        result shouldBe interval
+    }
+
+    @Test
+    fun `1 day - LocalDato`() {
+        val interval = DatoIntervall(1.januar(2022))
+
+        val result = (interval slåSammen 1.januar(2022)).getOrFail()
+
+        result shouldBe interval
+    }
+
+    @Test
+    fun `non-overlapping intervals return error - DatoIntervall`() {
+        val interval1 = DatoIntervall(1.januar(2022), 31.januar(2022))
+        val interval2 = DatoIntervall(1.mars(2022), 31.mars(2022))
+
+        val result = interval1 slåSammen interval2
+
+        result.isLeft() shouldBe true
+    }
+
+    @Test
+    fun `non-overlapping intervals return error - LocalDate`() {
+        val interval1 = DatoIntervall(1.januar(2022), 31.januar(2022))
+
+        val result = interval1 slåSammen 3.mars(2022)
+
+        result.isLeft() shouldBe true
+    }
+
+    @Test
+    fun `adjacent intervals are merged - DatoIntervall`() {
+        val interval1 = DatoIntervall(1.januar(2022), 31.januar(2022))
+        val interval2 = DatoIntervall(1.februar(2022), 28.februar(2022))
+
+        val result = (interval1 slåSammen interval2).getOrFail()
+
+        result shouldBe DatoIntervall(1.januar(2022), 28.februar(2022))
+    }
+
+    @Test
+    fun `adjacent intervals are merged - LocalDate - after`() {
+        val interval1 = DatoIntervall(1.januar(2022), 31.januar(2022))
+
+        val result = (interval1 slåSammen 1.februar(2022)).getOrFail()
+
+        result shouldBe DatoIntervall(1.januar(2022), 1.februar(2022))
+    }
+
+    @Test
+    fun `adjacent intervals are merged - LocalDate - before`() {
+        val interval1 = DatoIntervall(1.januar(2022), 31.januar(2022))
+
+        val result = (interval1 slåSammen 31.desember(2021)).getOrFail()
+
+        result shouldBe DatoIntervall(31.desember(2021), 31.januar(2022))
+    }
+
+    @Test
+    fun `partially overlapping intervals are merged`() {
+        val interval1 = DatoIntervall(1.januar(2022), 15.februar(2022))
+        val interval2 = DatoIntervall(10.februar(2022), 28.februar(2022))
+
+        val result = (interval1 slåSammen interval2).getOrFail()
+
+        result shouldBe DatoIntervall(1.januar(2022), 28.februar(2022))
+    }
+
+    @Test
+    fun `fully overlapping intervals - DatoIntervall`() {
+        val interval1 = DatoIntervall(1.januar(2022), 31.mars(2022))
+        val interval2 = DatoIntervall(1.februar(2022), 28.februar(2022))
+
+        val result = (interval1 slåSammen interval2).getOrFail()
+
+        result shouldBe DatoIntervall(1.januar(2022), 31.mars(2022))
+    }
+
+    @Test
+    fun `fully overlapping intervals - LocalDate`() {
+        val interval1 = DatoIntervall(1.januar(2022), 31.mars(2022))
+
+        val result = (interval1 slåSammen 30.mars(2022)).getOrFail()
+
+        result shouldBe DatoIntervall(1.januar(2022), 31.mars(2022))
+    }
+}

--- a/common/domain/src/test/kotlin/no/nav/su/se/bakover/common/domain/periode/MånedTest.kt
+++ b/common/domain/src/test/kotlin/no/nav/su/se/bakover/common/domain/periode/MånedTest.kt
@@ -215,12 +215,6 @@ internal class MånedTest {
     }
 
     @Test
-    fun `datoIntervall compareTo måned`() {
-        DatoIntervall(1.januar(2021), 31.januar(2021)).compareTo(januar(2021)) shouldBe 0
-        januar(2021).compareTo(DatoIntervall(1.januar(2021), 31.januar(2021))) shouldBe 0
-    }
-
-    @Test
     fun `datoIntervall skal ha samme hash som måned`() {
         januar(2021).hashCode() shouldBe DatoIntervall(1.januar(2021), 31.januar(2021)).hashCode()
         DatoIntervall(1.januar(2021), 31.januar(2021)).hashCode() shouldBe januar(2021).hashCode()

--- a/tilbakekreving/domain/src/main/kotlin/tilbakekreving/domain/kravgrunnlag/Kravgrunnlag.kt
+++ b/tilbakekreving/domain/src/main/kotlin/tilbakekreving/domain/kravgrunnlag/Kravgrunnlag.kt
@@ -41,12 +41,12 @@ data class Kravgrunnlag(
 
     init {
         grunnlagsperioder.map { it.periode }.let {
-            require(it.sorted() == it) {
-                "Kravgrunnlagsperiodene må være sortert."
+            require(it.map { it.fraOgMed }.sorted() == it.map { it.fraOgMed }) {
+                "Kravgrunnlagsperiodene må være sortert på fraOgMed, men var: $it"
             }
             it.zipWithNext { a, b ->
                 require(!a.overlapper(b)) {
-                    "Perioder kan ikke overlappe."
+                    "Perioder kan ikke overlappe, men var: $it"
                 }
             }
         }

--- a/tilbakekreving/domain/src/main/kotlin/tilbakekreving/domain/vurdering/Vurderinger.kt
+++ b/tilbakekreving/domain/src/main/kotlin/tilbakekreving/domain/vurdering/Vurderinger.kt
@@ -13,12 +13,12 @@ data class Vurderinger(
 ) : List<Vurderinger.Periodevurdering> by perioder {
     init {
         perioder.map { it.periode }.let {
-            require(it.sorted() == it) {
-                "Vurderingene må være sortert."
+            require(it.map { it.fraOgMed }.sorted() == it.map { it.fraOgMed }) {
+                "Vurderingene må være sortert på fraOgMed, men var: $it"
             }
             it.zipWithNext { a, b ->
                 require(!a.overlapper(b)) {
-                    "Perioder kan ikke overlappe."
+                    "Perioder kan ikke overlappe, men var: $it"
                 }
             }
         }

--- a/tilbakekreving/domain/src/main/kotlin/tilbakekreving/domain/vurdering/VurderingerMedKrav.kt
+++ b/tilbakekreving/domain/src/main/kotlin/tilbakekreving/domain/vurdering/VurderingerMedKrav.kt
@@ -31,12 +31,12 @@ data class VurderingerMedKrav private constructor(
 
     init {
         perioder.map { it.periode }.let {
-            require(it.sorted() == it) {
-                "Vurderingene må være sortert."
+            require(it.map { it.fraOgMed }.sorted() == it.map { it.fraOgMed }) {
+                "Vurderingene må være sortert på fraOgMed, men var: $it"
             }
             it.zipWithNext { a, b ->
                 require(!a.overlapper(b)) {
-                    "Perioder kan ikke overlappe."
+                    "Perioder kan ikke overlappe, men var: $it"
                 }
             }
         }


### PR DESCRIPTION
Det gir ikke mening og la en liste med DatoIntervall (som kan ha overlapp) være sorterbar.

Dette gjelder også Periode og Stønadsperiode, som må fikses senere.