### PR TITLE
Legg til endepunkt for pensjon for å sjekke om fnr+periode har stønadsperiode

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -27,6 +27,12 @@ spec:
           permissions:
             roles:
               - frikort
+        - application: pensjon-pen-q2
+          namespace: teampensjon
+          cluster: dev-fss
+          permissions:
+              roles:
+              - pensjon
     outbound:
       rules:
         - application: kodeverk-dev

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -27,6 +27,12 @@ spec:
           permissions:
             roles:
               - frikort
+        - application: pensjon-pen
+          namespace: pensjondeployer
+          cluster: prod-fss
+          permissions:
+              roles:
+              - pensjon
     outbound:
       rules:
         - application: kodeverk

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakService.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakService.kt
@@ -9,6 +9,7 @@ import no.nav.su.se.bakover.common.domain.Saksnummer
 import no.nav.su.se.bakover.common.domain.sak.Behandlingssammendrag
 import no.nav.su.se.bakover.common.domain.sak.SakInfo
 import no.nav.su.se.bakover.common.domain.sak.Sakstype
+import no.nav.su.se.bakover.common.domain.tid.periode.PeriodeMedOptionalTilOgMed
 import no.nav.su.se.bakover.common.ident.NavIdentBruker
 import no.nav.su.se.bakover.common.persistence.SessionContext
 import no.nav.su.se.bakover.common.person.Fnr
@@ -68,6 +69,7 @@ interface SakService {
     fun oppdaterFødselsnummer(command: OppdaterFødselsnummerPåSakCommand): Either<KunneIkkeOppdatereFødselsnummer, Sak>
 
     fun hentSakIdSaksnummerOgFnrForAlleSaker(): List<SakInfo>
+    fun harFnrStønadForPeriode(fnr: Fnr, periode: PeriodeMedOptionalTilOgMed): Boolean
 }
 
 data object FantIkkeSak

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakStønadsperiode.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakStønadsperiode.kt
@@ -1,0 +1,16 @@
+package no.nav.su.se.bakover.domain.sak
+
+import no.nav.su.se.bakover.common.domain.tid.periode.PeriodeMedOptionalTilOgMed
+import no.nav.su.se.bakover.domain.Sak
+import no.nav.su.se.bakover.domain.vedtak.VedtakInnvilgetSøknadsbehandling
+
+/**
+ * Sjekker om denne saken har en stønadsperiode som overlapper med angitt periode.
+ * Her tar vi kun høyde for innvilget søknadsbehandlinger.
+ * I.e. vi tar ikke høyde for opphør/stans.
+ */
+fun Sak.harStønadForPeriode(periode: PeriodeMedOptionalTilOgMed): Boolean {
+    return this.vedtakListe
+        .filterIsInstance<VedtakInnvilgetSøknadsbehandling>()
+        .any { periode.overlapper(it.periode) }
+}

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/sak/SakServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/sak/SakServiceImpl.kt
@@ -17,6 +17,7 @@ import no.nav.su.se.bakover.common.domain.Saksnummer
 import no.nav.su.se.bakover.common.domain.sak.Behandlingssammendrag
 import no.nav.su.se.bakover.common.domain.sak.SakInfo
 import no.nav.su.se.bakover.common.domain.sak.Sakstype
+import no.nav.su.se.bakover.common.domain.tid.periode.PeriodeMedOptionalTilOgMed
 import no.nav.su.se.bakover.common.persistence.SessionContext
 import no.nav.su.se.bakover.common.person.Fnr
 import no.nav.su.se.bakover.common.tid.Tidspunkt
@@ -36,6 +37,7 @@ import no.nav.su.se.bakover.domain.sak.SakRepo
 import no.nav.su.se.bakover.domain.sak.SakService
 import no.nav.su.se.bakover.domain.sak.fnr.KunneIkkeOppdatereFødselsnummer
 import no.nav.su.se.bakover.domain.sak.fnr.OppdaterFødselsnummerPåSakCommand
+import no.nav.su.se.bakover.domain.sak.harStønadForPeriode
 import no.nav.su.se.bakover.domain.statistikk.StatistikkEvent
 import no.nav.su.se.bakover.domain.statistikk.StatistikkEventObserver
 import no.nav.su.se.bakover.domain.søknad.Søknad
@@ -243,6 +245,11 @@ class SakServiceImpl(
 
     override fun hentSakIdSaksnummerOgFnrForAlleSaker(): List<SakInfo> {
         return sakRepo.hentSakIdSaksnummerOgFnrForAlleSaker()
+    }
+
+    override fun harFnrStønadForPeriode(fnr: Fnr, periode: PeriodeMedOptionalTilOgMed): Boolean {
+        val sak: Sak = sakRepo.hentSak(fnr, Sakstype.UFØRE) ?: return false
+        return sak.harStønadForPeriode(periode)
     }
 
     private fun sakTilBegrensetSakInfo(sak: Sak?): BegrensetSakinfo {

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/Routes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/Routes.kt
@@ -17,6 +17,7 @@ import no.nav.su.se.bakover.utenlandsopphold.application.korriger.KorrigerUtenla
 import no.nav.su.se.bakover.utenlandsopphold.application.registrer.RegistrerUtenlandsoppholdService
 import no.nav.su.se.bakover.utenlandsopphold.infrastruture.web.utenlandsoppholdRoutes
 import no.nav.su.se.bakover.web.external.frikortVedtakRoutes
+import no.nav.su.se.bakover.web.external.pensjonRoutes
 import no.nav.su.se.bakover.web.routes.avstemming.avstemmingRoutes
 import no.nav.su.se.bakover.web.routes.dokument.dokumentRoutes
 import no.nav.su.se.bakover.web.routes.drift.driftRoutes
@@ -59,6 +60,9 @@ internal fun Application.setupKtorRoutes(
     routing {
         authenticate("frikort") {
             frikortVedtakRoutes(services.vedtakService, clock)
+        }
+        authenticate("pensjon") {
+            pensjonRoutes(services.sak)
         }
 
         authenticate("jwt") {

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/external/PensjonRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/external/PensjonRoutes.kt
@@ -1,0 +1,40 @@
+package no.nav.su.se.bakover.web.external
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import no.nav.su.se.bakover.common.infrastructure.PeriodeMedOptionalTilOgMedJson
+import no.nav.su.se.bakover.common.infrastructure.web.Resultat
+import no.nav.su.se.bakover.common.infrastructure.web.svar
+import no.nav.su.se.bakover.common.infrastructure.web.withBody
+import no.nav.su.se.bakover.common.person.Fnr
+import no.nav.su.se.bakover.domain.sak.SakService
+
+/**
+ * Laget slik at uføre kan sende inn et fnr og tilhørende vedtaksperiode. Så svarer vi om fnr har supplerende stønad i den perioden.
+ */
+internal fun Route.pensjonRoutes(
+    sakService: SakService,
+) {
+    data class Body(
+        val fnr: String,
+        val vedtaksperiode: PeriodeMedOptionalTilOgMedJson,
+    ) {
+        fun fnrDomain() = Fnr(fnr)
+        fun periodeDomain() = vedtaksperiode.toDomain()
+    }
+    post("/pensjon/harSupplerendeStønad") {
+        this.call.withBody<Body> { body ->
+            if (sakService.harFnrStønadForPeriode(
+                    fnr = body.fnrDomain(),
+                    periode = body.periodeDomain(),
+                )
+            ) {
+                call.svar(Resultat.json(HttpStatusCode.OK, """{"harSupplerendeStønad": true}"""))
+            } else {
+                call.svar(Resultat.json(HttpStatusCode.NotFound, """{"harSupplerendeStønad": false}"""))
+            }
+        }
+    }
+}

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxy.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxy.kt
@@ -29,6 +29,7 @@ import no.nav.su.se.bakover.common.domain.oppgave.OppgaveId
 import no.nav.su.se.bakover.common.domain.sak.Behandlingssammendrag
 import no.nav.su.se.bakover.common.domain.sak.SakInfo
 import no.nav.su.se.bakover.common.domain.sak.Sakstype
+import no.nav.su.se.bakover.common.domain.tid.periode.PeriodeMedOptionalTilOgMed
 import no.nav.su.se.bakover.common.ident.NavIdentBruker
 import no.nav.su.se.bakover.common.persistence.SessionContext
 import no.nav.su.se.bakover.common.persistence.TransactionContext
@@ -412,6 +413,11 @@ open class AccessCheckProxy(
                 }
 
                 override fun hentSakIdSaksnummerOgFnrForAlleSaker() = kastKanKunKallesFraAnnenService()
+
+                override fun harFnrStønadForPeriode(fnr: Fnr, periode: PeriodeMedOptionalTilOgMed): Boolean {
+                    // Denne skal kun kalles av eksterne systembrukere og andre servicer.
+                    return services.sak.harFnrStønadForPeriode(fnr, periode)
+                }
 
                 override fun opprettSak(sak: NySak) {
                     assertHarTilgangTilPerson(sak.fnr)


### PR DESCRIPTION
Vi hadde en dialog med uføre som stoppet opp (de implementerte ingenting og fulgte ikke dette opp).

Men tanken er: Når det kommer utbetalings-endringer på uførepersoner som får SU, ønsker vi en Gosys-oppgave som saksbehandlerne kan følge opp. Ofte fanges dette opp for sent og fører til feilutbetalinger.

Vi trenger bare en av disse PRene basert på hvordan Uføre-teamet ønsker løse dette.