### PR TITLE
Legg til endepunkt for pensjon for å poste uførevedtak

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -27,6 +27,12 @@ spec:
           permissions:
             roles:
               - frikort
+        - application: pensjon-pen-q2
+          namespace: teampensjon
+          cluster: dev-fss
+          permissions:
+              roles:
+              - pensjon
     outbound:
       rules:
         - application: kodeverk-dev

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -27,6 +27,12 @@ spec:
           permissions:
             roles:
               - frikort
+        - application: pensjon-pen
+          namespace: pensjondeployer
+          cluster: prod-fss
+          permissions:
+              roles:
+              - pensjon
     outbound:
       rules:
         - application: kodeverk

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/oppgave/OppgaveHttpClient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/oppgave/OppgaveHttpClient.kt
@@ -221,6 +221,12 @@ internal class OppgaveHttpClient(
                     Tidspunkt.now(clock).toOppgaveFormat()
                 } - Opprettet av Supplerende Stønad ---\nSaksnummer : ${config.saksreferanse}"
             }
+
+            is OppgaveConfig.NyttUførevedtak -> {
+                "--- ${
+                    Tidspunkt.now(clock).toOppgaveFormat()
+                } - Opprettet av Supplerende Stønad ---\nSaksnummer : ${config.saksreferanse}\n${config.toBeskrivelse()}"
+            }
         }
 
         return Either.catch {

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/oppgave/PeriodeMedOptionalTilOgMedEx.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/oppgave/PeriodeMedOptionalTilOgMedEx.kt
@@ -1,0 +1,11 @@
+package no.nav.su.se.bakover.client.oppgave
+
+import no.nav.su.se.bakover.common.domain.tid.periode.PeriodeMedOptionalTilOgMed
+
+fun PeriodeMedOptionalTilOgMed.toOppgavePeriode(): String {
+    return if (this.tilOgMed != null) {
+        "${this.fraOgMed} - ${this.tilOgMed}"
+    } else {
+        "${this.fraOgMed} - ingen sluttdato"
+    }
+}

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/oppgave/UførevedtakMapper.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/oppgave/UførevedtakMapper.kt
@@ -1,0 +1,12 @@
+package no.nav.su.se.bakover.client.oppgave
+
+import no.nav.su.se.bakover.domain.oppgave.OppgaveConfig
+
+fun OppgaveConfig.NyttUførevedtak.toBeskrivelse(): String {
+    return "Nytt uførevedtak fra pensjon/pesys:\n" +
+        "\tPeriode: ${this.periode.toOppgavePeriode()}\n" +
+        "\tVedtakstype: ${this.uføreVedtakstype}\n" +
+        "\tBehandlingstype: ${this.behandlingstype}\n" +
+        "\tSakId: ${this.uføreSakId}\n" +
+        "\tVedtakId: ${this.uføreVedtakId}"
+}

--- a/common/domain/src/main/kotlin/no/nav/su/se/bakover/common/domain/tid/periode/PeriodeMedOptionalTilOgMed.kt
+++ b/common/domain/src/main/kotlin/no/nav/su/se/bakover/common/domain/tid/periode/PeriodeMedOptionalTilOgMed.kt
@@ -11,6 +11,9 @@ data class PeriodeMedOptionalTilOgMed(
     val fraOgMed: LocalDate,
     val tilOgMed: LocalDate? = null,
 ) {
+    init {
+        require(fraOgMed <= (tilOgMed ?: LocalDate.MAX)) { "PeriodeMedOptionalTilOgMed: Fra og med dato må være før eller lik til og med dato" }
+    }
 
     fun overlapper(other: PeriodeMedOptionalTilOgMed): Boolean {
         val thisEnd = tilOgMed ?: LocalDate.MAX

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppgave/OppgaveConfig.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/oppgave/OppgaveConfig.kt
@@ -5,6 +5,7 @@ import no.nav.su.se.bakover.common.domain.Saksnummer
 import no.nav.su.se.bakover.common.domain.kodeverk.Behandlingstema
 import no.nav.su.se.bakover.common.domain.kodeverk.Behandlingstype
 import no.nav.su.se.bakover.common.domain.sak.Sakstype
+import no.nav.su.se.bakover.common.domain.tid.periode.PeriodeMedOptionalTilOgMed
 import no.nav.su.se.bakover.common.ident.NavIdentBruker
 import no.nav.su.se.bakover.common.journal.JournalpostId
 import no.nav.su.se.bakover.common.person.Fnr
@@ -12,6 +13,7 @@ import no.nav.su.se.bakover.common.tid.Tidspunkt
 import no.nav.su.se.bakover.common.tid.periode.DatoIntervall
 import no.nav.su.se.bakover.domain.klage.KlageinstansUtfall
 import no.nav.su.se.bakover.domain.personhendelse.Personhendelse.TilknyttetSak.IkkeSendtTilOppgave
+import no.nav.su.se.bakover.domain.sak.UførevedtakBehandlingstype
 import no.nav.su.se.bakover.oppgave.domain.Oppgavetype
 import java.time.Clock
 import java.time.LocalDate
@@ -161,6 +163,30 @@ sealed interface OppgaveConfig {
     data class Institusjonsopphold(
         val saksnummer: Saksnummer,
         val sakstype: Sakstype,
+        override val fnr: Fnr,
+        override val clock: Clock,
+    ) : OppgaveConfig {
+        override val saksreferanse = saksnummer.toString()
+        override val journalpostId: JournalpostId? = null
+        override val tilordnetRessurs: NavIdentBruker? = null
+        override val behandlingstema = when (sakstype) {
+            Sakstype.ALDER -> Behandlingstema.SU_ALDER
+            Sakstype.UFØRE -> Behandlingstema.SU_UFØRE_FLYKTNING
+        }
+        override val behandlingstype = Behandlingstype.REVURDERING
+        override val oppgavetype = Oppgavetype.VURDER_KONSEKVENS_FOR_YTELSE
+        override val aktivDato: LocalDate = LocalDate.now(clock)
+        override val fristFerdigstillelse: LocalDate = aktivDato.plusDays(7)
+    }
+
+    data class NyttUførevedtak(
+        val saksnummer: Saksnummer,
+        val sakstype: Sakstype,
+        val periode: PeriodeMedOptionalTilOgMed,
+        val uføreSakId: String,
+        val uføreVedtakId: String,
+        val uføreVedtakstype: String,
+        val uføreBehandlingstype: UførevedtakBehandlingstype,
         override val fnr: Fnr,
         override val clock: Clock,
     ) : OppgaveConfig {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/OpprettOppgaveDersomAktueltUførevedtakCommand.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/OpprettOppgaveDersomAktueltUførevedtakCommand.kt
@@ -1,0 +1,26 @@
+package no.nav.su.se.bakover.domain.sak
+
+import no.nav.su.se.bakover.common.domain.tid.periode.PeriodeMedOptionalTilOgMed
+import no.nav.su.se.bakover.common.person.Fnr
+
+data class OpprettOppgaveDersomAktueltUførevedtakCommand(
+    val fnr: Fnr,
+    val periode: PeriodeMedOptionalTilOgMed,
+    val uføreSakId: String,
+    val uføreVedtakId: String,
+    val uføreVedtakstype: String,
+    val behandlingstype: UførevedtakBehandlingstype,
+) {
+
+    fun erBehandlingstypeAutomatisk() = behandlingstype == UførevedtakBehandlingstype.AUTOMATISK
+    fun erVedtakstypeRegulering() = uføreVedtakstype == "REGULERING"
+
+    override fun toString() = "OpprettOppgaveDersomAktueltUførevedtakCommand(fnr=***, periode=$periode, uføreSakId=$uføreSakId, uføreVedtakId=$uføreVedtakId, uføreVedtakstype=$uføreVedtakstype)"
+    fun toSikkerloggString() = "OpprettOppgaveDersomAktueltUførevedtakCommand(fnr=$fnr, periode=$periode, uføreSakId=$uføreSakId, uføreVedtakId=$uføreVedtakId, uføreVedtakstype=$uføreVedtakstype)"
+}
+
+enum class UførevedtakBehandlingstype {
+    AUTOMATISK,
+    DELVIS_AUTOMATISK,
+    MANUELL,
+}

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakService.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakService.kt
@@ -68,6 +68,13 @@ interface SakService {
     fun oppdaterFødselsnummer(command: OppdaterFødselsnummerPåSakCommand): Either<KunneIkkeOppdatereFødselsnummer, Sak>
 
     fun hentSakIdSaksnummerOgFnrForAlleSaker(): List<SakInfo>
+
+    /**
+     * Spesialfunksjon for å opprette oppgave dersom Pesys/Penson/Uføre fatter et nytt vedtak.
+     * Vi sammenligner kun med SU-Uføre-vedtak i førsteomgang.
+     * TODO jah: Det er usikkert om denne funksjonen bør ligge i SakService.kt. Men det er raskeste veien til mål i denne omgangen.
+     * */
+    fun opprettOppgaveDersomAktueltUførevedtak(command: OpprettOppgaveDersomAktueltUførevedtakCommand)
 }
 
 data object FantIkkeSak

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakStønadsperiode.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/sak/SakStønadsperiode.kt
@@ -1,0 +1,16 @@
+package no.nav.su.se.bakover.domain.sak
+
+import no.nav.su.se.bakover.common.domain.tid.periode.PeriodeMedOptionalTilOgMed
+import no.nav.su.se.bakover.domain.Sak
+import no.nav.su.se.bakover.domain.vedtak.VedtakInnvilgetSøknadsbehandling
+
+/**
+ * Sjekker om denne saken har en stønadsperiode som overlapper med angitt periode.
+ * Her tar vi kun høyde for innvilget søknadsbehandlinger.
+ * I.e. vi tar ikke høyde for opphør/stans.
+ */
+fun Sak.harStønadForPeriode(periode: PeriodeMedOptionalTilOgMed): Boolean {
+    return this.vedtakListe
+        .filterIsInstance<VedtakInnvilgetSøknadsbehandling>()
+        .any { periode.overlapper(it.periode) }
+}

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/sak/SakServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/sak/SakServiceImplTest.kt
@@ -57,7 +57,7 @@ internal class SakServiceImplTest {
 
         val observer: StatistikkEventObserver = mock()
 
-        val sakService = SakServiceImpl(sakRepo, fixedClock, mock(), mock(), mock(), mock())
+        val sakService = SakServiceImpl(sakRepo, fixedClock, mock(), mock(), mock(), mock(), mock())
         sakService.addObserver(observer)
         sakService.opprettSak(mock { on { id } doReturn sakId })
 
@@ -74,7 +74,7 @@ internal class SakServiceImplTest {
 
         val observer: StatistikkEventObserver = mock()
 
-        val sakService = SakServiceImpl(sakRepo, fixedClock, mock(), mock(), mock(), mock())
+        val sakService = SakServiceImpl(sakRepo, fixedClock, mock(), mock(), mock(), mock(), mock())
         sakService.addObserver(observer)
         assertThrows<RuntimeException> {
             sakService.opprettSak(mock())
@@ -99,7 +99,7 @@ internal class SakServiceImplTest {
             )
         }
 
-        val sakService = SakServiceImpl(sakRepo, fixedClock, mock(), mock(), mock(), mock())
+        val sakService = SakServiceImpl(sakRepo, fixedClock, mock(), mock(), mock(), mock(), mock())
         val sakMedÅpenSøknad = sakService.hentÅpneBehandlingerForAlleSaker()
 
         sakMedÅpenSøknad shouldBe listOf(
@@ -148,7 +148,7 @@ internal class SakServiceImplTest {
             )
         }
 
-        val sakService = SakServiceImpl(sakRepo, fixedClock, mock(), mock(), mock(), mock())
+        val sakService = SakServiceImpl(sakRepo, fixedClock, mock(), mock(), mock(), mock(), mock())
         val sakerMedÅpneBehandlinger = sakService.hentÅpneBehandlingerForAlleSaker()
 
         sakerMedÅpneBehandlinger shouldBe listOf(
@@ -236,7 +236,7 @@ internal class SakServiceImplTest {
             )
         }
 
-        val sakService = SakServiceImpl(sakRepo, fixedClock, mock(), mock(), mock(), mock())
+        val sakService = SakServiceImpl(sakRepo, fixedClock, mock(), mock(), mock(), mock(), mock())
         val sakerMedÅpneRevurderinger = sakService.hentÅpneBehandlingerForAlleSaker()
 
         sakerMedÅpneRevurderinger shouldBe listOf(
@@ -286,7 +286,7 @@ internal class SakServiceImplTest {
             } doReturn dokumentUtenMetadataInformasjonAnnet(tittel = "test-dokument-informasjon-annet").right()
         }
 
-        SakServiceImpl(sakRepo, fixedClock, mock(), brevService, mock(), mock())
+        SakServiceImpl(sakRepo, fixedClock, mock(), brevService, mock(), mock(), mock())
             .opprettFritekstDokument(
                 request = OpprettDokumentRequest(
                     sakId = sak.id,
@@ -308,7 +308,7 @@ internal class SakServiceImplTest {
                 Journalpost(JournalpostId("journalpostId"), "journalpost tittel"),
             ).right()
         }
-        SakServiceImpl(sakRepo, fixedClock, mock(), mock(), queryJournalpostClient, mock())
+        SakServiceImpl(sakRepo, fixedClock, mock(), mock(), queryJournalpostClient, mock(), mock())
             .hentAlleJournalposter(sak.id).shouldBeRight()
 
         verify(sakRepo).hentSakInfo(argThat { it shouldBe sak.id })
@@ -323,7 +323,7 @@ internal class SakServiceImplTest {
         }
 
         assertThrows<IllegalArgumentException> {
-            SakServiceImpl(sakRepo, fixedClock, mock(), mock(), mock(), mock())
+            SakServiceImpl(sakRepo, fixedClock, mock(), mock(), mock(), mock(), mock())
                 .hentAlleJournalposter(sak.id)
         }
         verify(sakRepo).hentSakInfo(argThat { it shouldBe sak.id })

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/Routes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/Routes.kt
@@ -17,6 +17,7 @@ import no.nav.su.se.bakover.utenlandsopphold.application.korriger.KorrigerUtenla
 import no.nav.su.se.bakover.utenlandsopphold.application.registrer.RegistrerUtenlandsoppholdService
 import no.nav.su.se.bakover.utenlandsopphold.infrastruture.web.utenlandsoppholdRoutes
 import no.nav.su.se.bakover.web.external.frikortVedtakRoutes
+import no.nav.su.se.bakover.web.external.pensjonOgUføreRoutes
 import no.nav.su.se.bakover.web.routes.avstemming.avstemmingRoutes
 import no.nav.su.se.bakover.web.routes.dokument.dokumentRoutes
 import no.nav.su.se.bakover.web.routes.drift.driftRoutes
@@ -59,6 +60,9 @@ internal fun Application.setupKtorRoutes(
     routing {
         authenticate("frikort") {
             frikortVedtakRoutes(services.vedtakService, clock)
+        }
+        authenticate("pensjon") {
+            pensjonOgUføreRoutes(services.sak)
         }
 
         authenticate("jwt") {

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/external/PensjonRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/external/PensjonRoutes.kt
@@ -1,0 +1,73 @@
+package no.nav.su.se.bakover.web.external
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import no.nav.su.se.bakover.common.infrastructure.PeriodeMedOptionalTilOgMedJson
+import no.nav.su.se.bakover.common.infrastructure.web.Resultat
+import no.nav.su.se.bakover.common.infrastructure.web.errorJson
+import no.nav.su.se.bakover.common.infrastructure.web.svar
+import no.nav.su.se.bakover.common.infrastructure.web.withBody
+import no.nav.su.se.bakover.common.person.Fnr
+import no.nav.su.se.bakover.domain.sak.OpprettOppgaveDersomAktueltUførevedtakCommand
+import no.nav.su.se.bakover.domain.sak.SakService
+import no.nav.su.se.bakover.domain.sak.UførevedtakBehandlingstype
+
+/**
+ * Laget slik at uføre kan sende inn et fnr og tilhørende vedtaksperiode. Så svarer vi om fnr har supplerende stønad i den perioden.
+ */
+internal fun Route.pensjonOgUføreRoutes(
+    sakService: SakService,
+) {
+    /**
+     * Alle verdiene er knyttet til pensjon sitt vedtak.
+     * Bør tydeliggjøres i domenekoden til SU.
+     *
+     */
+    data class Body(
+        val sakId: String,
+        val vedtakId: String,
+        val vedtakstype: String,
+        val fnr: String,
+        val vedtaksperiode: PeriodeMedOptionalTilOgMedJson,
+        val behandlingstype: String,
+    ) {
+        fun toDomain(): Either<Resultat, OpprettOppgaveDersomAktueltUførevedtakCommand> {
+            val behandlingstype: UførevedtakBehandlingstype = when (this.behandlingstype) {
+                "AUTO" -> UførevedtakBehandlingstype.AUTOMATISK
+                "DEL_AUTO" -> UførevedtakBehandlingstype.DELVIS_AUTOMATISK
+                "MAN" -> UførevedtakBehandlingstype.MANUELL
+                else -> return HttpStatusCode.BadRequest.errorJson(
+                    message = "Ukjent behandlingstype. Forventet AUTO, DEL_AUTO eller MAN.",
+                    code = "ukjent_behandlingstype",
+                ).left()
+            }
+            return OpprettOppgaveDersomAktueltUførevedtakCommand(
+                fnr = Fnr(this.fnr),
+                periode = this.vedtaksperiode.toDomain(),
+                uføreSakId = this.sakId,
+                uføreVedtakId = this.vedtakId,
+                uføreVedtakstype = this.vedtakstype,
+                behandlingstype = behandlingstype,
+            ).right()
+        }
+    }
+    post("/pensjon/vedtakshendelse") {
+        this.call.withBody<Body> { body ->
+            body.toDomain().fold(
+                { resultat -> call.svar(resultat) },
+                { command ->
+                    call.svar(Resultat.accepted())
+                    CoroutineScope(Dispatchers.IO).launch { sakService.opprettOppgaveDersomAktueltUførevedtak(command) }
+                },
+            )
+        }
+    }
+}

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxy.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxy.kt
@@ -125,6 +125,7 @@ import no.nav.su.se.bakover.domain.sak.KunneIkkeHenteGjeldendeVedtaksdata
 import no.nav.su.se.bakover.domain.sak.KunneIkkeOppretteDokument
 import no.nav.su.se.bakover.domain.sak.NySak
 import no.nav.su.se.bakover.domain.sak.OpprettDokumentRequest
+import no.nav.su.se.bakover.domain.sak.OpprettOppgaveDersomAktueltUførevedtakCommand
 import no.nav.su.se.bakover.domain.sak.SakService
 import no.nav.su.se.bakover.domain.sak.fnr.KunneIkkeOppdatereFødselsnummer
 import no.nav.su.se.bakover.domain.sak.fnr.OppdaterFødselsnummerPåSakCommand
@@ -412,6 +413,11 @@ open class AccessCheckProxy(
                 }
 
                 override fun hentSakIdSaksnummerOgFnrForAlleSaker() = kastKanKunKallesFraAnnenService()
+
+                override fun opprettOppgaveDersomAktueltUførevedtak(command: OpprettOppgaveDersomAktueltUførevedtakCommand) {
+                    // Denne skal kun kalles av eksterne systembrukere og andre servicer.
+                    return services.sak.opprettOppgaveDersomAktueltUførevedtak(command)
+                }
 
                 override fun opprettSak(sak: NySak) {
                     assertHarTilgangTilPerson(sak.fnr)

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/ServiceBuilder.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/ServiceBuilder.kt
@@ -73,6 +73,9 @@ data object ServiceBuilder {
             identClient = clients.identClient,
             clock = clock,
         )
+        val oppgaveService = OppgaveServiceImpl(
+            oppgaveClient = clients.oppgaveClient,
+        )
         val sakService = SakServiceImpl(
             sakRepo = databaseRepos.sak,
             clock = clock,
@@ -80,11 +83,9 @@ data object ServiceBuilder {
             brevService = brevService,
             clients.queryJournalpostClient,
             personService = personService,
+            oppgaveService = oppgaveService,
         ).apply { addObserver(statistikkEventObserver) }
 
-        val oppgaveService = OppgaveServiceImpl(
-            oppgaveClient = clients.oppgaveClient,
-        )
         val søknadService = SøknadServiceImpl(
             søknadRepo = databaseRepos.søknad,
             sakService = sakService,


### PR DESCRIPTION
Vi hadde en dialog med uføre som stoppet opp (de implementerte ingenting og fulgte ikke dette opp).

Men tanken er: Når det kommer utbetalings-endringer på uførepersoner som får SU, ønsker vi en Gosys-oppgave som saksbehandlerne kan følge opp. Ofte fanges dette opp for sent og fører til feilutbetalinger.

Vi trenger bare en av disse PRene basert på hvordan Uføre-teamet ønsker løse dette.