### PR TITLE
Aksepter kombinasjon av 0% og under 2% inntektsopphør

### DIFF
--- a/behandling/revurdering/domain/build.gradle.kts
+++ b/behandling/revurdering/domain/build.gradle.kts
@@ -19,6 +19,8 @@ dependencies {
     implementation(project(":vilkår:opplysningsplikt:domain"))
     implementation(project(":vilkår:familiegjenforening:domain"))
     implementation(project(":vilkår:bosituasjon:domain"))
+
+    testImplementation(project(":test-common"))
 }
 
 tasks.named<Jar>("jar") {

--- a/behandling/revurdering/domain/src/main/kotlin/behandling/revurdering/domain/Opphørsgrunn.kt
+++ b/behandling/revurdering/domain/src/main/kotlin/behandling/revurdering/domain/Opphørsgrunn.kt
@@ -61,3 +61,10 @@ fun List<Opphørsgrunn>.getDistinkteParagrafer(): List<Int> =
     this.map { it.getParagrafer() }.flatten().distinct().sorted()
 
 fun List<Avslagsgrunn>.tilOpphørsgrunn(): List<Opphørsgrunn> = this.map { it.tilOpphørsgrunn() }
+
+fun List<Opphørsgrunn>.slåSammenForHøyInntektOgSuUnderMinstegrense(): List<Opphørsgrunn> {
+    return when {
+        this.contains(Opphørsgrunn.FOR_HØY_INNTEKT) && this.contains(Opphørsgrunn.SU_UNDER_MINSTEGRENSE) -> this.filterNot { it == Opphørsgrunn.SU_UNDER_MINSTEGRENSE }
+        else -> this
+    }
+}

--- a/behandling/revurdering/domain/src/test/kotlin/vilkår/common/domain/OpphørsgrunnTest.kt
+++ b/behandling/revurdering/domain/src/test/kotlin/vilkår/common/domain/OpphørsgrunnTest.kt
@@ -1,0 +1,43 @@
+package vilkår.common.domain
+
+import behandling.revurdering.domain.Opphørsgrunn
+import behandling.revurdering.domain.slåSammenForHøyInntektOgSuUnderMinstegrense
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+internal class OpphørsgrunnTest {
+
+    @Test
+    fun `Velg FOR_HØY_INNTEKT over SU_UNDER_MINSTEGRENSE`() {
+        listOf(
+            Opphørsgrunn.SU_UNDER_MINSTEGRENSE,
+            Opphørsgrunn.FOR_HØY_INNTEKT,
+            Opphørsgrunn.FORMUE,
+        ).slåSammenForHøyInntektOgSuUnderMinstegrense() shouldBe listOf(
+            Opphørsgrunn.FOR_HØY_INNTEKT,
+            Opphørsgrunn.FORMUE,
+        )
+    }
+
+    @Test
+    fun `Beholder SU_UNDER_MINSTEGRENSE hvis vi ikke har FOR_HØY_INNTEKT`() {
+        listOf(
+            Opphørsgrunn.SU_UNDER_MINSTEGRENSE,
+            Opphørsgrunn.FORMUE,
+        ).slåSammenForHøyInntektOgSuUnderMinstegrense() shouldBe listOf(
+            Opphørsgrunn.SU_UNDER_MINSTEGRENSE,
+            Opphørsgrunn.FORMUE,
+        )
+    }
+
+    @Test
+    fun `Beholder FOR_HØY_INNTEKT hvis vi ikke har SU_UNDER_MINSTEGRENSE`() {
+        listOf(
+            Opphørsgrunn.FOR_HØY_INNTEKT,
+            Opphørsgrunn.FORMUE,
+        ).slåSammenForHøyInntektOgSuUnderMinstegrense() shouldBe listOf(
+            Opphørsgrunn.FOR_HØY_INNTEKT,
+            Opphørsgrunn.FORMUE,
+        )
+    }
+}

--- a/beregning/src/main/kotlin/beregning/domain/Beregningsgrunnlag.kt
+++ b/beregning/src/main/kotlin/beregning/domain/Beregningsgrunnlag.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import arrow.core.getOrElse
 import arrow.core.left
 import arrow.core.right
+import no.nav.su.se.bakover.common.tid.periode.Måned
 import no.nav.su.se.bakover.common.tid.periode.Periode
 import no.nav.su.se.bakover.common.tid.periode.harOverlappende
 import org.jetbrains.annotations.TestOnly
@@ -77,7 +78,11 @@ data class Beregningsgrunnlag private constructor(
                         forventedeInntekter.flatMap { it.periode.måneder() }.contains(it)
                     }
                 ) {
-                    return UgyldigBeregningsgrunnlag.ManglerForventetInntektForEnkelteMåneder.left()
+                    return UgyldigBeregningsgrunnlag.ManglerForventetInntektForEnkelteMåneder(
+                        beregningsperiode.måneder().filterNot { it ->
+                            forventedeInntekter.flatMap { it.periode.måneder() }.contains(it)
+                        },
+                    ).left()
                 }
             }
 
@@ -90,5 +95,5 @@ sealed interface UgyldigBeregningsgrunnlag {
     data object IkkeLovMedFradragUtenforPerioden : UgyldigBeregningsgrunnlag
     data object BrukerMåHaMinst1ForventetInntekt : UgyldigBeregningsgrunnlag
     data object OverlappendePerioderMedForventetInntekt : UgyldigBeregningsgrunnlag
-    data object ManglerForventetInntektForEnkelteMåneder : UgyldigBeregningsgrunnlag
+    data class ManglerForventetInntektForEnkelteMåneder(val måneder: List<Måned>) : UgyldigBeregningsgrunnlag
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/jsonRequest/OpphørsvedtakPdfInnhold.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/jsonRequest/OpphørsvedtakPdfInnhold.kt
@@ -43,7 +43,16 @@ data class OpphørsvedtakPdfInnhold(
         ): OpphørsvedtakPdfInnhold {
             return OpphørsvedtakPdfInnhold(
                 personalia = personalia,
-                opphørsgrunner = command.opphørsgrunner,
+                opphørsgrunner = command.opphørsgrunner.filter {
+                    !(
+                        command.opphørsgrunner.containsAll(
+                            listOf(
+                                Opphørsgrunn.FOR_HØY_INNTEKT,
+                                Opphørsgrunn.SU_UNDER_MINSTEGRENSE,
+                            ),
+                        ) && it == Opphørsgrunn.SU_UNDER_MINSTEGRENSE
+                        )
+                },
                 avslagsparagrafer = command.opphørsgrunner.getDistinkteParagrafer(),
                 harEktefelle = command.harEktefelle,
                 beregningsperioder = if (

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/opphør/VurderOpphørVedRevurdering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/revurdering/opphør/VurderOpphørVedRevurdering.kt
@@ -35,7 +35,7 @@ sealed interface VurderOpphørVedRevurdering {
         private val beregning: Beregning,
         private val clock: Clock,
     ) : VurderOpphørVedRevurdering {
-        val resultat = when (
+        val resultat: OpphørVedRevurdering = when (
             val opphør = setOf(
                 VurderOmVilkårGirOpphørVedRevurdering(vilkårsvurderinger).resultat,
                 VurderOmBeregningGirOpphørVedRevurdering(beregning, clock).resultat,
@@ -51,6 +51,13 @@ sealed interface VurderOpphørVedRevurdering {
 sealed interface OpphørVedRevurdering {
     data class Ja(val opphørsgrunner: List<Opphørsgrunn>, val opphørsdato: LocalDate) : OpphørVedRevurdering
     data object Nei : OpphørVedRevurdering
+
+    /**
+     * @return true dersom opphørsgrunnene inneholder Opphørsgrunn.SU_UNDER_MINSTEGRENSE eller Opphørsgrunn.FOR_HØY_INNTEKT
+     */
+    fun erOpphørPgaInntekt(): Boolean {
+        return this is Ja && (this.opphørsgrunner.contains(Opphørsgrunn.SU_UNDER_MINSTEGRENSE) || this.opphørsgrunner.contains(Opphørsgrunn.FOR_HØY_INNTEKT))
+    }
 }
 
 data class VurderOmVilkårGirOpphørVedRevurdering(

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/BeregningsgrunnlagTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/beregning/BeregningsgrunnlagTest.kt
@@ -15,7 +15,9 @@ import no.nav.su.se.bakover.common.domain.tid.mai
 import no.nav.su.se.bakover.common.domain.tid.november
 import no.nav.su.se.bakover.common.tid.periode.Periode
 import no.nav.su.se.bakover.common.tid.periode.desember
+import no.nav.su.se.bakover.common.tid.periode.februar
 import no.nav.su.se.bakover.common.tid.periode.januar
+import no.nav.su.se.bakover.common.tid.periode.november
 import no.nav.su.se.bakover.common.tid.periode.år
 import no.nav.su.se.bakover.test.fixedTidspunkt
 import no.nav.su.se.bakover.test.lagFradragsgrunnlag
@@ -279,7 +281,7 @@ internal class BeregningsgrunnlagTest {
                 ),
             ),
             fradragFraSaksbehandler = emptyList(),
-        ) shouldBe UgyldigBeregningsgrunnlag.ManglerForventetInntektForEnkelteMåneder.left()
+        ) shouldBe UgyldigBeregningsgrunnlag.ManglerForventetInntektForEnkelteMåneder((februar(2021)..november(2021)).måneder()).left()
 
         Beregningsgrunnlag.tryCreate(
             beregningsperiode = beregningsperiode,
@@ -292,7 +294,7 @@ internal class BeregningsgrunnlagTest {
                 ),
             ),
             fradragFraSaksbehandler = emptyList(),
-        ) shouldBe UgyldigBeregningsgrunnlag.ManglerForventetInntektForEnkelteMåneder.left()
+        ) shouldBe UgyldigBeregningsgrunnlag.ManglerForventetInntektForEnkelteMåneder(listOf(desember(2021))).left()
 
         Beregningsgrunnlag.tryCreate(
             beregningsperiode = beregningsperiode,
@@ -305,7 +307,7 @@ internal class BeregningsgrunnlagTest {
                 ),
             ),
             fradragFraSaksbehandler = emptyList(),
-        ) shouldBe UgyldigBeregningsgrunnlag.ManglerForventetInntektForEnkelteMåneder.left()
+        ) shouldBe UgyldigBeregningsgrunnlag.ManglerForventetInntektForEnkelteMåneder(januar(2021).måneder()).left()
 
         Beregningsgrunnlag.create(
             beregningsperiode = beregningsperiode,

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/opphør/IdentifiserRevurderingsopphørSomIkkeStøttesKombiopphørTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/opphør/IdentifiserRevurderingsopphørSomIkkeStøttesKombiopphørTest.kt
@@ -1,0 +1,157 @@
+package no.nav.su.se.bakover.domain.revurdering.opphør
+
+import arrow.core.NonEmptyList
+import arrow.core.nonEmptyListOf
+import beregning.domain.BeregningForMåned
+import io.kotest.assertions.arrow.core.shouldBeRight
+import no.nav.su.se.bakover.common.domain.tid.september
+import no.nav.su.se.bakover.common.tid.periode.april
+import no.nav.su.se.bakover.common.tid.periode.juni
+import no.nav.su.se.bakover.common.tid.periode.mai
+import no.nav.su.se.bakover.common.tid.periode.mars
+import no.nav.su.se.bakover.test.beregning
+import no.nav.su.se.bakover.test.bosituasjonEpsUnder67
+import no.nav.su.se.bakover.test.fixedClock
+import no.nav.su.se.bakover.test.forventetInntekt0FradragForMåned
+import no.nav.su.se.bakover.test.grunnlag.uføregrunnlagForventetInntekt
+import no.nav.su.se.bakover.test.lagFradragsgrunnlag
+import no.nav.su.se.bakover.test.satsFactoryTestPåDato
+import no.nav.su.se.bakover.test.vilkårsvurderinger.innvilgetUførevilkårFraGrunnlag
+import no.nav.su.se.bakover.test.vilkårsvurderingerRevurderingInnvilget
+import org.junit.jupiter.api.Test
+import vilkår.inntekt.domain.grunnlag.FradragForMåned
+import vilkår.inntekt.domain.grunnlag.FradragTilhører
+import vilkår.inntekt.domain.grunnlag.Fradragsgrunnlag
+import vilkår.inntekt.domain.grunnlag.Fradragstype
+import vilkår.uføre.domain.Uføregrunnlag
+
+/**
+ * Oppsto en bug som traff Opphørsgrunner.FOR_HØY_INNTEKT og OpphørOgAndreEndringerIKombinasjon
+ * Søknadsvedtak: 2023-07 -> 2024-06
+ * Stansvedtak: 2023-12 -> 2024-06
+ * Gjenopptaksvedtak: 2023-12 -> 2024-06
+ * Reguleringsvedtak: 2024-05 -> 2024-06
+ * Revurderingsperiode: 2024-03 -> 2024-06
+ */
+internal class IdentifiserRevurderingsopphørSomIkkeStøttesKombiopphørTest {
+
+    @Test
+    fun `skal støtte kombinasjon av 2pst og 0pst opphør`() {
+        val revurderingsperiode = mars(2024)..juni(2024)
+
+        val satsFactoryTestPåDato = satsFactoryTestPåDato(3.september(2024))
+        val eksisterendeMånedsberegning: NonEmptyList<BeregningForMåned> = nonEmptyListOf(
+            BeregningForMåned(
+                måned = mars(2024),
+                fradrag = listOf(
+                    FradragForMåned(
+                        fradragstype = Fradragstype.Uføretrygd,
+                        månedsbeløp = 6198.0,
+                        måned = mars(2024),
+                        tilhører = FradragTilhører.BRUKER,
+                    ),
+                    forventetInntekt0FradragForMåned(mars(2024)),
+                ),
+                fullSupplerendeStønadForMåned = satsFactoryTestPåDato.høyUføre(mars(2024)),
+                sumYtelse = 18317,
+                sumFradrag = 6198.0,
+            ),
+            BeregningForMåned(
+                måned = april(2024),
+                fradrag = listOf(
+                    FradragForMåned(
+                        fradragstype = Fradragstype.Uføretrygd,
+                        månedsbeløp = 6198.0,
+                        måned = april(2024),
+                        tilhører = FradragTilhører.BRUKER,
+                    ),
+                    forventetInntekt0FradragForMåned(april(2024)),
+                ),
+                fullSupplerendeStønadForMåned = satsFactoryTestPåDato.høyUføre(april(2024)),
+                sumYtelse = 18317,
+                sumFradrag = 6198.0,
+            ),
+            BeregningForMåned(
+                måned = mai(2024),
+                fradrag = listOf(
+                    FradragForMåned(
+                        fradragstype = Fradragstype.Uføretrygd,
+                        månedsbeløp = 6481.0,
+                        måned = mai(2024),
+                        tilhører = FradragTilhører.BRUKER,
+                    ),
+                    forventetInntekt0FradragForMåned(mai(2024)),
+                ),
+                fullSupplerendeStønadForMåned = satsFactoryTestPåDato.høyUføre(mai(2024)),
+                sumYtelse = 19151,
+                sumFradrag = 6481.0,
+            ),
+            BeregningForMåned(
+                måned = juni(2024),
+                fradrag = listOf(
+                    FradragForMåned(
+                        fradragstype = Fradragstype.Uføretrygd,
+                        månedsbeløp = 6481.0,
+                        måned = juni(2024),
+                        tilhører = FradragTilhører.BRUKER,
+                    ),
+                    forventetInntekt0FradragForMåned(juni(2024)),
+                ),
+                fullSupplerendeStønadForMåned = satsFactoryTestPåDato.høyUføre(juni(2024)),
+                sumYtelse = 19151,
+                sumFradrag = 6481.0,
+            ),
+        )
+        val nyeUføregrunnlag: NonEmptyList<Uføregrunnlag> = nonEmptyListOf(
+            uføregrunnlagForventetInntekt(periode = mars(2024)..juni(2024), forventetInntekt = 0),
+        )
+        val nyttFradragsgrunnlag: NonEmptyList<Fradragsgrunnlag> = nonEmptyListOf(
+            lagFradragsgrunnlag(
+                type = Fradragstype.Arbeidsavklaringspenger,
+                månedsbeløp = 18240.0,
+                periode = mars(2024),
+                tilhører = FradragTilhører.EPS,
+            ),
+            lagFradragsgrunnlag(
+                type = Fradragstype.Arbeidsavklaringspenger,
+                månedsbeløp = 27360.0,
+                periode = april(2024)..juni(2024),
+                tilhører = FradragTilhører.EPS,
+            ),
+            lagFradragsgrunnlag(
+                type = Fradragstype.Uføretrygd,
+                månedsbeløp = 6198.0,
+                periode = mars(2024)..april(2024),
+                tilhører = FradragTilhører.BRUKER,
+            ),
+            lagFradragsgrunnlag(
+                type = Fradragstype.Uføretrygd,
+                månedsbeløp = 6481.0,
+                periode = mai(2024)..juni(2024),
+                tilhører = FradragTilhører.BRUKER,
+            ),
+        )
+        val bosituasjon = bosituasjonEpsUnder67(periode = revurderingsperiode)
+        val nyBeregning = beregning(
+            periode = revurderingsperiode,
+            uføregrunnlag = nyeUføregrunnlag,
+            fradragsgrunnlag = nyttFradragsgrunnlag,
+            bosituasjon = bosituasjon,
+            satsFactory = satsFactoryTestPåDato,
+        )
+        val vilkårsvurderinger = vilkårsvurderingerRevurderingInnvilget(
+            periode = revurderingsperiode,
+            uføre = innvilgetUførevilkårFraGrunnlag(
+                grunnlag = nyeUføregrunnlag,
+            ),
+            bosituasjon = nonEmptyListOf(bosituasjon),
+        )
+        IdentifiserRevurderingsopphørSomIkkeStøttes.MedBeregning(
+            revurderingsperiode = nyBeregning.periode,
+            vilkårsvurderinger = vilkårsvurderinger,
+            gjeldendeMånedsberegninger = eksisterendeMånedsberegning,
+            nyBeregning = nyBeregning,
+            clock = fixedClock,
+        ).resultat.shouldBeRight()
+    }
+}

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/opphør/IdentifiserRevurderingsopphørSomIkkeStøttesTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/opphør/IdentifiserRevurderingsopphørSomIkkeStøttesTest.kt
@@ -1,4 +1,4 @@
-package no.nav.su.se.bakover.domain.revurdering
+package no.nav.su.se.bakover.domain.revurdering.opphør
 
 import arrow.core.left
 import arrow.core.nonEmptyListOf
@@ -17,8 +17,6 @@ import no.nav.su.se.bakover.common.tid.periode.juni
 import no.nav.su.se.bakover.common.tid.periode.november
 import no.nav.su.se.bakover.common.tid.periode.år
 import no.nav.su.se.bakover.domain.beregning.beregning.finnMerknaderForPeriode
-import no.nav.su.se.bakover.domain.revurdering.opphør.IdentifiserRevurderingsopphørSomIkkeStøttes
-import no.nav.su.se.bakover.domain.revurdering.opphør.RevurderingsutfallSomIkkeStøttes
 import no.nav.su.se.bakover.test.beregning
 import no.nav.su.se.bakover.test.fixedClock
 import no.nav.su.se.bakover.test.fradragsgrunnlagArbeidsinntekt
@@ -125,7 +123,6 @@ internal class IdentifiserRevurderingsopphørSomIkkeStøttesTest {
             nyBeregning = nyBeregning,
             clock = fixedClock,
         ).resultat shouldBe setOf(
-            RevurderingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon,
             RevurderingsutfallSomIkkeStøttes.DelvisOpphør,
         ).left()
     }
@@ -158,7 +155,6 @@ internal class IdentifiserRevurderingsopphørSomIkkeStøttesTest {
             nyBeregning = nyBeregning,
             clock = fixedClock,
         ).resultat shouldBe setOf(
-            RevurderingsutfallSomIkkeStøttes.OpphørOgAndreEndringerIKombinasjon,
             RevurderingsutfallSomIkkeStøttes.DelvisOpphør,
         ).left()
     }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/opphør/VurderOpphørVedRevurderingTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/revurdering/opphør/VurderOpphørVedRevurderingTest.kt
@@ -1,4 +1,4 @@
-package no.nav.su.se.bakover.domain.revurdering
+package no.nav.su.se.bakover.domain.revurdering.opphør
 
 import arrow.core.nonEmptyListOf
 import behandling.revurdering.domain.Opphørsgrunn
@@ -16,8 +16,6 @@ import no.nav.su.se.bakover.common.tid.periode.juli
 import no.nav.su.se.bakover.common.tid.periode.juni
 import no.nav.su.se.bakover.common.tid.periode.mars
 import no.nav.su.se.bakover.common.tid.periode.november
-import no.nav.su.se.bakover.domain.revurdering.opphør.OpphørVedRevurdering
-import no.nav.su.se.bakover.domain.revurdering.opphør.VurderOpphørVedRevurdering
 import no.nav.su.se.bakover.test.beregning
 import no.nav.su.se.bakover.test.beregningAvslagForHøyInntekt
 import no.nav.su.se.bakover.test.beregningAvslagUnderMinstebeløp

--- a/test-common/src/main/kotlin/GrunnlagsdataTestData.kt
+++ b/test-common/src/main/kotlin/GrunnlagsdataTestData.kt
@@ -179,3 +179,13 @@ fun arbeidsinntekt(periode: Periode, tilhører: FradragTilhører): Fradragsgrunn
         tilhører = tilhører,
     )
 }
+
+fun fradragsgrunnlagForventetInntekt0(periode: Periode, tilhører: FradragTilhører): Fradragsgrunnlag {
+    return lagFradragsgrunnlag(
+        type = Fradragstype.ForventetInntekt,
+        månedsbeløp = 0.0,
+        periode = periode,
+        utenlandskInntekt = null,
+        tilhører = tilhører,
+    )
+}

--- a/test-common/src/main/kotlin/RevurderingTestData.kt
+++ b/test-common/src/main/kotlin/RevurderingTestData.kt
@@ -532,17 +532,19 @@ fun lagFradragsgrunnlag(
     periode: Periode,
     utenlandskInntekt: UtenlandskInntekt? = null,
     tilhører: FradragTilhører,
-) = Fradragsgrunnlag.tryCreate(
-    id = id,
-    opprettet = opprettet,
-    fradrag = FradragFactory.nyFradragsperiode(
-        fradragstype = type,
-        månedsbeløp = månedsbeløp,
-        periode = periode,
-        utenlandskInntekt = utenlandskInntekt,
-        tilhører = tilhører,
-    ),
-).getOrFail()
+): Fradragsgrunnlag {
+    return Fradragsgrunnlag.tryCreate(
+        id = id,
+        opprettet = opprettet,
+        fradrag = FradragFactory.nyFradragsperiode(
+            fradragstype = type,
+            månedsbeløp = månedsbeløp,
+            periode = periode,
+            utenlandskInntekt = utenlandskInntekt,
+            tilhører = tilhører,
+        ),
+    ).getOrFail()
+}
 
 fun avsluttetRevurderingInnvilgetFraInnvilgetSøknadsbehandlingsVedtak(
     begrunnelse: String = "begrunnelsensen",

--- a/test-common/src/main/kotlin/vilkår/UførevilkårTestData.kt
+++ b/test-common/src/main/kotlin/vilkår/UførevilkårTestData.kt
@@ -1,5 +1,6 @@
 package no.nav.su.se.bakover.test.vilkårsvurderinger
 
+import arrow.core.NonEmptyList
 import arrow.core.nonEmptyListOf
 import no.nav.su.se.bakover.common.tid.Tidspunkt
 import no.nav.su.se.bakover.common.tid.periode.Periode
@@ -80,6 +81,24 @@ fun innvilgetUførevilkår(
                 periode = periode,
             ),
         ),
+    )
+}
+
+fun innvilgetUførevilkårFraGrunnlag(
+    vurderingsperiodeId: UUID = UUID.randomUUID(),
+    opprettet: Tidspunkt = fixedTidspunkt,
+    grunnlag: NonEmptyList<Uføregrunnlag>,
+): UføreVilkår.Vurdert {
+    return UføreVilkår.Vurdert.create(
+        vurderingsperioder = grunnlag.map {
+            VurderingsperiodeUføre.create(
+                id = vurderingsperiodeId,
+                opprettet = opprettet,
+                vurdering = Vurdering.Innvilget,
+                grunnlag = it,
+                periode = it.periode,
+            )
+        },
     )
 }
 


### PR DESCRIPTION
Legger til støtte for å opphøre en periode som har kombinasjon av opphørsgunnene: SU_UNDER_MINSTEGRENSE (2%) og FOR_HØY_INNTEKT (0%)

Sjekk samhendlingskanal på teams angående dette: https://teams.microsoft.com/l/message/19:jjE41BT-ZVDOi_UVyZsfeS6IT-ytXAFxFoGIkbBqatQ1@thread.skype/1725528028308