### PR TITLE
Nytt felt for om uføre sak fyller 67

### DIFF
--- a/bootstrap/src/test/kotlin/no/nav/su/se/bakover/domain/brev/command/PåminnelseNyStønadsperiodeDokumentCommandTest.kt
+++ b/bootstrap/src/test/kotlin/no/nav/su/se/bakover/domain/brev/command/PåminnelseNyStønadsperiodeDokumentCommandTest.kt
@@ -1,0 +1,30 @@
+package no.nav.su.se.bakover.domain.brev.command
+
+import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.common.domain.tid.juni
+import no.nav.su.se.bakover.common.person.AktørId
+import no.nav.su.se.bakover.common.person.Ident
+import no.nav.su.se.bakover.test.fnr
+import no.nav.su.se.bakover.test.getOrFail
+import no.nav.su.se.bakover.test.nySakUføre
+import org.junit.jupiter.api.Test
+import person.domain.Person
+
+class PåminnelseNyStønadsperiodeDokumentCommandTest {
+    @Test
+    fun `Skal sette flagg uføre fyller 67 hvis bruker fyller 67 samme måned som jobbkjøring`() {
+        with(
+            PåminnelseNyStønadsperiodeDokumentCommand.ny(
+                sak = nySakUføre().first,
+                person = Person(
+                    ident = Ident(fnr, AktørId("123")),
+                    navn = Person.Navn("", "", ""),
+                    fødsel = Person.Fødsel.MedFødselsdato(15.juni(1958)),
+                ),
+                utløpsdato = 1.juni(2025),
+            ).getOrFail(),
+        ) {
+            uføreSomFyller67 shouldBe true
+        }
+    }
+}

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/command/PåminnelseNyStønadsperiodeDokumentCommand.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/command/PåminnelseNyStønadsperiodeDokumentCommand.kt
@@ -21,6 +21,7 @@ data class PåminnelseNyStønadsperiodeDokumentCommand(
     override val saksnummer: Saksnummer,
     override val sakstype: Sakstype,
     val utløpsdato: LocalDate,
+    // Er en bruker med uføre som fyller 67 år i stønadsperiode sin siste måned
     val uføreSomFyller67: Boolean,
 ) : GenererDokumentCommand {
     companion object {

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/command/PåminnelseNyStønadsperiodeDokumentCommand.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/command/PåminnelseNyStønadsperiodeDokumentCommand.kt
@@ -1,9 +1,16 @@
 package no.nav.su.se.bakover.domain.brev.command
 
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
 import dokument.domain.GenererDokumentCommand
 import no.nav.su.se.bakover.common.domain.Saksnummer
 import no.nav.su.se.bakover.common.domain.sak.Sakstype
+import no.nav.su.se.bakover.common.domain.tid.endOfMonth
 import no.nav.su.se.bakover.common.person.Fnr
+import no.nav.su.se.bakover.domain.Sak
+import no.nav.su.se.bakover.domain.jobcontext.SendPåminnelseNyStønadsperiodeContext.KunneIkkeSendePåminnelse
+import person.domain.Person
 import java.time.LocalDate
 
 /**
@@ -14,5 +21,20 @@ data class PåminnelseNyStønadsperiodeDokumentCommand(
     override val saksnummer: Saksnummer,
     override val sakstype: Sakstype,
     val utløpsdato: LocalDate,
-    val halvtGrunnbeløp: Int,
-) : GenererDokumentCommand
+    val uføreSomFyller67: Boolean,
+) : GenererDokumentCommand {
+    companion object {
+        fun ny(sak: Sak, person: Person, utløpsdato: LocalDate): Either<KunneIkkeSendePåminnelse, PåminnelseNyStønadsperiodeDokumentCommand> {
+            val uføreSomFyller67 = person.er67EllerEldre(utløpsdato.endOfMonth())
+                ?: return KunneIkkeSendePåminnelse.PersonManglerFødselsdato.left()
+
+            return PåminnelseNyStønadsperiodeDokumentCommand(
+                fødselsnummer = sak.fnr,
+                saksnummer = sak.saksnummer,
+                sakstype = sak.type,
+                utløpsdato = utløpsdato,
+                uføreSomFyller67 = uføreSomFyller67,
+            ).right()
+        }
+    }
+}

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/jsonRequest/PåminnelseNyStønadsperiodePdfInnhold.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/jsonRequest/PåminnelseNyStønadsperiodePdfInnhold.kt
@@ -11,6 +11,7 @@ data class PåminnelseNyStønadsperiodePdfInnhold(
     override val sakstype: Sakstype,
     val personalia: PersonaliaPdfInnhold,
     val utløpsdato: String,
+    // Er en bruker med uføre som fyller 67 år i stønadsperiode sin siste måned
     val uføreSomFyller67: Boolean,
 ) : PdfInnhold {
     override val pdfTemplate = PdfTemplateMedDokumentNavn.PåminnelseNyStønadsperiode

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/jsonRequest/PåminnelseNyStønadsperiodePdfInnhold.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/brev/jsonRequest/PåminnelseNyStønadsperiodePdfInnhold.kt
@@ -11,7 +11,7 @@ data class PåminnelseNyStønadsperiodePdfInnhold(
     override val sakstype: Sakstype,
     val personalia: PersonaliaPdfInnhold,
     val utløpsdato: String,
-    val halvtGrunnbeløp: Int,
+    val uføreSomFyller67: Boolean,
 ) : PdfInnhold {
     override val pdfTemplate = PdfTemplateMedDokumentNavn.PåminnelseNyStønadsperiode
 
@@ -24,7 +24,7 @@ data class PåminnelseNyStønadsperiodePdfInnhold(
                 sakstype = command.sakstype,
                 personalia = personalia,
                 utløpsdato = command.utløpsdato.ddMMyyyy(),
-                halvtGrunnbeløp = command.halvtGrunnbeløp,
+                uføreSomFyller67 = command.uføreSomFyller67,
             )
         }
     }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/jobcontext/SendPåminnelseNyStønadsperiodeContextTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/jobcontext/SendPåminnelseNyStønadsperiodeContextTest.kt
@@ -13,12 +13,10 @@ import no.nav.su.se.bakover.domain.Sak
 import no.nav.su.se.bakover.test.TestSessionFactory
 import no.nav.su.se.bakover.test.TikkendeKlokke
 import no.nav.su.se.bakover.test.fixedClockAt
-import no.nav.su.se.bakover.test.formuegrenserFactoryTestPåDato
 import no.nav.su.se.bakover.test.getOrFail
 import no.nav.su.se.bakover.test.person
 import no.nav.su.se.bakover.test.søknadsbehandlingIverksattInnvilget
 import org.junit.jupiter.api.Test
-import java.time.LocalDate
 import java.time.Month
 import java.time.YearMonth
 
@@ -76,7 +74,6 @@ internal class SendPåminnelseNyStønadsperiodeContextTest {
             lagDokument = { throw IllegalStateException("Skal ikke komme så langt.") },
             lagreDokument = { _, _ -> },
             lagreContext = { _, _ -> },
-            formuegrenserFactory = formuegrenserFactoryTestPåDato(LocalDate.now(clock)),
             hentPerson = { person(dødsdato = 30.november(2021)).right() },
         ).getOrFail()
         actual shouldBe context.copy(

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/SendPåminnelserOmNyStønadsperiodeServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/SendPåminnelserOmNyStønadsperiodeServiceImpl.kt
@@ -53,7 +53,6 @@ class SendPåminnelserOmNyStønadsperiodeServiceImpl(
                         lagreContext = { ctx, tx ->
                             sendPåminnelseNyStønadsperiodeJobRepo.lagre(ctx, tx)
                         },
-                        formuegrenserFactory = formuegrenserFactory,
                         hentPerson = personService::hentPersonMedSystembruker,
                     ).fold(
                         {

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/SendPåminnelserOmNyStønadsperiodeServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/SendPåminnelserOmNyStønadsperiodeServiceImplTest.kt
@@ -147,8 +147,8 @@ internal class SendPåminnelserOmNyStønadsperiodeServiceImplTest {
                 saksnummer = Saksnummer(3001),
                 sakstype = Sakstype.UFØRE,
                 utløpsdato = LocalDate.of(2021, Month.DECEMBER, 31),
-                halvtGrunnbeløp = 50676,
                 fødselsnummer = sak2.fnr,
+                uføreSomFyller67 = false,
             )
 
             verify(serviceAndMocks.brevService).lagreDokument(


### PR DESCRIPTION
Legger til felt uføreSomFyller67 på PåminnelseNyStønadsperiodeDokumentCommand for å kunne vise riktig i brev.
Fjerner også felt "halvtGrunnbeløp" fordi det ikke brukes i brevet.