### PR TITLE
IKke la brevdistribusjoner gå evig pga feil fra saksbehandler

### DIFF
--- a/dokument/domain/src/main/kotlin/dokument/domain/Dokumentdistribusjon.kt
+++ b/dokument/domain/src/main/kotlin/dokument/domain/Dokumentdistribusjon.kt
@@ -2,7 +2,6 @@ package dokument.domain
 
 import arrow.core.Either
 import dokument.domain.brev.BrevbestillingId
-import dokument.domain.brev.KunneIkkeDistribuereBrev
 import dokument.domain.distribuering.KunneIkkeBestilleDistribusjon
 import no.nav.su.se.bakover.common.domain.backoff.Failures
 import no.nav.su.se.bakover.common.journal.JournalpostId

--- a/dokument/domain/src/main/kotlin/dokument/domain/JournalføringOgBrevdistribusjon.kt
+++ b/dokument/domain/src/main/kotlin/dokument/domain/JournalføringOgBrevdistribusjon.kt
@@ -3,7 +3,6 @@ package dokument.domain
 import arrow.core.Either
 import arrow.core.flatMap
 import arrow.core.left
-import dokument.domain.JournalføringOgBrevdistribusjon.IkkeJournalførtEllerDistribuert.medJournalpost
 import dokument.domain.brev.BrevbestillingId
 import dokument.domain.distribuering.KunneIkkeBestilleDistribusjon
 import no.nav.su.se.bakover.common.domain.backoff.Failures


### PR DESCRIPTION
Dette skjer typisk ved fritekstbrev som sb ikke vil sende ut allikevel, de går så i gosys å markerer journalposten som feilregistrert