### PR TITLE
Oppdaterer scope for dokdistfordeling

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -104,7 +104,7 @@ spec:
     - name: DOKDIST_URL
       value: "http://dokdistfordeling.teamdokumenthandtering.svc.nais.local"
     - name: DOKDIST_CLIENT_ID
-      value: "api://dev-fss.teamdokumenthandtering.saf"
+      value: "api://dev-fss.teamdokumenthandtering.dokdistfordeling"
     - name: SIMULERING_URL
       value: "https://cics-q1.adeo.no/oppdrag/simulerFpServiceWSBinding"
     - name: STS_URL_SOAP

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -95,7 +95,7 @@ spec:
     - name: DOKDIST_URL
       value: "http://dokdistfordeling.teamdokumenthandtering.svc.nais.local"
     - name: DOKDIST_CLIENT_ID
-      value: "api://prod-fss.teamdokumenthandtering.saf"
+      value: "api://prod-fss.teamdokumenthandtering.dokdistfordeling"
     - name: SIMULERING_URL
       value: "https://wasapp.adeo.no/cics/services/simulerFpServiceWSBinding"
     - name: STS_URL_SOAP


### PR DESCRIPTION
* Fra saf-scope til dokdistfordeling-scope for dokdistfordeling integrasjonen

> Vi gjør endringer på autentisering i dokdistfordeling, for å sørge for at autentisering med EntraID er implementert som tiltenkt. Pr i dag kalles distribuerJournalpost med EntraID tokens scopet mot SAF, hvor dokdistfordeling proxyer dette tokenet videre i kall til SAF. Vi ønsker på sikt å endre dette til av dokdistfordeling kun kan kalles med tokens som er scopet mot seg selv. Steg 1 av denne endringen innføres nå, hvor dokdistfordeling i en overgangsperiode vil akseptere tokens med enten saf- eller dokdistfordeling-scope. Dette innebærer at konsumenter ikke trenger å gjøre noe umiddelbart, men på sikt (helst så snart som mulig) må endre scope for tokenet de kaller dokdistfordeling med. Vi kommer til å bistå konsumenter med denne endringen. Liste med pre-autentiserte applikasjoner er populert for hvert miljø basert på kall mot distribuertJournalpost siste 7 dager.

Har dobbeltsjekket dokdistfordeling config og `prod-fss:supstonad:su-se-bakover` ligger inne i dokdistfordeling sin preauthorized liste. Så dere skal ikke merke noe. 🙇