### PR TITLE
Driftroute for fradragssjekk

### DIFF
--- a/test-common/src/main/kotlin/application/MockedServices.kt
+++ b/test-common/src/main/kotlin/application/MockedServices.kt
@@ -39,6 +39,7 @@ fun mockedServices() = Services(
     sakstatistikkBigQueryService = mock(),
     pesysJobService = mock(),
     aapJobService = mock(),
+    fradragsjobbenService = mock(),
     fritekstAvslagService = mock(),
     søknadStatistikkService = mock(),
     mottakerService = mock(),

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/Routes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/Routes.kt
@@ -94,6 +94,7 @@ internal fun Application.setupKtorRoutes(
                         ferdigstillVedtakService = accessProtectedServices.ferdigstillVedtak,
                         personhendelseService = accessProtectedServices.personhendelseService,
                         kontrollsamtaleDriftOversiktService = accessProtectedServices.kontrollsamtaleDriftOversiktService,
+                        fradragsjobbenService = accessProtectedServices.fradragsjobbenService,
                     )
                     revurderingRoutes(
                         revurderingService = accessProtectedServices.revurdering,

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/drift/DriftRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/drift/DriftRoutes.kt
@@ -15,6 +15,7 @@ import no.nav.su.se.bakover.service.statistikk.ResendStatistikkhendelserService
 import no.nav.su.se.bakover.service.søknad.SøknadService
 import no.nav.su.se.bakover.vedtak.application.FerdigstillVedtakService
 import no.nav.su.se.bakover.web.routes.drift.FixSøknaderResponseJson.Companion.toJson
+import no.nav.su.se.bakover.web.services.fradragssjekken.FradragsjobbenService
 
 internal const val DRIFT_PATH = "/drift"
 
@@ -24,6 +25,7 @@ internal fun Route.driftRoutes(
     ferdigstillVedtakService: FerdigstillVedtakService,
     personhendelseService: PersonhendelseService,
     kontrollsamtaleDriftOversiktService: KontrollsamtaleDriftOversiktService,
+    fradragsjobbenService: FradragsjobbenService,
 ) {
     patch("$DRIFT_PATH/søknader/fix") {
         authorize(Brukerrolle.Drift) {
@@ -42,6 +44,7 @@ internal fun Route.driftRoutes(
     resendStatistikkRoutes(resendStatistikkhendelserService)
     ferdigstillVedtakRoutes(ferdigstillVedtakService)
     innlesingPersonhendelserFraFilRoute(personhendelseService)
+    fradragssjekkDriftRoute(fradragsjobbenService)
 
     kontrollsamtalerDriftRoute(kontrollsamtaleDriftOversiktService)
 }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/drift/FradragssjekkDriftRoute.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/drift/FradragssjekkDriftRoute.kt
@@ -7,15 +7,18 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import no.nav.su.se.bakover.common.brukerrolle.Brukerrolle
+import no.nav.su.se.bakover.common.infrastructure.correlation.CORRELATION_ID_HEADER
 import no.nav.su.se.bakover.common.infrastructure.web.Feilresponser.ugyldigMåned
 import no.nav.su.se.bakover.common.infrastructure.web.Resultat
 import no.nav.su.se.bakover.common.infrastructure.web.authorize
+import no.nav.su.se.bakover.common.infrastructure.web.correlationId
 import no.nav.su.se.bakover.common.infrastructure.web.errorJson
 import no.nav.su.se.bakover.common.infrastructure.web.svar
 import no.nav.su.se.bakover.common.infrastructure.web.withBody
 import no.nav.su.se.bakover.common.tid.periode.Måned
 import no.nav.su.se.bakover.web.services.fradragssjekken.FradragsjobbenService
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 
 internal fun Route.fradragssjekkDriftRoute(
     fradragsjobbenService: FradragsjobbenService,
@@ -31,6 +34,7 @@ internal fun Route.fradragssjekkDriftRoute(
         authorize(Brukerrolle.Drift) {
             call.withBody<Body> { body ->
                 val måned = Måned.parse(body.maaned) ?: return@withBody call.svar(ugyldigMåned)
+                val correlationId = call.correlationId.toString()
 
                 if (!body.dryRun && fradragsjobbenService.harOrdinaerKjoringForMåned(måned)) {
                     return@withBody call.svar(
@@ -42,13 +46,25 @@ internal fun Route.fradragssjekkDriftRoute(
                 }
 
                 CoroutineScope(Dispatchers.IO).launch {
-                    runCatching {
-                        fradragsjobbenService.kjørFradragssjekkForMåned(
-                            måned = måned,
-                            dryRun = body.dryRun,
-                        )
-                    }.onFailure {
-                        log.error("Manuell fradragssjekk feilet for måned {}. dryRun={}", måned, body.dryRun, it)
+                    val previousCorrelationId = MDC.get(CORRELATION_ID_HEADER)
+
+                    try {
+                        MDC.put(CORRELATION_ID_HEADER, correlationId)
+
+                        runCatching {
+                            fradragsjobbenService.kjørFradragssjekkForMåned(
+                                måned = måned,
+                                dryRun = body.dryRun,
+                            )
+                        }.onFailure {
+                            log.error("Manuell fradragssjekk feilet for måned {}. dryRun={}", måned, body.dryRun, it)
+                        }
+                    } finally {
+                        if (previousCorrelationId == null) {
+                            MDC.remove(CORRELATION_ID_HEADER)
+                        } else {
+                            MDC.put(CORRELATION_ID_HEADER, previousCorrelationId)
+                        }
                     }
                 }
 

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/drift/FradragssjekkDriftRoute.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/drift/FradragssjekkDriftRoute.kt
@@ -17,6 +17,8 @@ import no.nav.su.se.bakover.common.infrastructure.web.svar
 import no.nav.su.se.bakover.common.infrastructure.web.withBody
 import no.nav.su.se.bakover.common.tid.periode.Måned
 import no.nav.su.se.bakover.web.services.fradragssjekken.FradragsjobbenService
+import no.nav.su.se.bakover.web.services.fradragssjekken.FradragssjekkAlleredeKjørtForMånedException
+import no.nav.su.se.bakover.web.services.fradragssjekken.FradragssjekkKanIkkeKjøresForTidligereMånedException
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 
@@ -36,11 +38,23 @@ internal fun Route.fradragssjekkDriftRoute(
                 val måned = Måned.parse(body.maaned) ?: return@withBody call.svar(ugyldigMåned)
                 val correlationId = call.correlationId.toString()
 
-                if (!body.dryRun && fradragsjobbenService.harOrdinaerKjoringForMåned(måned)) {
+                try {
+                    fradragsjobbenService.validerKjøringForMåned(
+                        måned = måned,
+                        dryRun = body.dryRun,
+                    )
+                } catch (_: FradragssjekkAlleredeKjørtForMånedException) {
                     return@withBody call.svar(
                         HttpStatusCode.Conflict.errorJson(
                             message = "Fradragssjekk er allerede kjørt for måned $måned",
                             code = "fradragssjekk_allerede_kjort_for_maaned",
+                        ),
+                    )
+                } catch (_: FradragssjekkKanIkkeKjøresForTidligereMånedException) {
+                    return@withBody call.svar(
+                        HttpStatusCode.BadRequest.errorJson(
+                            message = "Fradragssjekk kan ikke kjøres for tidligere måned $måned",
+                            code = "fradragssjekk_tidligere_maaned_ikke_tillatt",
                         ),
                     )
                 }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/drift/FradragssjekkDriftRoute.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/drift/FradragssjekkDriftRoute.kt
@@ -1,0 +1,59 @@
+package no.nav.su.se.bakover.web.routes.drift
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import no.nav.su.se.bakover.common.brukerrolle.Brukerrolle
+import no.nav.su.se.bakover.common.infrastructure.web.Feilresponser.ugyldigMåned
+import no.nav.su.se.bakover.common.infrastructure.web.Resultat
+import no.nav.su.se.bakover.common.infrastructure.web.authorize
+import no.nav.su.se.bakover.common.infrastructure.web.errorJson
+import no.nav.su.se.bakover.common.infrastructure.web.svar
+import no.nav.su.se.bakover.common.infrastructure.web.withBody
+import no.nav.su.se.bakover.common.tid.periode.Måned
+import no.nav.su.se.bakover.web.services.fradragssjekken.FradragsjobbenService
+import org.slf4j.LoggerFactory
+
+internal fun Route.fradragssjekkDriftRoute(
+    fradragsjobbenService: FradragsjobbenService,
+) {
+    data class Body(
+        val maaned: String,
+        val dryRun: Boolean = false,
+    )
+
+    val log = LoggerFactory.getLogger("FradragssjekkDriftRoute")
+
+    post("$DRIFT_PATH/fradragssjekk/kjor") {
+        authorize(Brukerrolle.Drift) {
+            call.withBody<Body> { body ->
+                val måned = Måned.parse(body.maaned) ?: return@withBody call.svar(ugyldigMåned)
+
+                if (!body.dryRun && fradragsjobbenService.harOrdinaerKjoringForMåned(måned)) {
+                    return@withBody call.svar(
+                        HttpStatusCode.Conflict.errorJson(
+                            message = "Fradragssjekk er allerede kjørt for måned $måned",
+                            code = "fradragssjekk_allerede_kjort_for_maaned",
+                        ),
+                    )
+                }
+
+                CoroutineScope(Dispatchers.IO).launch {
+                    runCatching {
+                        fradragsjobbenService.kjørFradragssjekkForMåned(
+                            måned = måned,
+                            dryRun = body.dryRun,
+                        )
+                    }.onFailure {
+                        log.error("Manuell fradragssjekk feilet for måned {}. dryRun={}", måned, body.dryRun, it)
+                    }
+                }
+
+                call.svar(Resultat.accepted())
+            }
+        }
+    }
+}

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxy.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxy.kt
@@ -1613,6 +1613,10 @@ open class AccessCheckProxy(
                     services.fradragsjobbenService.kjørFradragssjekkForMåned(måned, dryRun)
                 }
 
+                override fun validerKjøringForMåned(måned: Måned, dryRun: Boolean) {
+                    services.fradragsjobbenService.validerKjøringForMåned(måned, dryRun)
+                }
+
                 override fun harOrdinaerKjoringForMåned(måned: Måned): Boolean {
                     return services.fradragsjobbenService.harOrdinaerKjoringForMåned(måned)
                 }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxy.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxy.kt
@@ -251,6 +251,7 @@ import no.nav.su.se.bakover.vedtak.application.FerdigstillVedtakService
 import no.nav.su.se.bakover.vedtak.application.NySøknadCommandOmgjøring
 import no.nav.su.se.bakover.vedtak.application.VedtakService
 import no.nav.su.se.bakover.web.services.aap.AapJobService
+import no.nav.su.se.bakover.web.services.fradragssjekken.FradragsjobbenService
 import no.nav.su.se.bakover.web.services.pesys.PesysJobService
 import nøkkeltall.domain.NøkkeltallPerSakstype
 import person.domain.KunneIkkeHentePerson
@@ -1601,6 +1602,19 @@ open class AccessCheckProxy(
                 override fun hentMaksimum() {
                     throw RuntimeException("Skal ikke kalle AAP-jobb fra routes")
                     // NO-OP
+                }
+            },
+            fradragsjobbenService = object : FradragsjobbenService {
+                override fun sjekkLøpendeSakerForFradragIEksterneSystemer(dryRun: Boolean) {
+                    services.fradragsjobbenService.sjekkLøpendeSakerForFradragIEksterneSystemer(dryRun)
+                }
+
+                override fun kjørFradragssjekkForMåned(måned: Måned, dryRun: Boolean) {
+                    services.fradragsjobbenService.kjørFradragssjekkForMåned(måned, dryRun)
+                }
+
+                override fun harOrdinaerKjoringForMåned(måned: Måned): Boolean {
+                    return services.fradragsjobbenService.harOrdinaerKjoringForMåned(måned)
                 }
             },
             sakstatistikkBigQueryService = object : SakStatistikkBigQueryService {

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/ServiceBuilder.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/ServiceBuilder.kt
@@ -61,6 +61,8 @@ import no.nav.su.se.bakover.statistikk.StatistikkEventObserverBuilder
 import no.nav.su.se.bakover.vedtak.application.FerdigstillVedtakServiceImpl
 import no.nav.su.se.bakover.vedtak.application.VedtakServiceImpl
 import no.nav.su.se.bakover.web.services.aap.AapJobServiceImpl
+import no.nav.su.se.bakover.web.services.fradragssjekken.FradragsjobbenServiceImpl
+import no.nav.su.se.bakover.web.services.fradragssjekken.FradragssjekkRunPostgresRepo
 import no.nav.su.se.bakover.web.services.pesys.PesysJobServiceImpl
 import person.domain.PersonService
 import satser.domain.SatsFactory
@@ -264,6 +266,17 @@ data object ServiceBuilder {
             ),
             pesysJobService = PesysJobServiceImpl(client = clients.pesysklient),
             aapJobService = AapJobServiceImpl(client = clients.aapApiInternClient, clock = clock),
+            fradragsjobbenService = FradragsjobbenServiceImpl(
+                aapKlient = clients.aapApiInternClient,
+                pesysKlient = clients.pesysklient,
+                sakService = kjerneTjenester.sakService,
+                oppgaveService = kjerneTjenester.oppgaveService,
+                utbetalingsRepo = databaseRepos.utbetaling,
+                fradragssjekkRunPostgresRepo = FradragssjekkRunPostgresRepo(
+                    sessionFactory = databaseRepos.requirePostgresSessionFactory(),
+                ),
+                clock = clock,
+            ),
             sakstatistikkBigQueryService = kjerneTjenester.sakStatistikkBigQueryService,
             fritekstAvslagService = FritekstAvslagServiceImpl(databaseRepos.fritekstAvslagRepo),
             søknadStatistikkService = SøknadStatistikkServiceImpl(databaseRepos.søknadStatistikkRepo),

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/Services.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/Services.kt
@@ -31,6 +31,7 @@ import no.nav.su.se.bakover.service.søknadsbehandling.SøknadsbehandlingService
 import no.nav.su.se.bakover.vedtak.application.FerdigstillVedtakService
 import no.nav.su.se.bakover.vedtak.application.VedtakService
 import no.nav.su.se.bakover.web.services.aap.AapJobService
+import no.nav.su.se.bakover.web.services.fradragssjekken.FradragsjobbenService
 import no.nav.su.se.bakover.web.services.pesys.PesysJobService
 import person.domain.PersonService
 import vilkår.skatt.application.SkatteService
@@ -68,6 +69,7 @@ data class Services(
     val sakstatistikkBigQueryService: SakStatistikkBigQueryService,
     val pesysJobService: PesysJobService,
     val aapJobService: AapJobService,
+    val fradragsjobbenService: FradragsjobbenService,
     val fritekstAvslagService: FritekstAvslagService,
     val søknadStatistikkService: SøknadStatistikkService,
     val mottakerService: MottakerService,

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/fradragssjekken/EksterneFradragsoppslagService.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/fradragssjekken/EksterneFradragsoppslagService.kt
@@ -9,15 +9,12 @@ import no.nav.su.se.bakover.client.aap.AapApiInternClient
 import no.nav.su.se.bakover.client.pesys.PesysClient
 import no.nav.su.se.bakover.client.pesys.PesysPeriode
 import no.nav.su.se.bakover.client.pesys.PesysPerioderForPerson
-import no.nav.su.se.bakover.common.infrastructure.correlation.CORRELATION_ID_HEADER
-import no.nav.su.se.bakover.common.infrastructure.correlation.getOrCreateCorrelationIdFromThreadLocal
 import no.nav.su.se.bakover.common.person.Fnr
 import no.nav.su.se.bakover.common.sikkerLogg
 import no.nav.su.se.bakover.common.tid.periode.Måned
 import no.nav.su.se.bakover.domain.regulering.MaksimumVedtakDto
 import no.nav.su.se.bakover.domain.regulering.tilMånedsbeløpForSu
 import org.slf4j.Logger
-import org.slf4j.MDC
 import java.time.LocalDate
 
 private const val AAP_PARALLELLE_OPPSLAG = 8
@@ -107,16 +104,12 @@ internal class EksterneFradragsoppslagService(
     ): Map<Fnr, EksterntOppslag> {
         if (fnr.isEmpty()) return emptyMap()
 
-        val correlationId = getOrCreateCorrelationIdFromThreadLocal().toString()
-
         return runBlocking {
             fnr.chunked(AAP_PARALLELLE_OPPSLAG)
                 .flatMap { fnrChunk ->
                     fnrChunk.map { personFnr ->
                         async(Dispatchers.IO) {
-                            withMdcCorrelationId(correlationId) {
-                                personFnr to hentAapOppslagForFnr(personFnr, måned)
-                            }
+                            personFnr to hentAapOppslagForFnr(personFnr, måned)
                         }
                     }.awaitAll()
                 }
@@ -158,24 +151,6 @@ private fun List<SjekkPlan>.hentFnrForYtelsePåTversAvSjekkplaner(ytelse: Ekster
         .filter { it.ytelse == ytelse }
         .map { it.fnr }
         .distinct()
-}
-
-private inline fun <T> withMdcCorrelationId(
-    correlationId: String,
-    block: () -> T,
-): T {
-    val previousCorrelationId = MDC.get(CORRELATION_ID_HEADER)
-
-    return try {
-        MDC.put(CORRELATION_ID_HEADER, correlationId)
-        block()
-    } finally {
-        if (previousCorrelationId == null) {
-            MDC.remove(CORRELATION_ID_HEADER)
-        } else {
-            MDC.put(CORRELATION_ID_HEADER, previousCorrelationId)
-        }
-    }
 }
 
 private fun List<PesysPeriode>.gyldigPå(dato: LocalDate): Either<String, PesysPeriode?> {

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/fradragssjekken/EksterneFradragsoppslagService.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/fradragssjekken/EksterneFradragsoppslagService.kt
@@ -39,6 +39,8 @@ internal class EksterneFradragsoppslagService(
         fnr: List<Fnr>,
         dato: LocalDate,
     ): Map<Fnr, EksterntOppslag> {
+        if (fnr.isEmpty()) return emptyMap()
+
         return pesysKlient.hentVedtakForPersonPaaDatoAlder(fnr, dato).fold(
             ifLeft = {
                 log.warn("Fradragssjekk: Eksternt kall mot {} feilet for {} personer", EksternYtelse.PESYS_ALDER, fnr.size)
@@ -54,6 +56,8 @@ internal class EksterneFradragsoppslagService(
         fnr: List<Fnr>,
         dato: LocalDate,
     ): Map<Fnr, EksterntOppslag> {
+        if (fnr.isEmpty()) return emptyMap()
+
         return pesysKlient.hentVedtakForPersonPaaDatoUføre(fnr, dato).fold(
             ifLeft = {
                 log.warn("Fradragssjekk: Eksternt kall mot {} feilet for {} personer", EksternYtelse.PESYS_UFORE, fnr.size)

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/fradragssjekken/FradragsjobbenService.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/fradragssjekken/FradragsjobbenService.kt
@@ -17,6 +17,7 @@ import java.util.UUID
 interface FradragsjobbenService {
     fun sjekkLøpendeSakerForFradragIEksterneSystemer(dryRun: Boolean = false)
     fun kjørFradragssjekkForMåned(måned: Måned, dryRun: Boolean = false)
+    fun validerKjøringForMåned(måned: Måned, dryRun: Boolean = false)
     fun harOrdinaerKjoringForMåned(måned: Måned): Boolean
 }
 
@@ -56,7 +57,7 @@ internal class FradragsjobbenServiceImpl(
         måned: Måned,
         dryRun: Boolean,
     ) {
-        kanKjøreJobbForMåned(måned, dryRun)
+        validerKjøringForMåned(måned, dryRun)
 
         val sjekkplaner = hentAlleSaker()
             .chunked(INTERN_SAK_BATCH_STORRELSE)
@@ -77,10 +78,14 @@ internal class FradragsjobbenServiceImpl(
         return fradragssjekkRunPostgresRepo.harOrdinaerKjoringForMåned(måned)
     }
 
-    private fun kanKjøreJobbForMåned(
+    override fun validerKjøringForMåned(
         måned: Måned,
         dryRun: Boolean,
     ) {
+        if (måned < Måned.now(clock)) {
+            throw FradragssjekkKanIkkeKjøresForTidligereMånedException(måned)
+        }
+
         if (!dryRun && harOrdinaerKjoringForMåned(måned)) {
             throw FradragssjekkAlleredeKjørtForMånedException(måned)
         }
@@ -419,3 +424,7 @@ internal class FradragsjobbenServiceImpl(
 internal class FradragssjekkAlleredeKjørtForMånedException(
     måned: Måned,
 ) : IllegalStateException("Fradragssjekk er allerede kjørt for måned $måned")
+
+internal class FradragssjekkKanIkkeKjøresForTidligereMånedException(
+    måned: Måned,
+) : IllegalArgumentException("Fradragssjekk kan ikke kjøres for tidligere måned $måned")

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/fradragssjekken/FradragsjobbenService.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/fradragssjekken/FradragsjobbenService.kt
@@ -16,6 +16,8 @@ import java.util.UUID
 
 interface FradragsjobbenService {
     fun sjekkLøpendeSakerForFradragIEksterneSystemer(dryRun: Boolean = false)
+    fun kjørFradragssjekkForMåned(måned: Måned, dryRun: Boolean = false)
+    fun harOrdinaerKjoringForMåned(måned: Måned): Boolean
 }
 
 private const val INTERN_SAK_BATCH_STORRELSE = 500
@@ -47,7 +49,15 @@ internal class FradragsjobbenServiceImpl(
      *
      */
     override fun sjekkLøpendeSakerForFradragIEksterneSystemer(dryRun: Boolean) {
-        val måned = Måned.now(clock)
+        kjørFradragssjekkForMåned(måned = Måned.now(clock), dryRun = dryRun)
+    }
+
+    override fun kjørFradragssjekkForMåned(
+        måned: Måned,
+        dryRun: Boolean,
+    ) {
+        kanKjøreJobbForMåned(måned, dryRun)
+
         val sjekkplaner = hentAlleSaker()
             .chunked(INTERN_SAK_BATCH_STORRELSE)
             .flatMap { sakerPerBatch ->
@@ -61,6 +71,19 @@ internal class FradragsjobbenServiceImpl(
             sjekkplaner = sjekkplaner,
             startmelding = "Starter fradragssjekk for måned $måned",
         )
+    }
+
+    override fun harOrdinaerKjoringForMåned(måned: Måned): Boolean {
+        return fradragssjekkRunPostgresRepo.harOrdinaerKjoringForMåned(måned)
+    }
+
+    private fun kanKjøreJobbForMåned(
+        måned: Måned,
+        dryRun: Boolean,
+    ) {
+        if (!dryRun && harOrdinaerKjoringForMåned(måned)) {
+            throw FradragssjekkAlleredeKjørtForMånedException(måned)
+        }
     }
 
     private fun kjørOgLagreKjøring(
@@ -392,3 +415,7 @@ internal class FradragsjobbenServiceImpl(
         )
     }
 }
+
+internal class FradragssjekkAlleredeKjørtForMånedException(
+    måned: Måned,
+) : IllegalStateException("Fradragssjekk er allerede kjørt for måned $måned")

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/fradragssjekken/FradragssjekkRunPostgresRepo.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/fradragssjekken/FradragssjekkRunPostgresRepo.kt
@@ -84,14 +84,14 @@ internal class FradragssjekkRunPostgresRepo(
             """
                 select 1
                 from fradragssjekk_kjoring
-                where dato >= :fra_og_med
-                  and dato <= :til_og_med
+                where extract(year from dato) = :year
+                  and extract(month from dato) = :month
                   and dry_run = false
                 limit 1
             """.trimIndent().hent(
                 mapOf(
-                    "fra_og_med" to måned.fraOgMed,
-                    "til_og_med" to måned.tilOgMed,
+                    "year" to måned.fraOgMed.year,
+                    "month" to måned.fraOgMed.monthValue,
                 ),
                 session,
             ) { true } == true

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/fradragssjekken/FradragssjekkRunPostgresRepo.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/fradragssjekken/FradragssjekkRunPostgresRepo.kt
@@ -5,6 +5,7 @@ import no.nav.su.se.bakover.common.infrastructure.persistence.PostgresSessionFac
 import no.nav.su.se.bakover.common.infrastructure.persistence.hent
 import no.nav.su.se.bakover.common.infrastructure.persistence.insert
 import no.nav.su.se.bakover.common.serialize
+import no.nav.su.se.bakover.common.tid.periode.Måned
 import java.util.UUID
 
 internal class FradragssjekkRunPostgresRepo(
@@ -73,6 +74,27 @@ internal class FradragssjekkRunPostgresRepo(
                     feilmelding = row.stringOrNull("feilmelding"),
                 )
             }
+        }
+    }
+
+    fun harOrdinaerKjoringForMåned(
+        måned: Måned,
+    ): Boolean {
+        return sessionFactory.withSession { session ->
+            """
+                select 1
+                from fradragssjekk_kjoring
+                where dato >= :fra_og_med
+                  and dato <= :til_og_med
+                  and dry_run = false
+                limit 1
+            """.trimIndent().hent(
+                mapOf(
+                    "fra_og_med" to måned.fraOgMed,
+                    "til_og_med" to måned.tilOgMed,
+                ),
+                session,
+            ) { true } == true
         }
     }
 

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/TestServicesBuilder.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/TestServicesBuilder.kt
@@ -104,6 +104,7 @@ data object TestServicesBuilder {
         sakstatistikkBigQueryService = mock(),
         pesysJobService = mock(),
         aapJobService = mock(),
+        fradragsjobbenService = mock(),
         fritekstAvslagService = mock(),
         søknadStatistikkService = mock(),
         mottakerService = mock(),

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxyTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxyTest.kt
@@ -59,6 +59,7 @@ internal class AccessCheckProxyTest {
         stønadStatistikkJobService = mock(),
         pesysJobService = mock(),
         aapJobService = mock(),
+        fradragsjobbenService = mock(),
         sakstatistikkBigQueryService = mock(),
         fritekstAvslagService = mock(),
         søknadStatistikkService = mock(),

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/services/fradragssjekken/EksterneFradragsoppslagServiceTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/services/fradragssjekken/EksterneFradragsoppslagServiceTest.kt
@@ -1,0 +1,61 @@
+package no.nav.su.se.bakover.web.services.fradragssjekken
+
+import arrow.core.right
+import no.nav.su.se.bakover.client.aap.AapApiInternClient
+import no.nav.su.se.bakover.client.pesys.PesysClient
+import no.nav.su.se.bakover.client.pesys.ResponseDtoAlder
+import no.nav.su.se.bakover.common.domain.Saksnummer
+import no.nav.su.se.bakover.common.domain.sak.SakInfo
+import no.nav.su.se.bakover.common.domain.sak.Sakstype
+import no.nav.su.se.bakover.common.person.Fnr
+import no.nav.su.se.bakover.common.tid.periode.mars
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import vilkår.inntekt.domain.grunnlag.FradragTilhører
+import vilkår.inntekt.domain.grunnlag.Fradragstype
+import java.util.UUID
+
+internal class EksterneFradragsoppslagServiceTest {
+
+    @Test
+    fun `kaller ikke pesys ufore når det ikke finnes ufore-fnr`() {
+        val pesysClient = mock<PesysClient> {
+            on { hentVedtakForPersonPaaDatoAlder(any(), any()) } doReturn ResponseDtoAlder(resultat = emptyList()).right()
+        }
+
+        EksterneFradragsoppslagService(
+            aapKlient = mock<AapApiInternClient>(),
+            pesysKlient = pesysClient,
+            log = mock(),
+        ).hentOppslagsresultaterForYtelser(
+            sjekkplaner = listOf(
+                SjekkPlan(
+                    sak = SakInfo(
+                        sakId = UUID.randomUUID(),
+                        saksnummer = Saksnummer(2021001),
+                        fnr = Fnr("12345678901"),
+                        type = Sakstype.ALDER,
+                    ),
+                    sjekkpunkter = listOf(
+                        Sjekkpunkt(
+                            fnr = Fnr("12345678901"),
+                            tilhører = FradragTilhører.BRUKER,
+                            fradragstype = Fradragstype.Alderspensjon,
+                            ytelse = EksternYtelse.PESYS_ALDER,
+                            lokaltBeløp = 1000.0,
+                        ),
+                    ),
+                ),
+            ),
+            måned = mars(2026),
+        )
+
+        verify(pesysClient, times(1)).hentVedtakForPersonPaaDatoAlder(any(), any())
+        verifyNoMoreInteractions(pesysClient)
+    }
+}

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/services/fradragssjekken/FradragsjobbenServiceTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/services/fradragssjekken/FradragsjobbenServiceTest.kt
@@ -1,0 +1,49 @@
+package no.nav.su.se.bakover.web.services.fradragssjekken
+
+import no.nav.su.se.bakover.common.tid.periode.april
+import no.nav.su.se.bakover.common.tid.periode.mars
+import no.nav.su.se.bakover.test.defaultMock
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.test.assertFailsWith
+
+internal class FradragsjobbenServiceTest {
+
+    @Test
+    fun `kan ikke kjøre fradragssjekk for tidligere måned`() {
+        val service = lagService()
+
+        assertFailsWith<FradragssjekkKanIkkeKjøresForTidligereMånedException> {
+            service.validerKjøringForMåned(mars(2026), dryRun = false)
+        }
+    }
+
+    @Test
+    fun `kan kjøre fradragssjekk for inneværende måned`() {
+        val service = lagService(
+            fradragssjekkRunPostgresRepo = mock {
+                on { harOrdinaerKjoringForMåned(april(2026)) } doReturn false
+            },
+        )
+
+        service.validerKjøringForMåned(april(2026), dryRun = false)
+    }
+
+    private fun lagService(
+        fradragssjekkRunPostgresRepo: FradragssjekkRunPostgresRepo = mock(),
+    ): FradragsjobbenServiceImpl {
+        return FradragsjobbenServiceImpl(
+            aapKlient = defaultMock(),
+            pesysKlient = defaultMock(),
+            sakService = defaultMock(),
+            oppgaveService = defaultMock(),
+            utbetalingsRepo = defaultMock(),
+            fradragssjekkRunPostgresRepo = fradragssjekkRunPostgresRepo,
+            clock = Clock.fixed(Instant.parse("2026-04-15T12:00:00Z"), ZoneOffset.UTC),
+        )
+    }
+}


### PR DESCRIPTION
https://github.com/navikt/su-se-framover/pull/4445

burde egentlig bruke nel mot eksterne klienter som krever innhold i liste så man aldri kaller de med 0