### PR TITLE
Fiks corrid for fradragssjekk

### DIFF
--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/aap/AapApiInternHttpClient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/aap/AapApiInternHttpClient.kt
@@ -9,10 +9,10 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import no.nav.su.se.bakover.common.CORRELATION_ID_HEADER
+import no.nav.su.se.bakover.common.CorrelationId
 import no.nav.su.se.bakover.common.auth.AzureAd
 import no.nav.su.se.bakover.common.deserialize
 import no.nav.su.se.bakover.common.domain.client.ClientError
-import no.nav.su.se.bakover.common.infrastructure.correlation.getOrCreateCorrelationIdFromThreadLocal
 import no.nav.su.se.bakover.common.person.Fnr
 import no.nav.su.se.bakover.common.serialize
 import no.nav.su.se.bakover.common.sikkerLogg
@@ -30,6 +30,7 @@ interface AapApiInternClient {
         fnr: Fnr,
         fraOgMedDato: LocalDate,
         tilOgMedDato: LocalDate,
+        correlationId: CorrelationId,
     ): Either<ClientError, MaksimumResponseDto>
 }
 
@@ -38,6 +39,7 @@ class AapApiInternClientStub : AapApiInternClient {
         fnr: Fnr,
         fraOgMedDato: LocalDate,
         tilOgMedDato: LocalDate,
+        correlationId: CorrelationId,
     ): Either<ClientError, MaksimumResponseDto> {
         return MaksimumResponseDto(vedtak = emptyList()).right()
     }
@@ -56,8 +58,9 @@ class AapApiInternHttpClient(
         fnr: Fnr,
         fraOgMedDato: LocalDate,
         tilOgMedDato: LocalDate,
+        correlationId: CorrelationId,
     ): Either<ClientError, MaksimumResponseDto> {
-        val callId = getOrCreateCorrelationIdFromThreadLocal().toString()
+        val callId = correlationId.toString()
 
         val (_, response, result) = "$baseUrl$maksimumUri"
             .httpPost()

--- a/client/src/test/kotlin/no/nav/su/se/bakover/client/AapApiInternHttpClientTest.kt
+++ b/client/src/test/kotlin/no/nav/su/se/bakover/client/AapApiInternHttpClientTest.kt
@@ -16,6 +16,7 @@ import no.nav.su.se.bakover.client.aap.AapApiInternHttpClient
 import no.nav.su.se.bakover.client.aap.MaksimumRequestDto
 import no.nav.su.se.bakover.client.aap.MaksimumResponseDto
 import no.nav.su.se.bakover.common.CORRELATION_ID_HEADER
+import no.nav.su.se.bakover.common.CorrelationId
 import no.nav.su.se.bakover.common.auth.AzureAd
 import no.nav.su.se.bakover.common.domain.client.ClientError
 import no.nav.su.se.bakover.common.person.Fnr
@@ -74,12 +75,13 @@ class AapApiInternHttpClientTest {
                 ),
             )
 
+            val correlationid = "correlationId"
             stubFor(
                 post(urlPathEqualTo("/maksimum"))
                     .withHeader(HttpHeaders.ContentType, containing(ContentType.Application.Json.toString()))
                     .withHeader(HttpHeaders.Accept, containing(ContentType.Application.Json.toString()))
-                    .withHeader(NAV_CALL_ID_HEADER, equalTo("correlationId"))
-                    .withHeader(CORRELATION_ID_HEADER, equalTo("correlationId"))
+                    .withHeader(NAV_CALL_ID_HEADER, equalTo(correlationid))
+                    .withHeader(CORRELATION_ID_HEADER, equalTo(correlationid))
                     .withRequestBody(equalToJson(expectedRequest))
                     .willReturn(
                         aResponse()
@@ -89,7 +91,7 @@ class AapApiInternHttpClientTest {
                     ),
             )
 
-            val result = createClient(baseUrl()).hentMaksimum(fnr, fraOgMedDato, tilOgMedDato)
+            val result = createClient(baseUrl()).hentMaksimum(fnr, fraOgMedDato, tilOgMedDato, CorrelationId(correlationid))
 
             result.shouldBeRight(expectedResponse)
         }
@@ -113,6 +115,7 @@ class AapApiInternHttpClientTest {
                 fnr = Fnr("22503904369"),
                 fraOgMedDato = LocalDate.now(),
                 tilOgMedDato = LocalDate.now(),
+                CorrelationId.generate(),
             )
 
             result.shouldBeLeft().let { error: ClientError ->

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/regulering/AapReguleringerService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/regulering/AapReguleringerService.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
 import no.nav.su.se.bakover.client.aap.AapApiInternClient
+import no.nav.su.se.bakover.common.infrastructure.correlation.getOrCreateCorrelationIdFromThreadLocal
 import no.nav.su.se.bakover.common.person.Fnr
 import no.nav.su.se.bakover.domain.regulering.BeregnAap
 import no.nav.su.se.bakover.domain.regulering.EksterntRegulerteBeløp
@@ -85,6 +86,7 @@ class AapReguleringerServiceImpl(
         fnr = fnr,
         fraOgMedDato = fraOgMedDato,
         tilOgMedDato = reguleringstidspunkt,
+        correlationId = getOrCreateCorrelationIdFromThreadLocal(),
     ).fold(
         ifLeft = {
             log.warn("AAP-regulering: Klarte ikke hente maksimum for fnr {}", fnr)

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/regulering/AapReguleringerServiceImplTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/regulering/AapReguleringerServiceImplTest.kt
@@ -156,7 +156,7 @@ class AapReguleringerServiceImplTest {
     @Test
     fun `klientfeil gir eksplisitt AAP-feil`() {
         val client = mock<AapApiInternClient> {
-            on { hentMaksimum(any(), any(), any()) } doReturn ClientError(httpStatus = 500, message = "boom").left()
+            on { hentMaksimum(any(), any(), any(), any()) } doReturn ClientError(httpStatus = 500, message = "boom").left()
         }
         val service = AapReguleringerServiceImpl(client)
 
@@ -195,7 +195,7 @@ class AapReguleringerServiceImplTest {
 
     private fun lagService(vedtak: List<MaksimumVedtakDto>): AapReguleringerServiceImpl {
         val client = mock<AapApiInternClient> {
-            on { hentMaksimum(any(), any(), any()) } doReturn MaksimumResponseDto(vedtak).right()
+            on { hentMaksimum(any(), any(), any(), any()) } doReturn MaksimumResponseDto(vedtak).right()
         }
         return AapReguleringerServiceImpl(client)
     }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/aap/AapJobServiceImpl.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/aap/AapJobServiceImpl.kt
@@ -1,6 +1,7 @@
 package no.nav.su.se.bakover.web.services.aap
 
 import no.nav.su.se.bakover.client.aap.AapApiInternClient
+import no.nav.su.se.bakover.common.infrastructure.correlation.getOrCreateCorrelationIdFromThreadLocal
 import no.nav.su.se.bakover.common.person.Fnr
 import org.slf4j.LoggerFactory
 import java.time.Clock
@@ -37,6 +38,7 @@ class AapJobServiceImpl(
                 fnr = fnr,
                 fraOgMedDato = fraOgMedDato,
                 tilOgMedDato = tilOgMedDato,
+                correlationId = getOrCreateCorrelationIdFromThreadLocal(),
             ).fold(
                 { err ->
                     log.warn("AAP: Feil ved henting av maksimum for fnr {}. {} - {}", fnr, err.httpStatus, err.message)

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/fradragssjekken/EksterneFradragsoppslagService.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/fradragssjekken/EksterneFradragsoppslagService.kt
@@ -9,6 +9,8 @@ import no.nav.su.se.bakover.client.aap.AapApiInternClient
 import no.nav.su.se.bakover.client.pesys.PesysClient
 import no.nav.su.se.bakover.client.pesys.PesysPeriode
 import no.nav.su.se.bakover.client.pesys.PesysPerioderForPerson
+import no.nav.su.se.bakover.common.CorrelationId
+import no.nav.su.se.bakover.common.infrastructure.correlation.getOrCreateCorrelationIdFromThreadLocal
 import no.nav.su.se.bakover.common.person.Fnr
 import no.nav.su.se.bakover.common.sikkerLogg
 import no.nav.su.se.bakover.common.tid.periode.Måned
@@ -107,13 +109,14 @@ internal class EksterneFradragsoppslagService(
         måned: Måned,
     ): Map<Fnr, EksterntOppslag> {
         if (fnr.isEmpty()) return emptyMap()
+        val correlationId = getOrCreateCorrelationIdFromThreadLocal()
 
         return runBlocking {
             fnr.chunked(AAP_PARALLELLE_OPPSLAG)
                 .flatMap { fnrChunk ->
                     fnrChunk.map { personFnr ->
                         async(Dispatchers.IO) {
-                            personFnr to hentAapOppslagForFnr(personFnr, måned)
+                            personFnr to hentAapOppslagForFnr(personFnr, måned, correlationId)
                         }
                     }.awaitAll()
                 }
@@ -124,11 +127,13 @@ internal class EksterneFradragsoppslagService(
     private fun hentAapOppslagForFnr(
         fnr: Fnr,
         måned: Måned,
+        correlationId: CorrelationId,
     ): EksterntOppslag {
         return aapKlient.hentMaksimum(
             fnr = fnr,
             fraOgMedDato = måned.fraOgMed,
             tilOgMedDato = måned.tilOgMed,
+            correlationId = correlationId,
         ).fold(
             ifLeft = {
                 log.warn("Fradragssjekk: AAP-oppslag feilet for fnr {}", fnr)


### PR DESCRIPTION
fikser bruken av correlation id for asynce jobber
`Mangler 'X-Correlation-ID' på MDC. Er dette et asynk-kall? Da må det settes manuelt, så tidlig som mulig.`