### PR TITLE
Utfører toleransesjekk for beregning kun hvis det ligger an til automatisk regulering

### DIFF
--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/Regulering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/Regulering.kt
@@ -115,9 +115,11 @@ fun Sak.opprettReguleringForAutomatiskEllerManuellBehandling(
         eksterntRegulerteBeløp = eksterntRegulerteBeløp,
     )
 
-    val utenforToleransegrenser = beregnerUtenforToleransegrenser(this, opprettetRegulering, satsFactory, clock)
-    if (utenforToleransegrenser != null) {
-        return utenforToleransegrenser.left()
+    if (reguleringstype == Reguleringstype.AUTOMATISK) {
+        val utenforToleransegrenser = beregnerUtenforToleransegrenser(this, opprettetRegulering, satsFactory, clock)
+        if (utenforToleransegrenser != null) {
+            return utenforToleransegrenser.left()
+        }
     }
 
     return opprettetRegulering.right()


### PR DESCRIPTION
Det vil være årsaker som har ført til manuell behandling som ville slått ut på toleransesjekk, f.eks stanset ytelse eller fradrag som ikke lar seg regulere automatisk