### PR TITLE
Fiks timeout for tester som henger over makstid

### DIFF
--- a/web-regresjonstest/src/main/kotlin/no/nav/su/se/bakover/web/SharedRegressionTestData.kt
+++ b/web-regresjonstest/src/main/kotlin/no/nav/su/se/bakover/web/SharedRegressionTestData.kt
@@ -2,7 +2,8 @@ package no.nav.su.se.bakover.web
 
 import io.ktor.server.application.Application
 import io.ktor.server.testing.ApplicationTestBuilder
-import io.ktor.server.testing.testApplication
+import io.ktor.server.testing.runTestApplication
+import io.ktor.test.dispatcher.runTestWithRealTime
 import kotliquery.HikariCP.dataSource
 import no.nav.su.se.bakover.client.Clients
 import no.nav.su.se.bakover.client.ClientsBuilder
@@ -57,12 +58,24 @@ import vilkår.skatt.infrastructure.client.SkatteClientStub
 import java.time.Clock
 import java.time.LocalDate
 import javax.sql.DataSource
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 
 /**
  * TODO jah: Dette er foreløpig en kopi av TestEnvironment.kt og TestClientsBuilder.kt fra web/src/test (på sikt bør det meste av dette slettes derfra)
  * Vurder å trekk ut ting til test-common for de tingene som både web og web-regresjonstest trenger.
  */
 data object SharedRegressionTestData {
+    /**
+     * Timeout for [runTestApplication] i regresjonstestene.
+     *
+     * Ktor 3 sin `testApplication` wrapper testkroppen i `runTestWithRealTime` som har 60s default-timeout.
+     * Regresjonstestene her kjører hele applikasjonen og gjør ofte flere iverksettelser sekvensielt,
+     * så de er nær 60s-grensen på CI under last. To minutter gir komfortabelt headroom uten å gjøre
+     * en ekte hang umulig å oppdage.
+     */
+    internal val regresjonstestTimeout: Duration = 2.minutes
+
     internal val fnr: String = Fnr.generer().toString()
     internal val epsFnr: String = Fnr.generer().toString()
 
@@ -109,17 +122,19 @@ data object SharedRegressionTestData {
         val dataSource = DatabaseBuilder.newLocalDataSource()
         DatabaseBuilder.migrateDatabase(dataSource)
 
-        testApplication {
-            application {
-                testSusebakover(
-                    clock = clock,
-                    databaseRepos = databaseRepos(
-                        dataSource = dataSource,
+        runTestWithRealTime(timeout = regresjonstestTimeout) {
+            runTestApplication {
+                application {
+                    testSusebakover(
                         clock = clock,
-                    ),
-                )
+                        databaseRepos = databaseRepos(
+                            dataSource = dataSource,
+                            clock = clock,
+                        ),
+                    )
+                }
+                test()
             }
-            test()
         }
     }
 
@@ -143,11 +158,13 @@ data object SharedRegressionTestData {
                 pesysClientStub,
                 aapApiClientStub,
             )
-            testApplication {
-                application {
-                    testSusebakover(appComponents = appComponents)
+            runTestWithRealTime(timeout = regresjonstestTimeout) {
+                runTestApplication {
+                    application {
+                        testSusebakover(appComponents = appComponents)
+                    }
+                    test(appComponents)
                 }
-                test(appComponents)
             }
         }
     }
@@ -172,11 +189,13 @@ data object SharedRegressionTestData {
             pesysClientStub,
             aapApiClientStub,
         )
-        testApplication {
-            application {
-                testSusebakover(appComponents = appComponents)
+        runTestWithRealTime(timeout = regresjonstestTimeout) {
+            runTestApplication {
+                application {
+                    testSusebakover(appComponents = appComponents)
+                }
+                test(appComponents)
             }
-            test(appComponents)
         }
     }
 

--- a/web-regresjonstest/src/main/kotlin/no/nav/su/se/bakover/web/komponenttest/Komponenttest.kt
+++ b/web-regresjonstest/src/main/kotlin/no/nav/su/se/bakover/web/komponenttest/Komponenttest.kt
@@ -2,7 +2,8 @@ package no.nav.su.se.bakover.web.komponenttest
 
 import io.ktor.server.application.Application
 import io.ktor.server.testing.ApplicationTestBuilder
-import io.ktor.server.testing.testApplication
+import io.ktor.server.testing.runTestApplication
+import io.ktor.test.dispatcher.runTestWithRealTime
 import no.nav.su.se.bakover.client.Clients
 import no.nav.su.se.bakover.client.aap.AapApiInternClient
 import no.nav.su.se.bakover.client.aap.AapApiInternClientStub
@@ -353,10 +354,12 @@ fun testApplication(
     appComponents: AppComponents,
     test: ApplicationTestBuilder.(appComponents: AppComponents) -> Unit,
 ) {
-    testApplication {
-        application {
-            testSusebakover(appComponents)
+    runTestWithRealTime(timeout = SharedRegressionTestData.regresjonstestTimeout) {
+        runTestApplication {
+            application {
+                testSusebakover(appComponents)
+            }
+            test(appComponents)
         }
-        test(appComponents)
     }
 }


### PR DESCRIPTION
ref https://github.com/navikt/su-se-bakover/actions/runs/26029008910/job/76509758698
default timeout på 1 min holder ikke med forka jvms med mange coroutines på tvers alltid om de hopper nok frem og. tilbake til at det tar over 1 min så vil det kjøre rødt. øker til 2 min timeout for regresjonstestmodulen
vi har andre tester som tar lenger tid men de er ikke begrenset av default timeout til testapplication

Merk dette er ingen perfekt løsning men mer en måte å få bort random feil i denne testen fra tilfeldige kjøringer
ideelt burde man skrudd ned paralelliteten i kjøringene men det vil føre til ekstremt lange byggtider - det ville løst problemet siden da vil ikke mange tester startes og vente før de fullføres men det er nok ikke verdt det om dette fungerer.
Kunne sikkert satt timeout lenger også.