### PR TITLE
La BQ tillatte for ullikt antall kolonner fra oss

### DIFF
--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/statistikk/StønadBigQueryService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/statistikk/StønadBigQueryService.kt
@@ -3,7 +3,7 @@ package no.nav.su.se.bakover.service.statistikk
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.bigquery.BigQuery
 import com.google.cloud.bigquery.BigQueryOptions
-import com.google.cloud.bigquery.FormatOptions
+import com.google.cloud.bigquery.CsvOptions
 import com.google.cloud.bigquery.Job
 import com.google.cloud.bigquery.JobId
 import com.google.cloud.bigquery.JobStatistics
@@ -74,8 +74,14 @@ object StønadBigQueryService {
 
         log.info("Writing csv to bigquery. id: $jobId, project: $project, table: $tableId")
 
+        val csvOptions = CsvOptions.newBuilder()
+            // Tillater rader med færre felter enn skjemaet, slik at BigQuery-skjemaet kan utvides
+            // (append-only) før koden er deployet til alle miljøer. Manglende trailing felter blir NULL.
+            .setAllowJaggedRows(true)
+            .build()
+
         val writeConfig = WriteChannelConfiguration.newBuilder(tableId)
-            .setFormatOptions(FormatOptions.csv())
+            .setFormatOptions(csvOptions)
             .build()
 
         val writer = try {

--- a/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/StønadBigQueryServiceTest.kt
+++ b/service/src/test/kotlin/no/nav/su/se/bakover/service/statistikk/StønadBigQueryServiceTest.kt
@@ -1,0 +1,119 @@
+package no.nav.su.se.bakover.service.statistikk
+
+import io.kotest.matchers.shouldBe
+import no.nav.su.se.bakover.test.fixedTidspunkt
+import no.nav.su.se.bakover.test.fnr
+import org.junit.jupiter.api.Test
+import statistikk.domain.StønadstatistikkDto
+import statistikk.domain.StønadstatistikkMåned
+import java.time.LocalDate
+import java.time.YearMonth
+import java.util.UUID
+
+internal class StønadBigQueryServiceTest {
+
+    /**
+     * Antall kolonner i CSV-en MÅ matche antall kolonner i BigQuery-skjemaet for tabellen
+     * `stoenadstatistikk`. Hvis du legger til en ny kolonne i [toCSV], må du også:
+     *  1) Legge den til i BigQuery-skjemaet (append-only, sist).
+     *  2) Oppdatere kolonnelista i kommentaren over [toCSV].
+     *  3) Bumpe forventet antall under.
+     *
+     * Denne testen finnes for å sikre at vi sender over alle felter i StønadstatistikkMåned siden vi har skrudd på
+     * `setAllowJaggedRows(true)` i BigQuery-loaderen uten testen blitt silent NULL i BQ.
+     */
+    @Test
+    fun `CSV har eksakt forventet antall kolonner per rad`() {
+        val csv = listOf(minimalDto()).toCSV()
+        val rader = csv.lines().filter { it.isNotEmpty() }
+        rader.forEach { rad ->
+            rad.split(",").size shouldBe ANTALL_KOLONNER
+        }
+    }
+
+    private companion object {
+        private const val ANTALL_KOLONNER = 79
+
+        private fun minimalDto(): StønadstatistikkMåned = StønadstatistikkMåned(
+            id = UUID.randomUUID(),
+            måned = YearMonth.of(2025, 1),
+            funksjonellTid = fixedTidspunkt,
+            tekniskTid = fixedTidspunkt,
+            sakId = UUID.randomUUID(),
+            stonadstype = StønadstatistikkDto.Stønadstype.SU_UFØR,
+            personnummer = fnr,
+            personNummerEps = null,
+            vedtaksdato = LocalDate.of(2025, 1, 1),
+            vedtakstype = StønadstatistikkDto.Vedtakstype.SØKNAD,
+            vedtaksresultat = StønadstatistikkDto.Vedtaksresultat.INNVILGET,
+            vedtakFraOgMed = LocalDate.of(2025, 1, 1),
+            vedtakTilOgMed = LocalDate.of(2025, 12, 31),
+            opphorsgrunn = null,
+            opphorsdato = null,
+            årsakStans = null,
+            behandlendeEnhetKode = "4815",
+            stonadsklassifisering = null,
+            sats = null,
+            utbetales = null,
+            fradragSum = null,
+            uføregrad = null,
+            fribeløpEps = null,
+            alderspensjon = null,
+            alderspensjonEps = null,
+            arbeidsavklaringspenger = null,
+            arbeidsavklaringspengerEps = null,
+            arbeidsinntekt = null,
+            arbeidsinntektEps = null,
+            omstillingsstønad = null,
+            omstillingsstønadEps = null,
+            avtalefestetPensjon = null,
+            avtalefestetPensjonEps = null,
+            avtalefestetPensjonPrivat = null,
+            avtalefestetPensjonPrivatEps = null,
+            bidragEtterEkteskapsloven = null,
+            bidragEtterEkteskapslovenEps = null,
+            dagpenger = null,
+            dagpengerEps = null,
+            fosterhjemsgodtgjørelse = null,
+            fosterhjemsgodtgjørelseEps = null,
+            gjenlevendepensjon = null,
+            gjenlevendepensjonEps = null,
+            introduksjonsstønad = null,
+            introduksjonsstønadEps = null,
+            kapitalinntekt = null,
+            kapitalinntektEps = null,
+            kontantstøtte = null,
+            kontantstøtteEps = null,
+            kvalifiseringsstønad = null,
+            kvalifiseringsstønadEps = null,
+            navYtelserTilLivsopphold = null,
+            navYtelserTilLivsoppholdEps = null,
+            offentligPensjon = null,
+            offentligPensjonEps = null,
+            privatPensjon = null,
+            privatPensjonEps = null,
+            sosialstønad = null,
+            sosialstønadEps = null,
+            statensLånekasse = null,
+            statensLånekasseEps = null,
+            supplerendeStønad = null,
+            supplerendeStønadEps = null,
+            sykepenger = null,
+            sykepengerEps = null,
+            tiltakspenger = null,
+            tiltakspengerEps = null,
+            ventestønad = null,
+            ventestønadEps = null,
+            uføretrygd = null,
+            uføretrygdEps = null,
+            forventetInntekt = null,
+            forventetInntektEps = null,
+            avkortingUtenlandsopphold = null,
+            avkortingUtenlandsoppholdEps = null,
+            underMinstenivå = null,
+            underMinstenivåEps = null,
+            annet = null,
+            annetEps = null,
+        )
+    }
+}


### PR DESCRIPTION
For å få gjort endringer i BQ i begge skjemaer prod/dev uten å manuelt måtte huske dette til senere.
Sikringen ivaretas av testen
https://docs.cloud.google.com/bigquery/docs/loading-data-cloud-storage-csv