### PR TITLE
Reguleringsstatus håndter stans og vedtak frem i tid

### DIFF
--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPostgresRepo.kt
@@ -251,11 +251,11 @@ internal class VedtakPostgresRepo(
                 }
             }
 
-    /*
+    /**
      * Returnerer enkel informasjon om grunnbeløp og satsbeløp som er brukt på det siste vedtaket
      * som er gyldig på eller etter [fraOgMed] for en sak.
      * Hvis siste vedtak er stans/gjenopptak vil denne informasjonen mangle og det returneres null
-     * */
+     */
     override fun hentBruktGrunnbeløpOgSatsbeløpTilVedtak(
         sakInfo: SakInfo,
         fraOgMed: LocalDate,
@@ -264,7 +264,7 @@ internal class VedtakPostgresRepo(
         return dbMetrics.timeQuery("hentBruktGrunnbeløpOgSatsbeløpTilVedtak") {
             sessionFactory.withSession(tx) { session ->
                 """
-            select vedtaktype, beregning from vedtak
+            select beregning from vedtak
             where sakId = :sakId
             and vedtaktype IN (${
                     listOf(

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPostgresRepo.kt
@@ -259,9 +259,17 @@ internal class VedtakPostgresRepo(
         return dbMetrics.timeQuery("hentBruktGrunnbeløpOgSatsbeløpTilVedtak") {
             sessionFactory.withSession(tx) { session ->
                 """
-            select beregning from vedtak
+            select vedtaktype, beregning from vedtak
             where sakId = :sakId
-            and vedtaktype IN ('SØKNAD', 'ENDRING', 'REGULERING', 'GJENOPPTAK_AV_YTELSE', 'STANS_AV_YTELSE')
+            and vedtaktype IN (${
+                    listOf(
+                        VedtakType.SØKNAD,
+                        VedtakType.ENDRING,
+                        VedtakType.REGULERING,
+                        VedtakType.GJENOPPTAK_AV_YTELSE,
+                        VedtakType.STANS_AV_YTELSE,
+                    ).joinToString(", ") { "'${it.name}'" }
+                })
             and ((fraogmed <= :fraOgMed and tilogmed >= :fraOgMed) or fraogmed > :fraOgMed)
             order by opprettet desc
             limit 1
@@ -273,15 +281,28 @@ internal class VedtakPostgresRepo(
                         ),
                         session,
                     ) {
-                        it.stringOrNull("beregning")?.let { deserialize<PersistertBeregning>(it) }?.let { beregning ->
-                            val månedsberegning =
-                                beregning.månedsberegninger.first { it.periode.tilMåned().tilOgMed >= fraOgMed }
-                            GrunnbeløpOgSatsbeløpPåVedtak(
-                                periode = beregning.periode.toPeriode(),
-                                benyttetGrunnbeløp = månedsberegning.benyttetGrunnbeløp,
-                                benyttetSatsbeløp = månedsberegning.satsbeløp,
-                                satskategori = månedsberegning.sats.name,
+                        when (VedtakType.valueOf(it.string("vedtaktype"))) {
+                            VedtakType.STANS_AV_YTELSE -> GrunnbeløpOgSatsbeløpPåVedtak(
+                                stansetYtelse = true,
+                                fraOgMed = fraOgMed,
+                                benyttetGrunnbeløp = null,
+                                benyttetSatsbeløp = 0.0,
+                                satskategori = "",
                             )
+                            else -> {
+                                it.stringOrNull("beregning")?.let { deserialize<PersistertBeregning>(it) }
+                                    ?.let { beregning ->
+                                        val månedsberegning =
+                                            beregning.månedsberegninger.first { it.periode.tilMåned().tilOgMed >= fraOgMed }
+                                        GrunnbeløpOgSatsbeløpPåVedtak(
+                                            benyttetGrunnbeløp = månedsberegning.benyttetGrunnbeløp,
+                                            benyttetSatsbeløp = månedsberegning.satsbeløp,
+                                            satskategori = månedsberegning.sats.name,
+                                            fraOgMed = LocalDate.parse(beregning.periode.fraOgMed),
+                                            stansetYtelse = false,
+                                        )
+                                    }
+                            }
                         }
                     }
             }

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPostgresRepo.kt
@@ -114,8 +114,15 @@ internal class VedtakPostgresRepo(
 ) : VedtakRepo {
 
     override fun hentVedtakSomKanRevurderesForSak(sakId: UUID): List<VedtakSomKanRevurderes> {
+        return hentVedtakSomKanRevurderesForSak(sakId, null)
+    }
+
+    override fun hentVedtakSomKanRevurderesForSak(
+        sakId: UUID,
+        tx: TransactionContext?,
+    ): List<VedtakSomKanRevurderes> {
         return dbMetrics.timeQuery("hentVedtakSomKanRevurderesForSak") {
-            sessionFactory.withSession { session ->
+            sessionFactory.withSession(tx) { session ->
                 hentForSakId(sakId, session).filterIsInstance<VedtakSomKanRevurderes>()
             }
         }

--- a/database/src/main/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPostgresRepo.kt
+++ b/database/src/main/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPostgresRepo.kt
@@ -251,6 +251,11 @@ internal class VedtakPostgresRepo(
                 }
             }
 
+    /*
+     * Returnerer enkel informasjon om grunnbeløp og satsbeløp som er brukt på det siste vedtaket
+     * som er gyldig på eller etter [fraOgMed] for en sak.
+     * Hvis siste vedtak er stans/gjenopptak vil denne informasjonen mangle og det returneres null
+     * */
     override fun hentBruktGrunnbeløpOgSatsbeløpTilVedtak(
         sakInfo: SakInfo,
         fraOgMed: LocalDate,
@@ -281,29 +286,17 @@ internal class VedtakPostgresRepo(
                         ),
                         session,
                     ) {
-                        when (VedtakType.valueOf(it.string("vedtaktype"))) {
-                            VedtakType.STANS_AV_YTELSE -> GrunnbeløpOgSatsbeløpPåVedtak(
-                                stansetYtelse = true,
-                                fraOgMed = fraOgMed,
-                                benyttetGrunnbeløp = null,
-                                benyttetSatsbeløp = 0.0,
-                                satskategori = "",
-                            )
-                            else -> {
-                                it.stringOrNull("beregning")?.let { deserialize<PersistertBeregning>(it) }
-                                    ?.let { beregning ->
-                                        val månedsberegning =
-                                            beregning.månedsberegninger.first { it.periode.tilMåned().tilOgMed >= fraOgMed }
-                                        GrunnbeløpOgSatsbeløpPåVedtak(
-                                            benyttetGrunnbeløp = månedsberegning.benyttetGrunnbeløp,
-                                            benyttetSatsbeløp = månedsberegning.satsbeløp,
-                                            satskategori = månedsberegning.sats.name,
-                                            fraOgMed = LocalDate.parse(beregning.periode.fraOgMed),
-                                            stansetYtelse = false,
-                                        )
-                                    }
+                        it.stringOrNull("beregning")?.let { deserialize<PersistertBeregning>(it) }
+                            ?.let { beregning ->
+                                val månedsberegning =
+                                    beregning.månedsberegninger.first { it.periode.tilMåned().tilOgMed >= fraOgMed }
+                                GrunnbeløpOgSatsbeløpPåVedtak(
+                                    benyttetGrunnbeløp = månedsberegning.benyttetGrunnbeløp,
+                                    benyttetSatsbeløp = månedsberegning.satsbeløp,
+                                    satskategori = månedsberegning.sats.name,
+                                    fraOgMed = LocalDate.parse(beregning.periode.fraOgMed),
+                                )
                             }
-                        }
                     }
             }
         }

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/regulering/ReguleringStatusUteståendePostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/regulering/ReguleringStatusUteståendePostgresRepoTest.kt
@@ -104,7 +104,6 @@ internal class ReguleringStatusUteståendePostgresRepoTest {
                 benyttetGrunnbeløp = 118620,
                 benyttetSatskategori = Satskategori.ORDINÆR,
                 benyttetSats = 2.28,
-                vedtakFomSenereEnnMai = false,
             ),
         ),
     )

--- a/database/src/test/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPostgresRepoTest.kt
+++ b/database/src/test/kotlin/no/nav/su/se/bakover/database/vedtak/VedtakPostgresRepoTest.kt
@@ -823,13 +823,13 @@ internal class VedtakPostgresRepoTest(private val dataSource: DataSource) {
             testDataHelper.sessionFactory.withTransactionContext { tx ->
                 val result = vedtakRepo.hentBruktGrunnbeløpOgSatsbeløpTilVedtak(sakInfo, 1.mai(2021), tx)
                 result.shouldNotBeNull()
-                result.periode shouldBe vedtak.periode
+                result.fraOgMed shouldBe vedtak.periode.fraOgMed
                 result.benyttetGrunnbeløp.shouldNotBeNull()
             }
             testDataHelper.sessionFactory.withTransactionContext { tx ->
                 val result = vedtakRepo.hentBruktGrunnbeløpOgSatsbeløpTilVedtak(sakInfo, 30.april(2021), tx)
                 result.shouldNotBeNull()
-                result.periode shouldBe vedtak.periode
+                result.fraOgMed shouldBe vedtak.periode.fraOgMed
                 result.benyttetGrunnbeløp.shouldNotBeNull()
             }
         }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/Regulering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/Regulering.kt
@@ -10,6 +10,7 @@ import behandling.revurdering.domain.GrunnlagsdataOgVilkårsvurderingerRevurderi
 import behandling.revurdering.domain.VilkårsvurderingerRevurdering
 import beregning.domain.Beregning
 import beregning.domain.BeregningStrategyFactory
+import beregning.domain.Månedsberegning
 import no.nav.su.se.bakover.common.domain.extensions.toNonEmptyList
 import no.nav.su.se.bakover.common.domain.sak.SakInfo
 import no.nav.su.se.bakover.common.domain.sak.Sakstype
@@ -297,16 +298,17 @@ fun GjeldendeVedtaksdata.erRegulertMedNyttGrunnbeløp(
     etterspurtMai: Måned,
     sakstype: Sakstype,
     satsFactory: SatsFactory,
-): Boolean {
-    val sisteBeløper = SisteGrunnbeløpOgSatser(
+    sisteBeløper: SisteGrunnbeløpOgSatser = SisteGrunnbeløpOgSatser(
         grunnbeløp = satsFactory.grunnbeløp(etterspurtMai).grunnbeløpPerÅr,
-        garantipensjonOrdinærMåned = satsFactory.forSatskategoriAlder(etterspurtMai, Satskategori.ORDINÆR).satsForMånedAsDouble,
+        garantipensjonOrdinærMåned = satsFactory.forSatskategoriAlder(
+            etterspurtMai,
+            Satskategori.ORDINÆR,
+        ).satsForMånedAsDouble,
         garantipensjonHøyMåned = satsFactory.forSatskategoriAlder(etterspurtMai, Satskategori.HØY).satsForMånedAsDouble,
-    )
-
-    val beregning = hentMånedsberegning(etterspurtMai).singleOrNull()
-        ?: throw (IllegalStateException("Forventer kun én månedsberegning per måned"))
-
+    ),
+    beregning: Månedsberegning = hentMånedsberegning(etterspurtMai).singleOrNull()
+        ?: throw (IllegalStateException("Forventer kun én månedsberegning per måned")),
+): Boolean {
     val benyttetG = beregning.getBenyttetGrunnbeløp()
     val kategori = beregning.getSats()
     val benyttetSats = beregning.fullSupplerendeStønadForMåned.satsForMånedAsDouble

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/ReguleringStatusUteståendeService.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/ReguleringStatusUteståendeService.kt
@@ -3,7 +3,6 @@ package no.nav.su.se.bakover.domain.regulering
 import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
-import io.micrometer.core.instrument.MockClock.clock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -94,7 +93,7 @@ class ReguleringStatusUteståendeService(
                 vedtakRepo.hentBruktGrunnbeløpOgSatsbeløpTilVedtak(sakInfo, etterspurtMai.fraOgMed, tx)
                     .let { enkelVedtakInfo ->
                         val (_, saksnummer, _, saktype) = sakInfo
-                        if (enkelVedtakInfo != null && !enkelVedtakInfo.stansetYtelse && enkelVedtakInfo.fraOgMed <= etterspurtMai.fraOgMed) {
+                        if (enkelVedtakInfo != null && enkelVedtakInfo.fraOgMed <= etterspurtMai.fraOgMed) {
                             if (erRegulertMedNyttGrunnbeløp(enkelVedtakInfo, saktype, sisteBeløper)) {
                                 null
                             } else {
@@ -113,11 +112,18 @@ class ReguleringStatusUteståendeService(
                                 vedtakRepo.hentVedtakSomKanRevurderesForSak(sakInfo.sakId).toNonEmptyList().let {
                                     GjeldendeVedtaksdata(etterspurtMai, it, clock)
                                 }
-                            if (vedtakInfo.erRegulertMedNyttGrunnbeløp(etterspurtMai, sakInfo.type, satsFactory)) {
+                            val beregning = vedtakInfo.hentMånedsberegning(etterspurtMai).singleOrNull()
+                                ?: throw (IllegalStateException("Forventer kun én månedsberegning per måned"))
+                            if (vedtakInfo.erRegulertMedNyttGrunnbeløp(
+                                    etterspurtMai,
+                                    sakInfo.type,
+                                    satsFactory,
+                                    sisteBeløper,
+                                    beregning,
+                                )
+                            ) {
                                 null
                             } else {
-                                val beregning = vedtakInfo.hentMånedsberegning(etterspurtMai).singleOrNull()
-                                    ?: throw (IllegalStateException("Forventer kun én månedsberegning per måned"))
                                 SakMedGammeltGrunnbeløp(
                                     saksnummer = saksnummer,
                                     type = saktype,
@@ -182,15 +188,6 @@ class ReguleringStatusUteståendeService(
             }
         }
     }
-
-    private fun erRegulertMedNyttGrunnbeløp(
-        sakInfo: SakInfo,
-        etterspurtMai: Måned,
-    ) = GjeldendeVedtaksdata(
-        etterspurtMai,
-        vedtakRepo.hentVedtakSomKanRevurderesForSak(sakInfo.sakId).toNonEmptyList(),
-        clock,
-    ).erRegulertMedNyttGrunnbeløp(etterspurtMai, sakInfo.type, satsFactory)
 }
 
 object StatusPågående

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/ReguleringStatusUteståendeService.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/ReguleringStatusUteståendeService.kt
@@ -109,7 +109,7 @@ class ReguleringStatusUteståendeService(
                             // hentBruktGrunnbeløpOgSatsbeløpTilVedtak henter bare nyligste vedtak,
                             // så om vedtak starter senere enn mai, eller er en stans må sak sjekkes mer nøye
                             val vedtakInfo =
-                                vedtakRepo.hentVedtakSomKanRevurderesForSak(sakInfo.sakId).toNonEmptyList().let {
+                                vedtakRepo.hentVedtakSomKanRevurderesForSak(sakInfo.sakId, tx).toNonEmptyList().let {
                                     GjeldendeVedtaksdata(etterspurtMai, it, clock)
                                 }
                             val beregning = vedtakInfo.hentMånedsberegning(etterspurtMai).singleOrNull()

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/ReguleringStatusUteståendeService.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/ReguleringStatusUteståendeService.kt
@@ -7,11 +7,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import no.nav.su.se.bakover.common.domain.Saksnummer
+import no.nav.su.se.bakover.common.domain.extensions.toNonEmptyList
 import no.nav.su.se.bakover.common.domain.sak.SakInfo
 import no.nav.su.se.bakover.common.domain.sak.Sakstype
 import no.nav.su.se.bakover.common.persistence.SessionFactory
 import no.nav.su.se.bakover.common.tid.periode.Måned
 import no.nav.su.se.bakover.domain.sak.SakService
+import no.nav.su.se.bakover.domain.vedtak.GjeldendeVedtaksdata
 import no.nav.su.se.bakover.domain.vedtak.VedtakRepo
 import org.slf4j.LoggerFactory
 import satser.domain.SatsFactory
@@ -20,6 +22,7 @@ import vedtak.domain.GrunnbeløpOgSatsbeløpPåVedtak
 import økonomi.domain.utbetaling.UtbetalingRepo
 import økonomi.domain.utbetaling.UtbetalingslinjePåTidslinje
 import økonomi.domain.utbetaling.hentGjeldendeUtbetaling
+import java.time.Clock
 import java.time.YearMonth
 import java.util.UUID
 import javax.jms.IllegalStateException
@@ -34,6 +37,7 @@ class ReguleringStatusUteståendeService(
     private val satsFactory: SatsFactory,
     private val reguleringStatusRepo: ReguleringStatusUteståendeRepo,
     private val sessionFactory: SessionFactory,
+    private val clock: Clock,
 ) {
     private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -90,17 +94,26 @@ class ReguleringStatusUteståendeService(
                     val (_, saksnummer, _, saktype) = sakInfo
                     if (it == null) {
                         throw IllegalStateException("Fant ikke vedtak med brukt grunnbeløp for sak med løpende utbetaling eller stans. Sak=${sakInfo.saksnummer}")
-                    } else if (it.erRegulertMedNyttGrunnbeløp(saktype, sisteBeløper)) {
+                    } else if (
+                        !it.stansetYtelse &&
+                        it.fraOgMed <= etterspurtMai.fraOgMed &&
+                        erRegulertMedNyttGrunnbeløp(it, saktype, sisteBeløper)
+                    ) {
                         null
                     } else {
-                        SakMedGammeltGrunnbeløp(
-                            saksnummer = saksnummer,
-                            type = saktype,
-                            benyttetGrunnbeløp = it.benyttetGrunnbeløp,
-                            benyttetSatskategori = Satskategori.valueOf(it.satskategori),
-                            benyttetSats = it.benyttetSatsbeløp,
-                            vedtakFomSenereEnnMai = it.periode.fraOgMed > etterspurtMai.fraOgMed,
-                        )
+                        // hentBruktGrunnbeløpOgSatsbeløpTilVedtak henter bare nyligste vedtak,
+                        // så om vedtak starter senere enn mai, eller er en stans må sak sjekkes mer nøye
+                        if ((it.fraOgMed > etterspurtMai.fraOgMed || it.stansetYtelse) && erRegulertMedNyttGrunnbeløp(sakInfo, etterspurtMai)) {
+                            null
+                        } else {
+                            SakMedGammeltGrunnbeløp(
+                                saksnummer = saksnummer,
+                                type = saktype,
+                                benyttetGrunnbeløp = it.benyttetGrunnbeløp,
+                                benyttetSatskategori = Satskategori.valueOf(it.satskategori),
+                                benyttetSats = it.benyttetSatsbeløp,
+                            )
+                        }
                     }
                 }
             }
@@ -144,16 +157,28 @@ class ReguleringStatusUteståendeService(
         }
     }
 
-    private fun GrunnbeløpOgSatsbeløpPåVedtak.erRegulertMedNyttGrunnbeløp(
+    private fun erRegulertMedNyttGrunnbeløp(
+        grunnbeløpOgSatsbeløpPåVedtak: GrunnbeløpOgSatsbeløpPåVedtak,
         sakstype: Sakstype,
         sisteBeløper: SisteGrunnbeløpOgSatser,
-    ) = when (sakstype) {
-        Sakstype.UFØRE -> benyttetGrunnbeløp == sisteBeløper.grunnbeløp
-        Sakstype.ALDER -> when (Satskategori.valueOf(satskategori)) {
-            Satskategori.ORDINÆR -> benyttetSatsbeløp == sisteBeløper.garantipensjonOrdinærMåned
-            Satskategori.HØY -> benyttetSatsbeløp == sisteBeløper.garantipensjonHøyMåned
+    ) = with(grunnbeløpOgSatsbeløpPåVedtak) {
+        when (sakstype) {
+            Sakstype.UFØRE -> benyttetGrunnbeløp == sisteBeløper.grunnbeløp
+            Sakstype.ALDER -> when (Satskategori.valueOf(satskategori)) {
+                Satskategori.ORDINÆR -> benyttetSatsbeløp == sisteBeløper.garantipensjonOrdinærMåned
+                Satskategori.HØY -> benyttetSatsbeløp == sisteBeløper.garantipensjonHøyMåned
+            }
         }
     }
+
+    private fun erRegulertMedNyttGrunnbeløp(
+        sakInfo: SakInfo,
+        etterspurtMai: Måned,
+    ) = GjeldendeVedtaksdata(
+        etterspurtMai,
+        vedtakRepo.hentVedtakSomKanRevurderesForSak(sakInfo.sakId).toNonEmptyList(),
+        clock,
+    ).erRegulertMedNyttGrunnbeløp(etterspurtMai, sakInfo.type, satsFactory)
 }
 
 object StatusPågående
@@ -188,7 +213,6 @@ data class SakMedGammeltGrunnbeløp(
     val benyttetGrunnbeløp: Int?, // Kun uføre
     val benyttetSatskategori: Satskategori,
     val benyttetSats: Double,
-    val vedtakFomSenereEnnMai: Boolean,
 )
 
 data class SisteGrunnbeløpOgSatser(

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/ReguleringStatusUteståendeService.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/ReguleringStatusUteståendeService.kt
@@ -3,6 +3,7 @@ package no.nav.su.se.bakover.domain.regulering
 import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
+import io.micrometer.core.instrument.MockClock.clock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -90,32 +91,43 @@ class ReguleringStatusUteståendeService(
         log.info("hentStatusSisteGrunnbeløp - utleder saker som har gammelt grunnbeløp")
         val sakerMedGammeltGrunnbeløp = sessionFactory.withTransactionContext { tx ->
             sakerMedUtbetalingOgStansMai.mapNotNull { sakInfo ->
-                vedtakRepo.hentBruktGrunnbeløpOgSatsbeløpTilVedtak(sakInfo, etterspurtMai.fraOgMed, tx).let {
-                    val (_, saksnummer, _, saktype) = sakInfo
-                    if (it == null) {
-                        throw IllegalStateException("Fant ikke vedtak med brukt grunnbeløp for sak med løpende utbetaling eller stans. Sak=${sakInfo.saksnummer}")
-                    } else if (
-                        !it.stansetYtelse &&
-                        it.fraOgMed <= etterspurtMai.fraOgMed &&
-                        erRegulertMedNyttGrunnbeløp(it, saktype, sisteBeløper)
-                    ) {
-                        null
-                    } else {
-                        // hentBruktGrunnbeløpOgSatsbeløpTilVedtak henter bare nyligste vedtak,
-                        // så om vedtak starter senere enn mai, eller er en stans må sak sjekkes mer nøye
-                        if ((it.fraOgMed > etterspurtMai.fraOgMed || it.stansetYtelse) && erRegulertMedNyttGrunnbeløp(sakInfo, etterspurtMai)) {
-                            null
+                vedtakRepo.hentBruktGrunnbeløpOgSatsbeløpTilVedtak(sakInfo, etterspurtMai.fraOgMed, tx)
+                    .let { enkelVedtakInfo ->
+                        val (_, saksnummer, _, saktype) = sakInfo
+                        if (enkelVedtakInfo != null && !enkelVedtakInfo.stansetYtelse && enkelVedtakInfo.fraOgMed <= etterspurtMai.fraOgMed) {
+                            if (erRegulertMedNyttGrunnbeløp(enkelVedtakInfo, saktype, sisteBeløper)) {
+                                null
+                            } else {
+                                SakMedGammeltGrunnbeløp(
+                                    saksnummer = saksnummer,
+                                    type = saktype,
+                                    benyttetGrunnbeløp = enkelVedtakInfo.benyttetGrunnbeløp,
+                                    benyttetSatskategori = Satskategori.valueOf(enkelVedtakInfo.satskategori),
+                                    benyttetSats = enkelVedtakInfo.benyttetSatsbeløp,
+                                )
+                            }
                         } else {
-                            SakMedGammeltGrunnbeløp(
-                                saksnummer = saksnummer,
-                                type = saktype,
-                                benyttetGrunnbeløp = it.benyttetGrunnbeløp,
-                                benyttetSatskategori = Satskategori.valueOf(it.satskategori),
-                                benyttetSats = it.benyttetSatsbeløp,
-                            )
+                            // hentBruktGrunnbeløpOgSatsbeløpTilVedtak henter bare nyligste vedtak,
+                            // så om vedtak starter senere enn mai, eller er en stans må sak sjekkes mer nøye
+                            val vedtakInfo =
+                                vedtakRepo.hentVedtakSomKanRevurderesForSak(sakInfo.sakId).toNonEmptyList().let {
+                                    GjeldendeVedtaksdata(etterspurtMai, it, clock)
+                                }
+                            if (vedtakInfo.erRegulertMedNyttGrunnbeløp(etterspurtMai, sakInfo.type, satsFactory)) {
+                                null
+                            } else {
+                                val beregning = vedtakInfo.hentMånedsberegning(etterspurtMai).singleOrNull()
+                                    ?: throw (IllegalStateException("Forventer kun én månedsberegning per måned"))
+                                SakMedGammeltGrunnbeløp(
+                                    saksnummer = saksnummer,
+                                    type = saktype,
+                                    benyttetGrunnbeløp = beregning.getBenyttetGrunnbeløp(),
+                                    benyttetSatskategori = beregning.getSats(),
+                                    benyttetSats = beregning.fullSupplerendeStønadForMåned.satsForMånedAsDouble,
+                                )
+                            }
                         }
                     }
-                }
             }
         }
 

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakRepo.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/vedtak/VedtakRepo.kt
@@ -21,6 +21,7 @@ interface VedtakRepo {
     fun finnesVedtakForRevurderingId(revurderingId: RevurderingId): Boolean
     fun finnesVedtakForSøknadsbehandlingId(søknadsbehandlingId: SøknadsbehandlingId): Boolean
     fun hentVedtakSomKanRevurderesForSak(sakId: UUID): List<VedtakSomKanRevurderes>
+    fun hentVedtakSomKanRevurderesForSak(sakId: UUID, tx: TransactionContext? = null): List<VedtakSomKanRevurderes>
     fun hentVedtakForMåned(måned: Måned, tx: TransactionContext? = null): List<Vedtak>
 
     fun hentBruktGrunnbeløpOgSatsbeløpTilVedtak(

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/regulering/ReguleringStatusUteståendeServiceTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/regulering/ReguleringStatusUteståendeServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.su.se.bakover.domain.regulering
 
 import arrow.core.right
 import io.kotest.matchers.shouldBe
+import io.micrometer.core.instrument.MockClock.clock
 import no.nav.su.se.bakover.common.domain.Saksnummer
 import no.nav.su.se.bakover.common.domain.Stønadsperiode
 import no.nav.su.se.bakover.common.domain.sak.SakInfo
@@ -25,6 +26,7 @@ import no.nav.su.se.bakover.test.generer
 import no.nav.su.se.bakover.test.iverksattRevurdering
 import no.nav.su.se.bakover.test.iverksattSøknadsbehandlingAlder
 import no.nav.su.se.bakover.test.iverksattSøknadsbehandlingUføre
+import no.nav.su.se.bakover.test.saksnummer
 import no.nav.su.se.bakover.test.satsFactoryTestPåDato
 import no.nav.su.se.bakover.test.utbetaling.oversendtUtbetalingMedKvittering
 import no.nav.su.se.bakover.test.vedtakIverksattStansAvYtelseFraIverksattSøknadsbehandlingsvedtak
@@ -77,22 +79,12 @@ internal class ReguleringStatusUteståendeServiceTest {
                     )
                 } doReturn sak.vedtakListe.filterIsInstance<VedtakSomKanRevurderes>()
                     .last().let {
-                        if (it.beregning == null) {
-                            // TODO bør returnere null..
+                        it.beregning?.let { beregning ->
                             GrunnbeløpOgSatsbeløpPåVedtak(
-                                stansetYtelse = true,
-                                fraOgMed = it.periode.fraOgMed,
-                                benyttetGrunnbeløp = null,
-                                benyttetSatsbeløp = 0.0,
-                                satskategori = "",
-                            )
-                        } else {
-                            GrunnbeløpOgSatsbeløpPåVedtak(
-                                benyttetGrunnbeløp = it.beregning!!.getMånedsberegninger().last()
+                                benyttetGrunnbeløp = beregning.getMånedsberegninger().last()
                                     .getBenyttetGrunnbeløp(),
-                                benyttetSatsbeløp = it.beregning!!.getMånedsberegninger().last().getSatsbeløp(),
-                                satskategori = it.beregning!!.getMånedsberegninger().last().getSats().name,
-                                stansetYtelse = false,
+                                benyttetSatsbeløp = beregning.getMånedsberegninger().last().getSatsbeløp(),
+                                satskategori = beregning.getMånedsberegninger().last().getSats().name,
                                 fraOgMed = it.periode.fraOgMed,
                             )
                         }
@@ -254,7 +246,8 @@ internal class ReguleringStatusUteståendeServiceTest {
                             periode = Periode.create(1.juni(2025), 31.desember(2025)),
                         ),
                     ),
-                    sakOgVedtakSomKanRevurderes = it to it.vedtakListe.filterIsInstance<VedtakSomKanRevurderes>().single(),
+                    sakOgVedtakSomKanRevurderes = it to it.vedtakListe.filterIsInstance<VedtakSomKanRevurderes>()
+                        .single(),
                     satsPåDato = clock.instant().atZone(ZoneId.systemDefault()).toLocalDate(),
                 ).let { (sakUtenUtbetaling, revurdering, _) -> sakUtenUtbetaling.leggTilUtbetaling(revurdering, clock) }
             }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/regulering/ReguleringStatusUteståendeServiceTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/regulering/ReguleringStatusUteståendeServiceTest.kt
@@ -90,7 +90,12 @@ internal class ReguleringStatusUteståendeServiceTest {
                         }
                     }
 
-                on { hentVedtakSomKanRevurderesForSak(sak.id) } doReturn sak.vedtakListe.filterIsInstance<VedtakSomKanRevurderes>()
+                on {
+                    hentVedtakSomKanRevurderesForSak(
+                        sak.id,
+                        sessionFactory.newTransactionContext(),
+                    )
+                } doReturn sak.vedtakListe.filterIsInstance<VedtakSomKanRevurderes>()
             }
         }
 

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/regulering/ReguleringStatusUteståendeServiceTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/regulering/ReguleringStatusUteståendeServiceTest.kt
@@ -8,20 +8,26 @@ import no.nav.su.se.bakover.common.domain.sak.SakInfo
 import no.nav.su.se.bakover.common.domain.sak.Sakstype
 import no.nav.su.se.bakover.common.domain.tid.desember
 import no.nav.su.se.bakover.common.domain.tid.januar
+import no.nav.su.se.bakover.common.domain.tid.juni
+import no.nav.su.se.bakover.common.domain.tid.periode.EmptyPerioder.fraOgMed
 import no.nav.su.se.bakover.common.person.Fnr
 import no.nav.su.se.bakover.common.tid.periode.Periode
 import no.nav.su.se.bakover.domain.Sak
+import no.nav.su.se.bakover.domain.revurdering.Revurdering
 import no.nav.su.se.bakover.domain.sak.SakService
-import no.nav.su.se.bakover.domain.søknadsbehandling.IverksattSøknadsbehandling
+import no.nav.su.se.bakover.domain.søknadsbehandling.Søknadsbehandling
 import no.nav.su.se.bakover.domain.vedtak.VedtakRepo
 import no.nav.su.se.bakover.test.TestSessionFactory
+import no.nav.su.se.bakover.test.TikkendeKlokke
 import no.nav.su.se.bakover.test.bosituasjonBorMedAndreVoksne
 import no.nav.su.se.bakover.test.bosituasjongrunnlagEnslig
 import no.nav.su.se.bakover.test.generer
+import no.nav.su.se.bakover.test.iverksattRevurdering
 import no.nav.su.se.bakover.test.iverksattSøknadsbehandlingAlder
 import no.nav.su.se.bakover.test.iverksattSøknadsbehandlingUføre
 import no.nav.su.se.bakover.test.satsFactoryTestPåDato
 import no.nav.su.se.bakover.test.utbetaling.oversendtUtbetalingMedKvittering
+import no.nav.su.se.bakover.test.vedtakIverksattStansAvYtelseFraIverksattSøknadsbehandlingsvedtak
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -35,11 +41,14 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import java.util.UUID
+import kotlin.to
 
 internal class ReguleringStatusUteståendeServiceTest {
 
-    private val clock: Clock = Clock.fixed(Instant.parse("2025-06-15T10:15:30Z"), ZoneId.of("Europe/Oslo"))
-    private val gammelClock: Clock = Clock.fixed(Instant.parse("2024-06-15T10:15:30Z"), ZoneId.of("Europe/Oslo"))
+    private val clock: Clock =
+        TikkendeKlokke(Clock.fixed(Instant.parse("2025-06-15T10:15:30Z"), ZoneId.of("Europe/Oslo")))
+    private val gammelClock: Clock =
+        TikkendeKlokke(Clock.fixed(Instant.parse("2024-06-15T10:15:30Z"), ZoneId.of("Europe/Oslo")))
 
     @Test
     fun `returnerer ReguleringStatus for uføre og ordinær satskategori`() {
@@ -67,15 +76,29 @@ internal class ReguleringStatusUteståendeServiceTest {
                         sessionFactory.newTransactionContext(),
                     )
                 } doReturn sak.vedtakListe.filterIsInstance<VedtakSomKanRevurderes>()
-                    .single().let {
-                        GrunnbeløpOgSatsbeløpPåVedtak(
-                            benyttetGrunnbeløp = it.beregning!!.getMånedsberegninger().last().getBenyttetGrunnbeløp(),
-                            benyttetSatsbeløp = it.beregning!!.getMånedsberegninger().last().getSatsbeløp(),
-                            satskategori = it.beregning!!.getMånedsberegninger().last().getSats().name,
-                            stansetYtelse = false,
-                            fraOgMed = it.periode.fraOgMed,
-                        )
+                    .last().let {
+                        if (it.beregning == null) {
+                            // TODO bør returnere null..
+                            GrunnbeløpOgSatsbeløpPåVedtak(
+                                stansetYtelse = true,
+                                fraOgMed = it.periode.fraOgMed,
+                                benyttetGrunnbeløp = null,
+                                benyttetSatsbeløp = 0.0,
+                                satskategori = "",
+                            )
+                        } else {
+                            GrunnbeløpOgSatsbeløpPåVedtak(
+                                benyttetGrunnbeløp = it.beregning!!.getMånedsberegninger().last()
+                                    .getBenyttetGrunnbeløp(),
+                                benyttetSatsbeløp = it.beregning!!.getMånedsberegninger().last().getSatsbeløp(),
+                                satskategori = it.beregning!!.getMånedsberegninger().last().getSats().name,
+                                stansetYtelse = false,
+                                fraOgMed = it.periode.fraOgMed,
+                            )
+                        }
                     }
+
+                on { hentVedtakSomKanRevurderesForSak(sak.id) } doReturn sak.vedtakListe.filterIsInstance<VedtakSomKanRevurderes>()
             }
         }
 
@@ -98,18 +121,24 @@ internal class ReguleringStatusUteståendeServiceTest {
             garantipensjonOrdinærMåned shouldBe 18687.333333333332
             garantipensjonHøyMåned shouldBe 20201.5
         }
-        result.sakerMedUtebetalingIMai shouldBe 6
-        result.sakerMedGammelG.size shouldBe 2
-        with(result.sakerMedGammelG.single { it.type == Sakstype.UFØRE }) {
-            saksnummer shouldBe Saksnummer(1234565)
-            benyttetGrunnbeløp shouldBe 124028
-            benyttetSatskategori shouldBe Satskategori.HØY
-        }
-        with(result.sakerMedGammelG.single { it.type == Sakstype.ALDER }) {
+        result.sakerMedUtebetalingIMai shouldBe 8
+        result.sakerMedGammelG.size shouldBe 3
+
+        with(result.sakerMedGammelG[0]) {
             saksnummer shouldBe Saksnummer(1234564)
             benyttetGrunnbeløp shouldBe null
             benyttetSatskategori shouldBe Satskategori.ORDINÆR
             benyttetSats shouldBe 18018.833333333332
+        }
+        with(result.sakerMedGammelG[1]) {
+            saksnummer shouldBe Saksnummer(1234565)
+            benyttetGrunnbeløp shouldBe 124028
+            benyttetSatskategori shouldBe Satskategori.HØY
+        }
+        with(result.sakerMedGammelG[2]) {
+            saksnummer shouldBe Saksnummer(1234566)
+            benyttetGrunnbeløp shouldBe 124028
+            benyttetSatskategori shouldBe Satskategori.HØY
         }
     }
 
@@ -131,7 +160,7 @@ internal class ReguleringStatusUteståendeServiceTest {
                 bosituasjonBorMedAndreVoksne(periode = periode),
             ),
             satsPåDato = clock.instant().atZone(ZoneId.systemDefault()).toLocalDate(),
-        ).let { (sakUtenUtbetaling, behandling, _) -> sakUtenUtbetaling.leggTilUtbetaling(behandling) }
+        ).let { (sakUtenUtbetaling, behandling, _) -> sakUtenUtbetaling.leggTilUtbetaling(behandling, clock) }
 
         // Uføre med høy satskategori
         val sakUføreHøy = iverksattSøknadsbehandlingUføre(
@@ -147,7 +176,7 @@ internal class ReguleringStatusUteståendeServiceTest {
                 bosituasjongrunnlagEnslig(periode = periode),
             ),
             satsPåDato = clock.instant().atZone(ZoneId.systemDefault()).toLocalDate(),
-        ).let { (sakUtenUtbetaling, behandling, _) -> sakUtenUtbetaling.leggTilUtbetaling(behandling) }
+        ).let { (sakUtenUtbetaling, behandling, _) -> sakUtenUtbetaling.leggTilUtbetaling(behandling, clock) }
 
         // Alder med ordinær satskategori
         val sakAlderOrdinær = iverksattSøknadsbehandlingAlder(
@@ -159,7 +188,7 @@ internal class ReguleringStatusUteståendeServiceTest {
                 type = Sakstype.ALDER,
             ),
             stønadsperiode = stønadsperiode,
-        ).let { (sakUtenUtbetaling, behandling, _) -> sakUtenUtbetaling.leggTilUtbetaling(behandling) }
+        ).let { (sakUtenUtbetaling, behandling, _) -> sakUtenUtbetaling.leggTilUtbetaling(behandling, clock) }
 
         // Alder med høy satskategori
         val sakAlderHøy = iverksattSøknadsbehandlingAlder(
@@ -173,7 +202,7 @@ internal class ReguleringStatusUteståendeServiceTest {
             stønadsperiode = stønadsperiode,
             customGrunnlag = listOf(bosituasjongrunnlagEnslig(periode = periode)),
             satsPåDato = clock.instant().atZone(ZoneId.systemDefault()).toLocalDate(),
-        ).let { (sakUtenUtbetaling, behandling, _) -> sakUtenUtbetaling.leggTilUtbetaling(behandling) }
+        ).let { (sakUtenUtbetaling, behandling, _) -> sakUtenUtbetaling.leggTilUtbetaling(behandling, clock) }
 
         val sakAlderGammelSats = iverksattSøknadsbehandlingAlder(
             clock = gammelClock,
@@ -185,7 +214,7 @@ internal class ReguleringStatusUteståendeServiceTest {
             ),
             stønadsperiode = stønadsperiode,
             satsPåDato = gammelClock.instant().atZone(ZoneId.systemDefault()).toLocalDate(),
-        ).let { (sakUtenUtbetaling, behandling, _) -> sakUtenUtbetaling.leggTilUtbetaling(behandling) }
+        ).let { (sakUtenUtbetaling, behandling, _) -> sakUtenUtbetaling.leggTilUtbetaling(behandling, gammelClock) }
 
         val sakUføreGammelG = iverksattSøknadsbehandlingUføre(
             clock = gammelClock,
@@ -200,16 +229,86 @@ internal class ReguleringStatusUteståendeServiceTest {
                 bosituasjongrunnlagEnslig(periode = periode),
             ),
             satsPåDato = gammelClock.instant().atZone(ZoneId.systemDefault()).toLocalDate(),
-        ).let { (sakUtenUtbetaling, behandling, _) -> sakUtenUtbetaling.leggTilUtbetaling(behandling) }
+        ).let { (sakUtenUtbetaling, behandling, _) -> sakUtenUtbetaling.leggTilUtbetaling(behandling, gammelClock) }
 
-        return listOf(sakUføreOrdinær, sakUføreHøy, sakAlderOrdinær, sakAlderHøy, sakAlderGammelSats, sakUføreGammelG)
+        val sakMedVedtakEtterMai = iverksattSøknadsbehandlingUføre(
+            clock = gammelClock,
+            sakInfo = SakInfo(
+                sakId = UUID.randomUUID(),
+                saksnummer = Saksnummer(1234566),
+                fnr = Fnr.generer(),
+                type = Sakstype.UFØRE,
+            ),
+            stønadsperiode = Stønadsperiode.create(periode),
+            customGrunnlag = listOf(bosituasjongrunnlagEnslig(periode = periode)),
+            satsPåDato = gammelClock.instant().atZone(ZoneId.systemDefault()).toLocalDate(),
+        ).let { (sakUtenUtbetaling, behandling, _) -> sakUtenUtbetaling.leggTilUtbetaling(behandling, gammelClock) }
+            .let {
+                iverksattRevurdering(
+                    clock = clock,
+                    saksnummer = it.saksnummer,
+                    stønadsperiode = Stønadsperiode.create(periode),
+                    revurderingsperiode = Periode.create(1.juni(2025), 31.desember(2025)),
+                    grunnlagsdataOverrides = listOf(
+                        bosituasjongrunnlagEnslig(
+                            periode = Periode.create(1.juni(2025), 31.desember(2025)),
+                        ),
+                    ),
+                    sakOgVedtakSomKanRevurderes = it to it.vedtakListe.filterIsInstance<VedtakSomKanRevurderes>().single(),
+                    satsPåDato = clock.instant().atZone(ZoneId.systemDefault()).toLocalDate(),
+                ).let { (sakUtenUtbetaling, revurdering, _) -> sakUtenUtbetaling.leggTilUtbetaling(revurdering, clock) }
+            }
+
+        val sakStansRegulert = iverksattSøknadsbehandlingUføre(
+            clock = clock,
+            sakInfo = SakInfo(
+                sakId = UUID.randomUUID(),
+                saksnummer = Saksnummer(1234567),
+                fnr = Fnr.generer(),
+                type = Sakstype.UFØRE,
+            ),
+            stønadsperiode = stønadsperiode,
+            customGrunnlag = listOf(bosituasjongrunnlagEnslig(periode = periode)),
+            satsPåDato = clock.instant().atZone(ZoneId.systemDefault()).toLocalDate(),
+        ).let { (sakUtenUtbetaling, behandling, _) -> sakUtenUtbetaling.leggTilUtbetaling(behandling, clock) }.let {
+            vedtakIverksattStansAvYtelseFraIverksattSøknadsbehandlingsvedtak(
+                clock = clock,
+                Periode.create(1.juni(2025), 31.desember(2025)),
+                it to it.vedtakListe.filterIsInstance<VedtakSomKanRevurderes>().single(),
+            ).first
+        }
+
+        return listOf(
+            sakUføreOrdinær,
+            sakUføreHøy,
+            sakAlderOrdinær,
+            sakAlderHøy,
+            sakAlderGammelSats,
+            sakUføreGammelG,
+            sakMedVedtakEtterMai,
+            sakStansRegulert,
+        )
     }
 
-    private fun Sak.leggTilUtbetaling(behandling: IverksattSøknadsbehandling) = copy(
+    private fun Sak.leggTilUtbetaling(behandling: Søknadsbehandling, clock: Clock) = copy(
         utbetalinger = Utbetalinger(
             oversendtUtbetalingMedKvittering(
+                clock = clock,
                 periode = behandling.periode,
                 beregning = behandling.beregning!!,
+            ),
+        ),
+    )
+
+    private fun Sak.leggTilUtbetaling(behandling: Revurdering, clock: Clock) = copy(
+        utbetalinger = Utbetalinger(
+            utbetalinger.plus(
+                oversendtUtbetalingMedKvittering(
+                    clock = clock,
+                    periode = behandling.periode,
+                    beregning = behandling.beregning!!,
+                    eksisterendeUtbetalinger = utbetalinger,
+                ),
             ),
         ),
     )

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/regulering/ReguleringStatusUteståendeServiceTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/regulering/ReguleringStatusUteståendeServiceTest.kt
@@ -69,10 +69,11 @@ internal class ReguleringStatusUteståendeServiceTest {
                 } doReturn sak.vedtakListe.filterIsInstance<VedtakSomKanRevurderes>()
                     .single().let {
                         GrunnbeløpOgSatsbeløpPåVedtak(
-                            periode = it.periode,
                             benyttetGrunnbeløp = it.beregning!!.getMånedsberegninger().last().getBenyttetGrunnbeløp(),
                             benyttetSatsbeløp = it.beregning!!.getMånedsberegninger().last().getSatsbeløp(),
                             satskategori = it.beregning!!.getMånedsberegninger().last().getSats().name,
+                            stansetYtelse = false,
+                            fraOgMed = it.periode.fraOgMed,
                         )
                     }
             }
@@ -87,6 +88,7 @@ internal class ReguleringStatusUteståendeServiceTest {
             vedtakRepo = vedtaksRepo,
             reguleringStatusRepo = reguleringStatusRepo,
             sessionFactory = sessionFactory,
+            clock = clock,
         )
 
         val result = service.produserStatusSisteGrunnbeløp(2025)

--- a/test-common/src/main/kotlin/RevurderingTestData.kt
+++ b/test-common/src/main/kotlin/RevurderingTestData.kt
@@ -227,6 +227,7 @@ fun beregnetRevurdering(
     revurderingsårsak: Revurderingsårsak = no.nav.su.se.bakover.test.revurderingsårsak,
     vilkårOverrides: List<Vilkår> = emptyList(),
     grunnlagsdataOverrides: List<Grunnlag> = emptyList(),
+    satsPåDato: LocalDate = fixedLocalDate,
 ): Pair<Sak, BeregnetRevurdering> {
     return opprettetRevurdering(
         saksnummer = saksnummer,
@@ -246,7 +247,7 @@ fun beregnetRevurdering(
                 periode = opprettet.periode,
                 clock = clock,
             ).getOrFail(),
-            satsFactory = satsFactoryTestPåDato(),
+            satsFactory = satsFactoryTestPåDato(satsPåDato),
         ).getOrFail()
 
         sak.oppdaterRevurdering(beregnet) to beregnet
@@ -270,6 +271,7 @@ fun simulertRevurdering(
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
     utbetalingerKjørtTilOgMed: (clock: Clock) -> LocalDate = { LocalDate.now(it) },
     brevvalg: BrevvalgBehandling.Valgt = sendBrev(),
+    satsPåDato: LocalDate = fixedLocalDate,
 ): Pair<Sak, SimulertRevurdering> {
     return beregnetRevurdering(
         saksnummer = saksnummer,
@@ -281,6 +283,7 @@ fun simulertRevurdering(
         clock = clock,
         vilkårOverrides = vilkårOverrides,
         grunnlagsdataOverrides = grunnlagsdataOverrides,
+        satsPåDato = satsPåDato,
     ).let { (sak, beregnet) ->
         val simulert = when (beregnet) {
             is BeregnetRevurdering.Innvilget -> {
@@ -337,6 +340,7 @@ fun revurderingTilAttestering(
     saksbehandler: NavIdentBruker.Saksbehandler = no.nav.su.se.bakover.test.saksbehandler,
     utbetalingerKjørtTilOgMed: (clock: Clock) -> LocalDate = { LocalDate.now(it) },
     brevvalg: BrevvalgBehandling.Valgt = sendBrev(),
+    satsPåDato: LocalDate = fixedLocalDate,
 ): Pair<Sak, RevurderingTilAttestering> {
     return simulertRevurdering(
         saksnummer = saksnummer,
@@ -350,6 +354,7 @@ fun revurderingTilAttestering(
         grunnlagsdataOverrides = grunnlagsdataOverrides,
         utbetalingerKjørtTilOgMed = utbetalingerKjørtTilOgMed,
         brevvalg = brevvalg,
+        satsPåDato = satsPåDato,
     ).let { (sak, simulert) ->
         val tilAttestering = when (simulert) {
             is SimulertRevurdering.Innvilget -> {
@@ -421,6 +426,7 @@ fun iverksattRevurdering(
     brevvalg: BrevvalgBehandling.Valgt = sendBrev(),
     kvittering: Kvittering? = kvittering(clock = clock),
     kravgrunnlagPåSakHendelseId: HendelseId = HendelseId.generer(),
+    satsPåDato: LocalDate = fixedLocalDate,
 ): Tuple4<Sak, IverksattRevurdering, Utbetaling.OversendtUtbetaling, Revurderingsvedtak> {
     return revurderingTilAttestering(
         saksnummer = saksnummer,
@@ -435,6 +441,7 @@ fun iverksattRevurdering(
         saksbehandler = saksbehandler,
         utbetalingerKjørtTilOgMed = utbetalingerKjørtTilOgMed,
         brevvalg = brevvalg,
+        satsPåDato = satsPåDato,
     ).let { (sak, tilAttestering) ->
         sak.iverksettRevurdering(
             revurderingId = tilAttestering.id,
@@ -449,7 +456,7 @@ fun iverksattRevurdering(
                 )
             },
             genererPdf = { dokumentUtenMetadataVedtak().right() },
-            satsFactory = satsFactoryTestPåDato(),
+            satsFactory = satsFactoryTestPåDato(satsPåDato),
             fritekst = "",
         ).getOrFail().let { response ->
             /**

--- a/vedtak/domain/src/main/kotlin/vedtak/domain/GrunnbeløpOgSatsbeløpPåVedtak.kt
+++ b/vedtak/domain/src/main/kotlin/vedtak/domain/GrunnbeløpOgSatsbeløpPåVedtak.kt
@@ -6,6 +6,5 @@ data class GrunnbeløpOgSatsbeløpPåVedtak(
     val benyttetGrunnbeløp: Int?,
     val benyttetSatsbeløp: Double,
     val satskategori: String,
-    val stansetYtelse: Boolean = false,
     val fraOgMed: LocalDate,
 )

--- a/vedtak/domain/src/main/kotlin/vedtak/domain/GrunnbeløpOgSatsbeløpPåVedtak.kt
+++ b/vedtak/domain/src/main/kotlin/vedtak/domain/GrunnbeløpOgSatsbeløpPåVedtak.kt
@@ -1,10 +1,11 @@
 package vedtak.domain
 
-import no.nav.su.se.bakover.common.tid.periode.Periode
+import java.time.LocalDate
 
 data class GrunnbeløpOgSatsbeløpPåVedtak(
-    val periode: Periode,
     val benyttetGrunnbeløp: Int?,
     val benyttetSatsbeløp: Double,
     val satskategori: String,
+    val stansetYtelse: Boolean = false,
+    val fraOgMed: LocalDate,
 )

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/ServiceBuilder.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/ServiceBuilder.kt
@@ -664,6 +664,7 @@ data object ServiceBuilder {
             vedtakRepo = databaseRepos.vedtakRepo,
             reguleringStatusRepo = databaseRepos.reguleringStatusRepo,
             sessionFactory = databaseRepos.sessionFactory,
+            clock = clock,
         )
         return ReguleringServices(
             reguleringManuellService = reguleringManuellService,


### PR DESCRIPTION
Enkel og rask vedtaksinfo er ikke tilstrekkelig for tilfellene hvor sakhar et vedtak med fom senere enn mai. I disse tilfellene må det hentes mer utdypende vedtaksinfo for å avjgøre om sak er regulert.

Hvis sak er stanset eller gjenåpnet må siste løpende vedtak benyttes for å avjgøre om ble regulert før stans.