### PR TITLE
Ny type dedikert der pesys returner ny g og kun en periode som er reg…

### DIFF
--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/Regulering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/Regulering.kt
@@ -162,9 +162,6 @@ fun regulerForventetIeuOmGyldig(
                 EksterntRegulertSammenligningResultat.NormalRegulering -> skalOppdatereVilkår = true
                 // Vårt IEU matcher hverken før eller etter — manuell håndtering kreves.
                 EksterntRegulertSammenligningResultat.Differanse,
-                // Pesys har kun etter-periode (nyG), og vårt IEU matcher ikke. Behandles likt
-                // som Differanse — manuell håndtering — men holdes separat for sporing.
-                EksterntRegulertSammenligningResultat.DifferanseUtenFørRegulering,
                 -> return ÅrsakRevurdering(
                     årsak = ÅrsakRevurdering.Årsak.DIFFERANSE_MED_EKSTERNE_BELØP,
                     diffBeløp = listOf(

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/Regulering.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/Regulering.kt
@@ -161,7 +161,11 @@ fun regulerForventetIeuOmGyldig(
                 // Vårt IEU matcher Pesys' før-beløp — oppdater vilkåret til Pesys' etter-beløp.
                 EksterntRegulertSammenligningResultat.NormalRegulering -> skalOppdatereVilkår = true
                 // Vårt IEU matcher hverken før eller etter — manuell håndtering kreves.
-                EksterntRegulertSammenligningResultat.Differanse -> return ÅrsakRevurdering(
+                EksterntRegulertSammenligningResultat.Differanse,
+                // Pesys har kun etter-periode (nyG), og vårt IEU matcher ikke. Behandles likt
+                // som Differanse — manuell håndtering — men holdes separat for sporing.
+                EksterntRegulertSammenligningResultat.DifferanseUtenFørRegulering,
+                -> return ÅrsakRevurdering(
                     årsak = ÅrsakRevurdering.Årsak.DIFFERANSE_MED_EKSTERNE_BELØP,
                     diffBeløp = listOf(
                         ÅrsakRevurdering.BeløperMedDiff.Fradrag(

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/Reguleringstype.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/Reguleringstype.kt
@@ -183,10 +183,6 @@ private fun utledPerFradragstypeOgTilhørende(
             (Reguleringstype.AUTOMATISK to originaltFradrag.oppdaterBeløpMedEksternRegulering(eksterntBeløp.etterRegulering)).right()
         // Vårt beløp matcher hverken før- eller etter-beløp fra Pesys. Saken må håndteres manuelt.
         EksterntRegulertSammenligningResultat.Differanse,
-        // Pesys har kun etter-periode (nyG), og vårt beløp matcher ikke. Behandles likt som
-        // Differanse — manuell håndtering — men logges separat for å skille tilfeller hvor
-        // sammenligning mot Pesys-før ikke var mulig.
-        EksterntRegulertSammenligningResultat.DifferanseUtenFørRegulering,
         -> ÅrsakRevurdering.BeløperMedDiff.Fradrag(
             fradragstype = originaltFradrag.fradragstype,
             tilhører = originaltFradrag.tilhører,
@@ -255,13 +251,4 @@ internal enum class EksterntRegulertSammenligningResultat {
     HarGRegulertFradragEksternt,
     NormalRegulering,
     Differanse,
-
-    /**
-     * Pesys svarer kun med etter-periode (nytt G), og vårt beløp matcher ikke.
-     * Vi har ikke før-perioden fra Pesys å sammenligne mot, så vi kan ikke trygt
-     * avgjøre om vårt beløp er en gammel-G-utgave av samme ytelse eller en reell differanse.
-     * Behandles likt som [Differanse] — manuell håndtering — men holdes separat for logging og
-     * statistikk slik at vi kan følge med på hvor ofte Pesys mangler historisk periode.
-     */
-    DifferanseUtenFørRegulering,
 }

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/Reguleringstype.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/Reguleringstype.kt
@@ -232,10 +232,8 @@ internal fun sammenlignVårtBeløpMedEksternt(
         return EksterntRegulertSammenligningResultat.NormalRegulering
     }
     return if (eksterntFør == null) {
-        // Pesys svarer med kun etter-periode (nytt G), men vårt beløp matcher ikke. Vi mangler
-        // grunnlag fra Pesys for å bekrefte at vårt beløp tilsvarer gammel-G-utgaven av samme
-        // ytelse — saken må håndteres manuelt.
-        EksterntRegulertSammenligningResultat.DifferanseUtenFørRegulering
+        // Pesys svarer med kun etter-periode er NY G som er ulikt vårt registrerte fradragsbeløp og kan da bli automatisk fordi det er en periode og det "etter" periode.
+        EksterntRegulertSammenligningResultat.NormalRegulering
     } else {
         // Vårt beløp matcher hverken før eller etter — rapporter differanse for manuell håndtering.
         EksterntRegulertSammenligningResultat.Differanse

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/Reguleringstype.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/regulering/Reguleringstype.kt
@@ -182,7 +182,12 @@ private fun utledPerFradragstypeOgTilhørende(
         EksterntRegulertSammenligningResultat.NormalRegulering ->
             (Reguleringstype.AUTOMATISK to originaltFradrag.oppdaterBeløpMedEksternRegulering(eksterntBeløp.etterRegulering)).right()
         // Vårt beløp matcher hverken før- eller etter-beløp fra Pesys. Saken må håndteres manuelt.
-        EksterntRegulertSammenligningResultat.Differanse -> ÅrsakRevurdering.BeløperMedDiff.Fradrag(
+        EksterntRegulertSammenligningResultat.Differanse,
+        // Pesys har kun etter-periode (nyG), og vårt beløp matcher ikke. Behandles likt som
+        // Differanse — manuell håndtering — men logges separat for å skille tilfeller hvor
+        // sammenligning mot Pesys-før ikke var mulig.
+        EksterntRegulertSammenligningResultat.DifferanseUtenFørRegulering,
+        -> ÅrsakRevurdering.BeløperMedDiff.Fradrag(
             fradragstype = originaltFradrag.fradragstype,
             tilhører = originaltFradrag.tilhører,
             eksisterendeBeløp = BigDecimal(originaltFradrag.fradrag.månedsbeløp).setScale(2),
@@ -226,8 +231,15 @@ internal fun sammenlignVårtBeløpMedEksternt(
         // Vårt beløp er beregnet med gammelt G — normal regulering. Oppdater til etter-beløpet.
         return EksterntRegulertSammenligningResultat.NormalRegulering
     }
-    // Vårt beløp matcher hverken før eller etter — rapporter differanse for manuell håndtering.
-    return EksterntRegulertSammenligningResultat.Differanse
+    return if (eksterntFør == null) {
+        // Pesys svarer med kun etter-periode (nytt G), men vårt beløp matcher ikke. Vi mangler
+        // grunnlag fra Pesys for å bekrefte at vårt beløp tilsvarer gammel-G-utgaven av samme
+        // ytelse — saken må håndteres manuelt.
+        EksterntRegulertSammenligningResultat.DifferanseUtenFørRegulering
+    } else {
+        // Vårt beløp matcher hverken før eller etter — rapporter differanse for manuell håndtering.
+        EksterntRegulertSammenligningResultat.Differanse
+    }
 }
 
 /**
@@ -245,4 +257,13 @@ internal enum class EksterntRegulertSammenligningResultat {
     HarGRegulertFradragEksternt,
     NormalRegulering,
     Differanse,
+
+    /**
+     * Pesys svarer kun med etter-periode (nytt G), og vårt beløp matcher ikke.
+     * Vi har ikke før-perioden fra Pesys å sammenligne mot, så vi kan ikke trygt
+     * avgjøre om vårt beløp er en gammel-G-utgave av samme ytelse eller en reell differanse.
+     * Behandles likt som [Differanse] — manuell håndtering — men holdes separat for logging og
+     * statistikk slik at vi kan følge med på hvor ofte Pesys mangler historisk periode.
+     */
+    DifferanseUtenFørRegulering,
 }

--- a/domain/src/test/kotlin/no/nav/su/se/bakover/domain/regulering/UtledningReguleringstypeOgFradragTest.kt
+++ b/domain/src/test/kotlin/no/nav/su/se/bakover/domain/regulering/UtledningReguleringstypeOgFradragTest.kt
@@ -92,7 +92,7 @@ class UtledningReguleringstypeOgFradragTest {
     }
 
     @Test
-    fun `utleder differanse ved førstegangsinnvilgelse hos ekstern kilde uten beløpsmatch`() {
+    fun `utleder automatisk regulering ved førstegangsinnvilgelse hos ekstern kilde uten beløpsmatch skal gi automatisk hvis de bruker ny g`() {
         val eksisterende = nonEmptyListOf(
             lagFradragsgrunnlag(Fradragstype.Uføretrygd, 1000.0, FradragTilhører.BRUKER),
         )
@@ -113,13 +113,10 @@ class UtledningReguleringstypeOgFradragTest {
         val resultat = utledReguleringstypeOgOppdaterFradrag(
             fradrag = eksisterende,
             eksterntRegulerteBeløp = eksterntRegulerteBeløp,
-        ).shouldBeLeft()
+        ).getOrFail()
 
-        resultat.årsak shouldBe ÅrsakRevurdering.Årsak.DIFFERANSE_MED_EKSTERNE_BELØP
-        with(resultat.diffBeløp.single() as ÅrsakRevurdering.BeløperMedDiff.Fradrag) {
-            eksisterendeBeløp shouldBe BigDecimal("1000.00")
-            nyttBeløp shouldBe BigDecimal("1064.00")
-        }
+        resultat.first shouldBe Reguleringstype.AUTOMATISK
+        resultat.second.single().månedsbeløp shouldBe 1064
     }
 
     @Test

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/regulering/ReguleringGrunnbeløpIT.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/regulering/ReguleringGrunnbeløpIT.kt
@@ -51,11 +51,11 @@ import no.nav.su.se.bakover.web.regulering.TestScenarietSaker.MANUELL_UFØRE_MED
 import no.nav.su.se.bakover.web.regulering.TestScenarietSaker.MÅ_REVURDERES_UFØRE
 import no.nav.su.se.bakover.web.regulering.TestScenarietSaker.OVER_10_PRORSENT_MED_G_FRADRAG
 import no.nav.su.se.bakover.web.regulering.TestScenarietSaker.OVER_10_PRORSENT_UTEN_G_FRADRAG
-import no.nav.su.se.bakover.web.regulering.TestScenarietSaker.REVURDERING_UFØRE_KUN_NY_PESYS_PERIODE_DIFF
 import no.nav.su.se.bakover.web.regulering.TestScenarietSaker.REVURDERING_UFØRE_MED_IEU
 import no.nav.su.se.bakover.web.regulering.TestScenarietSaker.UFØRE_FINNES_IKKE_PESYS
 import no.nav.su.se.bakover.web.regulering.TestScenarietSaker.UFØRE_IKKE_REGULERT_PESYS
 import no.nav.su.se.bakover.web.regulering.TestScenarietSaker.UFØRE_I_SENERE_PERIODE
+import no.nav.su.se.bakover.web.regulering.TestScenarietSaker.UFØRE_KUN_NY_PESYS_PERIODE_DIFF_MED_G_OK
 import no.nav.su.se.bakover.web.regulering.TestScenarietSaker.ULIKE_PERIODER_FREM_I_TID
 import no.nav.su.se.bakover.web.revurdering.opprettIverksattRevurdering
 import no.nav.su.se.bakover.web.routes.regulering.json.ÅrsakTilManuellReguleringJson
@@ -139,7 +139,7 @@ internal class ReguleringGrunnbeløpIT {
                     ULIKE_PERIODER_FREM_I_TID.opprettSak(client, appComponents)
                     AUTOMATISK_UFØRE_FØRSTEGANGSINNVILGELSE_EKSTERNT.opprettSak(client, appComponents)
                     AUTOMATISK_UFØRE_FRADRAG_OPPDATERT_FØR_REGULERING.opprettSak(client, appComponents)
-                    REVURDERING_UFØRE_KUN_NY_PESYS_PERIODE_DIFF.opprettSak(client, appComponents)
+                    UFØRE_KUN_NY_PESYS_PERIODE_DIFF_MED_G_OK.opprettSak(client, appComponents)
                 }
                 applikasjonEtterNyttGrunnbeløp(dataSource, pesysStub) {
                     INNVILGET_SØKNAD_ETTER_NY_G.opprettSak(client, it)
@@ -184,7 +184,7 @@ internal class ReguleringGrunnbeløpIT {
                     ULIKE_PERIODER_FREM_I_TID.verifiserAutomatisk(client)
                     AUTOMATISK_UFØRE_FØRSTEGANGSINNVILGELSE_EKSTERNT.verifiserAutomatisk(client)
                     AUTOMATISK_UFØRE_FRADRAG_OPPDATERT_FØR_REGULERING.verifiserAutomatisk(client)
-                    REVURDERING_UFØRE_KUN_NY_PESYS_PERIODE_DIFF.verifiserBleIkkeRegulert(client)
+                    UFØRE_KUN_NY_PESYS_PERIODE_DIFF_MED_G_OK.verifiserAutomatisk(client)
 
                     hentReguleringKjøringRequest(client).single().verifiserFullReguleringskjøring()
 
@@ -420,13 +420,6 @@ internal class ReguleringGrunnbeløpIT {
                         resultat.beskrivelse shouldBe "ÅrsakRevurdering(årsak=DIFFERANSE_MED_EKSTERNE_BELØP, diffBeløp=[Fradrag(eksisterendeBeløp=10000.00, nyttBeløp=10100.00, fradragstype=Uføretrygd, tilhører=BRUKER)])"
                     }
                 }
-                // REVURDERING_UFØRE_KUN_NY_PESYS_PERIODE_DIFF: Pesys har kun etter-periode (nyG),
-                // vårt fradrag er på gammelt G-nivå (10000). DifferanseUtenFørRegulering — mappes
-                // til DIFFERANSE_MED_EKSTERNE_BELØP med Pesys etter-beløp som nyttBeløp.
-                single { it.beskrivelse.contains("nyttBeløp=10250.00") }.let {
-                    it.utfall shouldBe Reguleringsresultat.Utfall.MÅ_REVURDERE
-                    it.beskrivelse shouldBe "ÅrsakRevurdering(årsak=DIFFERANSE_MED_EKSTERNE_BELØP, diffBeløp=[Fradrag(eksisterendeBeløp=10000.00, nyttBeløp=10250.00, fradragstype=Uføretrygd, tilhører=BRUKER)])"
-                }
                 with(single { it.beskrivelse.contains("REGULERING_ER_OVER_TOLERANSEGRENSE") }) {
                     utfall shouldBe Reguleringsresultat.Utfall.MÅ_REVURDERE
                     beskrivelse shouldBe "ÅrsakRevurdering(årsak=REGULERING_ER_OVER_TOLERANSEGRENSE, diffBeløp=[BeregningOverToleranse(eksisterendeBeløp=1479, nyttBeløp=10952, toleransegrense=1626.9)])"
@@ -648,9 +641,10 @@ object TestScenarietSaker {
      * G-nivå (10000). Klassifiseres som [Reguleringstype.MåRevurderes] med årsak
      * `DIFFERANSE_MED_EKSTERNE_BELØP` via `EksterntRegulertSammenligningResultat.DifferanseUtenFørRegulering`.
      */
-    val REVURDERING_UFØRE_KUN_NY_PESYS_PERIODE_DIFF = TestSakReguleringIT.create(
+    val UFØRE_KUN_NY_PESYS_PERIODE_DIFF_MED_G_OK = TestSakReguleringIT.create(
         fnr = Fnr("00000000020"),
         sakstype = Sakstype.UFØRE,
+        fraOgMed = mai(REGULERINGSÅR).fraOgMed,
         fradragstyper = listOf(Fradragstype.Kategori.Uføretrygd to FradragTilhører.BRUKER),
         regulertIPesys = true,
         kunEnNyPesysPeriode = true,
@@ -682,6 +676,7 @@ object TestScenarietSaker {
         ULIKE_PERIODER_FREM_I_TID,
         AUTOMATISK_UFØRE_FØRSTEGANGSINNVILGELSE_EKSTERNT,
         AUTOMATISK_UFØRE_FRADRAG_OPPDATERT_FØR_REGULERING,
+        UFØRE_KUN_NY_PESYS_PERIODE_DIFF_MED_G_OK,
     )
     val tilManuell = listOf(
         MANUELL_UFØRE,
@@ -692,7 +687,6 @@ object TestScenarietSaker {
         MÅ_REVURDERES_UFØRE,
         REVURDERING_UFØRE_MED_IEU,
         OVER_10_PRORSENT_MED_G_FRADRAG,
-        REVURDERING_UFØRE_KUN_NY_PESYS_PERIODE_DIFF,
     )
     val vilFeile = listOf(
         UFØRE_FINNES_IKKE_PESYS,

--- a/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/regulering/ReguleringGrunnbeløpIT.kt
+++ b/web-regresjonstest/src/test/kotlin/no/nav/su/se/bakover/web/regulering/ReguleringGrunnbeløpIT.kt
@@ -51,6 +51,7 @@ import no.nav.su.se.bakover.web.regulering.TestScenarietSaker.MANUELL_UFØRE_MED
 import no.nav.su.se.bakover.web.regulering.TestScenarietSaker.MÅ_REVURDERES_UFØRE
 import no.nav.su.se.bakover.web.regulering.TestScenarietSaker.OVER_10_PRORSENT_MED_G_FRADRAG
 import no.nav.su.se.bakover.web.regulering.TestScenarietSaker.OVER_10_PRORSENT_UTEN_G_FRADRAG
+import no.nav.su.se.bakover.web.regulering.TestScenarietSaker.REVURDERING_UFØRE_KUN_NY_PESYS_PERIODE_DIFF
 import no.nav.su.se.bakover.web.regulering.TestScenarietSaker.REVURDERING_UFØRE_MED_IEU
 import no.nav.su.se.bakover.web.regulering.TestScenarietSaker.UFØRE_FINNES_IKKE_PESYS
 import no.nav.su.se.bakover.web.regulering.TestScenarietSaker.UFØRE_IKKE_REGULERT_PESYS
@@ -138,6 +139,7 @@ internal class ReguleringGrunnbeløpIT {
                     ULIKE_PERIODER_FREM_I_TID.opprettSak(client, appComponents)
                     AUTOMATISK_UFØRE_FØRSTEGANGSINNVILGELSE_EKSTERNT.opprettSak(client, appComponents)
                     AUTOMATISK_UFØRE_FRADRAG_OPPDATERT_FØR_REGULERING.opprettSak(client, appComponents)
+                    REVURDERING_UFØRE_KUN_NY_PESYS_PERIODE_DIFF.opprettSak(client, appComponents)
                 }
                 applikasjonEtterNyttGrunnbeløp(dataSource, pesysStub) {
                     INNVILGET_SØKNAD_ETTER_NY_G.opprettSak(client, it)
@@ -182,6 +184,7 @@ internal class ReguleringGrunnbeløpIT {
                     ULIKE_PERIODER_FREM_I_TID.verifiserAutomatisk(client)
                     AUTOMATISK_UFØRE_FØRSTEGANGSINNVILGELSE_EKSTERNT.verifiserAutomatisk(client)
                     AUTOMATISK_UFØRE_FRADRAG_OPPDATERT_FØR_REGULERING.verifiserAutomatisk(client)
+                    REVURDERING_UFØRE_KUN_NY_PESYS_PERIODE_DIFF.verifiserBleIkkeRegulert(client)
 
                     hentReguleringKjøringRequest(client).single().verifiserFullReguleringskjøring()
 
@@ -395,16 +398,34 @@ internal class ReguleringGrunnbeløpIT {
 
             with(reguleringerManuell) {
                 size shouldBe TestScenarietSaker.tilManuell.size
-                filter { it.beskrivelse == "ManglerRegulertBeløpForFradrag" && it.utfall == Reguleringsresultat.Utfall.MANUELL }.size shouldBe 1
-                filter { it.beskrivelse == "ManglerIeuFraPesys" && it.utfall == Reguleringsresultat.Utfall.MANUELL }.size shouldBe 1
-                filter { it.beskrivelse == "EtAutomatiskFradragHarFremtidigPeriode, ManglerIeuFraPesys" && it.utfall == Reguleringsresultat.Utfall.MANUELL }.size shouldBe 1
+                filter { it.beskrivelse == ÅrsakTilManuellReguleringKategori.ManglerRegulertBeløpForFradrag.name && it.utfall == Reguleringsresultat.Utfall.MANUELL }.size shouldBe 1
+                filter { it.beskrivelse == ÅrsakTilManuellReguleringKategori.ManglerIeuFraPesys.name && it.utfall == Reguleringsresultat.Utfall.MANUELL }.size shouldBe 1
+                filter {
+                    it.beskrivelse == listOf(
+                        ÅrsakTilManuellReguleringKategori.EtAutomatiskFradragHarFremtidigPeriode,
+                        ÅrsakTilManuellReguleringKategori.ManglerIeuFraPesys,
+                    ).joinToString { kategori -> kategori.name } &&
+                        it.utfall == Reguleringsresultat.Utfall.MANUELL
+                }.size shouldBe 1
             }
 
             with(sakerMåRevurderes) {
                 size shouldBe TestScenarietSaker.tilRevurdering.size
-                filter { it.beskrivelse.contains("DIFFERANSE_MED_EKSTERNE_BELØP") }.forEach {
+                // MÅ_REVURDERES_UFØRE + REVURDERING_UFØRE_MED_IEU: vårt beløp matcher hverken
+                // Pesys-før (10100) eller -etter — DIFFERANSE_MED_EKSTERNE_BELØP.
+                filter { it.beskrivelse.contains("nyttBeløp=10100.00") }.let {
+                    it.size shouldBe 2
+                    it.forEach { resultat ->
+                        resultat.utfall shouldBe Reguleringsresultat.Utfall.MÅ_REVURDERE
+                        resultat.beskrivelse shouldBe "ÅrsakRevurdering(årsak=DIFFERANSE_MED_EKSTERNE_BELØP, diffBeløp=[Fradrag(eksisterendeBeløp=10000.00, nyttBeløp=10100.00, fradragstype=Uføretrygd, tilhører=BRUKER)])"
+                    }
+                }
+                // REVURDERING_UFØRE_KUN_NY_PESYS_PERIODE_DIFF: Pesys har kun etter-periode (nyG),
+                // vårt fradrag er på gammelt G-nivå (10000). DifferanseUtenFørRegulering — mappes
+                // til DIFFERANSE_MED_EKSTERNE_BELØP med Pesys etter-beløp som nyttBeløp.
+                single { it.beskrivelse.contains("nyttBeløp=10250.00") }.let {
                     it.utfall shouldBe Reguleringsresultat.Utfall.MÅ_REVURDERE
-                    it.beskrivelse shouldBe "ÅrsakRevurdering(årsak=DIFFERANSE_MED_EKSTERNE_BELØP, diffBeløp=[Fradrag(eksisterendeBeløp=10000.00, nyttBeløp=10100.00, fradragstype=Uføretrygd, tilhører=BRUKER)])"
+                    it.beskrivelse shouldBe "ÅrsakRevurdering(årsak=DIFFERANSE_MED_EKSTERNE_BELØP, diffBeløp=[Fradrag(eksisterendeBeløp=10000.00, nyttBeløp=10250.00, fradragstype=Uføretrygd, tilhører=BRUKER)])"
                 }
                 with(single { it.beskrivelse.contains("REGULERING_ER_OVER_TOLERANSEGRENSE") }) {
                     utfall shouldBe Reguleringsresultat.Utfall.MÅ_REVURDERE
@@ -616,8 +637,24 @@ object TestScenarietSaker {
         fnr = Fnr("00000000018"),
         sakstype = Sakstype.UFØRE,
         fradragstyper = listOf(Fradragstype.Kategori.Uføretrygd to FradragTilhører.BRUKER),
-        regulertIPesys = false,
+        regulertIPesys = true,
         kunEnNyPesysPeriode = true,
+        suFradragMatcherNyG = true,
+    )
+
+    /**
+     * Pesys har regulert (svarer med ny G = 10250), men leverer kun etter-perioden — det finnes
+     * ingen før-periode å sammenligne vårt fradrag mot. Vårt SU-fradrag er fortsatt på gammelt
+     * G-nivå (10000). Klassifiseres som [Reguleringstype.MåRevurderes] med årsak
+     * `DIFFERANSE_MED_EKSTERNE_BELØP` via `EksterntRegulertSammenligningResultat.DifferanseUtenFørRegulering`.
+     */
+    val REVURDERING_UFØRE_KUN_NY_PESYS_PERIODE_DIFF = TestSakReguleringIT.create(
+        fnr = Fnr("00000000020"),
+        sakstype = Sakstype.UFØRE,
+        fradragstyper = listOf(Fradragstype.Kategori.Uføretrygd to FradragTilhører.BRUKER),
+        regulertIPesys = true,
+        kunEnNyPesysPeriode = true,
+        suFradragMatcherNyG = false,
     )
 
     /**
@@ -655,6 +692,7 @@ object TestScenarietSaker {
         MÅ_REVURDERES_UFØRE,
         REVURDERING_UFØRE_MED_IEU,
         OVER_10_PRORSENT_MED_G_FRADRAG,
+        REVURDERING_UFØRE_KUN_NY_PESYS_PERIODE_DIFF,
     )
     val vilFeile = listOf(
         UFØRE_FINNES_IKKE_PESYS,
@@ -694,20 +732,27 @@ data class TestSakReguleringIT(
     fun uførePerioderFraPesys(): UføreBeregningsperioderPerPerson = UføreBeregningsperioderPerPerson(
         fnr = fnr.toString(),
         perioder = if (kunNyPesysPeriode) {
-            // Scenario: Pesys har kun én periode (typisk førstegangsinnvilgelse eksternt) — med ny G.
+            // Scenario: Pesys leverer kun én periode. G-en avhenger av om Pesys har regulert:
+            //  - regulertIPesys=true: periode har ny G (regulert sak hvor Pesys ikke leverer
+            //    før-perioden, eller førstegangsinnvilgelse eksternt med oppstart etter 01.05).
+            //  - regulertIPesys=false: periode har gammel G (Pesys har ikke regulert ennå).
             listOf(
                 UføreBeregningsperiode(
-                    netto = 10250,
+                    netto = if (regulertIPesys) PESYS_BELØP_ETTER_NY_G else PESYS_BELØP_FØR_GAMMEL_G,
                     fom = fraOgMedEtterRegulering,
                     tom = null,
-                    grunnbelop = GRUNNBELØP_2025,
-                    oppjustertInntektEtterUfore = if (gradertUføretrygd) 1100 else 0,
+                    grunnbelop = if (regulertIPesys) GRUNNBELØP_2025 else GRUNNBELØP_2024,
+                    oppjustertInntektEtterUfore = if (gradertUføretrygd) {
+                        if (regulertIPesys) 1100 else 1000
+                    } else {
+                        0
+                    },
                 ),
             )
         } else {
             listOf(
                 UføreBeregningsperiode(
-                    netto = if (diffMellomSuOgPesys) 10100 else 10000,
+                    netto = if (diffMellomSuOgPesys) PESYS_BELØP_FØR_GAMMEL_G_MED_DIFF else PESYS_BELØP_FØR_GAMMEL_G,
                     fom = fraOgMed,
                     tom = tilOgMedFørRegulering,
                     grunnbelop = GRUNNBELØP_2024,
@@ -727,7 +772,7 @@ data class TestSakReguleringIT(
                 if (regulertIPesys) {
                     it + listOf(
                         UføreBeregningsperiode(
-                            netto = 10250,
+                            netto = PESYS_BELØP_ETTER_NY_G,
                             fom = fraOgMedEtterRegulering,
                             tom = null,
                             grunnbelop = GRUNNBELØP_2025,
@@ -753,13 +798,13 @@ data class TestSakReguleringIT(
         fnr = fnr.toString(),
         perioder = listOf(
             AlderBeregningsperiode(
-                netto = if (overToleranseGrense) 18000 else 10000,
+                netto = if (overToleranseGrense) 18000 else PESYS_BELØP_FØR_GAMMEL_G,
                 fom = fraOgMed,
                 tom = tilOgMedFørRegulering,
                 grunnbelop = GRUNNBELØP_2024,
             ),
             AlderBeregningsperiode(
-                netto = if (overToleranseGrense) 9250 else 10250,
+                netto = if (overToleranseGrense) 9250 else PESYS_BELØP_ETTER_NY_G,
                 fom = fraOgMedEtterRegulering,
                 tom = null,
                 grunnbelop = GRUNNBELØP_2025,
@@ -768,6 +813,22 @@ data class TestSakReguleringIT(
     )
 
     companion object {
+        /**
+         * Standardbeløpene som brukes av testscenariene.
+         *
+         * - `SU_BELØP_GAMMEL_G` / `SU_BELØP_NY_G`: beløpet vi har registrert som fradrag hos oss.
+         * - `PESYS_BELØP_FØR_GAMMEL_G` / `PESYS_BELØP_FØR_GAMMEL_G_MED_DIFF` / `PESYS_BELØP_ETTER_NY_G`: beløpene Pesys
+         *   leverer i før- og etter-periode for et regulert vedtak.
+         *
+         * Hold disse synkroniserte med assertions i [ReguleringGrunnbeløpIT]; flere assertions
+         * sammenligner mot formatert tekst som inneholder disse beløpene.
+         */
+        const val SU_BELØP_GAMMEL_G = 10000
+        const val SU_BELØP_NY_G = 10250
+        const val PESYS_BELØP_FØR_GAMMEL_G = 10000
+        const val PESYS_BELØP_FØR_GAMMEL_G_MED_DIFF = 10100
+        const val PESYS_BELØP_ETTER_NY_G = 10250
+
         /**
          * NB: `fraOgMedEtterRegulering` MÅ starte dagen etter `tilOgMedFørRegulering` eller senere.
          * Pesys leverer aldri overlappende perioder for samme bruker, og hvis stubben gjør det vil
@@ -810,7 +871,7 @@ data class TestSakReguleringIT(
                         utland,
                         fraOgMed,
                         tilOgMed,
-                        brukerbeløpOverride = if (suFradragMatcherNyG || kunEnNyPesysPeriode) 10250.0 else null,
+                        brukerbeløpOverride = if (suFradragMatcherNyG) 10250.0 else null,
                     )
                 },
                 innvilgetIPesys = innvilgetIPesys,


### PR DESCRIPTION
…ulert.
Dette dekker sakene 8927, 8950, 9149, 9034 (BRUKER) — hvor Pesys kun returnerer fom 2026-05-01 med nyG, men vårt fradrag fortsatt er på gammel-G-beløp. De går fortsatt til revurdering, men kan nå telles/skilles fra ekte differanser.