### PR TITLE
Fiks ny pod spawn på ny deploy pga cpu arbeid ved deploy

### DIFF
--- a/.nais/prod-gcp.yaml
+++ b/.nais/prod-gcp.yaml
@@ -133,6 +133,7 @@ spec:
     min: 1
     max: 2
     scalingStrategy:
+      scaleUpStabilizationWindowSeconds: 90
       cpu:
         thresholdPercentage: 85
   resources:


### PR DESCRIPTION
Ved deploy av ny versjon spiker cpu og av og til når den treshold på 85% cpu og nypod statert og avbryter eventuelle kjøringer som er lange. seetter 90 sekunder som startvindu i første omgang for cpu spike se https://docs.nais.io/workloads/application/reference/application-spec/