### PR TITLE
Regoppslag tilgjengelig for å sjekke adresse på mottaker

### DIFF
--- a/.nais/dev-gcp.yaml
+++ b/.nais/dev-gcp.yaml
@@ -227,4 +227,4 @@ spec:
     - name: REGOPPSLAG_URL
       value: "https://regoppslag.dev-fss-pub.nais.io"
     - name: REGOPPSLAG_SCOPE
-      value: "api://dev-fss.teamdokumenthandtering.regoppslag/.default"
+      value: "api://dev-fss.teamdokumenthandtering.regoppslag"

--- a/.nais/dev-gcp.yaml
+++ b/.nais/dev-gcp.yaml
@@ -108,6 +108,7 @@ spec:
         - host: dokdistfordeling.dev-fss-pub.nais.io
         - host: dokarkiv-q2.dev-fss-pub.nais.io
         - host: oppgave.dev-fss-pub.nais.io
+        - host: regoppslag.dev-fss-pub.nais.io
         - host: b27apvl220.preprod.local
           ports:
             - port: 1413
@@ -223,3 +224,7 @@ spec:
       value: "https://kodeverk-api.nav.no"
     - name: KODEVERK_CLIENT_ID
       value: "api://dev-gcp.team-rocket.kodeverk-api"
+    - name: REGOPPSLAG_URL
+      value: "https://regoppslag.dev-fss-pub.nais.io"
+    - name: REGOPPSLAG_SCOPE
+      value: "api://dev-fss.teamdokumenthandtering.regoppslag/.default"

--- a/.nais/prod-gcp.yaml
+++ b/.nais/prod-gcp.yaml
@@ -116,6 +116,7 @@ spec:
         - host: sigrun.prod-fss-pub.nais.io
         - host: kodeverk-api.nav.no
         - host: dokarkiv.prod-fss-pub.nais.io
+        - host: regoppslag.prod-fss-pub.nais.io
         - host: mpls02.adeo.no
           ports:
             - port: 1414
@@ -237,3 +238,7 @@ spec:
       value: "https://kodeverk-api.nav.no"
     - name: KODEVERK_CLIENT_ID
       value: "api://prod-gcp.team-rocket.kodeverk-api"
+    - name: REGOPPSLAG_URL
+      value: "https://regoppslag.prod-fss-pub.nais.io"
+    - name: REGOPPSLAG_SCOPE
+      value: "api://prod-fss.teamdokumenthandtering.regoppslag/.default"

--- a/.nais/prod-gcp.yaml
+++ b/.nais/prod-gcp.yaml
@@ -241,4 +241,4 @@ spec:
     - name: REGOPPSLAG_URL
       value: "https://regoppslag.prod-fss-pub.nais.io"
     - name: REGOPPSLAG_SCOPE
-      value: "api://prod-fss.teamdokumenthandtering.regoppslag/.default"
+      value: "api://prod-fss.teamdokumenthandtering.regoppslag"

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/ClientsBuilder.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/ClientsBuilder.kt
@@ -9,6 +9,7 @@ import no.nav.su.se.bakover.client.kodeverk.Kodeverk
 import no.nav.su.se.bakover.client.krr.KontaktOgReservasjonsregister
 import no.nav.su.se.bakover.client.pesys.PesysClient
 import no.nav.su.se.bakover.client.proxy.SUProxyClient
+import no.nav.su.se.bakover.client.regoppslag.RegoppslagKlient
 import no.nav.su.se.bakover.common.auth.AzureAd
 import no.nav.su.se.bakover.common.domain.kafka.KafkaPublisher
 import no.nav.su.se.bakover.common.infrastructure.config.ApplicationConfig
@@ -52,6 +53,7 @@ data class Clients(
     val pesysklient: PesysClient,
     val aapApiInternClient: AapApiInternClient,
     val suProxyClient: SUProxyClient,
+    val regoppslagKlient: RegoppslagKlient,
 )
 
 /**

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/ProdClientsBuilder.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/ProdClientsBuilder.kt
@@ -1,5 +1,6 @@
 package no.nav.su.se.bakover.client
 
+import io.ktor.client.HttpClient
 import no.nav.su.se.bakover.client.aap.AapApiInternHttpClient
 import no.nav.su.se.bakover.client.azure.AzureClient
 import no.nav.su.se.bakover.client.journalfør.skatt.påsak.JournalførSkattedokumentPåSakHttpClient
@@ -23,6 +24,7 @@ import no.nav.su.se.bakover.client.person.PersonClient
 import no.nav.su.se.bakover.client.person.PersonClientConfig
 import no.nav.su.se.bakover.client.pesys.PesysHttpClient
 import no.nav.su.se.bakover.client.proxy.SUProxyClientImpl
+import no.nav.su.se.bakover.client.regoppslag.RegoppslagKlientImpl
 import no.nav.su.se.bakover.client.skjerming.SkjermingClient
 import no.nav.su.se.bakover.common.SU_SE_BAKOVER_CONSUMER_ID
 import no.nav.su.se.bakover.common.auth.AzureAd
@@ -98,6 +100,12 @@ data class ProdClientsBuilder(
             azureAd = azureAd,
             suMetrics = suMetrics,
             clock = clock,
+        )
+        val httpClient = HttpClient()
+        val regoppslagKlient = RegoppslagKlientImpl(
+            httpClient = httpClient,
+            url = clientsConfig.regoppslagConfig.url,
+            suMetrics = suMetrics,
         )
 
         return Clients(
@@ -176,6 +184,7 @@ data class ProdClientsBuilder(
                 clientId = applicationConfig.clientsConfig.aapApiInternConfig.clientId,
             ),
             suProxyClient = SUProxyClientImpl(applicationConfig.clientsConfig.suProxyConfig, azure = azureAd),
+            regoppslagKlient = regoppslagKlient,
         )
     }
 }

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/ProdClientsBuilder.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/ProdClientsBuilder.kt
@@ -1,6 +1,4 @@
 package no.nav.su.se.bakover.client
-
-import io.ktor.client.HttpClient
 import no.nav.su.se.bakover.client.aap.AapApiInternHttpClient
 import no.nav.su.se.bakover.client.azure.AzureClient
 import no.nav.su.se.bakover.client.journalfør.skatt.påsak.JournalførSkattedokumentPåSakHttpClient
@@ -101,10 +99,10 @@ data class ProdClientsBuilder(
             suMetrics = suMetrics,
             clock = clock,
         )
-        val httpClient = HttpClient()
         val regoppslagKlient = RegoppslagKlientImpl(
-            httpClient = httpClient,
+            azureAd = azureAd,
             url = clientsConfig.regoppslagConfig.url,
+            scope = clientsConfig.regoppslagConfig.scope,
             suMetrics = suMetrics,
         )
 

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/StubClientsBuilder.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/StubClientsBuilder.kt
@@ -22,6 +22,7 @@ import no.nav.su.se.bakover.client.stubs.oppgave.OppgaveV2ClientStub
 import no.nav.su.se.bakover.client.stubs.pdf.PdfGeneratorStub
 import no.nav.su.se.bakover.client.stubs.person.IdentClientStub
 import no.nav.su.se.bakover.client.stubs.person.PersonOppslagStub
+import no.nav.su.se.bakover.client.stubs.regoppslag.RegoppslagKlientStub
 import no.nav.su.se.bakover.common.domain.kafka.KafkaPublisher
 import no.nav.su.se.bakover.common.infrastructure.config.ApplicationConfig
 import no.nav.su.se.bakover.common.infrastructure.metrics.SuMetrics
@@ -104,6 +105,7 @@ class StubClientsBuilder(
             suProxyClient = SuProxyClientStub(),
             pesysklient = PesysclientStub(),
             aapApiInternClient = AapApiInternClientStub(),
+            regoppslagKlient = RegoppslagKlientStub.also { log.warn("********** Using stub for ${RegoppslagKlientStub::class.java} **********") },
         )
     }
 }

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/regoppslag/RegoppslagKlient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/regoppslag/RegoppslagKlient.kt
@@ -14,6 +14,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import no.nav.su.se.bakover.client.cache.newCache
+import no.nav.su.se.bakover.client.person.Behandlingsnummer
 import no.nav.su.se.bakover.common.auth.AzureAd
 import no.nav.su.se.bakover.common.deserialize
 import no.nav.su.se.bakover.common.domain.kodeverk.Tema
@@ -109,6 +110,7 @@ internal class RegoppslagKlientImpl(
                 val (_, response, result) = "$url/rest/postadresse"
                     .httpPost()
                     .authentication().bearer(azureAd.onBehalfOfToken(brukerToken.value, scope))
+                    .header("behandlingsnummer", Behandlingsnummer.fraSakstype(sakType).value)
                     .header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                     .header(HttpHeaders.Accept, ContentType.Application.Json.toString())
                     .body(serialize(RegoppslagRequest(ident.toString(), Tema.SUPPLERENDE_STØNAD.value)))

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/regoppslag/RegoppslagKlient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/regoppslag/RegoppslagKlient.kt
@@ -1,0 +1,129 @@
+package no.nav.su.se.bakover.client.regoppslag
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.github.benmanes.caffeine.cache.Cache
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.ResponseException
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import no.nav.su.se.bakover.client.cache.newCache
+import no.nav.su.se.bakover.common.domain.kodeverk.Tema
+import no.nav.su.se.bakover.common.domain.sak.Sakstype
+import no.nav.su.se.bakover.common.infrastructure.metrics.SuMetrics
+import no.nav.su.se.bakover.common.person.Fnr
+import org.slf4j.LoggerFactory
+import java.time.Duration
+
+data class RegoppslagRequest(
+    val ident: String,
+    val tema: String,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class RegoppslagResponseDTO(
+    val navn: String,
+    val adresse: Adresse,
+) {
+    data class Adresse(
+        val type: AdresseType,
+        val adresseKilde: AdresseKilde?,
+        val adresselinje1: String?,
+        val adresselinje2: String?,
+        val adresselinje3: String?,
+        val postnummer: String?,
+        val poststed: String?,
+        val landkode: String,
+        val land: String,
+    )
+
+    enum class AdresseType {
+        NORSKPOSTADRESSE,
+        UTENLANDSKPOSTADRESSE,
+    }
+
+    enum class AdresseKilde {
+        BOSTEDSADRESSE,
+        OPPHOLDSADRESSE,
+        KONTAKTADRESSE,
+        DELTBOSTED,
+        KONTAKTINFORMASJONFORDØDSBO,
+        ENHETPOSTADRESSE,
+        ENHETFORRETNINGSADRESSE,
+    }
+}
+
+sealed class RegoppslagFeil {
+    data object IkkeFunnet : RegoppslagFeil()
+    data object PersonErDød : RegoppslagFeil()
+    data class UkjentFeil(val statusCode: Int, val detail: String) : RegoppslagFeil()
+}
+
+interface RegoppslagKlient {
+    suspend fun hentMottakerAdresse(
+        sakType: Sakstype,
+        ident: Fnr,
+    ): Either<RegoppslagFeil, RegoppslagResponseDTO>
+}
+
+internal class RegoppslagKlientImpl(
+    private val httpClient: HttpClient,
+    private val url: String,
+    suMetrics: SuMetrics,
+    private val cache: Cache<String, RegoppslagResponseDTO> = newCache(
+        cacheName = "regoppslag",
+        expireAfterWrite = Duration.ofMinutes(15),
+        suMetrics = suMetrics,
+    ),
+) : RegoppslagKlient {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    override suspend fun hentMottakerAdresse(
+        sakType: Sakstype,
+        ident: Fnr,
+    ): Either<RegoppslagFeil, RegoppslagResponseDTO> =
+        try {
+            val cacheKey = ident.toString()
+            val regoppslagCache = cache.getIfPresent(cacheKey)
+
+            if (regoppslagCache != null) {
+                logger.info("Fant cachet mottakeradresse for ident=$cacheKey")
+                regoppslagCache.right()
+            } else {
+                logger.info("Ingen cachet mottakeradresse funnet for ident=$cacheKey. Henter fra regoppslag")
+
+                httpClient.post("$url/rest/postadresse") {
+                    contentType(ContentType.Application.Json)
+                    setBody(RegoppslagRequest(ident.toString(), Tema.SUPPLERENDE_STØNAD.value))
+                }.body<RegoppslagResponseDTO>()
+                    .also {
+                        cache.put(cacheKey, it)
+                    }
+                    .right()
+            }
+        } catch (re: ResponseException) {
+            when (re.response.status) {
+                HttpStatusCode.NotFound -> {
+                    logger.info("Bruker har ukjent adresse for ident=$ident")
+                    RegoppslagFeil.IkkeFunnet.left()
+                }
+                HttpStatusCode.Gone -> {
+                    logger.warn("Person er død og har ukjent adresse for ident=$ident: ${re.response.status}")
+                    RegoppslagFeil.PersonErDød.left()
+                }
+                else -> {
+                    logger.error("Uhåndtert feil fra regoppslag for ident=$ident: ${re.response.status}")
+                    RegoppslagFeil.UkjentFeil(re.response.status.value, "Ukjent feil oppsto ved uthenting av mottakers adresse fra regoppslag").left()
+                }
+            }
+        } catch (e: Exception) {
+            logger.error("Uhåndtert exception fra regoppslag for ident=$ident", e)
+            RegoppslagFeil.UkjentFeil(500, "Ukjent feil oppsto ved uthenting av mottakers adresse fra regoppslag").left()
+        }
+}

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/regoppslag/RegoppslagKlient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/regoppslag/RegoppslagKlient.kt
@@ -5,19 +5,23 @@ import arrow.core.left
 import arrow.core.right
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.github.benmanes.caffeine.cache.Cache
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.plugins.ResponseException
-import io.ktor.client.request.post
-import io.ktor.client.request.setBody
+import com.github.kittinunf.fuel.core.Response
+import com.github.kittinunf.fuel.core.extensions.authentication
+import com.github.kittinunf.fuel.core.isServerError
+import com.github.kittinunf.fuel.core.isSuccessful
+import com.github.kittinunf.fuel.httpPost
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.contentType
 import no.nav.su.se.bakover.client.cache.newCache
+import no.nav.su.se.bakover.common.auth.AzureAd
+import no.nav.su.se.bakover.common.deserialize
 import no.nav.su.se.bakover.common.domain.kodeverk.Tema
 import no.nav.su.se.bakover.common.domain.sak.Sakstype
 import no.nav.su.se.bakover.common.infrastructure.metrics.SuMetrics
+import no.nav.su.se.bakover.common.infrastructure.token.JwtToken
 import no.nav.su.se.bakover.common.person.Fnr
+import no.nav.su.se.bakover.common.serialize
 import org.slf4j.LoggerFactory
 import java.time.Duration
 
@@ -73,8 +77,12 @@ interface RegoppslagKlient {
 }
 
 internal class RegoppslagKlientImpl(
-    private val httpClient: HttpClient,
+    private val azureAd: AzureAd,
     private val url: String,
+    private val scope: String,
+    private val hentBrukerToken: () -> JwtToken.BrukerToken = {
+        JwtToken.BrukerToken.fraCoroutineContext()
+    },
     suMetrics: SuMetrics,
     private val cache: Cache<String, RegoppslagResponseDTO> = newCache(
         cacheName = "regoppslag",
@@ -97,33 +105,79 @@ internal class RegoppslagKlientImpl(
                 regoppslagCache.right()
             } else {
                 logger.info("Ingen cachet mottakeradresse funnet for ident=$cacheKey. Henter fra regoppslag")
+                val brukerToken = hentBrukerToken()
+                val (_, response, result) = "$url/rest/postadresse"
+                    .httpPost()
+                    .authentication().bearer(azureAd.onBehalfOfToken(brukerToken.value, scope))
+                    .header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    .header(HttpHeaders.Accept, ContentType.Application.Json.toString())
+                    .body(serialize(RegoppslagRequest(ident.toString(), Tema.SUPPLERENDE_STØNAD.value)))
+                    .responseString()
 
-                httpClient.post("$url/rest/postadresse") {
-                    contentType(ContentType.Application.Json)
-                    setBody(RegoppslagRequest(ident.toString(), Tema.SUPPLERENDE_STØNAD.value))
-                }.body<RegoppslagResponseDTO>()
-                    .also {
-                        cache.put(cacheKey, it)
-                    }
-                    .right()
-            }
-        } catch (re: ResponseException) {
-            when (re.response.status) {
-                HttpStatusCode.NotFound -> {
-                    logger.info("Bruker har ukjent adresse for ident=$ident")
-                    RegoppslagFeil.IkkeFunnet.left()
-                }
-                HttpStatusCode.Gone -> {
-                    logger.warn("Person er død og har ukjent adresse for ident=$ident: ${re.response.status}")
-                    RegoppslagFeil.PersonErDød.left()
-                }
-                else -> {
-                    logger.error("Uhåndtert feil fra regoppslag for ident=$ident: ${re.response.status}")
-                    RegoppslagFeil.UkjentFeil(re.response.status.value, "Ukjent feil oppsto ved uthenting av mottakers adresse fra regoppslag").left()
+                håndterSvar(ident, response, result.fold({ it.right() }, { it.left() })).also {
+                    it.map { adresse -> cache.put(cacheKey, adresse) }
                 }
             }
         } catch (e: Exception) {
             logger.error("Uhåndtert exception fra regoppslag for ident=$ident", e)
             RegoppslagFeil.UkjentFeil(500, "Ukjent feil oppsto ved uthenting av mottakers adresse fra regoppslag").left()
         }
+
+    private fun håndterSvar(
+        ident: Fnr,
+        response: Response,
+        result: Either<Exception, String>,
+    ): Either<RegoppslagFeil, RegoppslagResponseDTO> {
+        return result.fold(
+            ifLeft = { error ->
+                when {
+                    response.statusCode == HttpStatusCode.NotFound.value -> {
+                        logger.info("Bruker har ukjent adresse for ident=$ident")
+                        RegoppslagFeil.IkkeFunnet.left()
+                    }
+
+                    response.statusCode == HttpStatusCode.Gone.value -> {
+                        logger.warn("Person er død og har ukjent adresse for ident=$ident: ${response.statusCode}")
+                        RegoppslagFeil.PersonErDød.left()
+                    }
+
+                    response.statusCode == HttpStatusCode.Unauthorized.value || response.isServerError -> {
+                        logger.error("Feil fra regoppslag for ident=$ident: ${response.statusCode}", error)
+                        RegoppslagFeil.UkjentFeil(
+                            response.statusCode,
+                            "Ukjent feil oppsto ved uthenting av mottakers adresse fra regoppslag",
+                        ).left()
+                    }
+
+                    else -> {
+                        logger.error("Uhåndtert feil fra regoppslag for ident=$ident: ${response.statusCode}", error)
+                        RegoppslagFeil.UkjentFeil(
+                            response.statusCode,
+                            "Ukjent feil oppsto ved uthenting av mottakers adresse fra regoppslag",
+                        ).left()
+                    }
+                }
+            },
+            ifRight = { body ->
+                if (!response.isSuccessful) {
+                    logger.error("Uhåndtert feil fra regoppslag for ident=$ident: ${response.statusCode}, body=$body")
+                    RegoppslagFeil.UkjentFeil(
+                        response.statusCode,
+                        "Ukjent feil oppsto ved uthenting av mottakers adresse fra regoppslag",
+                    ).left()
+                } else {
+                    Either.catch { deserialize<RegoppslagResponseDTO>(body) }.fold(
+                        ifLeft = {
+                            logger.error("Kunne ikke deserialisere respons fra regoppslag for ident=$ident", it)
+                            RegoppslagFeil.UkjentFeil(
+                                HttpStatusCode.InternalServerError.value,
+                                "Ukjent feil oppsto ved uthenting av mottakers adresse fra regoppslag",
+                            ).left()
+                        },
+                        ifRight = { it.right() },
+                    )
+                }
+            },
+        )
+    }
 }

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/regoppslag/RegoppslagKlient.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/regoppslag/RegoppslagKlient.kt
@@ -102,10 +102,10 @@ internal class RegoppslagKlientImpl(
             val regoppslagCache = cache.getIfPresent(cacheKey)
 
             if (regoppslagCache != null) {
-                logger.info("Fant cachet mottakeradresse for ident=$cacheKey")
+                logger.info("Fant cachet mottakeradresse")
                 regoppslagCache.right()
             } else {
-                logger.info("Ingen cachet mottakeradresse funnet for ident=$cacheKey. Henter fra regoppslag")
+                logger.info("Ingen cachet mottakeradresse funnet. Henter fra regoppslag")
                 val brukerToken = hentBrukerToken()
                 val (_, response, result) = "$url/rest/postadresse"
                     .httpPost()
@@ -116,17 +116,16 @@ internal class RegoppslagKlientImpl(
                     .body(serialize(RegoppslagRequest(ident.toString(), Tema.SUPPLERENDE_STØNAD.value)))
                     .responseString()
 
-                håndterSvar(ident, response, result.fold({ it.right() }, { it.left() })).also {
+                håndterSvar(response, result.fold({ it.right() }, { it.left() })).also {
                     it.map { adresse -> cache.put(cacheKey, adresse) }
                 }
             }
         } catch (e: Exception) {
-            logger.error("Uhåndtert exception fra regoppslag for ident=$ident", e)
+            logger.error("Uhåndtert exception fra regoppslag ", e)
             RegoppslagFeil.UkjentFeil(500, "Ukjent feil oppsto ved uthenting av mottakers adresse fra regoppslag").left()
         }
 
     private fun håndterSvar(
-        ident: Fnr,
         response: Response,
         result: Either<Exception, String>,
     ): Either<RegoppslagFeil, RegoppslagResponseDTO> {
@@ -134,17 +133,17 @@ internal class RegoppslagKlientImpl(
             ifLeft = { error ->
                 when {
                     response.statusCode == HttpStatusCode.NotFound.value -> {
-                        logger.info("Bruker har ukjent adresse for ident=$ident")
+                        logger.info("Bruker har ukjent adresse ")
                         RegoppslagFeil.IkkeFunnet.left()
                     }
 
                     response.statusCode == HttpStatusCode.Gone.value -> {
-                        logger.warn("Person er død og har ukjent adresse for ident=$ident: ${response.statusCode}")
+                        logger.warn("Person er død og har ukjent adresse: ${response.statusCode}")
                         RegoppslagFeil.PersonErDød.left()
                     }
 
                     response.statusCode == HttpStatusCode.Unauthorized.value || response.isServerError -> {
-                        logger.error("Feil fra regoppslag for ident=$ident: ${response.statusCode}", error)
+                        logger.error("Feil fra regoppslag : ${response.statusCode}", error)
                         RegoppslagFeil.UkjentFeil(
                             response.statusCode,
                             "Ukjent feil oppsto ved uthenting av mottakers adresse fra regoppslag",
@@ -152,7 +151,7 @@ internal class RegoppslagKlientImpl(
                     }
 
                     else -> {
-                        logger.error("Uhåndtert feil fra regoppslag for ident=$ident: ${response.statusCode}", error)
+                        logger.error("Uhåndtert feil fra regoppslag : ${response.statusCode}", error)
                         RegoppslagFeil.UkjentFeil(
                             response.statusCode,
                             "Ukjent feil oppsto ved uthenting av mottakers adresse fra regoppslag",
@@ -162,7 +161,7 @@ internal class RegoppslagKlientImpl(
             },
             ifRight = { body ->
                 if (!response.isSuccessful) {
-                    logger.error("Uhåndtert feil fra regoppslag for ident=$ident: ${response.statusCode}, body=$body")
+                    logger.error("Uhåndtert feil fra regoppslag : ${response.statusCode}, body=$body")
                     RegoppslagFeil.UkjentFeil(
                         response.statusCode,
                         "Ukjent feil oppsto ved uthenting av mottakers adresse fra regoppslag",
@@ -170,7 +169,7 @@ internal class RegoppslagKlientImpl(
                 } else {
                     Either.catch { deserialize<RegoppslagResponseDTO>(body) }.fold(
                         ifLeft = {
-                            logger.error("Kunne ikke deserialisere respons fra regoppslag for ident=$ident", it)
+                            logger.error("Kunne ikke deserialisere respons fra regoppslag ", it)
                             RegoppslagFeil.UkjentFeil(
                                 HttpStatusCode.InternalServerError.value,
                                 "Ukjent feil oppsto ved uthenting av mottakers adresse fra regoppslag",

--- a/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/regoppslag/RegoppslagKlientStub.kt
+++ b/client/src/main/kotlin/no/nav/su/se/bakover/client/stubs/regoppslag/RegoppslagKlientStub.kt
@@ -1,0 +1,27 @@
+package no.nav.su.se.bakover.client.stubs.regoppslag
+
+import arrow.core.right
+import no.nav.su.se.bakover.client.regoppslag.RegoppslagKlient
+import no.nav.su.se.bakover.client.regoppslag.RegoppslagResponseDTO
+import no.nav.su.se.bakover.common.domain.sak.Sakstype
+import no.nav.su.se.bakover.common.person.Fnr
+
+object RegoppslagKlientStub : RegoppslagKlient {
+    override suspend fun hentMottakerAdresse(
+        sakType: Sakstype,
+        ident: Fnr,
+    ) = RegoppslagResponseDTO(
+        navn = "Stub Person",
+        adresse = RegoppslagResponseDTO.Adresse(
+            type = RegoppslagResponseDTO.AdresseType.NORSKPOSTADRESSE,
+            adresseKilde = RegoppslagResponseDTO.AdresseKilde.BOSTEDSADRESSE,
+            adresselinje1 = "Storgata 1",
+            adresselinje2 = null,
+            adresselinje3 = null,
+            postnummer = "0150",
+            poststed = "Oslo",
+            landkode = "NO",
+            land = "Norge",
+        ),
+    ).right()
+}

--- a/common/infrastructure/src/main/kotlin/no/nav/su/se/bakover/common/infrastructure/config/ApplicationConfig.kt
+++ b/common/infrastructure/src/main/kotlin/no/nav/su/se/bakover/common/infrastructure/config/ApplicationConfig.kt
@@ -209,6 +209,7 @@ data class ApplicationConfig(
         val pesysConfig: PesysConfig,
         val aapApiInternConfig: AapApiInternConfig,
         val suProxyConfig: SuProxyConfig,
+        val regoppslagConfig: RegoppslagConfig,
     ) {
         companion object {
             fun createFromEnvironmentVariables() = ClientsConfig(
@@ -226,6 +227,7 @@ data class ApplicationConfig(
                 suProxyConfig = SuProxyConfig.createFromEnvironmentVariables(),
                 pesysConfig = PesysConfig.createFromEnvironmentVariables(),
                 aapApiInternConfig = AapApiInternConfig.createFromEnvironmentVariables(),
+                regoppslagConfig = RegoppslagConfig.createFromEnvironmentVariables(),
             )
 
             fun createLocalConfig() = ClientsConfig(
@@ -243,6 +245,7 @@ data class ApplicationConfig(
                 pesysConfig = PesysConfig.createLocalConfig(),
                 aapApiInternConfig = AapApiInternConfig.createLocalConfig(),
                 suProxyConfig = SuProxyConfig.createLocalConfig(),
+                regoppslagConfig = RegoppslagConfig.createLocalConfig(),
             )
         }
 
@@ -478,6 +481,23 @@ data class ApplicationConfig(
                 fun createLocalConfig() = DokArkivConfig(
                     url = "mocked",
                     clientId = "mocked",
+                )
+            }
+        }
+
+        data class RegoppslagConfig(
+            val url: String,
+            val scope: String,
+        ) {
+            companion object {
+                fun createFromEnvironmentVariables() = RegoppslagConfig(
+                    url = getEnvironmentVariableOrThrow("REGOPPSLAG_URL"),
+                    scope = getEnvironmentVariableOrThrow("REGOPPSLAG_SCOPE"),
+                )
+
+                fun createLocalConfig() = RegoppslagConfig(
+                    url = "mocked",
+                    scope = "mocked",
                 )
             }
         }

--- a/common/infrastructure/src/test/kotlin/no/nav/su/se/bakover/common/infrastructure/config/ApplicationConfigTest.kt
+++ b/common/infrastructure/src/test/kotlin/no/nav/su/se/bakover/common/infrastructure/config/ApplicationConfigTest.kt
@@ -125,7 +125,10 @@ class ApplicationConfigTest {
             suProxyConfig = ApplicationConfig.ClientsConfig.SuProxyConfig.createLocalConfig(),
             pesysConfig = ApplicationConfig.ClientsConfig.PesysConfig.createLocalConfig(),
             aapApiInternConfig = ApplicationConfig.ClientsConfig.AapApiInternConfig.createLocalConfig(),
-            regoppslagConfig = ApplicationConfig.ClientsConfig.RegoppslagConfig.createLocalConfig(),
+            regoppslagConfig = ApplicationConfig.ClientsConfig.RegoppslagConfig(
+                url = "regoppslagUrl",
+                scope = "regoppslagScope",
+            ),
         ),
         kafkaConfig = ApplicationConfig.KafkaConfig(
             producerCfg = ApplicationConfig.KafkaConfig.ProducerCfg(
@@ -214,6 +217,8 @@ class ApplicationConfigTest {
                 "PESYS_CLIENT_ID" to "PESYS_CLIENT_ID",
                 "AAP_API_INTERN_URL" to "AAP_API_INTERN_URL",
                 "AAP_API_INTERN_CLIENT_ID" to "AAP_API_INTERN_CLIENT_ID",
+                "REGOPPSLAG_URL" to "regoppslagUrl",
+                "REGOPPSLAG_SCOPE" to "regoppslagScope",
                 "SUPSTONAD_PROXY_URL" to "SUPSTONAD_PROXY_URL",
                 "SUPSTONAD_PROXY_CLIENT_ID" to "SUPSTONAD_PROXY_CLIENT_ID",
                 "serviceuser" to "username", // Disse ligger i en google secret

--- a/common/infrastructure/src/test/kotlin/no/nav/su/se/bakover/common/infrastructure/config/ApplicationConfigTest.kt
+++ b/common/infrastructure/src/test/kotlin/no/nav/su/se/bakover/common/infrastructure/config/ApplicationConfigTest.kt
@@ -125,6 +125,7 @@ class ApplicationConfigTest {
             suProxyConfig = ApplicationConfig.ClientsConfig.SuProxyConfig.createLocalConfig(),
             pesysConfig = ApplicationConfig.ClientsConfig.PesysConfig.createLocalConfig(),
             aapApiInternConfig = ApplicationConfig.ClientsConfig.AapApiInternConfig.createLocalConfig(),
+            regoppslagConfig = ApplicationConfig.ClientsConfig.RegoppslagConfig.createLocalConfig(),
         ),
         kafkaConfig = ApplicationConfig.KafkaConfig(
             producerCfg = ApplicationConfig.KafkaConfig.ProducerCfg(
@@ -315,6 +316,7 @@ class ApplicationConfigTest {
                     suProxyConfig = ApplicationConfig.ClientsConfig.SuProxyConfig.createLocalConfig(),
                     pesysConfig = ApplicationConfig.ClientsConfig.PesysConfig.createLocalConfig(),
                     aapApiInternConfig = ApplicationConfig.ClientsConfig.AapApiInternConfig.createLocalConfig(),
+                    regoppslagConfig = ApplicationConfig.ClientsConfig.RegoppslagConfig.createLocalConfig(),
                 ),
                 kafkaConfig = ApplicationConfig.KafkaConfig(
                     producerCfg = ApplicationConfig.KafkaConfig.ProducerCfg((emptyMap())),

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/regoppslag/RegoppslagService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/regoppslag/RegoppslagService.kt
@@ -1,0 +1,19 @@
+package no.nav.su.se.bakover.service.regoppslag
+
+import arrow.core.Either
+import no.nav.su.se.bakover.client.regoppslag.RegoppslagFeil
+import no.nav.su.se.bakover.client.regoppslag.RegoppslagKlient
+import no.nav.su.se.bakover.client.regoppslag.RegoppslagResponseDTO
+import no.nav.su.se.bakover.common.domain.sak.Sakstype
+import no.nav.su.se.bakover.common.person.Fnr
+
+class RegoppslagService(
+    private val regoppslagKlient: RegoppslagKlient,
+) {
+    suspend fun hentMottakerAdresse(
+        sakType: Sakstype,
+        ident: Fnr,
+    ): Either<RegoppslagFeil, RegoppslagResponseDTO> {
+        return regoppslagKlient.hentMottakerAdresse(sakType, ident)
+    }
+}

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/regoppslag/RegoppslagService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/regoppslag/RegoppslagService.kt
@@ -1,26 +1,32 @@
 package no.nav.su.se.bakover.service.regoppslag
 
 import arrow.core.Either
+import arrow.core.getOrElse
 import no.nav.su.se.bakover.client.regoppslag.RegoppslagFeil
 import no.nav.su.se.bakover.client.regoppslag.RegoppslagKlient
 import no.nav.su.se.bakover.client.regoppslag.RegoppslagResponseDTO
-import no.nav.su.se.bakover.common.domain.sak.Sakstype
 import no.nav.su.se.bakover.common.person.Fnr
+import no.nav.su.se.bakover.domain.sak.SakService
+import java.util.UUID
 
 interface RegoppslagServiceInterface {
     suspend fun hentMottakerAdresse(
-        sakType: Sakstype,
+        sakId: UUID,
         ident: Fnr,
     ): Either<RegoppslagFeil, RegoppslagResponseDTO>
 }
 
 class RegoppslagService(
     private val regoppslagKlient: RegoppslagKlient,
+    private val sakService: SakService,
 ) : RegoppslagServiceInterface {
     override suspend fun hentMottakerAdresse(
-        sakType: Sakstype,
+        sakId: UUID,
         ident: Fnr,
     ): Either<RegoppslagFeil, RegoppslagResponseDTO> {
-        return regoppslagKlient.hentMottakerAdresse(sakType, ident)
+        val sak = sakService.hentSakInfo(sakId = sakId).getOrElse {
+            return Either.Left(RegoppslagFeil.IkkeFunnet)
+        }
+        return regoppslagKlient.hentMottakerAdresse(sak.type, ident)
     }
 }

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/regoppslag/RegoppslagService.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/regoppslag/RegoppslagService.kt
@@ -7,10 +7,17 @@ import no.nav.su.se.bakover.client.regoppslag.RegoppslagResponseDTO
 import no.nav.su.se.bakover.common.domain.sak.Sakstype
 import no.nav.su.se.bakover.common.person.Fnr
 
+interface RegoppslagServiceInterface {
+    suspend fun hentMottakerAdresse(
+        sakType: Sakstype,
+        ident: Fnr,
+    ): Either<RegoppslagFeil, RegoppslagResponseDTO>
+}
+
 class RegoppslagService(
     private val regoppslagKlient: RegoppslagKlient,
-) {
-    suspend fun hentMottakerAdresse(
+) : RegoppslagServiceInterface {
+    override suspend fun hentMottakerAdresse(
         sakType: Sakstype,
         ident: Fnr,
     ): Either<RegoppslagFeil, RegoppslagResponseDTO> {

--- a/test-common/src/main/kotlin/ApplicationConfigTestData.kt
+++ b/test-common/src/main/kotlin/ApplicationConfigTestData.kt
@@ -97,6 +97,7 @@ fun applicationConfig() = ApplicationConfig(
         pesysConfig = ApplicationConfig.ClientsConfig.PesysConfig.createLocalConfig(),
         aapApiInternConfig = ApplicationConfig.ClientsConfig.AapApiInternConfig.createLocalConfig(),
         suProxyConfig = ApplicationConfig.ClientsConfig.SuProxyConfig.createLocalConfig(),
+        regoppslagConfig = ApplicationConfig.ClientsConfig.RegoppslagConfig.createLocalConfig(),
     ),
     kafkaConfig = ApplicationConfig.KafkaConfig(
         producerCfg = ApplicationConfig.KafkaConfig.ProducerCfg(emptyMap()),

--- a/test-common/src/main/kotlin/application/MockedClients.kt
+++ b/test-common/src/main/kotlin/application/MockedClients.kt
@@ -36,4 +36,5 @@ fun mockedClients() = Clients(
     pesysklient = mock(),
     aapApiInternClient = mock(),
     suProxyClient = mock(),
+    regoppslagKlient = mock(),
 )

--- a/test-common/src/main/kotlin/application/MockedServices.kt
+++ b/test-common/src/main/kotlin/application/MockedServices.kt
@@ -44,4 +44,5 @@ fun mockedServices() = Services(
     mottakerService = mock(),
     kontrollsamtaleDriftOversiktService = mock(),
     reguleringRetryService = mock(),
+    regoppslagService = mock(),
 )

--- a/web-regresjonstest/src/main/kotlin/no/nav/su/se/bakover/web/SharedRegressionTestData.kt
+++ b/web-regresjonstest/src/main/kotlin/no/nav/su/se/bakover/web/SharedRegressionTestData.kt
@@ -280,6 +280,7 @@ data class TestClientsBuilder(
         pesysklient = pesysClient,
         aapApiInternClient = aapApiClient,
         suProxyClient = mock(),
+        regoppslagKlient = mock(),
     )
 
     override fun build(applicationConfig: ApplicationConfig): Clients = testClients

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/Routes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/Routes.kt
@@ -80,7 +80,6 @@ internal fun Application.setupKtorRoutes(
                     personRoutes(accessProtectedServices.person, clock)
                     adresseOppslagRoutes(
                         regoppslagService = accessProtectedServices.regoppslagService,
-                        sakService = services.sak,
                     )
                     sakRoutes(accessProtectedServices.sak, clock, formuegrenserFactoryIDag)
                     søknadRoutes(

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/Routes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/Routes.kt
@@ -28,6 +28,7 @@ import no.nav.su.se.bakover.web.routes.klage.klageRoutes
 import no.nav.su.se.bakover.web.routes.me.meRoutes
 import no.nav.su.se.bakover.web.routes.mottaker.mottakerRoutes
 import no.nav.su.se.bakover.web.routes.nøkkeltall.nøkkeltallRoutes
+import no.nav.su.se.bakover.web.routes.person.adresseOppslagRoutes
 import no.nav.su.se.bakover.web.routes.person.personRoutes
 import no.nav.su.se.bakover.web.routes.regulering.regulerTestRoute
 import no.nav.su.se.bakover.web.routes.regulering.reguleringRoutes
@@ -77,6 +78,7 @@ internal fun Application.setupKtorRoutes(
                 ) { accessProtectedServices ->
                     extraRoutes(this, services)
                     personRoutes(accessProtectedServices.person, clock)
+                    adresseOppslagRoutes(accessProtectedServices.regoppslagService, accessProtectedServices.sak)
                     sakRoutes(accessProtectedServices.sak, clock, formuegrenserFactoryIDag)
                     søknadRoutes(
                         søknadService = accessProtectedServices.søknad,

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/Routes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/Routes.kt
@@ -78,7 +78,11 @@ internal fun Application.setupKtorRoutes(
                 ) { accessProtectedServices ->
                     extraRoutes(this, services)
                     personRoutes(accessProtectedServices.person, clock)
-                    adresseOppslagRoutes(accessProtectedServices.regoppslagService, accessProtectedServices.sak)
+                    adresseOppslagRoutes(
+                        regoppslagService = accessProtectedServices.regoppslagService,
+                        sakService = services.sak,
+                        personService = accessProtectedServices.person,
+                    )
                     sakRoutes(accessProtectedServices.sak, clock, formuegrenserFactoryIDag)
                     søknadRoutes(
                         søknadService = accessProtectedServices.søknad,

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/Routes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/Routes.kt
@@ -81,7 +81,6 @@ internal fun Application.setupKtorRoutes(
                     adresseOppslagRoutes(
                         regoppslagService = accessProtectedServices.regoppslagService,
                         sakService = services.sak,
-                        personService = accessProtectedServices.person,
                     )
                     sakRoutes(accessProtectedServices.sak, clock, formuegrenserFactoryIDag)
                     søknadRoutes(

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/person/AdresseOppslagRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/person/AdresseOppslagRoutes.kt
@@ -15,14 +15,12 @@ import no.nav.su.se.bakover.common.infrastructure.web.withBody
 import no.nav.su.se.bakover.common.infrastructure.web.withSakId
 import no.nav.su.se.bakover.common.person.Fnr
 import no.nav.su.se.bakover.common.serialize
-import no.nav.su.se.bakover.domain.sak.SakService
 import no.nav.su.se.bakover.service.regoppslag.RegoppslagServiceInterface
 
 internal const val ADRESSE_OPPSLAG_PATH = "/adresse-oppslag"
 
 internal fun Route.adresseOppslagRoutes(
     regoppslagService: RegoppslagServiceInterface,
-    sakService: SakService,
 ) {
     post("$ADRESSE_OPPSLAG_PATH/{sakId}/sjekkAdresse") {
         data class Body(
@@ -41,34 +39,16 @@ internal fun Route.adresseOppslagRoutes(
                             )
                         },
                         ifRight = { fnr ->
-                            sakService.hentSakInfo(sakId).fold(
-                                ifLeft = { _ ->
-                                    call.svar(
+                            call.svar(
+                                regoppslagService.hentMottakerAdresse(sakId, fnr).fold(
+                                    ifLeft = { feil -> feil.tilResultat() },
+                                    ifRight = { response ->
                                         Resultat.json(
-                                            HttpStatusCode.NotFound,
-                                            serialize(
-                                                mapOf(
-                                                    "status" to HttpStatusCode.NotFound.value,
-                                                    "code" to "FANT_IKKE_SAK",
-                                                    "detail" to "Fant ikke sak",
-                                                ),
-                                            ),
-                                        ),
-                                    )
-                                },
-                                ifRight = { sakInfo ->
-                                    call.svar(
-                                        regoppslagService.hentMottakerAdresse(sakInfo.type, fnr).fold(
-                                            ifLeft = { feil -> feil.tilResultat() },
-                                            ifRight = { response ->
-                                                Resultat.json(
-                                                    HttpStatusCode.OK,
-                                                    serialize(response.tilResponse()),
-                                                )
-                                            },
-                                        ),
-                                    )
-                                },
+                                            HttpStatusCode.OK,
+                                            serialize(response.tilResponse()),
+                                        )
+                                    },
+                                ),
                             )
                         },
                     )

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/person/AdresseOppslagRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/person/AdresseOppslagRoutes.kt
@@ -17,12 +17,14 @@ import no.nav.su.se.bakover.common.person.Fnr
 import no.nav.su.se.bakover.common.serialize
 import no.nav.su.se.bakover.domain.sak.SakService
 import no.nav.su.se.bakover.service.regoppslag.RegoppslagServiceInterface
+import person.domain.PersonService
 
 internal const val ADRESSE_OPPSLAG_PATH = "/adresse-oppslag"
 
 internal fun Route.adresseOppslagRoutes(
     regoppslagService: RegoppslagServiceInterface,
     sakService: SakService,
+    personService: PersonService,
 ) {
     post("$ADRESSE_OPPSLAG_PATH/{sakId}/sjekkAdresse") {
         data class Body(
@@ -57,16 +59,28 @@ internal fun Route.adresseOppslagRoutes(
                                     )
                                 },
                                 ifRight = { sakInfo ->
-                                    call.svar(
-                                        regoppslagService.hentMottakerAdresse(sakInfo.type, fnr).fold(
-                                            ifLeft = { feil -> feil.tilResultat() },
-                                            ifRight = { response ->
-                                                Resultat.json(
-                                                    HttpStatusCode.OK,
-                                                    serialize(response.tilResponse()),
-                                                )
-                                            },
-                                        ),
+                                    personService.sjekkTilgangTilPerson(sakInfo.fnr, sakInfo.type).fold(
+                                        ifLeft = {
+                                            call.svar(
+                                                HttpStatusCode.Forbidden.errorJson(
+                                                    "Du har ikke tilgang til denne saken",
+                                                    "ikke_tilgang_til_sak",
+                                                ),
+                                            )
+                                        },
+                                        ifRight = {
+                                            call.svar(
+                                                regoppslagService.hentMottakerAdresse(sakInfo.type, fnr).fold(
+                                                    ifLeft = { feil -> feil.tilResultat() },
+                                                    ifRight = { response ->
+                                                        Resultat.json(
+                                                            HttpStatusCode.OK,
+                                                            serialize(response.tilResponse()),
+                                                        )
+                                                    },
+                                                ),
+                                            )
+                                        },
                                     )
                                 },
                             )

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/person/AdresseOppslagRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/person/AdresseOppslagRoutes.kt
@@ -16,12 +16,12 @@ import no.nav.su.se.bakover.common.infrastructure.web.withSakId
 import no.nav.su.se.bakover.common.person.Fnr
 import no.nav.su.se.bakover.common.serialize
 import no.nav.su.se.bakover.domain.sak.SakService
-import no.nav.su.se.bakover.service.regoppslag.RegoppslagService
+import no.nav.su.se.bakover.service.regoppslag.RegoppslagServiceInterface
 
 internal const val ADRESSE_OPPSLAG_PATH = "/adresse-oppslag"
 
 internal fun Route.adresseOppslagRoutes(
-    regoppslagService: RegoppslagService,
+    regoppslagService: RegoppslagServiceInterface,
     sakService: SakService,
 ) {
     post("$ADRESSE_OPPSLAG_PATH/{sakId}/sjekkAdresse") {

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/person/AdresseOppslagRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/person/AdresseOppslagRoutes.kt
@@ -17,14 +17,12 @@ import no.nav.su.se.bakover.common.person.Fnr
 import no.nav.su.se.bakover.common.serialize
 import no.nav.su.se.bakover.domain.sak.SakService
 import no.nav.su.se.bakover.service.regoppslag.RegoppslagServiceInterface
-import person.domain.PersonService
 
 internal const val ADRESSE_OPPSLAG_PATH = "/adresse-oppslag"
 
 internal fun Route.adresseOppslagRoutes(
     regoppslagService: RegoppslagServiceInterface,
     sakService: SakService,
-    personService: PersonService,
 ) {
     post("$ADRESSE_OPPSLAG_PATH/{sakId}/sjekkAdresse") {
         data class Body(
@@ -44,7 +42,7 @@ internal fun Route.adresseOppslagRoutes(
                         },
                         ifRight = { fnr ->
                             sakService.hentSakInfo(sakId).fold(
-                                ifLeft = { feil ->
+                                ifLeft = { _ ->
                                     call.svar(
                                         Resultat.json(
                                             HttpStatusCode.NotFound,
@@ -59,28 +57,16 @@ internal fun Route.adresseOppslagRoutes(
                                     )
                                 },
                                 ifRight = { sakInfo ->
-                                    personService.sjekkTilgangTilPerson(sakInfo.fnr, sakInfo.type).fold(
-                                        ifLeft = {
-                                            call.svar(
-                                                HttpStatusCode.Forbidden.errorJson(
-                                                    "Du har ikke tilgang til denne saken",
-                                                    "ikke_tilgang_til_sak",
-                                                ),
-                                            )
-                                        },
-                                        ifRight = {
-                                            call.svar(
-                                                regoppslagService.hentMottakerAdresse(sakInfo.type, fnr).fold(
-                                                    ifLeft = { feil -> feil.tilResultat() },
-                                                    ifRight = { response ->
-                                                        Resultat.json(
-                                                            HttpStatusCode.OK,
-                                                            serialize(response.tilResponse()),
-                                                        )
-                                                    },
-                                                ),
-                                            )
-                                        },
+                                    call.svar(
+                                        regoppslagService.hentMottakerAdresse(sakInfo.type, fnr).fold(
+                                            ifLeft = { feil -> feil.tilResultat() },
+                                            ifRight = { response ->
+                                                Resultat.json(
+                                                    HttpStatusCode.OK,
+                                                    serialize(response.tilResponse()),
+                                                )
+                                            },
+                                        ),
                                     )
                                 },
                             )

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/person/AdresseOppslagRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/person/AdresseOppslagRoutes.kt
@@ -1,0 +1,105 @@
+package no.nav.su.se.bakover.web.routes.person
+
+import arrow.core.Either
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import no.nav.su.se.bakover.client.regoppslag.RegoppslagFeil
+import no.nav.su.se.bakover.common.infrastructure.web.Resultat
+import no.nav.su.se.bakover.common.infrastructure.web.errorJson
+import no.nav.su.se.bakover.common.infrastructure.web.svar
+import no.nav.su.se.bakover.common.infrastructure.web.withBody
+import no.nav.su.se.bakover.common.infrastructure.web.withSakId
+import no.nav.su.se.bakover.common.person.Fnr
+import no.nav.su.se.bakover.common.serialize
+import no.nav.su.se.bakover.domain.sak.SakService
+import no.nav.su.se.bakover.service.regoppslag.RegoppslagService
+
+internal const val ADRESSE_OPPSLAG_PATH = "/adresse-oppslag"
+
+internal fun Route.adresseOppslagRoutes(
+    regoppslagService: RegoppslagService,
+    sakService: SakService,
+) {
+    post("$ADRESSE_OPPSLAG_PATH/{sakId}/sjekkAdresse") {
+        data class Body(
+            val fnr: String,
+        )
+        call.withSakId { sakId ->
+            call.withBody<Body> { body ->
+                Either.catch { Fnr(body.fnr) }.fold(
+                    ifLeft = {
+                        call.svar(
+                            HttpStatusCode.BadRequest.errorJson(
+                                "Inneholder ikke et gyldig fødselsnummer",
+                                "ikke_gyldig_fødselsnummer",
+                            ),
+                        )
+                    },
+                    ifRight = { fnr ->
+
+                        sakService.hentSakInfo(sakId).fold(
+                            ifLeft = { feil ->
+                                call.svar(
+                                    Resultat.json(
+                                        HttpStatusCode.NotFound,
+                                        serialize(
+                                            mapOf(
+                                                "status" to HttpStatusCode.NotFound.value,
+                                                "code" to "FANT_IKKE_SAK",
+                                                "detail" to "Fant ikke sak",
+                                            ),
+                                        ),
+                                    ),
+                                )
+                            },
+                            ifRight = { sakInfo ->
+                                call.svar(
+                                    regoppslagService.hentMottakerAdresse(sakInfo.type, fnr).fold(
+                                        ifLeft = { feil -> feil.tilResultat() },
+                                        ifRight = { response -> Resultat.json(HttpStatusCode.OK, serialize(response)) },
+                                    ),
+                                )
+                            },
+                        )
+                    },
+                )
+            }
+        }
+    }
+}
+
+internal fun RegoppslagFeil.tilResultat(): Resultat {
+    return when (this) {
+        RegoppslagFeil.IkkeFunnet -> Resultat.json(
+            HttpStatusCode.NotFound,
+            serialize(
+                mapOf(
+                    "status" to HttpStatusCode.NotFound.value,
+                    "code" to "BRUKER_HAR_UKJENT_ADRESSE",
+                    "detail" to "Bruker har ukjent adresse",
+                ),
+            ),
+        )
+        RegoppslagFeil.PersonErDød -> Resultat.json(
+            HttpStatusCode.Gone,
+            serialize(
+                mapOf(
+                    "status" to HttpStatusCode.Gone.value,
+                    "code" to "PERSON_ER_DØD",
+                    "detail" to "Person er død og har ukjent adresse",
+                ),
+            ),
+        )
+        is RegoppslagFeil.UkjentFeil -> Resultat.json(
+            HttpStatusCode.InternalServerError,
+            serialize(
+                mapOf(
+                    "status" to this.statusCode,
+                    "code" to "UKJENT_FEIL_REGOPPSLAG",
+                    "detail" to this.detail,
+                ),
+            ),
+        )
+    }
+}

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/person/AdresseOppslagRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/person/AdresseOppslagRoutes.kt
@@ -5,6 +5,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.post
 import no.nav.su.se.bakover.client.regoppslag.RegoppslagFeil
+import no.nav.su.se.bakover.client.regoppslag.RegoppslagResponseDTO
 import no.nav.su.se.bakover.common.infrastructure.web.Resultat
 import no.nav.su.se.bakover.common.infrastructure.web.errorJson
 import no.nav.su.se.bakover.common.infrastructure.web.svar
@@ -57,7 +58,7 @@ internal fun Route.adresseOppslagRoutes(
                                 call.svar(
                                     regoppslagService.hentMottakerAdresse(sakInfo.type, fnr).fold(
                                         ifLeft = { feil -> feil.tilResultat() },
-                                        ifRight = { response -> Resultat.json(HttpStatusCode.OK, serialize(response)) },
+                                        ifRight = { response -> Resultat.json(HttpStatusCode.OK, serialize(response.tilResponse())) },
                                     ),
                                 )
                             },
@@ -69,25 +70,51 @@ internal fun Route.adresseOppslagRoutes(
     }
 }
 
+internal data class AdresseOppslagResponse(
+    val type: Type,
+    val aarsak: Aarsak? = null,
+    val melding: String? = null,
+    val navn: String? = null,
+    val adresse: RegoppslagResponseDTO.Adresse? = null,
+) {
+    enum class Type {
+        FANT_ADRESSE,
+        INGEN_ADRESSE,
+    }
+
+    enum class Aarsak {
+        UKJENT_ADRESSE,
+        PERSON_ER_DOD,
+    }
+}
+
+internal fun RegoppslagResponseDTO.tilResponse(): AdresseOppslagResponse {
+    return AdresseOppslagResponse(
+        type = AdresseOppslagResponse.Type.FANT_ADRESSE,
+        navn = navn,
+        adresse = adresse,
+    )
+}
+
 internal fun RegoppslagFeil.tilResultat(): Resultat {
     return when (this) {
         RegoppslagFeil.IkkeFunnet -> Resultat.json(
-            HttpStatusCode.NotFound,
+            HttpStatusCode.OK,
             serialize(
-                mapOf(
-                    "status" to HttpStatusCode.NotFound.value,
-                    "code" to "BRUKER_HAR_UKJENT_ADRESSE",
-                    "detail" to "Bruker har ukjent adresse",
+                AdresseOppslagResponse(
+                    type = AdresseOppslagResponse.Type.INGEN_ADRESSE,
+                    aarsak = AdresseOppslagResponse.Aarsak.UKJENT_ADRESSE,
+                    melding = "Adresse finnes ikke. Avvent videre behandling. Du kan legge til annen mottaker om brevet skal sendes til annen mottaker.",
                 ),
             ),
         )
         RegoppslagFeil.PersonErDød -> Resultat.json(
-            HttpStatusCode.Gone,
+            HttpStatusCode.OK,
             serialize(
-                mapOf(
-                    "status" to HttpStatusCode.Gone.value,
-                    "code" to "PERSON_ER_DØD",
-                    "detail" to "Person er død og har ukjent adresse",
+                AdresseOppslagResponse(
+                    type = AdresseOppslagResponse.Type.INGEN_ADRESSE,
+                    aarsak = AdresseOppslagResponse.Aarsak.PERSON_ER_DOD,
+                    melding = "Adresse finnes ikke. Avvent videre behandling. Du kan legge til annen mottaker om brevet skal sendes til annen mottaker.",
                 ),
             ),
         )

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/person/AdresseOppslagRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/person/AdresseOppslagRoutes.kt
@@ -6,7 +6,9 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.post
 import no.nav.su.se.bakover.client.regoppslag.RegoppslagFeil
 import no.nav.su.se.bakover.client.regoppslag.RegoppslagResponseDTO
+import no.nav.su.se.bakover.common.brukerrolle.Brukerrolle
 import no.nav.su.se.bakover.common.infrastructure.web.Resultat
+import no.nav.su.se.bakover.common.infrastructure.web.authorize
 import no.nav.su.se.bakover.common.infrastructure.web.errorJson
 import no.nav.su.se.bakover.common.infrastructure.web.svar
 import no.nav.su.se.bakover.common.infrastructure.web.withBody
@@ -28,43 +30,49 @@ internal fun Route.adresseOppslagRoutes(
         )
         call.withSakId { sakId ->
             call.withBody<Body> { body ->
-                Either.catch { Fnr(body.fnr) }.fold(
-                    ifLeft = {
-                        call.svar(
-                            HttpStatusCode.BadRequest.errorJson(
-                                "Inneholder ikke et gyldig fødselsnummer",
-                                "ikke_gyldig_fødselsnummer",
-                            ),
-                        )
-                    },
-                    ifRight = { fnr ->
-
-                        sakService.hentSakInfo(sakId).fold(
-                            ifLeft = { feil ->
-                                call.svar(
-                                    Resultat.json(
-                                        HttpStatusCode.NotFound,
-                                        serialize(
-                                            mapOf(
-                                                "status" to HttpStatusCode.NotFound.value,
-                                                "code" to "FANT_IKKE_SAK",
-                                                "detail" to "Fant ikke sak",
+                authorize(Brukerrolle.Saksbehandler) {
+                    Either.catch { Fnr(body.fnr) }.fold(
+                        ifLeft = {
+                            call.svar(
+                                HttpStatusCode.BadRequest.errorJson(
+                                    "Inneholder ikke et gyldig fødselsnummer",
+                                    "ikke_gyldig_fødselsnummer",
+                                ),
+                            )
+                        },
+                        ifRight = { fnr ->
+                            sakService.hentSakInfo(sakId).fold(
+                                ifLeft = { feil ->
+                                    call.svar(
+                                        Resultat.json(
+                                            HttpStatusCode.NotFound,
+                                            serialize(
+                                                mapOf(
+                                                    "status" to HttpStatusCode.NotFound.value,
+                                                    "code" to "FANT_IKKE_SAK",
+                                                    "detail" to "Fant ikke sak",
+                                                ),
                                             ),
                                         ),
-                                    ),
-                                )
-                            },
-                            ifRight = { sakInfo ->
-                                call.svar(
-                                    regoppslagService.hentMottakerAdresse(sakInfo.type, fnr).fold(
-                                        ifLeft = { feil -> feil.tilResultat() },
-                                        ifRight = { response -> Resultat.json(HttpStatusCode.OK, serialize(response.tilResponse())) },
-                                    ),
-                                )
-                            },
-                        )
-                    },
-                )
+                                    )
+                                },
+                                ifRight = { sakInfo ->
+                                    call.svar(
+                                        regoppslagService.hentMottakerAdresse(sakInfo.type, fnr).fold(
+                                            ifLeft = { feil -> feil.tilResultat() },
+                                            ifRight = { response ->
+                                                Resultat.json(
+                                                    HttpStatusCode.OK,
+                                                    serialize(response.tilResponse()),
+                                                )
+                                            },
+                                        ),
+                                    )
+                                },
+                            )
+                        },
+                    )
+                }
             }
         }
     }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/person/AdresseOppslagRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/person/AdresseOppslagRoutes.kt
@@ -112,7 +112,7 @@ internal fun RegoppslagFeil.tilResultat(): Resultat {
                 AdresseOppslagResponse(
                     type = AdresseOppslagResponse.Type.INGEN_ADRESSE,
                     aarsak = AdresseOppslagResponse.Aarsak.UKJENT_ADRESSE,
-                    melding = "Adresse finnes ikke. Avvent videre behandling. Du kan legge til annen mottaker om brevet skal sendes til annen mottaker.",
+                    melding = "Adresse finnes ikke. Vurder å avvente videre behandling. Du kan legge til annen mottaker om brevet skal sendes til annen mottaker.",
                 ),
             ),
         )
@@ -122,7 +122,7 @@ internal fun RegoppslagFeil.tilResultat(): Resultat {
                 AdresseOppslagResponse(
                     type = AdresseOppslagResponse.Type.INGEN_ADRESSE,
                     aarsak = AdresseOppslagResponse.Aarsak.PERSON_ER_DOD,
-                    melding = "Adresse finnes ikke. Avvent videre behandling. Du kan legge til annen mottaker om brevet skal sendes til annen mottaker.",
+                    melding = "Adresse finnes ikke. Vurder å avvente videre behandling. Du kan legge til annen mottaker om brevet skal sendes til annen mottaker.",
                 ),
             ),
         )

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxy.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxy.kt
@@ -24,6 +24,8 @@ import dokument.domain.brev.FantIkkeDokument
 import dokument.domain.brev.HentDokumenterForIdType
 import dokument.domain.journalføring.Journalpost
 import dokument.domain.journalføring.KunneIkkeHenteJournalposter
+import no.nav.su.se.bakover.client.regoppslag.RegoppslagFeil
+import no.nav.su.se.bakover.client.regoppslag.RegoppslagResponseDTO
 import no.nav.su.se.bakover.common.UUID30
 import no.nav.su.se.bakover.common.domain.PdfA
 import no.nav.su.se.bakover.common.domain.Saksnummer
@@ -237,6 +239,7 @@ import no.nav.su.se.bakover.service.klage.VurderKlagevilkårCommand
 import no.nav.su.se.bakover.service.nøkkeltall.NøkkeltallService
 import no.nav.su.se.bakover.service.personhendelser.DryrunResult
 import no.nav.su.se.bakover.service.personhendelser.PersonhendelseService
+import no.nav.su.se.bakover.service.regoppslag.RegoppslagServiceInterface
 import no.nav.su.se.bakover.service.statistikk.FritekstAvslagService
 import no.nav.su.se.bakover.service.statistikk.ResendStatistikkhendelserService
 import no.nav.su.se.bakover.service.statistikk.SakStatistikkBigQueryService
@@ -1692,7 +1695,15 @@ open class AccessCheckProxy(
             },
             reguleringStatusUteståendeService = services.reguleringStatusUteståendeService,
             reguleringRetryService = services.reguleringRetryService,
-            regoppslagService = services.regoppslagService,
+            regoppslagService = object : RegoppslagServiceInterface {
+                override suspend fun hentMottakerAdresse(
+                    sakType: Sakstype,
+                    ident: Fnr,
+                ): Either<RegoppslagFeil, RegoppslagResponseDTO> {
+                    assertHarTilgangTilPerson(ident, sakType)
+                    return services.regoppslagService.hentMottakerAdresse(sakType, ident)
+                }
+            },
         )
     }
 

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxy.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxy.kt
@@ -1697,11 +1697,11 @@ open class AccessCheckProxy(
             reguleringRetryService = services.reguleringRetryService,
             regoppslagService = object : RegoppslagServiceInterface {
                 override suspend fun hentMottakerAdresse(
-                    sakType: Sakstype,
+                    sakId: UUID,
                     ident: Fnr,
                 ): Either<RegoppslagFeil, RegoppslagResponseDTO> {
-                    assertHarTilgangTilPerson(ident, sakType)
-                    return services.regoppslagService.hentMottakerAdresse(sakType, ident)
+                    assertHarTilgangTilSak(sakId)
+                    return services.regoppslagService.hentMottakerAdresse(sakId, ident)
                 }
             },
         )

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxy.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxy.kt
@@ -1412,8 +1412,14 @@ open class AccessCheckProxy(
                 }
             },
             reguleringAutomatiskService = object : ReguleringAutomatiskService {
-                override fun startAutomatiskRegulering(fraOgMedMåned: Måned, grunnbeløpRegulering: Boolean): List<Either<BleIkkeRegulert, ReguleringOppsummering>> {
-                    return services.reguleringAutomatiskService.startAutomatiskRegulering(fraOgMedMåned, grunnbeløpRegulering)
+                override fun startAutomatiskRegulering(
+                    fraOgMedMåned: Måned,
+                    grunnbeløpRegulering: Boolean,
+                ): List<Either<BleIkkeRegulert, ReguleringOppsummering>> {
+                    return services.reguleringAutomatiskService.startAutomatiskRegulering(
+                        fraOgMedMåned,
+                        grunnbeløpRegulering,
+                    )
                 }
 
                 override fun startAutomatiskReguleringForInnsyn(
@@ -1615,7 +1621,10 @@ open class AccessCheckProxy(
                     return services.fradragsjobbenService.sjekkLøpendeSakerForFradragIEksterneSystemer(måned, dryRun)
                 }
 
-                override fun kjørFradragssjekkForMånedMedValidering(måned: Måned, dryRun: Boolean): Either<FradragsSjekkFeil, Unit> {
+                override fun kjørFradragssjekkForMånedMedValidering(
+                    måned: Måned,
+                    dryRun: Boolean,
+                ): Either<FradragsSjekkFeil, Unit> {
                     return services.fradragsjobbenService.kjørFradragssjekkForMånedMedValidering(måned, dryRun)
                 }
 
@@ -1683,6 +1692,7 @@ open class AccessCheckProxy(
             },
             reguleringStatusUteståendeService = services.reguleringStatusUteståendeService,
             reguleringRetryService = services.reguleringRetryService,
+            regoppslagService = services.regoppslagService,
         )
     }
 

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/ServiceBuilder.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/ServiceBuilder.kt
@@ -295,7 +295,7 @@ data object ServiceBuilder {
                 sakRepo = databaseRepos.sak,
             ),
             reguleringRetryService = reguleringServices.reguleringRetryService,
-            regoppslagService = RegoppslagService(clients.regoppslagKlient),
+            regoppslagService = RegoppslagService(clients.regoppslagKlient, kjerneTjenester.sakService),
         )
     }
 

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/ServiceBuilder.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/ServiceBuilder.kt
@@ -34,6 +34,7 @@ import no.nav.su.se.bakover.service.nøkkeltall.NøkkeltallServiceImpl
 import no.nav.su.se.bakover.service.oppgave.OppgaveServiceImpl
 import no.nav.su.se.bakover.service.person.PersonServiceImpl
 import no.nav.su.se.bakover.service.personhendelser.PersonhendelseServiceImpl
+import no.nav.su.se.bakover.service.regoppslag.RegoppslagService
 import no.nav.su.se.bakover.service.regulering.AapReguleringerServiceImpl
 import no.nav.su.se.bakover.service.regulering.ReguleringAutomatiskServiceImpl
 import no.nav.su.se.bakover.service.regulering.ReguleringManuellServiceImpl
@@ -294,6 +295,7 @@ data object ServiceBuilder {
                 sakRepo = databaseRepos.sak,
             ),
             reguleringRetryService = reguleringServices.reguleringRetryService,
+            regoppslagService = RegoppslagService(clients.regoppslagKlient),
         )
     }
 

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/Services.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/Services.kt
@@ -21,7 +21,7 @@ import no.nav.su.se.bakover.service.klage.KlageService
 import no.nav.su.se.bakover.service.klage.KlageinstanshendelseService
 import no.nav.su.se.bakover.service.nøkkeltall.NøkkeltallService
 import no.nav.su.se.bakover.service.personhendelser.PersonhendelseService
-import no.nav.su.se.bakover.service.regoppslag.RegoppslagService
+import no.nav.su.se.bakover.service.regoppslag.RegoppslagServiceInterface
 import no.nav.su.se.bakover.service.statistikk.FritekstAvslagService
 import no.nav.su.se.bakover.service.statistikk.ResendStatistikkhendelserService
 import no.nav.su.se.bakover.service.statistikk.SakStatistikkBigQueryService
@@ -75,5 +75,5 @@ data class Services(
     val søknadStatistikkService: SøknadStatistikkService,
     val mottakerService: MottakerService,
     val kontrollsamtaleDriftOversiktService: KontrollsamtaleDriftOversiktService,
-    val regoppslagService: RegoppslagService,
+    val regoppslagService: RegoppslagServiceInterface,
 )

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/services/Services.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/services/Services.kt
@@ -21,6 +21,7 @@ import no.nav.su.se.bakover.service.klage.KlageService
 import no.nav.su.se.bakover.service.klage.KlageinstanshendelseService
 import no.nav.su.se.bakover.service.nøkkeltall.NøkkeltallService
 import no.nav.su.se.bakover.service.personhendelser.PersonhendelseService
+import no.nav.su.se.bakover.service.regoppslag.RegoppslagService
 import no.nav.su.se.bakover.service.statistikk.FritekstAvslagService
 import no.nav.su.se.bakover.service.statistikk.ResendStatistikkhendelserService
 import no.nav.su.se.bakover.service.statistikk.SakStatistikkBigQueryService
@@ -74,4 +75,5 @@ data class Services(
     val søknadStatistikkService: SøknadStatistikkService,
     val mottakerService: MottakerService,
     val kontrollsamtaleDriftOversiktService: KontrollsamtaleDriftOversiktService,
+    val regoppslagService: RegoppslagService,
 )

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/TestClientsBuilder.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/TestClientsBuilder.kt
@@ -67,6 +67,7 @@ data class TestClientsBuilder(
         pesysklient = mock(),
         aapApiInternClient = mock(),
         suProxyClient = SuProxyClientStub(),
+        regoppslagKlient = mock(),
     )
 
     override fun build(applicationConfig: ApplicationConfig): Clients = testClients

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/TestServicesBuilder.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/TestServicesBuilder.kt
@@ -111,5 +111,6 @@ data object TestServicesBuilder {
         mottakerService = mock(),
         kontrollsamtaleDriftOversiktService = mock(),
         reguleringRetryService = mock(),
+        regoppslagService = mock(),
     )
 }

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxyTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/services/AccessCheckProxyTest.kt
@@ -67,6 +67,7 @@ internal class AccessCheckProxyTest {
         reguleringManuellService = mock(),
         reguleringAutomatiskService = mock(),
         reguleringStatusUteståendeService = mock(),
+        regoppslagService = mock(),
     )
 
     @Nested

--- a/web/src/test/kotlin/no/nav/su/se/bakover/web/services/ServiceBuilderTest.kt
+++ b/web/src/test/kotlin/no/nav/su/se/bakover/web/services/ServiceBuilderTest.kt
@@ -89,6 +89,7 @@ internal class ServiceBuilderTest {
                 pesysklient = mock(),
                 aapApiInternClient = mock(),
                 suProxyClient = mock(),
+                regoppslagKlient = mock(),
             ),
             clock = Clock.systemUTC(),
             satsFactory = satsFactoryTestPåDato(),


### PR DESCRIPTION
tilgang https://github.com/navikt/regoppslag/pull/390
https://regoppslag.intern.dev.nav.no/swagger-ui/index.html#/Postadresse/postadresse
https://confluence.adeo.no/spaces/BOA/pages/366967381/POST+rest+postadresse

Skal brukes av frontend for å si om bruker har adresse eller ei.

se her https://github.com/navikt/su-se-framover/pull/4505