### PR TITLE
Opprett løpende innvilgelse med tom søknadstype for infotrygd saker

### DIFF
--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknad/Søknad.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknad/Søknad.kt
@@ -23,6 +23,7 @@ import no.nav.su.se.bakover.domain.brev.command.TrukketSøknadDokumentCommand
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.ForNav
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.SøknadInnhold
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.SøknadsinnholdAlder
+import no.nav.su.se.bakover.domain.søknad.søknadinnhold.SøknadsinnholdInfotrygd
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.SøknadsinnholdUføre
 import java.time.LocalDate
 import java.util.UUID
@@ -44,6 +45,7 @@ sealed interface Søknad {
         get() = when (søknadInnhold) {
             is SøknadsinnholdAlder -> Sakstype.ALDER
             is SøknadsinnholdUføre -> Sakstype.UFØRE
+            is SøknadsinnholdInfotrygd -> Sakstype.ALDER
         }
 
     /**
@@ -56,6 +58,7 @@ sealed interface Søknad {
         get() = when (val søknadstype = søknadInnhold.forNav) {
             is ForNav.DigitalSøknad -> opprettet.toLocalDate(zoneIdOslo)
             is ForNav.Papirsøknad -> søknadstype.mottaksdatoForSøknad
+            null -> TODO()
         }
 
     data class Ny(

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknad/søknadinnhold/Søknadsinnhold.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknad/søknadinnhold/Søknadsinnhold.kt
@@ -20,12 +20,12 @@ import no.nav.su.se.bakover.domain.søknad.søknadinnhold.SøknadInnhold.Compani
 )
 sealed interface SøknadInnhold {
     val personopplysninger: FnrWrapper
-    val boforhold: Boforhold
-    val utenlandsopphold: Utenlandsopphold
-    val oppholdstillatelse: Oppholdstillatelse
-    val inntektOgPensjon: InntektOgPensjon
-    val formue: Formue
-    val forNav: ForNav
+    val boforhold: Boforhold?
+    val utenlandsopphold: Utenlandsopphold?
+    val oppholdstillatelse: Oppholdstillatelse?
+    val inntektOgPensjon: InntektOgPensjon?
+    val formue: Formue?
+    val forNav: ForNav?
     val ektefelle: Ektefelle?
 
     fun oppdaterFnr(fnr: Fnr): SøknadInnhold
@@ -33,10 +33,11 @@ sealed interface SøknadInnhold {
     fun type() = when (this) {
         is SøknadsinnholdAlder -> Sakstype.ALDER
         is SøknadsinnholdUføre -> Sakstype.UFØRE
+        is SøknadsinnholdInfotrygd -> Sakstype.ALDER
     }
 
     fun erPapirsøknad(): Boolean {
-        return forNav.erPapirsøknad()
+        return forNav?.erPapirsøknad() ?: false
     }
 
     companion object {
@@ -45,6 +46,23 @@ sealed interface SøknadInnhold {
             ektefelle: Ektefelle?,
         ) =
             if (boforhold.delerBoligMed == Boforhold.DelerBoligMed.EKTEMAKE_SAMBOER && ektefelle == null) FeilVedValideringAvBoforholdOgEktefelle.EktefelleErIkkeutfylt.left() else Unit.right()
+    }
+}
+
+data class SøknadsinnholdInfotrygd(
+    override val personopplysninger: FnrWrapper,
+    override val boforhold: Boforhold? = null,
+    override val utenlandsopphold: Utenlandsopphold? = null,
+    override val oppholdstillatelse: Oppholdstillatelse? = null,
+    override val inntektOgPensjon: InntektOgPensjon? = null,
+    override val formue: Formue? = null,
+    override val forNav: ForNav? = null,
+    override val ektefelle: Ektefelle? = null,
+) : SøknadInnhold {
+    override fun oppdaterFnr(fnr: Fnr): SøknadInnhold {
+        return this.copy(
+            personopplysninger = FnrWrapper(fnr),
+        )
     }
 }
 
@@ -168,6 +186,7 @@ data class SøknadsinnholdUføre private constructor(
             ).right()
         }
     }
+
     override fun oppdaterFnr(fnr: Fnr): SøknadsinnholdUføre {
         return this.copy(
             personopplysninger = FnrWrapper(fnr),

--- a/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknad/søknadinnhold/Søknadsinnhold.kt
+++ b/domain/src/main/kotlin/no/nav/su/se/bakover/domain/søknad/søknadinnhold/Søknadsinnhold.kt
@@ -50,13 +50,14 @@ sealed interface SøknadInnhold {
 }
 
 data class SøknadsinnholdInfotrygd(
+    val harSøktAlderspensjon: HarSøktAlderspensjon, // TODO må være en egen etterhvert??
     override val personopplysninger: FnrWrapper,
+    override val forNav: ForNav.DigitalSøknad,
     override val boforhold: Boforhold? = null,
     override val utenlandsopphold: Utenlandsopphold? = null,
     override val oppholdstillatelse: Oppholdstillatelse? = null,
     override val inntektOgPensjon: InntektOgPensjon? = null,
     override val formue: Formue? = null,
-    override val forNav: ForNav? = null,
     override val ektefelle: Ektefelle? = null,
 ) : SøknadInnhold {
     override fun oppdaterFnr(fnr: Fnr): SøknadInnhold {

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/SøknadServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/SøknadServiceImpl.kt
@@ -31,6 +31,8 @@ import no.nav.su.se.bakover.domain.statistikk.notify
 import no.nav.su.se.bakover.domain.søknad.Søknad
 import no.nav.su.se.bakover.domain.søknad.SøknadPdfInnhold
 import no.nav.su.se.bakover.domain.søknad.SøknadRepo
+import no.nav.su.se.bakover.domain.søknad.søknadinnhold.ForNav
+import no.nav.su.se.bakover.domain.søknad.søknadinnhold.HarSøktAlderspensjon
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.SøknadInnhold
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.SøknadsinnholdAlder
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.SøknadsinnholdInfotrygd
@@ -112,7 +114,9 @@ class SøknadServiceImpl(
         val innsendtFødselsnummer: Fnr = søknadInnhold.personopplysninger.fnr
 
         val søknadInnhold = SøknadsinnholdInfotrygd(
+            HarSøktAlderspensjon(true),
             personopplysninger = søknadInnhold.personopplysninger,
+            forNav = ForNav.DigitalSøknad(),
         )
 
         if (!søknadInnhold.kanSendeInnSøknad()) {
@@ -147,15 +151,19 @@ class SøknadServiceImpl(
             )
         }
 
+        // TODO switch på om er fra infotrygd
         val søknadMedOppgave = opprettJournalpostOgOppgave(sak.info(), person, søknad)
         søknadMedOppgave?.let {
-            sak.opprettNySøknadsbehandling(
+            val nySøknad = sak.opprettNySøknadsbehandling(
                 søknad = it,
                 clock = clock,
                 saksbehandler = null,
-            ).map { (_, uavklartSøknadsbehandling) ->
+            )
+            // TODO switch påå fra infotrygd
+            nySøknad.map { (_, uavklartSøknadsbehandling) ->
                 sessionFactory.withTransactionContext { tx ->
                     søknadsbehandlingRepo.lagre(uavklartSøknadsbehandling, tx)
+                    // TODO skal det sendes statistikk????
                     val sakStatistikkEvent = StatistikkEvent.Behandling.Søknad.Opprettet(
                         uavklartSøknadsbehandling,
                         uavklartSøknadsbehandling.saksbehandler ?: NavIdentBruker.Saksbehandler.systembruker(),

--- a/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/SøknadServiceImpl.kt
+++ b/service/src/main/kotlin/no/nav/su/se/bakover/service/søknad/SøknadServiceImpl.kt
@@ -33,6 +33,7 @@ import no.nav.su.se.bakover.domain.søknad.SøknadPdfInnhold
 import no.nav.su.se.bakover.domain.søknad.SøknadRepo
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.SøknadInnhold
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.SøknadsinnholdAlder
+import no.nav.su.se.bakover.domain.søknad.søknadinnhold.SøknadsinnholdInfotrygd
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.SøknadsinnholdUføre
 import no.nav.su.se.bakover.domain.søknadsbehandling.SøknadsbehandlingRepo
 import no.nav.su.se.bakover.domain.søknadsbehandling.opprett.opprettNySøknadsbehandling
@@ -110,6 +111,10 @@ class SøknadServiceImpl(
     ): Either<KunneIkkeOppretteSøknad, Pair<Saksnummer, Søknad.Ny>> {
         val innsendtFødselsnummer: Fnr = søknadInnhold.personopplysninger.fnr
 
+        val søknadInnhold = SøknadsinnholdInfotrygd(
+            personopplysninger = søknadInnhold.personopplysninger,
+        )
+
         if (!søknadInnhold.kanSendeInnSøknad()) {
             return KunneIkkeOppretteSøknad.SøknadsinnsendingIkkeTillatt.left()
         }
@@ -151,7 +156,10 @@ class SøknadServiceImpl(
             ).map { (_, uavklartSøknadsbehandling) ->
                 sessionFactory.withTransactionContext { tx ->
                     søknadsbehandlingRepo.lagre(uavklartSøknadsbehandling, tx)
-                    val sakStatistikkEvent = StatistikkEvent.Behandling.Søknad.Opprettet(uavklartSøknadsbehandling, uavklartSøknadsbehandling.saksbehandler ?: NavIdentBruker.Saksbehandler.systembruker())
+                    val sakStatistikkEvent = StatistikkEvent.Behandling.Søknad.Opprettet(
+                        uavklartSøknadsbehandling,
+                        uavklartSøknadsbehandling.saksbehandler ?: NavIdentBruker.Saksbehandler.systembruker(),
+                    )
                     observers.notify(
                         sakStatistikkEvent,
                         tx,
@@ -376,5 +384,6 @@ class SøknadServiceImpl(
     private fun SøknadInnhold.kanSendeInnSøknad(): Boolean = when (this) {
         is SøknadsinnholdAlder -> true
         is SøknadsinnholdUføre -> true
+        else -> true
     }
 }

--- a/statistikk/application/src/main/kotlin/no/nav/su/se/bakover/statistikk/behandling/MottattDatoMapper.kt
+++ b/statistikk/application/src/main/kotlin/no/nav/su/se/bakover/statistikk/behandling/MottattDatoMapper.kt
@@ -9,5 +9,6 @@ internal fun Søknad.mottattDato(): LocalDate {
     return when (val forNav = this.søknadInnhold.forNav) {
         is ForNav.DigitalSøknad -> this.opprettet.toLocalDate(zoneIdOslo)
         is ForNav.Papirsøknad -> forNav.mottaksdatoForSøknad
+        null -> TODO()
     }
 }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutes.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknad/SøknadRoutes.kt
@@ -53,6 +53,7 @@ import no.nav.su.se.bakover.web.routes.søknad.søknadinnholdJson.FeilVedOpprett
 import no.nav.su.se.bakover.web.routes.søknad.søknadinnholdJson.InputValidator
 import no.nav.su.se.bakover.web.routes.søknad.søknadinnholdJson.KunneIkkeLageSøknadinnhold
 import no.nav.su.se.bakover.web.routes.søknad.søknadinnholdJson.SøknadsinnholdAlderJson
+import no.nav.su.se.bakover.web.routes.søknad.søknadinnholdJson.SøknadsinnholdInfotrygdJson
 import no.nav.su.se.bakover.web.routes.søknad.søknadinnholdJson.SøknadsinnholdInputValidator
 import no.nav.su.se.bakover.web.routes.søknad.søknadinnholdJson.SøknadsinnholdJson
 import no.nav.su.se.bakover.web.routes.søknad.søknadinnholdJson.SøknadsinnholdUføreJson
@@ -104,7 +105,7 @@ internal fun Route.søknadRoutes(
                     søknadsinnholdResultat.fold(
                         { call.svar(it.tilResultat()) },
                         {
-                            søknadService.nySøknad(it, søknadsinnholdJson.forNav.identBruker(call))
+                            søknadService.nySøknad(it, søknadsinnholdJson.forNav!!.identBruker(call))
                                 .fold(
                                     { call.svar(it.tilResultat(type)) },
                                     { (saksnummer, søknad) ->
@@ -338,6 +339,7 @@ internal fun validerSøknadstypePathMotBody(
     val bodyType = when (søknadsinnholdJson) {
         is SøknadsinnholdAlderJson -> SøknadstypePath.ALDER
         is SøknadsinnholdUføreJson -> SøknadstypePath.UFORE
+        is SøknadsinnholdInfotrygdJson -> SøknadstypePath.ALDER
     }
 
     return if (pathType != bodyType) {

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknad/søknadinnholdJson/SøknadsinnholdInputValidator.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknad/søknadinnholdJson/SøknadsinnholdInputValidator.kt
@@ -22,7 +22,7 @@ internal object SøknadsinnholdInputValidator {
     private fun MutableList<UgyldigInput>.validerFellesTekstfelter(søknadsinnhold: SøknadsinnholdJson) {
         validerTekst(
             felt = "oppholdstillatelse.statsborgerskapAndreLandFritekst",
-            verdi = søknadsinnhold.oppholdstillatelse.statsborgerskapAndreLandFritekst,
+            verdi = søknadsinnhold.oppholdstillatelse!!.statsborgerskapAndreLandFritekst,
             maksLengde = STANDARD_MAKS_LENGDE,
         )
         // TODO validere mot PDL da veileder/sb ikke kan velge selv MEN mulig å sette i redux så må ha validering på adressen mtp sikkerhet
@@ -42,10 +42,12 @@ internal object SøknadsinnholdInputValidator {
                     maksLengde = 500,
                 )
             }
+
+            null -> TODO()
         }
 
-        validerFormue("formue", søknadsinnhold.formue)
-        validerInntektOgPensjon("inntektOgPensjon", søknadsinnhold.inntektOgPensjon)
+        validerFormue("formue", søknadsinnhold.formue!!)
+        validerInntektOgPensjon("inntektOgPensjon", søknadsinnhold.inntektOgPensjon!!)
     }
 
     private fun MutableList<UgyldigInput>.validerFormue(

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknad/søknadinnholdJson/SøknadsinnholdJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknad/søknadinnholdJson/SøknadsinnholdJson.kt
@@ -13,6 +13,7 @@ import no.nav.su.se.bakover.domain.søknad.søknadinnhold.FeilVedOpprettelseAvOp
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.FeilVedOpprettelseAvSøknadinnhold
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.SøknadInnhold
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.SøknadsinnholdAlder
+import no.nav.su.se.bakover.domain.søknad.søknadinnhold.SøknadsinnholdInfotrygd
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.SøknadsinnholdUføre
 import no.nav.su.se.bakover.web.routes.søknad.søknadinnholdJson.BoforholdJson.Companion.toBoforholdJson
 import no.nav.su.se.bakover.web.routes.søknad.søknadinnholdJson.EktefelleJson.Companion.toJson
@@ -40,26 +41,43 @@ import no.nav.su.se.bakover.web.routes.søknad.søknadinnholdJson.Utenlandsoppho
 )
 sealed interface SøknadsinnholdJson {
     val personopplysninger: FnrJsonWrapper
-    val boforhold: BoforholdJson
-    val utenlandsopphold: UtenlandsoppholdJson
-    val oppholdstillatelse: OppholdstillatelseJson
-    val inntektOgPensjon: InntektOgPensjonJson
-    val formue: FormueJson
-    val forNav: ForNavJson
+    val boforhold: BoforholdJson?
+    val utenlandsopphold: UtenlandsoppholdJson?
+    val oppholdstillatelse: OppholdstillatelseJson?
+    val inntektOgPensjon: InntektOgPensjonJson?
+    val formue: FormueJson?
+    val forNav: ForNavJson?
     val ektefelle: EktefelleJson?
 
     fun toSøknadsinnhold() = when (this) {
         is SøknadsinnholdAlderJson -> toSøknadsinnholdAlder()
         is SøknadsinnholdUføreJson -> toSøknadsinnholdUføre()
+        is SøknadsinnholdInfotrygdJson -> SøknadsinnholdInfotrygd(
+            personopplysninger = personopplysninger.toFnrWrapper(),
+        ).right()
     }
 
     companion object {
         fun SøknadInnhold.toSøknadsinnholdJson() = when (this) {
             is SøknadsinnholdAlder -> toSøknadsinnholdAlderJson()
             is SøknadsinnholdUføre -> toSøknadsinnholdUføreJson()
+            is SøknadsinnholdInfotrygd -> SøknadsinnholdInfotrygdJson(
+                personopplysninger = personopplysninger.toFnrJsonWrapper(),
+            )
         }
     }
 }
+
+data class SøknadsinnholdInfotrygdJson(
+    override val personopplysninger: FnrJsonWrapper,
+    override val boforhold: BoforholdJson? = null,
+    override val utenlandsopphold: UtenlandsoppholdJson? = null,
+    override val oppholdstillatelse: OppholdstillatelseJson? = null,
+    override val inntektOgPensjon: InntektOgPensjonJson? = null,
+    override val formue: FormueJson? = null,
+    override val forNav: ForNavJson? = null,
+    override val ektefelle: EktefelleJson? = null,
+) : SøknadsinnholdJson
 
 data class SøknadsinnholdAlderJson(
     val harSøktAlderspensjon: HarSøktAlderspensjonJson,
@@ -237,12 +255,20 @@ private fun UgyldigFnrException.tilUgyldigSøknadsinnholdInput(
 private fun UgyldigSøknadsinnholdInputFraJson.tilKunneIkkeLageSøknadinnhold(): KunneIkkeLageSøknadinnhold =
     KunneIkkeLageSøknadinnhold.UgyldigSøknadsinnholdInputWeb(listOf(this))
 
-private fun FeilVedOpprettelseAvBoforholdJson.tilKunneIkkeLageSøknadinnhold(): KunneIkkeLageSøknadinnhold = when (this) {
-    is FeilVedOpprettelseAvBoforholdJson.DomeneFeil -> KunneIkkeLageSøknadinnhold.FeilVedOpprettelseAvBoforholdWeb(underliggendeFeil)
-    is FeilVedOpprettelseAvBoforholdJson.UgyldigInput -> underliggendeFeil.tilKunneIkkeLageSøknadinnhold()
-}
+private fun FeilVedOpprettelseAvBoforholdJson.tilKunneIkkeLageSøknadinnhold(): KunneIkkeLageSøknadinnhold =
+    when (this) {
+        is FeilVedOpprettelseAvBoforholdJson.DomeneFeil -> KunneIkkeLageSøknadinnhold.FeilVedOpprettelseAvBoforholdWeb(
+            underliggendeFeil,
+        )
 
-private fun FeilVedOpprettelseAvOppholdstillatelseJson.tilKunneIkkeLageSøknadinnhold(): KunneIkkeLageSøknadinnhold = when (this) {
-    is FeilVedOpprettelseAvOppholdstillatelseJson.DomeneFeil -> KunneIkkeLageSøknadinnhold.FeilVedOpprettelseAvOppholdstillatelseWeb(underliggendeFeil)
-    is FeilVedOpprettelseAvOppholdstillatelseJson.UgyldigInput -> underliggendeFeil.tilKunneIkkeLageSøknadinnhold()
-}
+        is FeilVedOpprettelseAvBoforholdJson.UgyldigInput -> underliggendeFeil.tilKunneIkkeLageSøknadinnhold()
+    }
+
+private fun FeilVedOpprettelseAvOppholdstillatelseJson.tilKunneIkkeLageSøknadinnhold(): KunneIkkeLageSøknadinnhold =
+    when (this) {
+        is FeilVedOpprettelseAvOppholdstillatelseJson.DomeneFeil -> KunneIkkeLageSøknadinnhold.FeilVedOpprettelseAvOppholdstillatelseWeb(
+            underliggendeFeil,
+        )
+
+        is FeilVedOpprettelseAvOppholdstillatelseJson.UgyldigInput -> underliggendeFeil.tilKunneIkkeLageSøknadinnhold()
+    }

--- a/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknad/søknadinnholdJson/SøknadsinnholdJson.kt
+++ b/web/src/main/kotlin/no/nav/su/se/bakover/web/routes/søknad/søknadinnholdJson/SøknadsinnholdJson.kt
@@ -11,6 +11,8 @@ import no.nav.su.se.bakover.domain.søknad.søknadinnhold.FeilVedOpprettelseAvBo
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.FeilVedOpprettelseAvFormue
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.FeilVedOpprettelseAvOppholdstillatelse
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.FeilVedOpprettelseAvSøknadinnhold
+import no.nav.su.se.bakover.domain.søknad.søknadinnhold.ForNav
+import no.nav.su.se.bakover.domain.søknad.søknadinnhold.HarSøktAlderspensjon
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.SøknadInnhold
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.SøknadsinnholdAlder
 import no.nav.su.se.bakover.domain.søknad.søknadinnhold.SøknadsinnholdInfotrygd
@@ -53,7 +55,9 @@ sealed interface SøknadsinnholdJson {
         is SøknadsinnholdAlderJson -> toSøknadsinnholdAlder()
         is SøknadsinnholdUføreJson -> toSøknadsinnholdUføre()
         is SøknadsinnholdInfotrygdJson -> SøknadsinnholdInfotrygd(
+            HarSøktAlderspensjon(true),
             personopplysninger = personopplysninger.toFnrWrapper(),
+            forNav = ForNav.DigitalSøknad(),
         ).right()
     }
 
@@ -62,20 +66,23 @@ sealed interface SøknadsinnholdJson {
             is SøknadsinnholdAlder -> toSøknadsinnholdAlderJson()
             is SøknadsinnholdUføre -> toSøknadsinnholdUføreJson()
             is SøknadsinnholdInfotrygd -> SøknadsinnholdInfotrygdJson(
+                HarSøktAlderspensjonJson(true),
                 personopplysninger = personopplysninger.toFnrJsonWrapper(),
+                forNav = ForNavJson.DigitalSøknad(),
             )
         }
     }
 }
 
 data class SøknadsinnholdInfotrygdJson(
+    val harSøktAlderspensjon: HarSøktAlderspensjonJson,
     override val personopplysninger: FnrJsonWrapper,
+    override val forNav: ForNavJson,
     override val boforhold: BoforholdJson? = null,
     override val utenlandsopphold: UtenlandsoppholdJson? = null,
     override val oppholdstillatelse: OppholdstillatelseJson? = null,
     override val inntektOgPensjon: InntektOgPensjonJson? = null,
     override val formue: FormueJson? = null,
-    override val forNav: ForNavJson? = null,
     override val ektefelle: EktefelleJson? = null,
 ) : SøknadsinnholdJson
 


### PR DESCRIPTION
Eksperimentering med søknadsinnhold for å kunne behandle inn saker fra infotrygd uten søknad og vedtaksbrev.